### PR TITLE
[containerized-data-importer] fix customCertificate

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -73,6 +73,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/490-virtualization/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/491-containerized-data-importer/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/491-containerized-data-importer/hooks/https"
 	_ "github.com/deckhouse/deckhouse/modules/500-cilium-hubble/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/500-cilium-hubble/hooks/https"
 	_ "github.com/deckhouse/deckhouse/modules/500-dashboard/hooks"

--- a/modules/490-virtualization/images/artifact/patches/007-tolerations-for-strategy-dumper-job.patch
+++ b/modules/490-virtualization/images/artifact/patches/007-tolerations-for-strategy-dumper-job.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/virt-operator/kubevirt.go b/pkg/virt-operator/kubevirt.go
-index 640750c7a..185ee8d0f 100644
+index ff9645371..08f9a36f5 100644
 --- a/pkg/virt-operator/kubevirt.go
 +++ b/pkg/virt-operator/kubevirt.go
-@@ -741,6 +741,19 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
+@@ -744,6 +744,19 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
  					},
  				},
  				Spec: k8sv1.PodSpec{

--- a/modules/491-containerized-data-importer/hooks/https/copy_custom_certificate.go
+++ b/modules/491-containerized-data-importer/hooks/https/copy_custom_certificate.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/hooks/copy_custom_certificate"
+)
+
+var _ = copy_custom_certificate.RegisterHook("containerizedDataImporter")

--- a/modules/491-containerized-data-importer/openapi/config-values.yaml
+++ b/modules/491-containerized-data-importer/openapi/config-values.yaml
@@ -7,3 +7,57 @@ properties:
       Manually enable the high availability mode.
 
       By default, Deckhouse automatically decides whether to enable the HA mode. Click [here](../../deckhouse-configure-global.html#parameters) to learn more about the HA mode for modules.
+  https:
+    type: object
+    x-examples:
+      - mode: Disabled
+      - mode: OnlyInURI
+      - mode: CustomCertificate
+        customCertificate:
+          secretName: "foobar"
+      - mode: CertManager
+        certManager:
+          clusterIssuerName: letsencrypt
+    description: |
+      What certificate type to use.
+
+      This parameter completely overrides the `global.modules.https` settings.
+    properties:
+      mode:
+        type: string
+        default: "CertManager"
+        description: |
+          The HTTPS usage mode:
+          - `CertManager` — the web UI is accessed over HTTPS using a certificate obtained from a clusterIssuer specified in the `certManager.clusterIssuerName` parameter;
+          - `CustomCertificate` — the web UI is accessed over HTTPS using a certificate from the `d8-system` namespace;
+          - `Disabled` — in this mode, the documentation web UI can only be accessed over HTTP;
+          - `OnlyInURI` — the documentation web UI will work over HTTP (thinking that there is an external HTTPS load balancer in front of it that terminates HTTPS traffic). All the links in the `user-authn` will be generated using the HTTPS scheme.
+        enum:
+          - "Disabled"
+          - "CertManager"
+          - "CustomCertificate"
+          - "OnlyInURI"
+      certManager:
+        type: object
+        description: |
+          Parameters for certmanager.
+        properties:
+          clusterIssuerName:
+            type: string
+            default: "letsencrypt"
+            x-examples: ["letsencrypt", "letsencrypt-staging", "selfsigned"]
+            description: |
+              What ClusterIssuer to use for getting an SSL certificate (currently, `letsencrypt`, `letsencrypt-staging`, `selfsigned` are available; also, you can define your own).
+      customCertificate:
+        type: object
+        default: {}
+        description: |
+          Parameters for custom certificate usage.
+        properties:
+          secretName:
+            type: string
+            description: |
+              The name of the secret in the `d8-system` namespace to use with CDI upload proxy.
+
+              This secret must have the [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets) format.
+

--- a/modules/491-containerized-data-importer/openapi/doc-ru-config-values.yaml
+++ b/modules/491-containerized-data-importer/openapi/doc-ru-config-values.yaml
@@ -5,3 +5,41 @@ properties:
       Ручное управление режимом отказоустойчивости.
 
       По умолчанию режим отказоустойчивости определяется автоматически. [Подробнее](../../deckhouse-configure-global.html#параметры) про режим отказоустойчивости.
+  https:
+    description: |
+      Тип используемого сертификата.
+
+      Этот параметр задаёт особые настройки https для модуля, переопределяя глобальные настройки `global.modules.https`.
+    properties:
+      mode:
+        description: |
+          Режим работы HTTPS:
+          - `CertManager` — доступ по HTTPS с заказом сертификата согласно ClusterIssuer'у, заданному в параметре `certManager.clusterIssuerName`.
+          - `CustomCertificate` — доступ по HTTPS с использованием сертификата из пространства имён `d8-system`.
+          - `Disabled` — доступ только по HTTP.
+          - `OnlyInURI` — доступ по HTTP, подразумевая, что перед web-интерфейсом стоит внешний HTTPS-балансер, который терминирует HTTPS и все ссылки в `user-authn` будут генерироваться с HTTPS-схемой.
+      certManager:
+        description: "Настройки для certmanager."
+        properties:
+          clusterIssuerName:
+            description: |
+              Тип ClusterIssuer'а, используемого для заказа SSL-сертификата (в данный момент доступны `letsencrypt`, `letsencrypt-staging`, `selfsigned`, но возможно определить свои).
+      customCertificate:
+        description: Настройки для использования пользовательского сертификата.
+        properties:
+          secretName:
+            description: |
+              Имя Secret'а в пространстве имён `d8-system`, который будет использоваться для web-интерфейса загрузки модуля CDI.
+
+              Secret должен быть в формате [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets).
+  nodeSelector:
+    description: |
+      Структура, аналогичная `spec.nodeSelector` Kubernetes pod.
+
+      Если ничего не указано или указано `false` — `nodeSelector` будет определяться [автоматически](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+  tolerations:
+    type: array
+    description: |
+      Структура, аналогичная  `spec.tolerations` в Kubernetes Pod.
+
+      Если ничего не указано или указано `false` — `tolerations` будет определяться [автоматически](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).

--- a/modules/491-containerized-data-importer/openapi/openapi-case-tests.yaml
+++ b/modules/491-containerized-data-importer/openapi/openapi-case-tests.yaml
@@ -3,6 +3,14 @@ positive:
   - {}
   values:
   - { internal: {} }
+  - https:
+      mode: CustomCertificate
+      customCertificate:
+        secretName: "plainstring"
+    internal:
+      customCertificateData:
+        tls.crt: plainstring
+        tls.key: plainstring
 negative:
   configValues:
   - { somethingInConfig: yes }

--- a/modules/491-containerized-data-importer/openapi/values.yaml
+++ b/modules/491-containerized-data-importer/openapi/values.yaml
@@ -5,3 +5,13 @@ properties:
   internal:
     type: object
     default: {}
+    properties:
+      customCertificateData:
+        type: object
+        properties:
+          tls.crt:
+            type: string
+          tls.key:
+            type: string
+          ca.crt:
+            type: string


### PR DESCRIPTION
## Description

Make CDI working with customCertificate

## Why do we need it, and what problem does it solve?

If cluster configured to use customCertificate method, cdi module can't be installed

## What is the expected result?

CDI able to work with customCertificate

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: containerized-data-importer
type: fix
summary: Make CDI working with `customCertificate`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
