### PR TITLE
[gs] Remove notice about installing in EKS

### DIFF
--- a/docs/site/_includes/getting_started/existing/partials/TROUBLESHOOT.liquid
+++ b/docs/site/_includes/getting_started/existing/partials/TROUBLESHOOT.liquid
@@ -53,8 +53,3 @@ kubectl create -f ingress-nginx-controller.yml
 </li>
 </ul>
 {% endofftopic %}
-
-{% offtopic title="Cluster in EKS AWS (Amazon Elastic Kubernetes Service)" %}
-Installing Deckhouse into an existing EKS AWS cluster is not currently supported.
-{% endofftopic %}
-

--- a/docs/site/_includes/getting_started/existing/partials/TROUBLESHOOT_RU.liquid
+++ b/docs/site/_includes/getting_started/existing/partials/TROUBLESHOOT_RU.liquid
@@ -54,10 +54,6 @@ kubectl create -f ingress-nginx-controller.yml
 </ul>
 {% endofftopic %}
 
-{% offtopic title="Кластер в EKS AWS (Amazon Elastic Kubernetes Service)" %}
-Установка Deckhouse в существующий кластер EKS AWS в настоящий момент не поддерживается.
-{% endofftopic %}
-
 
 {% offtopic title="Кластер в VK Cloud Solutions (MailRu Cloud Solutions)" %}
 <ul>

--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -2,18 +2,12 @@
 {%- if page.platform_code == "azure" %}
 > **Внимание!** Поддерживаются только [регионы](https://docs.microsoft.com/ru-ru/azure/availability-zones/az-region) в которых доступны `Availability Zones`.
 {%- endif %}
-{%- if page.platform_type == 'existing' %}
-> **Внимание!** Установка Deckhouse в существующий кластер EKS AWS (Amazon Elastic Kubernetes Service) в настоящий момент не поддерживается.
-{%- endif %}
 {%- if page.platform_code == 'bm-private' %}
 > **Внимание!** В версии Deckhouse 1.42 изменились [параметры](../../documentation/v1/installing/configuration.html#parameters-proxy) настройки работы через proxy-сервер ([подробнее](https://github.com/deckhouse/deckhouse/pull/3185)). Текущее руководство рассчитано на версию Deckhouse 1.42+.
 {%- endif %}
 {%- else %}
 {%- if page.platform_code == "azure" %}
 > **Caution!** Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-region) where `Availability Zones` are available are supported.
-{%- endif %}
-{%- if page.platform_type == 'existing' %}
-> **Caution!** Installing Deckhouse into an existing EKS AWS (Amazon Elastic Kubernetes Service) cluster is not currently supported.
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
 > **Caution!** The [settings for working through a proxy server](../../documentation/v1/installing/configuration.html#parameters-proxy) have changed in Deckhouse 1.42 ([issue](https://github.com/deckhouse/deckhouse/pull/3185)). The guide is for Deckhouse 1.42+.

--- a/docs/site/_includes/getting_started/global/partials/NOTICES_ENVIRONMENT.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES_ENVIRONMENT.liquid
@@ -14,9 +14,4 @@
 {%- endif %}
 {%- endif %}
 {%- if page.platform_type == 'existing' %}
-{%- if page.lang == "ru" %}
-> **Внимание!** Установка Deckhouse в существующий кластер EKS AWS (Amazon Elastic Kubernetes Service) в настоящий момент не поддерживается.
-{%- else %}
-> **Caution!** Installing Deckhouse into an existing EKS AWS (Amazon Elastic Kubernetes Service) cluster is not currently supported.
-{%- endif %}
 {%- endif %}


### PR DESCRIPTION
## Description
Deckhouse supports installing in an existing EKS cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Deckhouse supports installing in an existing EKS cluster.
impact_level: low
```
