### PR TITLE
[virtualization] Fix tolerations for virt-operator-strategy-dumper job

### DIFF
--- a/modules/490-virtualization/images/artifact/patches/007-tolerations-for-strategy-dumper-job.patch
+++ b/modules/490-virtualization/images/artifact/patches/007-tolerations-for-strategy-dumper-job.patch
@@ -1,0 +1,24 @@
+diff --git a/pkg/virt-operator/kubevirt.go b/pkg/virt-operator/kubevirt.go
+index 640750c7a..185ee8d0f 100644
+--- a/pkg/virt-operator/kubevirt.go
++++ b/pkg/virt-operator/kubevirt.go
+@@ -741,6 +741,19 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
+ 					},
+ 				},
+ 				Spec: k8sv1.PodSpec{
++					Tolerations: []k8sv1.Toleration{{Operator: k8sv1.TolerationOpExists}},
++					Affinity: &k8sv1.Affinity{PodAffinity: &k8sv1.PodAffinity{
++						RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{{
++							TopologyKey: "kubernetes.io/hostname",
++							LabelSelector: &metav1.LabelSelector{
++								MatchExpressions: []metav1.LabelSelectorRequirement{{
++									Key:      v1.AppLabel,
++									Operator: metav1.LabelSelectorOpIn,
++									Values:   []string{VirtOperator},
++								}},
++							},
++						}},
++					}},
+ 					ServiceAccountName: "kubevirt-operator",
+ 					RestartPolicy:      k8sv1.RestartPolicyNever,
+ 					Containers: []k8sv1.Container{

--- a/modules/490-virtualization/images/artifact/patches/README.md
+++ b/modules/490-virtualization/images/artifact/patches/README.md
@@ -40,3 +40,10 @@ This PR adds macvtap networking mode for binding podNetwork.
 When a block volume is non-hotpluggable (i.e. it is specified explicitly in the VMI spec), the device cgroup permissions are managed purely by Kubernetes and CRI. For v2, that means a BPF program is assigned to the POD's cgroup. However, when we manage hotplug volumes, we overwrite the BPF program to allow access to the new block device. The problem is that we do not know what the existing BPF program does, hence we just follow some assumptions about the 'default' devices that we need to allow (e.g. /dev/kvm and some others). We need to also consider the non-hotpluggable volumes, otherwise a VM with a block PVC or DV will fail to start if a hotplug volume is attached to it.
 
 - https://github.com/kubevirt/kubevirt/pull/8828
+
+### `007-tolerations-for-strategy-dumper-job.patch`
+
+There is a problem when all nodes in cluster have taints, KubeVirt can't run virt-operator-strategy-dumper job.
+The provided fix will always run the job in same place where virt-operator runs
+
+- https://github.com/kubevirt/kubevirt/pull/9360


### PR DESCRIPTION
## Description

Backport from upstream https://github.com/kubevirt/kubevirt/pull/9360

This PR specifies:

```yaml
tolerations:
- operator: "Exists"
affinity:
  podAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchExpressions:
        - key: kubevirt.io
          operator: In
          values:
          - virt-operator
      topologyKey: "kubernetes.io/hostname"
```

for virt-operator-strategy-dumper job spawned by virt-operator

## Why do we need it, and what problem does it solve?

There is a problem when all nodes in cluster have taints, KubeVirt can't run virt-operator-strategy-dumper job.
The provided fix will always run the job in same place where `virt-operator` runs


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: virtualization
type: fix
summary: Fix tolerations for virt-operator-strategy-dumper job
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
