### PR TITLE
[virtualization] Enable ExpandDisks feature gate

### DIFF
--- a/modules/490-virtualization/templates/kubevirt.yaml
+++ b/modules/490-virtualization/templates/kubevirt.yaml
@@ -20,6 +20,7 @@ spec:
       - Macvtap
       - HotplugVolumes
       - GPU
+      - ExpandDisks
   customizeComponents:
     patches:
     - resourceType: Deployment


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description
This PR enables feature gate for online-resizing disks for virtual machines

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

When user changes size of virtual machine disk it also resizes it for virtual machine

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: virtualization
type: feature
summary: Enable the `ExpandDisks` feature gate.
impact_level: low
```
