### PR TITLE
[testing] [ci]  add deckhouse logs if not READY pod

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -514,6 +514,8 @@ check_e2e_labels:
         path: |
           ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
           ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+          testing/cloud_layouts/
+          !testing/cloud_layouts/**/sshkey
 
     - name: Save test results
       if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -514,8 +514,7 @@ check_e2e_labels:
         path: |
           ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
           ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-          testing/cloud_layouts/
-          !testing/cloud_layouts/**/sshkey
+          ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
     - name: Save test results
       if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -524,6 +523,7 @@ check_e2e_labels:
         name: test_output_{!{ printf "%s_%s_%s" $ctx.provider $ctx.cri $ctx.kubernetesVersionSlug }!}
         path: |
           ${{ steps.setup.outputs.dhctl-log-file}}*
+          ${{ steps.setup.outputs.tmp-dir-path}}/logs
           testing/cloud_layouts/
           !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -591,8 +591,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -601,6 +600,7 @@ jobs:
           name: test_output_aws_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1040,8 +1040,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1050,6 +1049,7 @@ jobs:
           name: test_output_aws_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1489,8 +1489,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1499,6 +1498,7 @@ jobs:
           name: test_output_aws_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1938,8 +1938,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1948,6 +1947,7 @@ jobs:
           name: test_output_aws_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2387,8 +2387,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2397,6 +2396,7 @@ jobs:
           name: test_output_aws_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2836,8 +2836,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2846,6 +2845,7 @@ jobs:
           name: test_output_aws_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3285,8 +3285,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3295,6 +3294,7 @@ jobs:
           name: test_output_aws_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3734,8 +3734,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3744,6 +3743,7 @@ jobs:
           name: test_output_aws_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4183,8 +4183,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4193,6 +4192,7 @@ jobs:
           name: test_output_aws_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4632,8 +4632,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4642,6 +4641,7 @@ jobs:
           name: test_output_aws_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -5081,8 +5081,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5091,6 +5090,7 @@ jobs:
           name: test_output_aws_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5530,8 +5530,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5540,6 +5539,7 @@ jobs:
           name: test_output_aws_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -591,6 +591,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1038,6 +1040,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1485,6 +1489,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1932,6 +1938,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2379,6 +2387,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2826,6 +2836,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3273,6 +3285,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3720,6 +3734,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4167,6 +4183,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4614,6 +4632,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5061,6 +5081,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5508,6 +5530,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -599,6 +599,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1054,6 +1056,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1509,6 +1513,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1964,6 +1970,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2419,6 +2427,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2874,6 +2884,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3329,6 +3341,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3784,6 +3798,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4239,6 +4255,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4694,6 +4712,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5149,6 +5169,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5604,6 +5626,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -599,8 +599,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -609,6 +608,7 @@ jobs:
           name: test_output_azure_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1056,8 +1056,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1066,6 +1065,7 @@ jobs:
           name: test_output_azure_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1513,8 +1513,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1523,6 +1522,7 @@ jobs:
           name: test_output_azure_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1970,8 +1970,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1980,6 +1979,7 @@ jobs:
           name: test_output_azure_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2427,8 +2427,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2437,6 +2436,7 @@ jobs:
           name: test_output_azure_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2884,8 +2884,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2894,6 +2893,7 @@ jobs:
           name: test_output_azure_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3341,8 +3341,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3351,6 +3350,7 @@ jobs:
           name: test_output_azure_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3798,8 +3798,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3808,6 +3807,7 @@ jobs:
           name: test_output_azure_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4255,8 +4255,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4265,6 +4264,7 @@ jobs:
           name: test_output_azure_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4712,8 +4712,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4722,6 +4721,7 @@ jobs:
           name: test_output_azure_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -5169,8 +5169,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5179,6 +5178,7 @@ jobs:
           name: test_output_azure_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5626,8 +5626,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5636,6 +5635,7 @@ jobs:
           name: test_output_azure_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -472,8 +472,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -482,6 +481,7 @@ jobs:
           name: test_output_aws_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -904,8 +904,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -914,6 +913,7 @@ jobs:
           name: test_output_azure_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1324,8 +1324,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1334,6 +1333,7 @@ jobs:
           name: test_output_gcp_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1752,8 +1752,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1762,6 +1761,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2172,8 +2172,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2182,6 +2181,7 @@ jobs:
           name: test_output_openstack_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2596,8 +2596,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2606,6 +2605,7 @@ jobs:
           name: test_output_vsphere_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3016,8 +3016,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3026,6 +3025,7 @@ jobs:
           name: test_output_static_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -472,6 +472,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -902,6 +904,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1320,6 +1324,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1746,6 +1752,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2164,6 +2172,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2586,6 +2596,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3004,6 +3016,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -626,6 +626,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1108,6 +1110,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1590,6 +1594,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2072,6 +2078,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2554,6 +2562,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3036,6 +3046,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3518,6 +3530,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4000,6 +4014,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4482,6 +4498,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4964,6 +4982,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5446,6 +5466,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5928,6 +5950,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -626,8 +626,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -636,6 +635,7 @@ jobs:
           name: test_output_eks_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1110,8 +1110,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1120,6 +1119,7 @@ jobs:
           name: test_output_eks_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1594,8 +1594,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1604,6 +1603,7 @@ jobs:
           name: test_output_eks_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2078,8 +2078,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2088,6 +2087,7 @@ jobs:
           name: test_output_eks_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2562,8 +2562,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2572,6 +2571,7 @@ jobs:
           name: test_output_eks_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3046,8 +3046,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3056,6 +3055,7 @@ jobs:
           name: test_output_eks_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3530,8 +3530,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3540,6 +3539,7 @@ jobs:
           name: test_output_eks_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4014,8 +4014,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4024,6 +4023,7 @@ jobs:
           name: test_output_eks_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4498,8 +4498,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4508,6 +4507,7 @@ jobs:
           name: test_output_eks_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4982,8 +4982,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4992,6 +4991,7 @@ jobs:
           name: test_output_eks_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5466,8 +5466,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5476,6 +5475,7 @@ jobs:
           name: test_output_eks_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5950,8 +5950,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5960,6 +5959,7 @@ jobs:
           name: test_output_eks_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -587,8 +587,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -597,6 +596,7 @@ jobs:
           name: test_output_gcp_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1032,8 +1032,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1042,6 +1041,7 @@ jobs:
           name: test_output_gcp_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1477,8 +1477,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1487,6 +1486,7 @@ jobs:
           name: test_output_gcp_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1922,8 +1922,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1932,6 +1931,7 @@ jobs:
           name: test_output_gcp_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2367,8 +2367,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2377,6 +2376,7 @@ jobs:
           name: test_output_gcp_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2812,8 +2812,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2822,6 +2821,7 @@ jobs:
           name: test_output_gcp_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3257,8 +3257,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3267,6 +3266,7 @@ jobs:
           name: test_output_gcp_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3702,8 +3702,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3712,6 +3711,7 @@ jobs:
           name: test_output_gcp_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4147,8 +4147,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4157,6 +4156,7 @@ jobs:
           name: test_output_gcp_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4592,8 +4592,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4602,6 +4601,7 @@ jobs:
           name: test_output_gcp_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -5037,8 +5037,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5047,6 +5046,7 @@ jobs:
           name: test_output_gcp_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5482,8 +5482,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5492,6 +5491,7 @@ jobs:
           name: test_output_gcp_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -587,6 +587,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1030,6 +1032,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1473,6 +1477,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1916,6 +1922,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2359,6 +2367,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2802,6 +2812,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3245,6 +3257,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3688,6 +3702,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4131,6 +4147,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4574,6 +4592,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5017,6 +5037,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5460,6 +5482,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -5037,8 +5037,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5047,6 +5046,7 @@ jobs:
           name: test_output_openstack_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5482,8 +5482,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5492,6 +5491,7 @@ jobs:
           name: test_output_openstack_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -587,8 +587,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -597,6 +596,7 @@ jobs:
           name: test_output_openstack_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1032,8 +1032,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1042,6 +1041,7 @@ jobs:
           name: test_output_openstack_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1477,8 +1477,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1487,6 +1486,7 @@ jobs:
           name: test_output_openstack_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1922,8 +1922,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1932,6 +1931,7 @@ jobs:
           name: test_output_openstack_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2367,8 +2367,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2377,6 +2376,7 @@ jobs:
           name: test_output_openstack_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2812,8 +2812,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2822,6 +2821,7 @@ jobs:
           name: test_output_openstack_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3257,8 +3257,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3267,6 +3266,7 @@ jobs:
           name: test_output_openstack_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3702,8 +3702,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3712,6 +3711,7 @@ jobs:
           name: test_output_openstack_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4147,8 +4147,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4157,6 +4156,7 @@ jobs:
           name: test_output_openstack_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4592,8 +4592,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4602,6 +4601,7 @@ jobs:
           name: test_output_openstack_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -587,6 +587,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1030,6 +1032,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1473,6 +1477,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1916,6 +1922,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2359,6 +2367,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2802,6 +2812,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3245,6 +3257,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3688,6 +3702,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4131,6 +4147,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4574,6 +4592,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5017,6 +5037,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5460,6 +5482,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -5037,8 +5037,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5047,6 +5046,7 @@ jobs:
           name: test_output_static_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5482,8 +5482,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5492,6 +5491,7 @@ jobs:
           name: test_output_static_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -587,8 +587,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -597,6 +596,7 @@ jobs:
           name: test_output_static_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1032,8 +1032,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1042,6 +1041,7 @@ jobs:
           name: test_output_static_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1477,8 +1477,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1487,6 +1486,7 @@ jobs:
           name: test_output_static_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1922,8 +1922,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1932,6 +1931,7 @@ jobs:
           name: test_output_static_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2367,8 +2367,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2377,6 +2376,7 @@ jobs:
           name: test_output_static_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2812,8 +2812,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2822,6 +2821,7 @@ jobs:
           name: test_output_static_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3257,8 +3257,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3267,6 +3266,7 @@ jobs:
           name: test_output_static_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3702,8 +3702,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3712,6 +3711,7 @@ jobs:
           name: test_output_static_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4147,8 +4147,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4157,6 +4156,7 @@ jobs:
           name: test_output_static_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4592,8 +4592,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4602,6 +4601,7 @@ jobs:
           name: test_output_static_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -587,6 +587,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1030,6 +1032,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1473,6 +1477,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1916,6 +1922,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2359,6 +2367,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2802,6 +2812,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3245,6 +3257,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3688,6 +3702,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4131,6 +4147,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4574,6 +4592,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5017,6 +5037,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5460,6 +5482,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -591,8 +591,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -601,6 +600,7 @@ jobs:
           name: test_output_vsphere_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1040,8 +1040,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1050,6 +1049,7 @@ jobs:
           name: test_output_vsphere_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1489,8 +1489,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1499,6 +1498,7 @@ jobs:
           name: test_output_vsphere_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1938,8 +1938,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1948,6 +1947,7 @@ jobs:
           name: test_output_vsphere_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2387,8 +2387,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2397,6 +2396,7 @@ jobs:
           name: test_output_vsphere_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2836,8 +2836,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2846,6 +2845,7 @@ jobs:
           name: test_output_vsphere_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3285,8 +3285,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3295,6 +3294,7 @@ jobs:
           name: test_output_vsphere_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3734,8 +3734,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3744,6 +3743,7 @@ jobs:
           name: test_output_vsphere_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4183,8 +4183,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4193,6 +4192,7 @@ jobs:
           name: test_output_vsphere_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4632,8 +4632,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4642,6 +4641,7 @@ jobs:
           name: test_output_vsphere_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -5081,8 +5081,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5091,6 +5090,7 @@ jobs:
           name: test_output_vsphere_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5530,8 +5530,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5540,6 +5539,7 @@ jobs:
           name: test_output_vsphere_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -591,6 +591,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1038,6 +1040,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1485,6 +1489,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1932,6 +1938,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2379,6 +2387,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2826,6 +2836,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3273,6 +3285,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3720,6 +3734,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4167,6 +4183,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4614,6 +4632,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5061,6 +5081,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5508,6 +5530,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -595,6 +595,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1046,6 +1048,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1497,6 +1501,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1948,6 +1954,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2399,6 +2407,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2850,6 +2860,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3301,6 +3313,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3752,6 +3766,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4203,6 +4219,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4654,6 +4672,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5105,6 +5125,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5556,6 +5578,8 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
