### PR TITLE
[monitoring][istio] remove pod and instance labels from D8IstioDeprecatedIstioVersionInstalled alert

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/versions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/versions.yaml
@@ -6,9 +6,8 @@
           There is deprecated istio version `{{$labels.version}}` installed.
           Impact — version support will be removed in future deckhouse releases. The higher alert severity — the higher probability of support cancelling.
           Upgrading instructions — https://deckhouse.io/documentation/v1/modules/110-istio/examples.html#upgrading-istio.
-        plk_create_group_if_not_exists__d8_istio_versions_misconfigurations: D8IstioVersionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        plk_grouped_by__d8_istio_versions_misconfigurations: D8IstioVersionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_markup_format: markdown
+        plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"
         summary: There is deprecated istio version installed
       expr: |


### PR DESCRIPTION
## Description
Remove pod and instance labels from D8IstioDeprecatedIstioVersionInstalled alert.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Each alert contains pod and instance labels, which are generated by the deckhouse itself. When the deckhouse rolls, a new alert fires.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix 
summary: Got rid of pod, instance and group excess labels in D8IstioDeprecatedIstioVersionInstalled alert.
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
