### PR TITLE
[ingress-nginx] improve daemonset failover rollout hook

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -254,10 +254,6 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/flant/addon-operator v1.1.2 h1:pZv/v0AHNtyyf9xqjquitSOn8SL3B9BZnvaQcMkWbIM=
-github.com/flant/addon-operator v1.1.2/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
-github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa h1:mSS4yv3bqEg4c1eScC1gWt7HZ0wQXVd1NJ/ZRyRRJZw=
-github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974 h1:F1r5blw6uMXnE49GCNtqFUPsgpZzYpaK1i9vVLUpM6E=
 github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -19,6 +19,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -230,6 +231,10 @@ func daemonSetDeletePodInDs(input *go_hook.HookInput, namespace, dsName string, 
 	if len(podList.Items) == 0 {
 		return nil
 	}
+
+	sort.SliceStable(podList.Items, func(i, j int) bool {
+		return podList.Items[i].Name < podList.Items[j].Name
+	})
 
 	for _, pod := range podList.Items {
 		// if at least one pod is not ready or has Terminating state - abort mission to avoid parallel pod deletion

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -232,6 +232,8 @@ func daemonSetDeletePodInDs(input *go_hook.HookInput, namespace, dsName string, 
 		return nil
 	}
 
+	// it's a reinsurance, to have pods list always in the same order
+	// we don't trust api-server here
 	sort.SliceStable(podList.Items, func(i, j int) bool {
 		return podList.Items[i].Name < podList.Items[j].Name
 	})

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -133,6 +133,7 @@ func safeControllerUpdate(input *go_hook.HookInput, dc dependency.Container) (er
 				if (failover.Status.NumberAvailable == failover.Status.CurrentNumberScheduled) &&
 					(failover.Status.UpdatedNumberScheduled >= failover.Status.DesiredNumberScheduled) {
 					failoverReady = true
+					input.LogEntry.Infof("Failover daemonset %q is ready: available: %d, currentScheduled: %d, updatedScheduled: %d, desiredScheduler: %d", failover.Name, failover.Status.NumberAvailable, failover.Status.CurrentNumberScheduled, failover.Status.UpdatedNumberScheduled, failover.Status.DesiredNumberScheduled)
 					break
 				}
 			}
@@ -231,8 +232,9 @@ func daemonSetDeletePodInDs(input *go_hook.HookInput, namespace, dsName string, 
 	}
 
 	for _, pod := range podList.Items {
-		// if at least one pod is not ready or has Terminating state - abort mission
+		// if at least one pod is not ready or has Terminating state - abort mission to avoid parallel pod deletion
 		if !podIsReady(pod) {
+			input.LogEntry.Infof("Pod %q for ds %q is not ready. Skipping other pod deleting", pod.Name, dsName)
 			return nil
 		}
 	}

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -131,6 +131,10 @@ metadata:
     app: controller
     name: main
     pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 `
 
 	pod2ControllerMainInitialYAML := `
@@ -144,6 +148,10 @@ metadata:
     app: controller
     name: main
     pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 `
 	pod1ProxyMainFailoverInitialYAML := `
 ---
@@ -156,6 +164,10 @@ metadata:
     app: proxy-failover
     name: main
     pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 `
 	pod2ProxyMainFailoverInitialYAML := `
 ---
@@ -168,6 +180,10 @@ metadata:
     app: proxy-failover
     name: main
     pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 `
 	pod1ControllerMainFailoverInitialYAML := `
 ---
@@ -180,6 +196,10 @@ metadata:
     app: controller
     name: main-failover
     pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 `
 	pod2ControllerMainFailoverInitialYAML := `
 ---
@@ -192,6 +212,10 @@ metadata:
     app: controller
     name: main-failover
     pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 `
 	var dsControllerMain *v1.DaemonSet
 	var dsProxyMainFailover *v1.DaemonSet

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -217,6 +217,24 @@ status:
   - status: "True"
     type: Ready
 `
+
+	pod2TerminatingControllerMainInitialYAML := `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  deletionTimestamp: "2023-02-19T11:28:08Z"
+  name: controller-main-2
+  namespace: d8-ingress-nginx
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+`
 	var dsControllerMain *v1.DaemonSet
 	var dsProxyMainFailover *v1.DaemonSet
 	var dsControllerMainFailover *v1.DaemonSet
@@ -226,6 +244,7 @@ status:
 	var pod2ProxyMainFailover *corev1.Pod
 	var pod1ControllerMainFailover *corev1.Pod
 	var pod2ControllerMainFailover *corev1.Pod
+	var pod2TerminatingControllerMain *corev1.Pod
 
 	BeforeEach(func() {
 		_ = yaml.Unmarshal([]byte(dsControllerMainInitialYAML), &dsControllerMain)
@@ -237,6 +256,7 @@ status:
 		_ = yaml.Unmarshal([]byte(pod2ProxyMainFailoverInitialYAML), &pod2ProxyMainFailover)
 		_ = yaml.Unmarshal([]byte(pod1ControllerMainFailoverInitialYAML), &pod1ControllerMainFailover)
 		_ = yaml.Unmarshal([]byte(pod2ControllerMainFailoverInitialYAML), &pod2ControllerMainFailover)
+		_ = yaml.Unmarshal([]byte(pod2TerminatingControllerMainInitialYAML), &pod2TerminatingControllerMain)
 	})
 
 	Context("all daemonsets updated", func() {
@@ -280,6 +300,58 @@ status:
 
 			Expect(pod1ControllerMainAfterRunHook).To(Equal(pod1ControllerMain))
 			Expect(pod2ControllerMainAfterRunHook).To(Equal(pod2ControllerMain))
+			Expect(pod1ProxyMainFailoverAfterRunHook).To(Equal(pod1ProxyMainFailover))
+			Expect(pod2ProxyMainFailoverAfterRunHook).To(Equal(pod2ProxyMainFailover))
+			Expect(pod1ControllerMainFailoverAfterRunHook).To(Equal(pod1ControllerMainFailover))
+			Expect(pod2ControllerMainFailoverAfterRunHook).To(Equal(pod2ControllerMainFailover))
+		})
+	})
+
+	Context("daemonset controller-main with terminating pod update scheduled", func() {
+		BeforeEach(func() {
+			dsControllerMain.Generation = 2
+			dsControllerMain.Status.UpdatedNumberScheduled = 1
+			pod2ControllerMain.Labels["pod-template-generation"] = "2"
+
+			dsControllerMainYAML, _ := yaml.Marshal(&dsControllerMain)
+			dsProxyMainFailoverYAML, _ := yaml.Marshal(&dsProxyMainFailover)
+			dsControllerMainFailoverYAML, _ := yaml.Marshal(&dsControllerMainFailover)
+			pod1ControllerMainYAML, _ := yaml.Marshal(&pod1ControllerMain)
+			pod2TerminatingControllerMainYAML, _ := yaml.Marshal(&pod2TerminatingControllerMain)
+			pod1ProxyMainFailoverYAML, _ := yaml.Marshal(&pod1ProxyMainFailover)
+			pod2ProxyMainFailoverYAML, _ := yaml.Marshal(&pod2ProxyMainFailover)
+			pod1ControllerMainFailoverYAML, _ := yaml.Marshal(&pod1ControllerMainFailover)
+			pod2ControllerMainFailoverYAML, _ := yaml.Marshal(&pod2ControllerMainFailover)
+
+			clusterState := strings.Join([]string{string(dsControllerMainYAML), string(dsProxyMainFailoverYAML), string(dsControllerMainFailoverYAML), string(pod1ControllerMainYAML), string(pod2TerminatingControllerMainYAML), string(pod1ProxyMainFailoverYAML), string(pod2ProxyMainFailoverYAML), string(pod1ControllerMainFailoverYAML), string(pod2ControllerMainFailoverYAML)}, "---\n")
+
+			f.BindingContexts.Set(f.KubeStateSet(clusterState))
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			_, _ = f.KubeClient().AppsV1().DaemonSets("d8-ingress-nginx").Create(context.TODO(), dsControllerMain, metav1.CreateOptions{})
+			_, _ = f.KubeClient().AppsV1().DaemonSets("d8-ingress-nginx").Create(context.TODO(), dsProxyMainFailover, metav1.CreateOptions{})
+			_, _ = f.KubeClient().AppsV1().DaemonSets("d8-ingress-nginx").Create(context.TODO(), dsControllerMainFailover, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Create(context.TODO(), pod1ControllerMain, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Create(context.TODO(), pod2TerminatingControllerMain, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Create(context.TODO(), pod1ProxyMainFailover, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Create(context.TODO(), pod2ProxyMainFailover, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Create(context.TODO(), pod1ControllerMainFailover, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Create(context.TODO(), pod2ControllerMainFailover, metav1.CreateOptions{})
+
+			f.RunHook()
+		})
+
+		It("pod controller-main-1 must not be deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			pod1ControllerMainAfterRunHook, _ := f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Get(context.TODO(), pod1ControllerMain.Name, metav1.GetOptions{})
+			pod2ControllerMainAfterRunHook, _ := f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Get(context.TODO(), pod2ControllerMain.Name, metav1.GetOptions{})
+			pod1ProxyMainFailoverAfterRunHook, _ := f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Get(context.TODO(), pod1ProxyMainFailover.Name, metav1.GetOptions{})
+			pod2ProxyMainFailoverAfterRunHook, _ := f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Get(context.TODO(), pod2ProxyMainFailover.Name, metav1.GetOptions{})
+			pod1ControllerMainFailoverAfterRunHook, _ := f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Get(context.TODO(), pod1ControllerMainFailover.Name, metav1.GetOptions{})
+			pod2ControllerMainFailoverAfterRunHook, _ := f.KubeClient().CoreV1().Pods("d8-ingress-nginx").Get(context.TODO(), pod2ControllerMainFailover.Name, metav1.GetOptions{})
+
+			Expect(pod1ControllerMainAfterRunHook).To(Equal(pod1ControllerMain))
+			Expect(pod2ControllerMainAfterRunHook).To(Equal(pod2TerminatingControllerMain))
 			Expect(pod1ProxyMainFailoverAfterRunHook).To(Equal(pod1ProxyMainFailover))
 			Expect(pod2ProxyMainFailoverAfterRunHook).To(Equal(pod2ProxyMainFailover))
 			Expect(pod1ControllerMainFailoverAfterRunHook).To(Equal(pod1ControllerMainFailover))


### PR DESCRIPTION
## Description
Improve rollout hook:
- wait for all pods to be ready before delete a next one
- sort slice of pods to have an equal one in the each iteration

## Why do we need it, and what problem does it solve?
In a multi-master cloud the list of pods could be sorted in the different order. This way we can have a few pods to be deleted at once

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix 
summary: Improve rollout hook to avoid concurrent controller pod deletion
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