+            testing/cloud_layouts/
+            !testing/cloud_layouts/**/sshkey
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -5125,8 +5125,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5135,6 +5134,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -5578,8 +5578,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -5588,6 +5587,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -595,8 +595,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -605,6 +604,7 @@ jobs:
           name: test_output_yandex-cloud_docker_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1048,8 +1048,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1058,6 +1057,7 @@ jobs:
           name: test_output_yandex-cloud_docker_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1501,8 +1501,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1511,6 +1510,7 @@ jobs:
           name: test_output_yandex-cloud_docker_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -1954,8 +1954,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -1964,6 +1963,7 @@ jobs:
           name: test_output_yandex-cloud_docker_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2407,8 +2407,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2417,6 +2416,7 @@ jobs:
           name: test_output_yandex-cloud_docker_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -2860,8 +2860,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -2870,6 +2869,7 @@ jobs:
           name: test_output_yandex-cloud_docker_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3313,8 +3313,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3323,6 +3322,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_22
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -3766,8 +3766,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -3776,6 +3775,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_23
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4219,8 +4219,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4229,6 +4228,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_24
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 
@@ -4672,8 +4672,7 @@ jobs:
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
-            testing/cloud_layouts/
-            !testing/cloud_layouts/**/sshkey
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
 
       - name: Save test results
         if: ${{ steps.setup.outputs.dhctl-log-file }}
