### PR TITLE
[deckhouse-config] disable webhook ha mode

### DIFF
--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse-config-webhook")) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
+  replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -52,10 +52,16 @@ spec:
         module: {{ .Chart.Name }}
         app: deckhouse-config-webhook
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: deckhouse
+              topologyKey: kubernetes.io/hostname
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "deckhouse-config-webhook")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       serviceAccountName: deckhouse-config-webhook
       imagePullSecrets:

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/pdb.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/pdb.yaml
@@ -2,14 +2,11 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  annotations:
-    helm.sh/hook: post-upgrade, post-install
-    helm.sh/hook-delete-policy: before-hook-creation
   name: deckhouse-config-webhook
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse-config-webhook")) | nindent 2 }}
 spec:
-  minAvailable: {{ include "helm_lib_is_ha_to_value" (list . 1 0) }}
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: deckhouse-config-webhook

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/pdb.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/pdb.yaml
@@ -2,6 +2,9 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
+  annotations:
+    helm.sh/hook: post-upgrade, post-install
+    helm.sh/hook-delete-policy: before-hook-creation
   name: deckhouse-config-webhook
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse-config-webhook")) | nindent 2 }}


### PR DESCRIPTION
## Description
Disable HA mode
Set podAffinity

## Why do we need it, and what problem does it solve?
Deckhouse-config have to be on the same node as Deckhouse to have access to the external-modules directory and also, actual external-modules

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-config
type: fix
summary: Place deckhouse-config-webhook on the same node as Deckhouse
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
