### PR TITLE
[node-manager] show instance class link to NG

### DIFF
--- a/candi/cloud-providers/aws/openapi/instance_class.yaml
+++ b/candi/cloud-providers/aws/openapi/instance_class.yaml
@@ -11,7 +11,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -99,10 +99,25 @@ spec:
                     The additional security groups to add to provisioned instances of the specific InstanceClass.
                   items:
                     type: string
+            status:
+              type: object
+              properties:
+                nodeGroupConsumers:
+                  type: array
+                  items:
+                    type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
+      additionalPrinterColumns:
+        - name: "Node Groups"
+          type: string
+          description: NodeGroups which use this instance class.
+          jsonPath: .status.nodeGroupConsumers
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Cluster
   names:
     plural: awsinstanceclasses

--- a/candi/cloud-providers/azure/openapi/instance_class.yaml
+++ b/candi/cloud-providers/azure/openapi/instance_class.yaml
@@ -11,7 +11,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -101,10 +101,25 @@ spec:
                   description: |
                     Accelerated Networking provides up to 30Gbps in networking throughput.
                   x-doc-default: true
+            status:
+              type: object
+              properties:
+                nodeGroupConsumers:
+                  type: array
+                  items:
+                    type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
+      additionalPrinterColumns:
+        - name: "Node Groups"
+          type: string
+          description: NodeGroups which use this instance class.
+          jsonPath: .status.nodeGroupConsumers
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Cluster
   names:
     plural: azureinstanceclasses

--- a/candi/cloud-providers/gcp/openapi/instance_class.yaml
+++ b/candi/cloud-providers/gcp/openapi/instance_class.yaml
@@ -11,7 +11,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -110,10 +110,25 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                   additionalProperties:
                     type: string
+            status:
+              type: object
+              properties:
+                nodeGroupConsumers:
+                  type: array
+                  items:
+                    type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
+      additionalPrinterColumns:
+        - name: "Node Groups"
+          type: string
+          description: NodeGroups which use this instance class.
+          jsonPath: .status.nodeGroupConsumers
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Cluster
   names:
     plural: gcpinstanceclasses

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -11,7 +11,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -126,7 +126,7 @@ spec:
                     Network type: STANDARD or SOFTWARE_ACCELERATED
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object
@@ -240,6 +240,21 @@ spec:
                   default: Standard
                   description: |
                     Network type: Standard or SoftwareAccelerated
+            status:
+              type: object
+              properties:
+                nodeGroupConsumers:
+                  type: array
+                  items:
+                    type: string
+      additionalPrinterColumns:
+        - name: "Node Groups"
+          type: string
+          description: NodeGroups which use this instance class.
+          jsonPath: .status.nodeGroupConsumers
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Cluster
   names:
     plural: yandexinstanceclasses

--- a/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
@@ -138,6 +138,9 @@ spec:
           type: string
           description: NodeGroups which use this instance class.
           jsonPath: .status.nodeGroupConsumers
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Cluster
   names:
     plural: openstackinstanceclasses

--- a/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
@@ -11,7 +11,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -122,9 +122,16 @@ spec:
                   additionalProperties:
                     type: string
                   x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                nodeGroupConsumers:
+                  type: array
+                  items:
+                    type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
   scope: Cluster
   names:

--- a/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
@@ -133,6 +133,11 @@ spec:
       served: true
       storage: true
       schema: *schema
+      additionalPrinterColumns:
+        - name: "Node Groups"
+          type: string
+          description: NodeGroups which use this instance class.
+          jsonPath: .status.nodeGroupConsumers
   scope: Cluster
   names:
     plural: openstackinstanceclasses

--- a/ee/candi/cloud-providers/vsphere/openapi/instance_class.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/instance_class.yaml
@@ -11,7 +11,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -119,10 +119,25 @@ spec:
                       x-doc-default: 80
                       minimum: 0
                       maximum: 100
+            status:
+              type: object
+              properties:
+                nodeGroupConsumers:
+                  type: array
+                  items:
+                    type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
+      additionalPrinterColumns:
+        - name: "Node Groups"
+          type: string
+          description: NodeGroups which use this instance class.
+          jsonPath: .status.nodeGroupConsumers
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Cluster
   names:
     plural: vsphereinstanceclasses

