### PR TITLE
[docs][node-manager] Fix bug in generating OpenAPI values for the module

### DIFF
--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -4,7 +4,7 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
-  excludePaths: ['*/docs/internal/','040-node-manager/crds/mcm.yaml','490-virtualization/crds/kubevirt.yaml']
+  excludePaths: ['*/openapi/values.yaml', '*/openapi/*-tests.yaml', '*/docs/internal/','040-node-manager/crds/mcm.yaml','490-virtualization/crds/kubevirt.yaml']
   includePaths: ['*/docs/','*/openapi/','*/crds/', '*/oss.yaml']
 - add: /modules
   to: /srv/jekyll-data/documentation/_data/bundles/raw/ce
@@ -42,7 +42,7 @@
   stageDependencies:
     setup: ['**/*']
   includePaths: ['*/docs/','*/openapi/','*/crds/', '*/oss.yaml']
-  excludePaths: ['*/docs/internal/','110-istio/crds/istio','040-node-manager']
+  excludePaths: ['*/openapi/values.yaml', '*/openapi/*-tests.yaml', '*/docs/internal/','110-istio/crds/istio']
 - add: /ee/candi/cloud-providers/openstack/openapi
   to: /src/ee/modules/030-cloud-provider-openstack/crds
   owner: jekyll
@@ -87,7 +87,7 @@
   stageDependencies:
     setup: ['**/*']
   includePaths: ['*/docs/','*/openapi/','*/crds/', '*/oss.yaml']
-  excludePaths: ['*/docs/internal/']
+  excludePaths: ['*/openapi/values.yaml', '*/openapi/*-tests.yaml''*/docs/internal/']
 {{- end }}
 # CRDs
 - add: /modules/010-user-authn-crd/crds

--- a/modules/040-node-manager/crds/doc-ru-nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/crds/doc-ru-nodegroupconfiguration.yaml
@@ -29,5 +29,8 @@ spec:
                 nodeGroups:
                   description: Список NodeGroup к которым применять шаг конфигурации. Для выбора всех NodeGroups нужно указать '*'.
                 bundles:
-                  description: Список bundles, для которых выполнять скрипт. Для выбора всех bundles нужно указать `'*'`.
+                  description: |
+                    Список bundle'ов, для которых выполнять скрипт. Для выбора всех bundle'ов нужно указать `'*'`.
+
+                    Список возможных bundle'ов такой же, как у параметра [allowedBundles](configuration.html#parameters-allowedbundles) модуля.
 

--- a/modules/040-node-manager/crds/nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/crds/nodegroupconfiguration.yaml
@@ -54,7 +54,10 @@ spec:
                     - ["ubuntu-lts", "centos-7"]
                     - ["ubuntu-lts"]
                     - ["*"]
-                  description: Bundles for step execution. You can set `'*'` for selecting all bundles.
+                  description: |
+                    Bundles for step execution. You can set `'*'` for selecting all bundles.
+
+                    See the list of possible bundles in the [allowedBundles](configuration.html#parameters-allowedbundles) module parameter.
                   items:
                     type: string
       additionalPrinterColumns:


### PR DESCRIPTION
## Description
For the node-manager module the openapi spec from the CE revision is used on the site, but the spec from the FE version is needed. The PR fix this bug.

## What is the expected result?
The allowBundles parameter of the node-manager module use the allowed values list of more than 3 items (FE revision spec).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix bug in generating OpenAPI values for the module.
impact_level: low
```
