### PR TITLE
[deckhouse] Handle pending release

### DIFF
--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -28,11 +28,6 @@ signal_handler() {
     wait "${PID}"
     run_deckhouse
     ;;
-  "SIGTERM")
-    # always sleep 10 seconds on modules converge to avoid Deckhouse self-upgrade helm race (release is stuck into pending-upgrade)
-    /usr/bin/deckhouse-controller queue main | grep ConvergeModules && echo "{\"level\":\"info\", \"msg\": \"Deckhouse is restarting during the modules converge. Sleeping 10 seconds.\"}" && sleep 10
-    kill -"${1}" "${PID}"
-    ;;
   *)
     kill -"${1}" "${PID}"
     ;;

--- a/modules/002-deckhouse/hooks/handle_pending_upgrade.go
+++ b/modules/002-deckhouse/hooks/handle_pending_upgrade.go
@@ -22,7 +22,6 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"

--- a/modules/002-deckhouse/hooks/handle_pending_upgrade.go
+++ b/modules/002-deckhouse/hooks/handle_pending_upgrade.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"time"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+// We have to delete last release in pending state
+// otherwise helm release would stuck in the pending-upgrade state and deckhouse will rollback to the previous release
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:         "releases",
+			ApiVersion:   "v1",
+			Kind:         "Secret",
+			NameSelector: nil,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-system"},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": "deckhouse", "owner": "helm"},
+			},
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   filterDeckhouseHelmRelease,
+		},
+	},
+}, pendingReleaseHandler)
+
+func pendingReleaseHandler(input *go_hook.HookInput) error {
+	var latestRelease *deckhouseHelmRelease
+
+	snap := input.Snapshots["releases"]
+
+	if len(snap) == 0 {
+		return nil
+	}
+
+	for _, sn := range snap {
+		rel := sn.(deckhouseHelmRelease)
+
+		if latestRelease == nil || rel.CreatedAt.After(latestRelease.CreatedAt) {
+			latestRelease = &rel
+		}
+	}
+
+	if latestRelease.Status == "pending-install" || latestRelease.Status == "pending-upgrade" || latestRelease.Status == "pending-rollback" {
+		input.PatchCollector.Delete("v1", "Secret", "d8-system", latestRelease.SecretName)
+	}
+
+	return nil
+}
+
+func filterDeckhouseHelmRelease(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return deckhouseHelmRelease{
+		SecretName: obj.GetName(),
+		Status:     obj.GetLabels()["status"],
+		CreatedAt:  obj.GetCreationTimestamp().Time,
+	}, nil
+}
+
+type deckhouseHelmRelease struct {
+	SecretName string
+	Status     string
+	CreatedAt  time.Time
+}

--- a/modules/002-deckhouse/hooks/handle_pending_upgrade_test.go
+++ b/modules/002-deckhouse/hooks/handle_pending_upgrade_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: deckhouse :: hooks :: wait for deckhouse update ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	Context("Deckhouse release is upgrading", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(`
+apiVersion: v1
+kind: Secret
+type: helm.sh/release.v1
+metadata:
+  creationTimestamp: "2023-03-02T12:01:00Z"
+  labels:
+    name: deckhouse
+    owner: helm
+    status: superseded
+  name: sh.helm.release.v1.deckhouse.v1
+  namespace: d8-system
+---
+apiVersion: v1
+kind: Secret
+type: helm.sh/release.v1
+metadata:
+  creationTimestamp: "2023-03-02T12:02:00Z"
+  labels:
+    name: deckhouse
+    owner: helm
+    status: deployed
+  name: sh.helm.release.v1.deckhouse.v2
+  namespace: d8-system
+---
+apiVersion: v1
+kind: Secret
+type: helm.sh/release.v1
+metadata:
+  creationTimestamp: "2023-03-02T12:03:00Z"
+  labels:
+    name: deckhouse
+    owner: helm
+    status: pending-upgrade
+  name: sh.helm.release.v1.deckhouse.v3
+  namespace: d8-system
+`)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Should delete the secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Secret", "d8-system", "sh.helm.release.v1.deckhouse.v3").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Secret", "d8-system", "sh.helm.release.v1.deckhouse.v2").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("Deckhouse release is deployed", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(`
+apiVersion: v1
+kind: Secret
+type: helm.sh/release.v1
+metadata:
+  creationTimestamp: "2023-03-02T12:04:00Z"
+  labels:
+    name: deckhouse
+    owner: helm
+    status: superseded
+  name: sh.helm.release.v1.deckhouse.v4
+  namespace: d8-system
+---
+apiVersion: v1
+kind: Secret
+type: helm.sh/release.v1
+metadata:
+  creationTimestamp: "2023-03-02T12:05:00Z"
+  labels:
+    name: deckhouse
+    owner: helm
+    status: superseded
+  name: sh.helm.release.v1.deckhouse.v5
+  namespace: d8-system
+---
+apiVersion: v1
+kind: Secret
+type: helm.sh/release.v1
+metadata:
+  creationTimestamp: "2023-03-02T12:06:00Z"
+  labels:
+    name: deckhouse
+    owner: helm
+    status: deployed
+  name: sh.helm.release.v1.deckhouse.v6
+  namespace: d8-system
+`)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Should keep the secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Secret", "d8-system", "sh.helm.release.v1.deckhouse.v6").Exists()).To(BeTrue())
+		})
+	})
+
+})


### PR DESCRIPTION
## Description
Fix deckhouse release stuck in the pending state

## Why do we need it, and what problem does it solve?
Deckhouse could restart in the middle of upgrade process and helm release will stuck in the pending-upgrade state.
Entrypoint sleep breaks module-configs logic, so we have to repair releases in the Deckhouse module

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: remove pending releases before Deckhouse upgrade
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
