### PR TITLE
[getting-started] Minor updates for the bare-metal installation

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -10,7 +10,7 @@ For real-world conditions (production and test environments), you need to add ad
 <p>If you install Deckhouse for <strong>evaluation purposes</strong> and one node in  the cluster is enough for you, allow Deckhouse components to work on the master node. To do this, remove the taint from the master node by running the following command:</p>
 {% snippetcut %}
 ```bash
-kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
+sudo kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
 ```
 {% endsnippetcut %}
 </blockquote>
@@ -24,7 +24,7 @@ After that, there will be three more actions.
   <p>Apply it using the following command on the <strong>master node</strong>>:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f ingress-nginx-controller.yml
+sudo kubectl create -f ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -36,7 +36,7 @@ kubectl create -f ingress-nginx-controller.yml
 <p>Apply it using the following command on the <strong>master node</strong>:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f user.yml
+sudo kubectl create -f user.yml
 ```
 {% endsnippetcut %}
 </li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -10,7 +10,7 @@
 <p>Если вы развернули кластер <strong>для ознакомительных целей</strong> и одного узла вам достаточно, разрешите компонентам Deckhouse работать на master-узле. Для этого, снимите с master-узла taint, выполнив на master-узле следующую команду:</p>
 {% snippetcut %}
 ```bash
-kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
+sudo kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
 ```
 {% endsnippetcut %}
 </blockquote>
@@ -24,7 +24,7 @@ kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f ingress-nginx-controller.yml
+sudo kubectl create -f ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -36,7 +36,7 @@ kubectl create -f ingress-nginx-controller.yml
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f user.yml
+sudo kubectl create -f user.yml
 ```
 {% endsnippetcut %}
 </li>


### PR DESCRIPTION
## Description
In case of installation on bare metal, in the getting started steps, you have to run kubectl with sudo, as kubectl is automatically configured in the root user.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Minor updates for the bare-metal installation.
impact_level: low
```
