### PR TITLE
[site] Add support of Astra 1.7.3

### DIFF
--- a/docs/documentation/_data/version_map_addition.yml
+++ b/docs/documentation/_data/version_map_addition.yml
@@ -6,6 +6,9 @@
     '1.7.2':
       ru_support: 'true'
       en_support: 'false'
+    '1.7.3':
+      ru_support: 'true'
+      en_support: 'false'
   rocky:
     '8':
     '9':


### PR DESCRIPTION
## Description

It's already included in e2e, so there are no reasons to omit it from the list of the supported versions of the OS.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add support of Astra 1.7.3 on the site.
impact_level: low
```
