### PR TITLE
[docs][user-authz] Add links to the enableMultiTenancy module parameter

### DIFF
--- a/modules/140-user-authz/crds/crd.yaml
+++ b/modules/140-user-authz/crds/crd.yaml
@@ -64,7 +64,7 @@ spec:
                   description: |
                     Allow access to System namespaces (kube-*, d8-*, loghouse, default).
 
-                    Option available **only** if `enableMultiTenancy` option is enabled.
+                    Option available **only** if the [enableMultiTenancy](configuration.html#parameters-enablemultitenancy) option is enabled.
                   x-doc-d8Revision: ee
                   x-doc-default: false
                 limitNamespaces:
@@ -76,7 +76,7 @@ spec:
                     * If the list is defined, then only its constituents are accessible.
                     * If the list is not defined, then all namespaces are accessible (except for the system ones - see `spec.allowAccessToSystemNamespaces` below).
 
-                    Option available only if `enableMultiTenancy` option is enabled.
+                    Option available only if [enableMultiTenancy](configuration.html#parameters-enablemultitenancy) option is enabled.
                   x-doc-d8Revision: ee
                   example: ['production-.*']
                   items:

--- a/modules/140-user-authz/crds/doc-ru-crd.yaml
+++ b/modules/140-user-authz/crds/doc-ru-crd.yaml
@@ -34,7 +34,7 @@ spec:
                   description: |
                     Разрешить пользователю доступ в служебные namespace (`["kube-.*", "d8-.*", "loghouse", "default"]`).
 
-                    **Доступно только** с включённым параметром `enableMultiTenancy`.
+                    **Доступно только** с включённым параметром [enableMultiTenancy](configuration.html#parameters-enablemultitenancy).
                 limitNamespaces:
                   description: |
                     Список разрешённых namespace в формате регулярных выражений.
@@ -43,7 +43,7 @@ spec:
                     * Если список указан, то разрешаем доступ только по нему.
                     * Если список не указан, то считаем, что разрешено всё, кроме системных namespace (см. `spec.allowAccessToSystemNamespaces` ниже).
 
-                    **Доступно только** с включённым параметром `enableMultiTenancy`.
+                    **Доступно только** с включённым параметром [enableMultiTenancy](configuration.html#parameters-enablemultitenancy).
                 subjects:
                   description: |
                     Пользователи и/или группы, которым необходимо предоставить права.

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -233,7 +233,7 @@ spec:
 
 ## Configuring kube-apiserver for multi-tenancy mode
 
-The multi-tenancy mode, which allows you to restrict access to namespaces, is enabled by the `enableMultiTenancy` module's parameter.
+The multi-tenancy mode, which allows you to restrict access to namespaces, is enabled by the [enableMultiTenancy](configuration.html#parameters-enablemultitenancy) module's parameter.
 
 Working in multi-tenancy mode requires enabling the [Webhook authorization plugin](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) and configuring a `kube-apiserver.` All actions necessary for the multi-tenancy mode are performed **automatically** by the [control-plane-manager](../../modules/040-control-plane-manager/) module; no additional steps are required.
 

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -233,7 +233,7 @@ spec:
 
 ### Настройка `kube-apiserver` для работы в режиме multi-tenancy
 
-Режим multi-tenancy, позволяющий ограничивать доступ к namespace, включается [параметром](configuration.html) `enableMultiTenancy` модуля.
+Режим multi-tenancy, позволяющий ограничивать доступ к namespace, включается параметром [enableMultiTenancy](configuration.html#parameters-enablemultitenancy) модуля.
 
 Работа в режиме multi-tenancy требует включения [плагина авторизации Webhook](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) и выполнения настройки `kube-apiserver`. Все необходимые для работы режима multi-tenancy действия **выполняются автоматически** модулем [control-plane-manager](../../modules/040-control-plane-manager/), никаких ручных действий не требуется.
 


### PR DESCRIPTION
## Description
Add links to the `enableMultiTenancy` module parameter.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authz
type: chore
summary: Add links to the `enableMultiTenancy` module parameter.
impact_level: low
```
