### PR TITLE
[deckhouse] add sleep to prevent deckhouse abnormal termination

### DIFF
--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -28,6 +28,11 @@ signal_handler() {
     wait "${PID}"
     run_deckhouse
     ;;
+  "SIGTERM")
+    # always sleep 10 seconds on modules converge to avoid Deckhouse self-upgrade helm race (release is stuck into pending-upgrade)
+    /usr/bin/deckhouse-controller queue main | grep ConvergeModules && sleep 10
+    kill -"${1}" "${PID}"
+    ;;
   *)
     kill -"${1}" "${PID}"
     ;;

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -30,7 +30,7 @@ signal_handler() {
     ;;
   "SIGTERM")
     # always sleep 10 seconds on modules converge to avoid Deckhouse self-upgrade helm race (release is stuck into pending-upgrade)
-    /usr/bin/deckhouse-controller queue main | grep ConvergeModules && sleep 10
+    /usr/bin/deckhouse-controller queue main | grep ConvergeModules && echo "{\"level\":\"info\", \"msg\": \"Deckhouse is restarting during the modules converge. Sleeping 10 seconds.\"}" && sleep 10
     kill -"${1}" "${PID}"
     ;;
   *)


### PR DESCRIPTION
## Description
Sleep for 10 seconds if Deckhouse in the ConvergeModules phase

## Why do we need it, and what problem does it solve?
We need this to prevent Deckhouse restart. Helm release could stuck in the `pending-upgrade` state and it's hard fix it

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Prevent restart during the ConvergeModule phase
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
