### PR TITLE
[cloud-provider-gcp] update kube-proxy configuration to set listen address to 0.0.0.0/0 when using GCP cloud provider

### DIFF
--- a/modules/021-kube-proxy/images/init-container/nodeport-bind-address.sh
+++ b/modules/021-kube-proxy/images/init-container/nodeport-bind-address.sh
@@ -26,7 +26,7 @@ if [ -z "$internalip" ]; then
   exit 1
 fi
 
-if [ "$nodeport_bind_internal_ip" == "false" ]; then
+if [[ ("$nodeport_bind_internal_ip" == "false") || ("$CLOUD_PROVIDER" == "gcp") ]]; then
   internalip="0.0.0.0/0"
 fi
 

--- a/modules/021-kube-proxy/templates/daemonset.yaml
+++ b/modules/021-kube-proxy/templates/daemonset.yaml
@@ -4,6 +4,7 @@ memory: 25Mi
 {{- end }}
 
 {{- $kubeVersion := semver .Values.global.discovery.kubernetesVersion -}}
+{{- $cloudProvider := .Values.global.clusterConfiguration.cloud.provider | lower -}}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -76,6 +77,9 @@ spec:
         {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "initContainer") }}
         command: ["/nodeport-bind-address.sh"]
+        env:
+        - name: CLOUD_PROVIDER
+          value: {{ $cloudProvider }}
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: config

--- a/modules/030-cloud-provider-gcp/docs/README.md
+++ b/modules/030-cloud-provider-gcp/docs/README.md
@@ -12,5 +12,3 @@ The `cloud-provider-gcp` module:
 - Provisions disks in GCP using the `CSI storage` component.
 - Enables the necessary CNI plugin (using the [simple bridge](../../modules/035-cni-simple-bridge/)).
 - Registers with the [node-manager](../../modules/040-node-manager/) module so that [GCPInstanceClasses](cr.html#gcpinstanceclass) can be used when creating the [NodeGroup](../../modules/040-node-manager/cr.html#nodegroup).
-
-> **Caution!** Starting with Kubernetes 1.23, for load balancers to work correctly, you must add an [annotation](../021-kube-proxy/) to the nodes that enables kube-proxy to accept connections to external IP addresses. This is necessary because load balancers' healthcheck uses the load balancer's external address.

--- a/modules/030-cloud-provider-gcp/docs/README_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/README_RU.md
@@ -12,5 +12,3 @@ title: "Cloud provider — GCP"
 - Заказывает диски в GCP с помощью компонента `CSI storage`.
 - Включает необходимый CNI (использует [simple bridge](../../modules/035-cni-simple-bridge/)).
 - Регистрируется в модуле [node-manager](../../modules/040-node-manager/), чтобы [GCPInstanceClass'ы](cr.html#gcpinstanceclass) можно было использовать при описании [NodeGroup](../../modules/040-node-manager/cr.html#nodegroup).
-
-> **Внимание!** Начиная с версии Kubernetes 1.23, для корректной работы балансировщиков нагрузки на узлы необходимо добавить [аннотацию](../021-kube-proxy/), разрешающую kube-proxy принимать подключения  на внешние IP-адреса. Это необходимо, поскольку healthcheck балансировщиков нагрузки использует внешний адрес балансировщика.


### PR DESCRIPTION
## Description
Update kube-proxy configuration to set listen address to 0.0.0.0/0 when using GCP cloud provider.

## Why do we need it, and what problem does it solve?
Closes (https://github.com/deckhouse/deckhouse/issues/3734)

## What is the expected result?
For GCP cloud provider, kube-proxy will handle connections on 0.0.0.0/0.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: cloud-provider-gcp
type: fix
summary: update kube-proxy configuration to set listen address to 0.0.0.0/0 when using GCP cloud provider.
impact: "`kube-proxy` Pods will be recreated."
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
