### PR TITLE
[control-plane-manager] kubernetes version EOL

### DIFF
--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -36,7 +36,7 @@
 
   - alert: D8KubernetesVersionIsDeprecated
     for: 10m
-    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.21"}) == 1
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.22"}) == 1
     labels:
       severity_level: "7"
       tier: cluster
@@ -47,6 +47,23 @@
       description: |-
         Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed within 6 months
 
-        Please migrate to the next kubernetes version (at least 1.22)
-        
+        Please migrate to the next kubernetes version (at least 1.23)
+
+        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
+
+  - alert: D8KubernetesVersionEndOfLife
+    for: 10m
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.21"}) == 1
+    labels:
+      severity_level: "4"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: Kubernetes version "{{ $labels.k8s_version }}" has reached End Of Life.
+      description: |-
+        Current kubernetes version "{{ $labels.k8s_version }}" support will be removed in the next Deckhouse release (1.45).
+
+        Please migrate to the next kubernetes version (at least 1.22) as soon as possible.
+
         Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster


### PR DESCRIPTION
## Description
Add alert with higher severity level to notice about EOL of the 1.21 kubernetes version

## Why do we need it, and what problem does it solve?
1.21 kubernetes will be unsupported in the next release (1.45)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: control-plane-manager
type: chore
summary: Kubernetes version 1.21 support will be remove in the next (1.45) Deckhouse release. An alert have been added to keep you from forgetting about it.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
