### PR TITLE
[cni-cilium] Perform routing lookup for custom tables

### DIFF
--- a/modules/021-cni-cilium/images/virt-cilium/patches/004-fib.patch
+++ b/modules/021-cni-cilium/images/virt-cilium/patches/004-fib.patch
@@ -1,0 +1,14 @@
+diff --git a/bpf/lib/fib.h b/bpf/lib/fib.h
+index f24d6c7a47..24f78beb34 100644
+--- a/bpf/lib/fib.h
++++ b/bpf/lib/fib.h
+@@ -31,8 +31,7 @@ redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
+ 	ipv6_addr_copy((union v6addr *)&fib_params.ipv6_dst,
+ 		       (union v6addr *)&ip6->daddr);
+ 
+-	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
+-			 BPF_FIB_LOOKUP_DIRECT);
++	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params), 0);
+ 	switch (ret) {
+ 	case BPF_FIB_LKUP_RET_SUCCESS:
+ 		break;

--- a/modules/021-cni-cilium/images/virt-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/virt-cilium/patches/README.md
@@ -14,8 +14,14 @@ Use predicted MAC-address generation mechanism to make live-migration working.
 
 Upstream <https://github.com/cilium/cilium/pull/24100>
 
-## 002-mtu.patch
+## 003-mtu.patch
 
 Set correct MTU value for veth interfaces
 
 Upstream issue <https://github.com/cilium/cilium/issues/23711>
+
+## 004-fib.patch
+
+Perform routing lookup for custom tables
+
+Upstream <https://github.com/cilium/cilium/pull/24271>


### PR DESCRIPTION
## Description

Perform routing lookup for custom tables
Upstream fix: https://github.com/cilium/cilium/pull/24271

## Why do we need it, and what problem does it solve?

Pod-to-pod communication is not working in case when routes are located in different routing tables.
See https://github.com/cilium/cilium/issues/24252 for more details.

That makes our virtualization workloads not working because per-vm routes are adding into additional routing table.

## What is the expected result?

That will fix communication between VMs when cilium runs in direct-node-routing mode.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Perform routing lookup for custom tables.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
