### PR TITLE
[chore] Add www. redirect on the site

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -13,6 +13,7 @@ kind: Ingress
 metadata:
   name: main-{{ .Lang }}
   annotations:
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: '*'
     nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
## Description
Fix ingress to allow redirection from the www.deckhouse on the site.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix ingress to allow redirection from the www.deckhouse on the site.
impact_level: low
```

