### PR TITLE
[helm_lib] Upgrade lib-helm to 1.0.1 and update readme

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 0.0.20
-digest: sha256:fae20603d0ab4dd437b8c046fb93db8dd7dea15948f4f6c9364276d4f44b01e7
-generated: "2023-03-09T16:45:03.741061+03:00"
+  version: 1.0.1
+digest: sha256:b644a68012380f4e6c187c7525cb85813e56b88b67fc8be5c57e56ac3b0db9ab
+generated: "2023-03-15T12:12:19.294786807+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "0.0.20"
+    version: "1.0.1"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/README.md
+++ b/helm_lib/README.md
@@ -18,9 +18,9 @@ make version=0.0.2 update-lib-helm
 ATTENTION!
 
 Do not backport new minor and major releases of `lib-helm` to an existing (already released on the Alpha channel) Deckhouse release. 
-These releases may contain breaking changes. Also, you can't use the [backporting mechanism](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs#backporting-a-pr)! 
+These releases may contain breaking changes. Also, you can't (!) use the [backporting mechanism](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs#backporting-a-pr)! 
 If you need to make a fix, follow the instructions below:
-- Release a patch release of `lib-helm` [as follows instruction](https://github.com/deckhouse/lib-helm/blob/main/README.md#fix-bug-in-minor-release-xx).
+- Release a patch release of `lib-helm` [as follows instruction](https://github.com/deckhouse/lib-helm/blob/main/README.md#backport-fix-in-previous-minor-release-xx).
 - Create a new branch from the release branch (release-1.XXX).
 - Update `lib-helm` as instructed above.
 - Create a PR to the release branch and merge it.

--- a/helm_lib/README.md
+++ b/helm_lib/README.md
@@ -18,7 +18,7 @@ make version=0.0.2 update-lib-helm
 ATTENTION!
 
 Do not backport new minor and major releases of `lib-helm` to an existing (already released on the Alpha channel) Deckhouse release. 
-These releases may contain breaking changes. Also, you can't (!) use the [backporting mechanism](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs#backporting-a-pr)! 
+These releases may contain breaking changes. Also, you **cannot** use the [backporting mechanism](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs#backporting-a-pr)! 
 If you need to make a fix, follow the instructions below:
 - Release a patch release of `lib-helm` [as follows instruction](https://github.com/deckhouse/lib-helm/blob/main/README.md#backport-fix-in-previous-minor-release-xx).
 - Create a new branch from the release branch (release-1.XXX).

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 0.0.20
+version: 1.0.1


### PR DESCRIPTION
## Description
Upgrade lib-helm to 1.0.1 and update readme.

## Why do we need it, and what problem does it solve?
Broken link in readme.
Release 1.0 for lib-helm (without any changes)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: Upgrade lib-helm to 1.0.1 and update readme 
type: chore
summary: Upgrade lib-helm to 1.0.1 and update readme
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
