### PR TITLE
[upmeter][smoke-mini] Rename deprecated annotations for upmeter

### DIFF
--- a/modules/500-upmeter/hooks/smokemini/internal/snapshot/node.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/snapshot/node.go
@@ -31,7 +31,7 @@ type Node struct {
 	Schedulable bool
 }
 
-const zoneLabelKey = "failure-domain.beta.kubernetes.io/zone"
+const zoneLabelKey = "topology.kubernetes.io/zone"
 
 func NewNode(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	node := new(v1.Node)

--- a/modules/500-upmeter/hooks/smokemini/internal/snapshot/node_test.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/snapshot/node_test.go
@@ -152,7 +152,7 @@ func newNodeObject(args testNodeObjectArgs) *unstructured.Unstructured {
 
 	if args.zone != "" {
 		node.ObjectMeta.Labels = map[string]string{
-			"failure-domain.beta.kubernetes.io/zone": args.zone,
+			"topology.kubernetes.io/zone": args.zone,
 		}
 	}
 

--- a/modules/500-upmeter/hooks/smokemini/reschedule_test.go
+++ b/modules/500-upmeter/hooks/smokemini/reschedule_test.go
@@ -50,7 +50,7 @@ kind: Node
 metadata:
   labels:
     kubernetes.io/hostname: node-a-1
-    failure-domain.beta.kubernetes.io/zone: nova
+    topology.kubernetes.io/zone: nova
   name: node-a-1
 status:
   conditions:
@@ -64,7 +64,7 @@ kind: Node
 metadata:
   labels:
     kubernetes.io/hostname: node-a-1
-    failure-domain.beta.kubernetes.io/zone: nova
+    topology.kubernetes.io/zone: nova
   name: node-a-1
 status:
   conditions:
@@ -139,7 +139,7 @@ kind: Node
 metadata:
   labels:
     kubernetes.io/hostname: node-a-1
-    failure-domain.beta.kubernetes.io/zone: nova
+    topology.kubernetes.io/zone: nova
   name: node-a-1
 status:
   conditions:
@@ -151,7 +151,7 @@ kind: Node
 metadata:
   labels:
     kubernetes.io/hostname: node-a-2
-    failure-domain.beta.kubernetes.io/zone: nova
+    topology.kubernetes.io/zone: nova
   name: node-a-2
 status:
   conditions:
@@ -226,7 +226,7 @@ kind: Node
 metadata:
   labels:
     kubernetes.io/hostname: node-a-1
-    failure-domain.beta.kubernetes.io/zone: nova
+    topology.kubernetes.io/zone: nova
   name: node-a-1
 status:
   conditions:
@@ -308,7 +308,7 @@ kind: Node
 metadata:
   labels:
     kubernetes.io/hostname: node-a-1
-    failure-domain.beta.kubernetes.io/zone: nova
+    topology.kubernetes.io/zone: nova
   name: node-a-1
 status:
   conditions:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Rename deprecated annotations
https://kubernetes.io/docs/reference/labels-annotations-taints/#failure-domainbetakubernetesiozone
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #2850 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: chore
summary: rename deprecated annotations
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
