### PR TITLE
[extended-monitoring] exclude openvpn-pki secrets from CertificateSec…

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -3,7 +3,7 @@
   - alert: CertificateSecretExpiredSoon
     expr: |
       max by (name, namespace) (
-        cert_exporter_secret_not_after{job="cert-exporter", secretkey!="ca.crt"} - time() < 1209600
+        cert_exporter_secret_not_after{job="cert-exporter", name!~"openvpn-pki-.*", secretkey!="ca.crt"} - time() < 1209600
       ) * on (namespace) group_left() max by (namespace) (extended_monitoring_enabled)
     for: 1h
     labels:


### PR DESCRIPTION
## Description
Exclude openvpn clients secrets from alert CertificateSecretExpiredSoon

## Why do we need it, and what problem does it solve?
At the moment, the certificates that are issued to clients for connecting via openvpn get into the alert.

## What is the expected result?
Need to exclude that secrets from alerting 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix 
summary: Exclude openvpn clients secrets from alert CertificateSecretExpiredSoon
impact_level: low
```