--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -508,7 +508,7 @@ var detectInstanceClassKind = func(input *go_hook.HookInput, config *go_hook.Hoo
 		}
 	}
 
-	return getCRDsHookConfig.Kubernetes[0].Kind, fromSecret
+	return config.Kubernetes[0].Kind, fromSecret
 }
 
 const EpochWindowSize int64 = 4 * 60 * 60 // 4 hours

--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
@@ -20,24 +20,49 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
 
 	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 )
 
-var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+var setInstanceClassNGUsageConfig = &go_hook.HookConfig{
 	Queue: "/modules/node-manager/update_instance_class_ng",
 	Kubernetes: []go_hook.KubernetesConfig{
+		// A binding with dynamic kind has index 0 for simplicity.
 		{
-			Name:                   "ings",
+			Name:                "ics",
+			ApiVersion:          "",
+			Kind:                "",
+			ExecuteHookOnEvents: pointer.Bool(false),
+			FilterFunc:          applyUsedInstanceClassFilter,
+		},
+		{
+			Name:                   "ngs",
 			Kind:                   "NodeGroup",
 			ApiVersion:             "deckhouse.io/v1",
 			WaitForSynchronization: pointer.Bool(false),
 			FilterFunc:             filterCloudEphemeralNG,
 		},
+		{
+			Name:       "cloud_provider_secret",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-node-manager-cloud-provider"},
+			},
+			FilterFunc: applyCloudProviderSecretKindZonesFilter,
+		},
 	},
