### PR TITLE
[user-authn] Robots.txt

### DIFF
--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -4,13 +4,14 @@ ARG BASE_ALPINE
 FROM $BASE_GOLANG_18_ALPINE as artifact
 RUN apk add --no-cache git ca-certificates gcc build-base sqlite patch make curl
 WORKDIR /dex
-COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch patches/connector-data.patch patches/oidc-ca-insecure.patch /
+COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch patches/connector-data.patch patches/oidc-ca-insecure.patch patches/robots-txt.patch /
 RUN wget https://github.com/dexidp/dex/archive/v2.35.3.tar.gz -O - | tar -xz --strip-components=1 \
   && git apply /client-groups.patch \
   && git apply /static-user-groups.patch \
   && git apply /gitlab-refresh-context.patch \
   && git apply /connector-data.patch \
-  && git apply /oidc-ca-insecure.patch
+  && git apply /oidc-ca-insecure.patch \
+  && git apply /robots-txt.patch
 RUN go build ./cmd/dex
 
 FROM $BASE_ALPINE

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -30,3 +30,9 @@ Upstream PR - https://github.com/dexidp/dex/pull/2729.
 Allows OIDC connector to work with providers using self-signed certificates.
 
 Upstream PR that should fix the problem in general - https://github.com/dexidp/dex/pull/1632.
+
+### Robots.txt
+
+Add robots.txt to avoid indexing by bots.
+
+Upstream PR  - https://github.com/dexidp/dex/pull/2834

--- a/modules/150-user-authn/images/dex/patches/robots-txt.patch
+++ b/modules/150-user-authn/images/dex/patches/robots-txt.patch
@@ -1,0 +1,84 @@
+diff --git a/server/server.go b/server/server.go
+index df16e655..0aac0a6c 100755
+--- a/server/server.go
++++ b/server/server.go
+@@ -252,7 +252,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
+ 		extra:     c.Web.Extra,
+ 	}
+ 
+-	static, theme, tmpls, err := loadWebConfig(web)
++	static, theme, robots, tmpls, err := loadWebConfig(web)
+ 	if err != nil {
+ 		return nil, fmt.Errorf("server: failed to load web static: %v", err)
+ 	}
+@@ -390,6 +390,8 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
+ 
+ 	handlePrefix("/static", static)
+ 	handlePrefix("/theme", theme)
++	handleFunc("/robots.txt", robots)
++
+ 	s.mux = r
+ 
+ 	s.startKeyRotation(ctx, rotationStrategy, now)
+diff --git a/server/templates.go b/server/templates.go
+index 33f00fda..7d4371ea 100644
+--- a/server/templates.go
++++ b/server/templates.go
+@@ -89,7 +89,7 @@ func getFuncMap(c webConfig) (template.FuncMap, error) {
+ //    |  |- (theme name)
+ //    |- templates
+ //
+-func loadWebConfig(c webConfig) (http.Handler, http.Handler, *templates, error) {
++func loadWebConfig(c webConfig) (http.Handler, http.Handler, http.HandlerFunc, *templates, error) {
+ 	// fallback to the default theme if the legacy theme name is provided
+ 	if c.theme == "coreos" || c.theme == "tectonic" {
+ 		c.theme = ""
+@@ -106,18 +106,24 @@ func loadWebConfig(c webConfig) (http.Handler, http.Handler, *templates, error)
+ 
+ 	staticFiles, err := fs.Sub(c.webFS, "static")
+ 	if err != nil {
+-		return nil, nil, nil, fmt.Errorf("read static dir: %v", err)
++		return nil, nil, nil, nil, fmt.Errorf("read static dir: %v", err)
+ 	}
+ 	themeFiles, err := fs.Sub(c.webFS, path.Join("themes", c.theme))
+ 	if err != nil {
+-		return nil, nil, nil, fmt.Errorf("read themes dir: %v", err)
++		return nil, nil, nil, nil, fmt.Errorf("read themes dir: %v", err)
++	}
++	robotsContent, err := fs.ReadFile(c.webFS, "robots.txt")
++	if err != nil {
++		return nil, nil, nil, nil, fmt.Errorf("read robots.txt dir: %v", err)
+ 	}
+ 
+ 	static := http.FileServer(http.FS(staticFiles))
+ 	theme := http.FileServer(http.FS(themeFiles))
++	robots := func(w http.ResponseWriter, r *http.Request) { fmt.Fprintf(w, string(robotsContent)) }
+ 
+ 	templates, err := loadTemplates(c, "templates")
+-	return static, theme, templates, err
++
++	return static, theme, robots, templates, err
+ }
+ 
+ // loadTemplates parses the expected templates from the provided directory.
+diff --git a/web/web.go b/web/web.go
+index c5ff7514..0c7e9873 100644
+--- a/web/web.go
++++ b/web/web.go
+@@ -5,7 +5,7 @@ import (
+ 	"io/fs"
+ )
+ 
+-//go:embed static/* templates/* themes/*
++//go:embed static/* templates/* themes/* robots.txt
+ var files embed.FS
+ 
+ // FS returns a filesystem with the default web assets.
+diff --git a/web/robots.txt b/web/robots.txt
+new file mode 100644
+index 00000000..1f53798b
+--- /dev/null
++++ b/web/robots.txt
+@@ -0,0 +1,2 @@
++User-agent: *
++Disallow: /


### PR DESCRIPTION
## Description
<img width="625" alt="image" src="https://user-images.githubusercontent.com/32434187/220758596-5ac7b541-fb07-4a2b-b14d-3ee0c3f60447.png">

## Why do we need it, and what problem does it solve?
To avoid Dex being accidentally scraped by robots.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: feature
summary: Add robots.txt for Dex

```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
