### PR TITLE
[cni-cilium] do not SNAT vmCIDRs

### DIFF
--- a/modules/021-cni-cilium/images/cilium/Dockerfile
+++ b/modules/021-cni-cilium/images/cilium/Dockerfile
@@ -85,8 +85,10 @@ WORKDIR /tmp/cilium-repo/cilium-1.11.14
 
 COPY patches/001-customer-annotations.patch /
 COPY patches/002-mtu.patch /
+COPY patches/003-vms-cidr.patch /
 RUN patch -p1 < /001-customer-annotations.patch && \
-    patch -p1 < /002-mtu.patch
+    patch -p1 < /002-mtu.patch && \
+    patch -p1 < /003-vms-cidr.patch
 
 RUN make PKG_BUILD=1 \
     SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container-binary

--- a/modules/021-cni-cilium/images/cilium/patches/003-vms-cidr.patch
+++ b/modules/021-cni-cilium/images/cilium/patches/003-vms-cidr.patch
@@ -1,0 +1,175 @@
+diff --git a/bpf/lib/nodeport.h b/bpf/lib/nodeport.h
+index 85e23f90c8..9735434fdd 100644
+--- a/bpf/lib/nodeport.h
++++ b/bpf/lib/nodeport.h
+@@ -1186,6 +1186,18 @@ skip_egress_gateway:
+ 		return false;
+ #endif
+ 
++#ifdef IPV4_SNAT_EXCLUSION_DST_VM_CIDR
++	/* Do not MASQ if a dst IP belongs to a vms CIDR
++	 * (ipv4-native-routing-vm-cidr if specified).
++	 * The check is performed before we determine that a packet is
++	 * sent from a local pod, as this check is cheaper than
++	 * the map lookup done in the latter check.
++	 */
++	if (ipv4_is_in_subnet(ip4->daddr, IPV4_SNAT_EXCLUSION_DST_VM_CIDR,
++			      IPV4_SNAT_EXCLUSION_DST_VM_CIDR_LEN))
++		return false;
++#endif
++
+ 	/* if this is a localhost endpoint, no SNAT is needed */
+ 	if (local_ep && (local_ep->flags & ENDPOINT_F_HOST))
+ 		return false;
+diff --git a/daemon/cmd/daemon_main.go b/daemon/cmd/daemon_main.go
+index b523d64462..92e2fc7166 100644
+--- a/daemon/cmd/daemon_main.go
++++ b/daemon/cmd/daemon_main.go
+@@ -672,6 +672,8 @@ func initializeFlags() {
+ 
+ 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the IPv4 CIDR for native routing. This value corresponds to the configured cluster-cidr.")
+ 	option.BindEnv(option.IPv4NativeRoutingCIDR)
++	flags.String(option.IPv4NativeRoutingVMCIDR, "", "Allows to explicitly specify the IPv4 CIDR for native routing. This value corresponds to the configured cluster-cidr.")
++	option.BindEnv(option.IPv4NativeRoutingVMCIDR)
+ 
+ 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")
+ 	option.BindEnv(option.LibDir)
+diff --git a/pkg/datapath/config.go b/pkg/datapath/config.go
+index 85ae88a017..c350fc58c6 100644
+--- a/pkg/datapath/config.go
++++ b/pkg/datapath/config.go
+@@ -128,6 +128,13 @@ func RemoteSNATDstAddrExclusionCIDRv4() *cidr.CIDR {
+ 	return node.GetIPv4AllocRange()
+ }
+ 
++// RemoteSNATDstAddrExclusionVMCIDRv4 returns a CIDR for SNAT exclusion. Any
++// packet sent from a local endpoint to an IP address belonging to the CIDR
++// should not be SNAT'd.
++func RemoteSNATDstAddrExclusionVMCIDRv4() *cidr.CIDR {
++	return option.Config.GetIPv4NativeRoutingVMCIDR()
++}
++
+ // RemoteSNATDstAddrExclusionCIDRv6 returns a IPv6 CIDR for SNAT exclusion. Any
+ // packet sent from a local endpoint to an IP address belonging to the CIDR
+ // should not be SNAT'd.
+diff --git a/pkg/datapath/iptables/iptables.go b/pkg/datapath/iptables/iptables.go
+index d1cc66b4a9..273cc15eb9 100644
+--- a/pkg/datapath/iptables/iptables.go
++++ b/pkg/datapath/iptables/iptables.go
+@@ -1442,6 +1442,12 @@ func (m *IptablesManager) installRules(ifName string) error {
+ 		if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
+ 			return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
+ 		}
++		if vmsCIDR := option.Config.GetIPv4NativeRoutingVMCIDR(); vmsCIDR != nil {
++			if err := m.addNoTrackVMTrafficRules(ip4tables, vmsCIDR.String()); err != nil {
++				return fmt.Errorf("cannot install vm traffic no CT rules: %w", err)
++			}
++		}
++
+ 	}
+ 
+ 	for _, c := range ciliumChains {
+@@ -1559,6 +1565,30 @@ func (m *IptablesManager) addNoTrackPodTrafficRules(prog iptablesInterface, pods
+ 	return nil
+ }
+ 
++func (m *IptablesManager) addNoTrackVMTrafficRules(prog iptablesInterface, vmsCIDR string) error {
++	for _, chain := range []string{ciliumPreRawChain, ciliumOutputRawChain} {
++		if err := prog.runProg([]string{
++			"-t", "raw",
++			"-I", chain,
++			"-s", vmsCIDR,
++			"-m", "comment", "--comment", "cilium: NOTRACK for vm traffic",
++			"-j", "CT", "--notrack"}); err != nil {
++			return err
++		}
++
++		if err := prog.runProg([]string{
++			"-t", "raw",
++			"-I", chain,
++			"-d", vmsCIDR,
++			"-m", "comment", "--comment", "cilium: NOTRACK for vm traffic",
++			"-j", "CT", "--notrack"}); err != nil {
++			return err
++		}
++	}
++
++	return nil
++}
++
+ func (m *IptablesManager) addCiliumENIRules() error {
+ 	if !option.Config.EnableIPv4 {
+ 		return nil
+diff --git a/pkg/datapath/linux/config/config.go b/pkg/datapath/linux/config/config.go
+index f47f5a5124..f14387cc03 100644
+--- a/pkg/datapath/linux/config/config.go
++++ b/pkg/datapath/linux/config/config.go
+@@ -518,6 +518,13 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
+ 			ones, _ := cidr.Mask.Size()
+ 			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
+ 
++			if cidr = datapath.RemoteSNATDstAddrExclusionVMCIDRv4(); cidr != nil {
++				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_VM_CIDR"] =
++					fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(cidr.IP))
++				ones, _ = cidr.Mask.Size()
++				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_VM_CIDR_LEN"] = fmt.Sprintf("%d", ones)
++			}
++
+ 			// ip-masq-agent depends on bpf-masq
+ 			if option.Config.EnableIPMasqAgent {
+ 				cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
+diff --git a/pkg/option/config.go b/pkg/option/config.go
+index a1548650b9..e2deb8514f 100644
+--- a/pkg/option/config.go
++++ b/pkg/option/config.go
+@@ -828,6 +828,9 @@ const (
+ 	// IPv4NativeRoutingCIDR describes a v4 CIDR in which pod IPs are routable
+ 	IPv4NativeRoutingCIDR = "ipv4-native-routing-cidr"
+ 
++	// IPv4NativeRoutingVMCIDR describes a v4 CIDR in which pod IPs are routable
++	IPv4NativeRoutingVMCIDR = "ipv4-native-routing-vm-cidr"
++
+ 	// EgressMasqueradeInterfaces is the selector used to select interfaces
+ 	// subject to egress masquerading
+ 	EgressMasqueradeInterfaces = "egress-masquerade-interfaces"
+@@ -1902,6 +1905,9 @@ type DaemonConfig struct {
+ 	// IPv4NativeRoutingCIDR describes a CIDR in which pod IPs are routable
+ 	IPv4NativeRoutingCIDR *cidr.CIDR
+ 
++	// IPv4NativeRoutingVMCIDR describes a CIDR in which vm IPs are routable
++	IPv4NativeRoutingVMCIDR *cidr.CIDR
++
+ 	// EgressMasqueradeInterfaces is the selector used to select interfaces
+ 	// subject to egress masquerading
+ 	EgressMasqueradeInterfaces string
+@@ -2181,6 +2187,14 @@ func (c *DaemonConfig) GetIPv4NativeRoutingCIDR() (cidr *cidr.CIDR) {
+ 	return
+ }
+ 
++// GetIPv4NativeRoutingVMCIDR returns the native routing VM CIDR if configured
++func (c *DaemonConfig) GetIPv4NativeRoutingVMCIDR() (cidr *cidr.CIDR) {
++	c.ConfigPatchMutex.RLock()
++	cidr = c.IPv4NativeRoutingVMCIDR
++	c.ConfigPatchMutex.RUnlock()
++	return
++}
++
+ // SetIPv4NativeRoutingCIDR sets the native routing CIDR
+ func (c *DaemonConfig) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {
+ 	c.ConfigPatchMutex.Lock()
+@@ -2809,6 +2823,15 @@ func (c *DaemonConfig) Populate() {
+ 		}
+ 	}
+ 
++	ipv4NativeRoutingVMCIDR := viper.GetString(IPv4NativeRoutingVMCIDR)
++	if ipv4NativeRoutingVMCIDR != "" {
++		c.IPv4NativeRoutingVMCIDR = cidr.MustParseCIDR(ipv4NativeRoutingVMCIDR)
++
++		if len(c.IPv4NativeRoutingVMCIDR.IP) != net.IPv4len {
++			log.Fatalf("%s must be an IPv4 CIDR", IPv4NativeRoutingVMCIDR)
++		}
++	}
++
+ 	if err := c.calculateBPFMapSizes(); err != nil {
+ 		log.Fatal(err)
+ 	}

--- a/modules/021-cni-cilium/images/cilium/patches/003-vms-cidr.patch.v12
+++ b/modules/021-cni-cilium/images/cilium/patches/003-vms-cidr.patch.v12
@@ -1,0 +1,202 @@
+diff --git a/bpf/lib/nat.h b/bpf/lib/nat.h
+index 92726b04d6..db45539195 100644
+--- a/bpf/lib/nat.h
++++ b/bpf/lib/nat.h
+@@ -705,6 +705,21 @@ skip_egress_gateway:
+ 		return false;
+ #endif
+ 
++
++#ifdef ENABLE_VM_MASQUERADE /* SNAT local vm to world packets */
++# ifdef IPV4_SNAT_EXCLUSION_DST_VM_CIDR
++	/* Do not MASQ if a dst IP belongs to a vms CIDR
++	 * (ipv4-native-routing-vm-cidr if specified).
++	 * The check is performed before we determine that a packet is
++	 * sent from a local pod, as this check is cheaper than
++	 * the map lookup done in the latter check.
++	 */
++	if (ipv4_is_in_subnet(ip4->daddr, IPV4_SNAT_EXCLUSION_DST_VM_CIDR,
++			      IPV4_SNAT_EXCLUSION_DST_VM_CIDR_LEN))
++		return false;
++# endif
++#endif /*ENABLE_VM_MASQUERADE */
++
+ 	/* if this is a localhost endpoint, no SNAT is needed */
+ 	if (local_ep && (local_ep->flags & ENDPOINT_F_HOST))
+ 		return false;
+diff --git a/bpf/node_config.h b/bpf/node_config.h
+index 65042148b8..b8f314484e 100644
+--- a/bpf/node_config.h
++++ b/bpf/node_config.h
+@@ -78,6 +78,10 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
+ # ifdef ENABLE_MASQUERADE
+ #  define IPV4_SNAT_EXCLUSION_DST_CIDR 0xffff0000
+ #  define IPV4_SNAT_EXCLUSION_DST_CIDR_LEN 16
++#  ifdef ENABLE_VM_MASQUERADE
++#   define IPV4_SNAT_EXCLUSION_DST_VM_CIDR 0xffff0000
++#   define IPV4_SNAT_EXCLUSION_DST_VM_CIDR_LEN 16
++#  endif /* ENABLE_VM_MASQUERADE */
+ # endif /* ENABLE_MASQUERADE */
+ #ifdef ENABLE_NODEPORT
+ #define SNAT_MAPPING_IPV4 test_cilium_snat_v4_external
+diff --git a/daemon/cmd/daemon_main.go b/daemon/cmd/daemon_main.go
+index 84fda249f6..a5ee98af3d 100644
+--- a/daemon/cmd/daemon_main.go
++++ b/daemon/cmd/daemon_main.go
+@@ -621,6 +621,12 @@ func initializeFlags() {
+ 		"To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.")
+ 	option.BindEnv(Vp, option.IPv4NativeRoutingCIDR)
+ 
++	flags.String(option.IPv4NativeRoutingVMCIDR, "", "Allows to explicitly specify the IPv4 CIDR for native routing. "+
++		"When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. "+
++		"Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. "+
++		"To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach vmss, either manually or by setting the auto-direct-node-routes flag.")
++	option.BindEnv(Vp, option.IPv4NativeRoutingVMCIDR)
++
+ 	flags.String(option.IPv6NativeRoutingCIDR, "", "Allows to explicitly specify the IPv6 CIDR for native routing. "+
+ 		"When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. "+
+ 		"Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. "+
+diff --git a/pkg/datapath/config.go b/pkg/datapath/config.go
+index 08a7696d9c..2a5bc430be 100644
+--- a/pkg/datapath/config.go
++++ b/pkg/datapath/config.go
+@@ -127,6 +127,13 @@ func RemoteSNATDstAddrExclusionCIDRv4() *cidr.CIDR {
+ 	return node.GetIPv4AllocRange()
+ }
+ 
++// RemoteSNATDstAddrExclusionVMCIDRv4 returns a CIDR for SNAT exclusion. Any
++// packet sent from a local endpoint to an IP address belonging to the CIDR
++// should not be SNAT'd.
++func RemoteSNATDstAddrExclusionVMCIDRv4() *cidr.CIDR {
++	return option.Config.GetIPv4NativeRoutingVMCIDR()
++}
++
+ // RemoteSNATDstAddrExclusionCIDRv6 returns a IPv6 CIDR for SNAT exclusion. Any
+ // packet sent from a local endpoint to an IP address belonging to the CIDR
+ // should not be SNAT'd.
+diff --git a/pkg/datapath/iptables/iptables.go b/pkg/datapath/iptables/iptables.go
+index 79dff98c54..7df208a566 100644
+--- a/pkg/datapath/iptables/iptables.go
++++ b/pkg/datapath/iptables/iptables.go
+@@ -1478,6 +1478,12 @@ func (m *IptablesManager) installRules(ifName string) error {
+ 		if err := m.addNoTrackPodTrafficRules(ip4tables, podsCIDR); err != nil {
+ 			return fmt.Errorf("cannot install pod traffic no CT rules: %w", err)
+ 		}
++		if vmsCIDR := option.Config.GetIPv4NativeRoutingVMCIDR(); vmsCIDR != nil {
++			if err := m.addNoTrackPodTrafficRules(ip4tables, vmsCIDR.String()); err != nil {
++				return fmt.Errorf("cannot install vm traffic no CT rules: %w", err)
++			}
++		}
++
+ 	}
+ 
+ 	for _, c := range ciliumChains {
+@@ -1595,6 +1601,30 @@ func (m *IptablesManager) addNoTrackPodTrafficRules(prog iptablesInterface, pods
+ 	return nil
+ }
+ 
++func (m *IptablesManager) addNoTrackVMTrafficRules(prog iptablesInterface, vmsCIDR string) error {
++	for _, chain := range []string{ciliumPreRawChain, ciliumOutputRawChain} {
++		if err := prog.runProg([]string{
++			"-t", "raw",
++			"-I", chain,
++			"-s", vmsCIDR,
++			"-m", "comment", "--comment", "cilium: NOTRACK for vm traffic",
++			"-j", "CT", "--notrack"}); err != nil {
++			return err
++		}
++
++		if err := prog.runProg([]string{
++			"-t", "raw",
++			"-I", chain,
++			"-d", vmsCIDR,
++			"-m", "comment", "--comment", "cilium: NOTRACK for vm traffic",
++			"-j", "CT", "--notrack"}); err != nil {
++			return err
++		}
++	}
++
++	return nil
++}
++
+ func (m *IptablesManager) addCiliumENIRules() error {
+ 	if !option.Config.EnableIPv4 {
+ 		return nil
+diff --git a/pkg/datapath/linux/config/config.go b/pkg/datapath/linux/config/config.go
+index 6a074211fb..30e4590bdd 100644
+--- a/pkg/datapath/linux/config/config.go
++++ b/pkg/datapath/linux/config/config.go
+@@ -571,6 +571,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
+ 			ones, _ := cidr.Mask.Size()
+ 			cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
+ 
++			if cidr = datapath.RemoteSNATDstAddrExclusionVMCIDRv4(); cidr != nil {
++				cDefinesMap["ENABLE_VM_MASQUERADE"] = "1"
++				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_VM_CIDR"] =
++					fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(cidr.IP))
++				ones, _ = cidr.Mask.Size()
++				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_VM_CIDR_LEN"] = fmt.Sprintf("%d", ones)
++			}
++
+ 			// ip-masq-agent depends on bpf-masq
+ 			if option.Config.EnableIPMasqAgent {
+ 				cDefinesMap["ENABLE_IP_MASQ_AGENT"] = "1"
+diff --git a/pkg/option/config.go b/pkg/option/config.go
+index c76338d746..249fdd615d 100644
+--- a/pkg/option/config.go
++++ b/pkg/option/config.go
+@@ -866,6 +866,9 @@ const (
+ 	// IPv4NativeRoutingCIDR describes a v4 CIDR in which pod IPs are routable
+ 	IPv4NativeRoutingCIDR = "ipv4-native-routing-cidr"
+ 
++	// IPv4NativeRoutingVMCIDR describes a v4 CIDR in which pod IPs are routable
++	IPv4NativeRoutingVMCIDR = "ipv4-native-routing-vm-cidr"
++
+ 	// IPv6NativeRoutingCIDR describes a v6 CIDR in which pod IPs are routable
+ 	IPv6NativeRoutingCIDR = "ipv6-native-routing-cidr"
+ 
+@@ -2039,6 +2042,9 @@ type DaemonConfig struct {
+ 	// IPv4NativeRoutingCIDR describes a CIDR in which pod IPs are routable
+ 	IPv4NativeRoutingCIDR *cidr.CIDR
+ 
++	// IPv4NativeRoutingVMCIDR describes a CIDR in which vm IPs are routable
++	IPv4NativeRoutingVMCIDR *cidr.CIDR
++
+ 	// IPv6NativeRoutingCIDR describes a CIDR in which pod IPs are routable
+ 	IPv6NativeRoutingCIDR *cidr.CIDR
+ 
+@@ -2379,6 +2385,14 @@ func (c *DaemonConfig) GetIPv4NativeRoutingCIDR() (cidr *cidr.CIDR) {
+ 	return
+ }
+ 
++// GetIPv4NativeRoutingVMCIDR returns the native routing VM CIDR if configured
++func (c *DaemonConfig) GetIPv4NativeRoutingVMCIDR() (cidr *cidr.CIDR) {
++	c.ConfigPatchMutex.RLock()
++	cidr = c.IPv4NativeRoutingVMCIDR
++	c.ConfigPatchMutex.RUnlock()
++	return
++}
++
+ // SetIPv4NativeRoutingCIDR sets the native routing CIDR
+ func (c *DaemonConfig) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {
+ 	c.ConfigPatchMutex.Lock()
+@@ -3101,6 +3115,19 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
+ 		}
+ 	}
+ 
++	ipv4NativeRoutingVMCIDR := vp.GetString(IPv4NativeRoutingVMCIDR)
++
++	if ipv4NativeRoutingVMCIDR != "" {
++		c.IPv4NativeRoutingVMCIDR, err = cidr.ParseCIDR(ipv4NativeRoutingVMCIDR)
++		if err != nil {
++			log.WithError(err).Fatalf("Unable to parse VM CIDR '%s'", ipv4NativeRoutingVMCIDR)
++		}
++
++		if len(c.IPv4NativeRoutingVMCIDR.IP) != net.IPv4len {
++			log.Fatalf("%s must be an IPv4 CIDR", IPv4NativeRoutingVMCIDR)
++		}
++	}
++
+ 	if c.EnableIPv4 && ipv4NativeRoutingCIDR == "" && c.EnableAutoDirectRouting {
+ 		log.Warnf("If %s is enabled, then you are recommended to also configure %s. If %s is not configured, this may lead to pod to pod traffic being masqueraded, "+
+ 			"which can cause problems with performance, observability and policy", EnableAutoDirectRoutingName, IPv4NativeRoutingCIDR, IPv4NativeRoutingCIDR)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
