### PR TITLE
[admission-policy-engine] Change recommended imagePullPolicy to Always

### DIFF
--- a/modules/015-admission-policy-engine/docs/README.md
+++ b/modules/015-admission-policy-engine/docs/README.md
@@ -50,7 +50,8 @@ spec:
       - readinessProbe
     maxRevisionHistoryLimit: 3
     imagePullPolicy: Always
-    priorityClassName: production-low
+    priorityClassNames:
+    - production-low
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true
   match:

--- a/modules/015-admission-policy-engine/docs/README.md
+++ b/modules/015-admission-policy-engine/docs/README.md
@@ -51,6 +51,7 @@ spec:
     maxRevisionHistoryLimit: 3
     imagePullPolicy: Always
     priorityClassNames:
+    - production-high
     - production-low
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true

--- a/modules/015-admission-policy-engine/docs/README.md
+++ b/modules/015-admission-policy-engine/docs/README.md
@@ -49,7 +49,7 @@ spec:
       - livenessProbe
       - readinessProbe
     maxRevisionHistoryLimit: 3
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
     priorityClassName: production-low
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true

--- a/modules/015-admission-policy-engine/docs/README_RU.md
+++ b/modules/015-admission-policy-engine/docs/README_RU.md
@@ -51,7 +51,7 @@ spec:
       - livenessProbe
       - readinessProbe
     maxRevisionHistoryLimit: 3
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
     priorityClassName: production-low
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true

--- a/modules/015-admission-policy-engine/docs/README_RU.md
+++ b/modules/015-admission-policy-engine/docs/README_RU.md
@@ -52,7 +52,8 @@ spec:
       - readinessProbe
     maxRevisionHistoryLimit: 3
     imagePullPolicy: Always
-    priorityClassName: production-low
+    priorityClassNames:
+    - production-low
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true
   match:

--- a/modules/015-admission-policy-engine/docs/README_RU.md
+++ b/modules/015-admission-policy-engine/docs/README_RU.md
@@ -53,6 +53,7 @@ spec:
     maxRevisionHistoryLimit: 3
     imagePullPolicy: Always
     priorityClassNames:
+    - production-high
     - production-low
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true

--- a/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
@@ -213,7 +213,7 @@ spec:
         kinds: ["Pod"]
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    priorityClassName:
+    priorityClassNames:
       {{- $cr.spec.policies.priorityClassNames | toYaml | nindent 6 }}
 {{- end }}
 

--- a/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
@@ -268,10 +268,12 @@ spec:
       {{- $cr.spec.match.namespaceSelector.excludeNames | toYaml | nindent 6 }}
       {{- end }}
       {{- if hasKey $cr.spec.match.namespaceSelector "labelSelector" }}
-    namespaceSelector: {{ $cr.spec.match.namespaceSelector.labelSelector }}
+    namespaceSelector:
+      {{- $cr.spec.match.namespaceSelector.labelSelector | toYaml | nindent 6 }}
       {{- end }}
     {{- end }}
     {{- if hasKey $cr.spec.match "labelSelector" }}
-    labelSelector: {{ $cr.spec.match.labelSelector }}
+    labelSelector:
+      {{- $cr.spec.match.labelSelector | toYaml | nindent 6 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. Change recommended imagePullPolicy to Always.
2. Fix template rendering

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
1. `Always` is the recommended policy. More information [here](https://www.fairwinds.com/blog/kubernetes-devops-tip-5-why-setting-imagepullpolicy-to-always-is-more-necessary-than-you-think). Kubernetes has admission plugin [AlwaysPullImages](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages) to force this policy.
2. Fix error
   ```
   spec:
     enforcementAction: "deny"
     match:
       kinds:
         - apiGroups: [""]
           kinds: ["Pod"]
       namespaceSelector: map[matchLabels:map[operation-policy.deckhouse.io/enabled:true]]
       
   spec:
     enforcementAction: "deny"
     match:
       kinds:
         - apiGroups: [""]
           kinds: ["Pod"]
       namespaces:
         - foxtrot-demo
       labelSelector: map[matchLabels:map[operation-policy.deckhouse.io/enabled:true]]
   
   
    1. ModuleRun:main:admission-policy-engine:Kubernetes-Change-ModuleValues:failures 22:helm upgrade failed: error validating "": error validating data: ValidationError
   
    1. ModuleRun:main:admission-policy-engine:doStartup:OperatorStartup:failures 21:helm upgrade failed: error validating "": error validating data: ValidationError
   ```
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: admission-policy-engine
type: chore
summary: Change recommended `imagePullPolicy` to `Always`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
