### PR TITLE
[prometheus] Links in the "Enabled modules" section of the grafana home page direct to the inner cluster docs

### DIFF
--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -922,7 +922,7 @@
           "links": [
             {
               "title": "",
-              "url": "https://deckhouse.io/documentation/v1/modules/${__data.fields.module_name}"
+              "url": "https://${__data.fields.docs_url}/modules/${__data.fields.module_name}"
             }
           ],
           "mappings": [],
@@ -945,6 +945,18 @@
             "matcher": {
               "id": "byName",
               "options": "module_name"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "docs_url"
             },
             "properties": [
               {
@@ -977,7 +989,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (module, module_name) (label_replace(deckhouse_binding_count{module!=\"\", module!~\".+-crd\"}, \"module_name\", \"$1\", \"hook\", \"([0-9]+[A-Za-z-]+).*\"))",
+          "expr": "max by (module, module_name, docs_url) (\n  (\n    label_replace(deckhouse_web_interfaces{job=\"deckhouse\", name=\"docs\"}, \"docs_url\", \"$1/en\", \"url\", \"(.*)\")\n  )\n    + on (job) group_right(docs_url)\n  (\n    label_replace(deckhouse_binding_count{module!=\"\", module!~\".+-crd\"}, \"module_name\", \"$1\", \"hook\", \"([0-9]+[A-Za-z-]+).*\")\n  )\n  or\n  label_replace(label_replace(deckhouse_binding_count{module!=\"\", module!~\".+-crd\"}, \"module_name\", \"$1\", \"hook\", \"([0-9]+[A-Za-z-]+).*\"), \"docs_url\", \"deckhouse.io/documentation/v1\", \"\", \"\")\n) \n",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -994,7 +1006,8 @@
             "include": {
               "names": [
                 "module",
-                "module_name"
+                "module_name",
+                "docs_url"
               ]
             }
           }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Now on home grafana dashboard `Enabled modules` table links directs to the `deckhouse.io` documentation. This PR adds functionality to direct to the inner deckhouse installation documentation if `deckhouse-web` module is enabled
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #3404 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
If `deckhouse-web` module is enabled links in `Enabled modules` dashboard will direct to inner cluster docs, if not - to `deckhouse.io` docs
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: feature
summary: if deckhouse-web is `Enabled modules` table on home grafana dashboard directs to inner deckhouse documentation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