-}, setInstanceClassUsage)
+}
+
+var _ = sdk.RegisterFunc(setInstanceClassNGUsageConfig, setInstanceClassUsage)
 
 func filterCloudEphemeralNG(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var ng ngv1.NodeGroup
@@ -51,7 +76,7 @@ func filterCloudEphemeralNG(obj *unstructured.Unstructured) (go_hook.FilterResul
 		return nil, nil
 	}
 
-	return instanceClassWithNG{
+	return ngUsedInstanceClass{
 		usedInstanceClass: usedInstanceClass{
 			Kind: ng.Spec.CloudInstances.ClassReference.Kind,
 			Name: ng.Spec.CloudInstances.ClassReference.Name,
@@ -61,25 +86,62 @@ func filterCloudEphemeralNG(obj *unstructured.Unstructured) (go_hook.FilterResul
 }
 
 func setInstanceClassUsage(input *go_hook.HookInput) error {
-	snap := input.Snapshots["ings"]
-	if len(snap) == 0 {
-		return nil
-	}
+	// dynamic InstanceClass binding
+	{
+		kindInUse, kindFromSecret := detectInstanceClassKind(input, setInstanceClassNGUsageConfig)
 
-	m := make(map[usedInstanceClass][]string)
+		// Kind is changed, so objects in "dynamic-kind" can be ignored. Update kind and stop the hook.
+		if kindInUse != kindFromSecret {
+			if kindFromSecret == "" {
+				input.LogEntry.Infof("InstanceClassKind has changed from '%s' to '': disable binding 'ics'", kindInUse)
+				*input.BindingActions = append(*input.BindingActions, go_hook.BindingAction{
+					Name:       "ics",
+					Action:     "Disable",
+					Kind:       "",
+					ApiVersion: "",
+				})
+			} else {
+				input.LogEntry.Infof("InstanceClassKind has changed from '%s' to '%s': update kind for binding 'ics'", kindInUse, kindFromSecret)
+				*input.BindingActions = append(*input.BindingActions, go_hook.BindingAction{
+					Name:       "ics",
+					Action:     "UpdateKind",
+					Kind:       kindFromSecret,
+					ApiVersion: "deckhouse.io/v1",
+				})
+			}
+			// Save new kind as current kind.
+			setInstanceClassNGUsageConfig.Kubernetes[0].Kind = kindFromSecret
+			// Binding changed, hook will be restarted with new objects in "ics" snapshot.
+			return nil
+		}
+	} // end dynamic
 
+	icNodeConsumers := make(map[usedInstanceClass][]string)
+
+	snap := input.Snapshots["ngs"]
 	for _, sn := range snap {
 		if sn == nil {
 			// not ephemeral
 			continue
 		}
 
-		usedIC := sn.(instanceClassWithNG)
+		usedIC := sn.(ngUsedInstanceClass)
 
-		m[usedIC.usedInstanceClass] = append(m[usedIC.usedInstanceClass], usedIC.NodeGroupName)
+		icNodeConsumers[usedIC.usedInstanceClass] = append(icNodeConsumers[usedIC.usedInstanceClass], usedIC.NodeGroupName)
 	}
 
-	for ic, ngNames := range m {
+	// find instanceClasses which were unbound from NG (or ng deleted)
+	snap = input.Snapshots["ics"]
+	for _, sn := range snap {
+		icm := sn.(usedInstanceClassWithConsumers)
+
+		// if not found in NGs - remove consumers
+		if _, ok := icNodeConsumers[icm.usedInstanceClass]; !ok {
+			icNodeConsumers[icm.usedInstanceClass] = []string{}
+		}
+	}
+
+	for ic, ngNames := range icNodeConsumers {
 		statusPatch := map[string]interface{}{
 			"status": map[string]interface{}{
 				"nodeGroupConsumers": ngNames,
@@ -96,7 +158,31 @@ type usedInstanceClass struct {
 	Name string
 }
 
-type instanceClassWithNG struct {
+type usedInstanceClassWithConsumers struct {
+	usedInstanceClass
+	NodeGroupConsumers []string
+}
+
+type ngUsedInstanceClass struct {
 	usedInstanceClass
 	NodeGroupName string
+}
+
+func applyUsedInstanceClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	nodeGroupConsumers, ok, err := unstructured.NestedStringSlice(obj.Object, "status", "nodeGroupConsumers")
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		nodeGroupConsumers = make([]string, 0)
+	}
+
+	return usedInstanceClassWithConsumers{
+		usedInstanceClass: usedInstanceClass{
+			Kind: obj.GetKind(),
+			Name: obj.GetName(),
+		},
+		NodeGroupConsumers: nodeGroupConsumers,
+	}, nil
 }

--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
@@ -46,9 +46,11 @@ var setInstanceClassNGUsageConfig = &go_hook.HookConfig{
 			FilterFunc:             filterCloudEphemeralNG,
 		},
 		{
-			Name:       "cloud_provider_secret",
-			ApiVersion: "v1",
-			Kind:       "Secret",
+			Name:                         "cloud_provider_secret",
+			ApiVersion:                   "v1",
+			Kind:                         "Secret",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
 					MatchNames: []string{"kube-system"},

--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/update_instance_class_ng",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                   "ings",
+			Kind:                   "NodeGroup",
+			ApiVersion:             "deckhouse.io/v1",
+			WaitForSynchronization: pointer.BoolPtr(false),
+			FilterFunc:             filterCloudEphemeralNG,
+		},
+	},
+}, setInstanceClassUsage)
+
+func filterCloudEphemeralNG(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var ng ngv1.NodeGroup
+
+	err := sdk.FromUnstructured(obj, &ng)
+	if err != nil {
+		return nil, err
+	}
+
+	if ng.Spec.NodeType != ngv1.NodeTypeCloudEphemeral {
+		return nil, nil
+	}
+
+	return usedInstanceClass{
+		Kind:          ng.Spec.CloudInstances.ClassReference.Kind,
+		Name:          ng.Spec.CloudInstances.ClassReference.Name,
+		NodeGroupName: ng.Name,
+	}, nil
+}
+
+func setInstanceClassUsage(input *go_hook.HookInput) error {
+	snap := input.Snapshots["ings"]
+	if len(snap) == 0 {
+		return nil
+	}
+
+	m := make(map[usedInstanceClass][]string)
+
+	for _, sn := range snap {
+		if sn == nil {
+			// not ephemeral
+			continue
+		}
+
+		usedIC := sn.(usedInstanceClass)
+
+		m[usedIC] = append(m[usedIC], usedIC.NodeGroupName)
+	}
+
+	for ic, ngNames := range m {
+		statusPatch := map[string]interface{}{
+			"status": map[string]interface{}{
+				"nodeGroupConsumers": ngNames,
+			},
+		}
+		input.PatchCollector.MergePatch(statusPatch, "deckhouse.io/v1", ic.Kind, "", ic.Name)
+	}
+
+	return nil
+}
+
+type usedInstanceClass struct {
+	Kind string
+	Name string
+
+	NodeGroupName string
+}

--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage_test.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: set_instance_class_usage ::", func() {
+	f := HookExecutionConfigInit(`
+global: {}
+nodeManager:
+  internal: {}
+`, `{}`)
+	f.RegisterCRD("deckhouse.io", "v1", "OpenStackInstanceClass", false)
+	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
+
+	FContext("AAA", func() {
+		BeforeEach(func() {
+			state := `
+apiVersion: deckhouse.io/v1
+kind: OpenStackInstanceClass
+metadata:
+  name: worker
+spec:
+  flavorName: m1.large
+  imageName: ubuntu-22-04-cloud-amd64
+  mainNetwork: test
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  cloudInstances:
+    classReference:
+      kind: OpenStackInstanceClass
+      name: worker
+    maxPerZone: 3
+    minPerZone: 3
+  nodeType: CloudEphemeral
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: another-worker
+spec:
+  cloudInstances:
+    classReference:
+      kind: OpenStackInstanceClass
+      name: worker
+    maxPerZone: 0
+    minPerZone: 2
+  nodeType: CloudEphemeral
+`
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(state, 1))
+			f.RunHook()
+		})
+
+		It("Hook must not fail and nodeManager.internal.instancePrefix is 'global'", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			worker := f.KubernetesGlobalResource("OpenStackInstanceClass", "worker")
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).To(HaveLen(2))
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).To(ContainElements(ContainSubstring("worker"), ContainSubstring("another-worker")))
+		})
+	})
+
+	FContext("BBB", func() {
+		BeforeEach(func() {
+			state := `
+apiVersion: deckhouse.io/v1
+kind: OpenStackInstanceClass
+metadata:
+  name: worker
+spec:
+  flavorName: m1.large
+  imageName: ubuntu-22-04-cloud-amd64
+  mainNetwork: test
+status:
+  nodeGroupConsumers:
+    - old-worker
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  cloudInstances:
+    classReference:
+      kind: OpenStackInstanceClass
+      name: next
+    maxPerZone: 3
+    minPerZone: 3
+  nodeType: CloudEphemeral
+`
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(state, 1))
+			f.RunHook()
+		})
+
+		It("Hook must not fail and nodeManager.internal.instancePrefix is 'global'", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			worker := f.KubernetesGlobalResource("OpenStackInstanceClass", "worker")
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).To(HaveLen(0))
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).ToNot(ContainElements(ContainSubstring("old-worker")))
+			//Expect(worker.Field("status.nodeGroupConsumers").Array()).To(ContainElements(ContainSubstring("worker"), ContainSubstring("another-worker")))
+		})
+	})
+
+	FContext("CCC", func() {
+		BeforeEach(func() {
+			state := `
+apiVersion: deckhouse.io/v1
+kind: OpenStackInstanceClass
+metadata:
+  name: worker
+spec:
+  flavorName: m1.large
+  imageName: ubuntu-22-04-cloud-amd64
+  mainNetwork: test
+status:
+  nodeGroupConsumers:
+    - old-worker
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  cloudInstances:
+    classReference:
+      kind: OpenStackInstanceClass
+      name: worker
+    maxPerZone: 3
+    minPerZone: 3
+  nodeType: CloudEphemeral
+`
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(state, 1))
+			f.RunHook()
+		})
+
+		It("Hook must not fail and nodeManager.internal.instancePrefix is 'global'", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			worker := f.KubernetesGlobalResource("OpenStackInstanceClass", "worker")
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).To(HaveLen(1))
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).To(ContainElements(ContainSubstring("worker")))
+			Expect(worker.Field("status.nodeGroupConsumers").Array()).ToNot(ContainElements(ContainSubstring("old-worker")))
+		})
+	})
+})


### PR DESCRIPTION
## Description
Extend InstanceClass status field to show node groups which use it

## Why do we need it, and what problem does it solve?
Improve user experience. Easy to figure out which instance classes is not used

## What is the expected result?
```yaml
apiVersion: deckhouse.io/v1
kind: OpenStackInstanceClass
metadata:
  name: worker
spec:
  flavorName: m1.large
  imageName: ubuntu-22-04-cloud-amd64
  mainNetwork: ndev
status:
  nodeGroupConsumers:
  - testme
  - worker
```

or via the IC list:
```bash
NAME     NODE GROUPS           AGE
test     []                    3d3h
worker   ["testme","worker"]   75d
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature 
summary: Show used NodeGroups in the InstanceClass status field
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
