### PR TITLE
[cni-cilium] Preserve default tunnel port 8472 for virtualization workloads (direct routing mode)

### DIFF
--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -32,10 +32,6 @@ data:
 
   {{- if eq .Values.cniCilium.internal.mode "VXLAN" }}
   tunnel: "vxlan"
-  {{- if has "virtualization" .Values.global.enabledModules }}
-  # Preserve default tunnel port 8472 for virtualization workloads
-  tunnel-port: "8469"
-  {{- end }}
   {{- else if eq .Values.cniCilium.internal.mode "DirectWithNodeRoutes" }}
   tunnel: "disabled"
   auto-direct-node-routes: "true"
@@ -46,6 +42,8 @@ data:
   {{- end }}
 
   {{- if has "virtualization" .Values.global.enabledModules }}
+  # Preserve default tunnel port 8472 for virtualization workloads
+  tunnel-port: "8469"
   enable-ip-masq-agent: "true"
   ip-masq-agent-config-path: /etc/config/ip-masq-agent
   {{- end }}


### PR DESCRIPTION
## Description

Specify `--tunnel-port=8472` for direct routing mode too.
This fix extends solution from https://github.com/deckhouse/deckhouse/pull/3887 also for direct routing mode.

## Why do we need it, and what problem does it solve?

I found out that cilium continues blocking 8472/udp port even when it is not using tunnel.

## What is the expected result?

Cilium in direct routing mode not blocking 8472/udp port the same way in tunneled mode.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: fix
summary: Preserve default tunnel port `8472` for virtualization workloads (direct routing mode).
impact_level: low
```
