### PR TITLE
[network] fix install flannel binary in centos-based distros

### DIFF
--- a/ee/modules/007-registrypackages/images/kubernetes-cni-alteros/scripts/install
+++ b/ee/modules/007-registrypackages/images/kubernetes-cni-alteros/scripts/install
@@ -13,5 +13,6 @@ if ! rpm --quiet -q "${rpm_name}-${rpm_version}"; then
 else
   echo "RPM ${package_file} already installed."
 fi
+[[ -e flannel ]] && cp -f flannel /opt/cni/bin/flannel
 
 yum versionlock add ${package}

--- a/ee/modules/007-registrypackages/images/kubernetes-cni-alteros/scripts/uninstall
+++ b/ee/modules/007-registrypackages/images/kubernetes-cni-alteros/scripts/uninstall
@@ -5,3 +5,4 @@
 set -Eeo pipefail
 yum versionlock delete kubernetes-cni
 rpm -e kubernetes-cni
+rm -f /opt/cni/bin/flannel

--- a/ee/modules/007-registrypackages/images/kubernetes-cni-alteros/werf.inc.yaml
+++ b/ee/modules/007-registrypackages/images/kubernetes-cni-alteros/werf.inc.yaml
@@ -14,6 +14,7 @@ import:
   to: /
   includePaths:
   - kubernetes-cni.x86_64.rpm
+  - flannel
   - install
   - uninstall
   before: setup
@@ -37,4 +38,8 @@ shell:
   setup:
   - RPM_PACKAGE="$(curl -s https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/primary.xml | grep "<location href=" | grep "kubernetes-cni-{{ $version }}-0" | awk -F "\"" '{print $2}')"
   - curl -sfL https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/${RPM_PACKAGE} --output /kubernetes-cni.x86_64.rpm
+  {{- /* flannel plugin was removed from kubernetes-cni after v0.9.1 */ -}}
+  {{- if semverCompare ">0.9.1" $version }}
+  - curl -sfL https://github.com/flannel-io/cni-plugin/releases/download/v1.1.2/cni-plugin-flannel-linux-amd64-v1.1.2.tgz | tar -xz ./flannel-amd64 && mv flannel-amd64 flannel
+  {{- end }}
 {{- end }}

--- a/ee/modules/007-registrypackages/images/kubernetes-cni-redos/scripts/install
+++ b/ee/modules/007-registrypackages/images/kubernetes-cni-redos/scripts/install
@@ -13,5 +13,6 @@ if ! rpm --quiet -q "${rpm_name}-${rpm_version}"; then
 else
   echo "RPM ${package_file} already installed."
 fi
+[[ -e flannel ]] && cp -f flannel /opt/cni/bin/flannel
 
 yum versionlock add ${package}

--- a/ee/modules/007-registrypackages/images/kubernetes-cni-redos/scripts/uninstall
+++ b/ee/modules/007-registrypackages/images/kubernetes-cni-redos/scripts/uninstall
@@ -5,3 +5,4 @@
 set -Eeo pipefail
 yum versionlock delete kubernetes-cni
 rpm -e kubernetes-cni
+rm -f /opt/cni/bin/flannel

--- a/ee/modules/007-registrypackages/images/kubernetes-cni-redos/werf.inc.yaml
+++ b/ee/modules/007-registrypackages/images/kubernetes-cni-redos/werf.inc.yaml
@@ -14,6 +14,7 @@ import:
   to: /
   includePaths:
   - kubernetes-cni.x86_64.rpm
+  - flannel
   - install
   - uninstall
   before: setup
@@ -37,4 +38,8 @@ shell:
   setup:
   - RPM_PACKAGE="$(curl -s https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/primary.xml | grep "<location href=" | grep "kubernetes-cni-{{ $version }}-0" | awk -F "\"" '{print $2}')"
   - curl -sfL https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/${RPM_PACKAGE} --output /kubernetes-cni.x86_64.rpm
+  {{- /* flannel plugin was removed from kubernetes-cni after v0.9.1 */ -}}
+  {{- if semverCompare ">0.9.1" $version }}
+  - curl -sfL https://github.com/flannel-io/cni-plugin/releases/download/v1.1.2/cni-plugin-flannel-linux-amd64-v1.1.2.tgz | tar -xz ./flannel-amd64 && mv flannel-amd64 flannel
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes https://github.com/deckhouse/deckhouse/issues/3625.
Install flannel 1.1.2 binary to CentOS-based distros for kubernetes-cni newer than 0.9.1 due to missing flannel binary.
Flannel was moved to sepatate repo in https://github.com/containernetworking/plugins/pull/633.

This is additional part of https://github.com/deckhouse/deckhouse/pull/3534 for centos-based distros supported by Deckhouse.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Cni flannel binary is absent in kubernetes-cni package > 0.9.1.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: network
type: fix
summary:  fix install flannel binary in centos-based distros.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