@@ -4682,6 +4681,7 @@ jobs:
           name: test_output_yandex-cloud_containerd_1_25
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
+            ${{ steps.setup.outputs.tmp-dir-path}}/logs
             testing/cloud_layouts/
             !testing/cloud_layouts/**/sshkey
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -382,8 +382,7 @@ END_SCRIPT
       set +x
       return 0
     else
-      test_failed="true"
-      >&2 echo "Run test script via SSH: attempt $i/$getDeckhouseLogsAttempts failed. Sleeping 5 seconds..."
+      >&2 echo "Getting deckhouse logs $i/$getDeckhouseLogsAttempts failed. Sleeping 5 seconds..."
       sleep 5
     fi
   done
@@ -671,10 +670,16 @@ ENDSSH
 function bootstrap() {
   >&2 echo "Run dhctl bootstrap ..."
   dhctl bootstrap --yes-i-want-to-drop-cache --ssh-agent-private-keys "$ssh_private_key_path" --ssh-user "$ssh_user" \
-  --resources "$cwd/resources.yaml" --config "$cwd/configuration.yaml" | tee -a "$bootstrap_log" || return $?
+  --resources "$cwd/resources.yaml" --config "$cwd/configuration.yaml" | tee -a "$bootstrap_log"
+
+  dhctl_exit_code=$?
 
   if ! master_ip="$(parse_master_ip_from_log)"; then
     return 1
+  fi
+
+  if [[ $dhctl_exit_code -ne 0 ]]; then
+    return "$dhctl_exit_code"
   fi
 
   >&2 echo "==============================================================

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -106,7 +106,7 @@ bootstrap_log="${DHCTL_LOG_FILE}"
 terraform_state_file="/tmp/static-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}.tfstate"
 # Logs dir
 logs=/tmp/logs
-mkdir $logs
+mkdir -p $logs
 
 # function generates temp ssh parameters file
 function set_common_ssh_parameters() {

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -750,7 +750,12 @@ END_SCRIPT
   $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${infoScript}";
 
   if [[ "$PROVIDER" == "Static" ]]; then
-    run_linstor_tests || return $?
+    if ! run_linstor_tests; then
+      >&2 echo -n "Linstor tests failed"
+      >&2 echo -n "Fetch Deckhouse logs after test ..."
+      $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$logs/deckhouse.json.log" <<<"${testLog}"
+      return 1
+    fi
   fi
   echo "Linstor test suite: success"
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -104,6 +104,9 @@ master_ip=
 # bootstrap log
 bootstrap_log="${DHCTL_LOG_FILE}"
 terraform_state_file="/tmp/static-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}.tfstate"
+# Logs dir
+logs=/tmp/logs
+mkdir $logs
 
 # function generates temp ssh parameters file
 function set_common_ssh_parameters() {
@@ -725,7 +728,7 @@ END_SCRIPT
     fi
   done
   >&2 echo -n "Fetch Deckhouse logs if error test ..."
-  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$cwd/deckhouse.json.log" <<<"${testLog}"
+  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$logs/deckhouse.json.log" <<<"${testLog}"
   return 1
 }
 
@@ -768,7 +771,7 @@ END_SCRIPT
   done
 
   >&2 echo -n "Fetch Deckhouse logs after test ..."
-  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$cwd/deckhouse.json.log" <<<"${testLog}"
+  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$logs/deckhouse.json.log" <<<"${testLog}"
 
   if [[ $test_failed == "true" ]] ; then
     return 1

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -366,7 +366,6 @@ function prepare_environment() {
 }
 
 function write_deckhouse_logs() {
-  set -x
   testLog=$(cat <<"END_SCRIPT"
 export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export LANG=C
@@ -379,7 +378,6 @@ END_SCRIPT
   attempt=0
   for ((i=1; i<=$getDeckhouseLogsAttempts; i++)); do
     if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$logs/deckhouse.json.log" <<<"${testLog}"; then
-      set +x
       return 0
     else
       >&2 echo "Getting deckhouse logs $i/$getDeckhouseLogsAttempts failed. Sleeping 5 seconds..."
@@ -388,7 +386,6 @@ END_SCRIPT
   done
 
   >&2 echo "ERROR: getting deckhouse logs after $getDeckhouseLogsAttempts)"
-  set +x
   return 1
 }
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -703,6 +703,12 @@ kubectl -n d8-system get pods -l app=deckhouse
 [[ "$(kubectl -n d8-system get pods -l app=deckhouse -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}{..status.phase}')" ==  "TrueRunning" ]]
 END_SCRIPT
 )
+  testLog=$(cat <<"END_SCRIPT"
+export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export LANG=C
+kubectl -n d8-system logs deploy/deckhouse
+END_SCRIPT
+)
 
   testRunAttempts=60
   for ((i=1; i<=$testRunAttempts; i++)); do
@@ -718,6 +724,8 @@ END_SCRIPT
       >&2 echo -n "  Deckhouse Pod not ready. Attempt $i/$testRunAttempts failed."
     fi
   done
+  >&2 echo -n "Fetch Deckhouse logs if error test ..."
+  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$cwd/deckhouse.json.log" <<<"${testLog}"
   return 1
 }
 
@@ -728,6 +736,12 @@ END_SCRIPT
 #  - ssh_user
 #  - master_ip
 function wait_cluster_ready() {
+  testLog=$(cat <<"END_SCRIPT"
+export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export LANG=C
+kubectl -n d8-system logs deploy/deckhouse
+END_SCRIPT
+)
   # Print deckhouse info and enabled modules.
   infoScript=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/info_script.sh")
   $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${infoScript}";
@@ -753,12 +767,8 @@ function wait_cluster_ready() {
     fi
   done
 
-  >&2 echo "Fetch Deckhouse logs after test ..."
-  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$cwd/deckhouse.json.log" <<"ENDSSH"
-export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-export LANG=C
-kubectl -n d8-system logs deploy/deckhouse
-ENDSSH
+  >&2 echo -n "Fetch Deckhouse logs after test ..."
+  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash > "$cwd/deckhouse.json.log" <<<"${testLog}"
 
   if [[ $test_failed == "true" ]] ; then
     return 1


### PR DESCRIPTION
## Description
Adds Deckhouse logs if Pod hasn't changed to ready status.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We cannot get deckhouse logs when e2e test was failed.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Manual testing proofs
Negative (e2e tests was failed) tested [here](https://github.com/deckhouse/deckhouse-test-2/pull/326)
Positive (e2e tests was passed) [here](https://github.com/deckhouse/deckhouse-test-2/pull/327)

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
```changes
section: ci
type: fix 
summary: Added deckhouse logs if the Pod hasn't changed to ready status.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
