### PR TITLE
[linstor] Update alerts and labels

### DIFF
--- a/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -42,23 +42,30 @@
 
           The recommended course of action:
           1. Login into node with the problem: `kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash`
-          2. Check the LINSTOR resource states: `linstor resource list -r {{ $labels.name }}`
-          3. Make sure if {{ $labels.node }} persists in output of above command
+          2. Check the drbd resource state: `drbd status {{ $labels.name }}`
+             If all the connections are green (Diskless or UpToDate) but you see `quorum:no blocked:upper`, then most probably you're faced with this [DRBD bug](https://lists.linbit.com/pipermail/drbd-user/2023-March/026373.html).
+             To fix this it should be enough to remove and create an additional diskless replica:
+             ```
+             linstor resource create some-node {{ $labels.name }} -d
+             linstor resource delete some-node {{ $labels.name }}
+             ```
+
+          3. Check the LINSTOR resource states: `linstor resource list -r {{ $labels.name }}`
+          4. Make sure if {{ $labels.node }} persists in output of above command
 
           If non-persists:
-          4a. Try to remove the resource from the kernel: `drbdsetup down {{ $labels.name }}`
-          5a. If command has stuck consider rebooting the node {{ $labels.node }}
+          5a. Try to remove the resource from the kernel: `drbdsetup down {{ $labels.name }}`
+          6a. If command has stuck consider rebooting the node {{ $labels.node }}
 
           If persists:
-          4b. Check the LINSTOR node and peer node states: `linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}`
-          
-          5b. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
-          6b. View the status of the DRBD device on the node and try to figure out why it has no quorum:
+          5b. Check the LINSTOR node and peer node states: `linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}`
+          6b. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
+          7b. View the status of the DRBD device on the node and try to figure out why it has no quorum:
               ```
               drbdsetup status --verbose {{ $labels.name }}
               dmesg --color=always | grep 'drbd {{ $labels.name }}'
               ```
-          7b. Consider recreating failed resources in LINSTOR
+          8b. Consider recreating failed resources in LINSTOR
               ```
               linstor resource delete {{ $labels.node }} {{ $labels.name }}
               linstor resource-definition auto-place {{ $labels.name }}
@@ -157,7 +164,6 @@
 
           If persists:
           4b. Check the LINSTOR node and peer node states: `linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}`
-          
           5b. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
           6b. View the status of the DRBD device on the node and try to figure out why it is not connected:
               ```

--- a/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -38,39 +38,63 @@
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: DRBD device has no quorum
         description: |
-          DRBD device {{ $labels.name }} on node {{ $labels.node }} has no quorum
+          DRBD device {{ $labels.name }} on node {{ $labels.node }} has no quorum.
 
           The recommended course of action:
-          1. Login into node with the problem: `kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash`
-          2. Check the drbd resource state: `drbd status {{ $labels.name }}`
-             If all the connections are green (Diskless or UpToDate) but you see `quorum:no blocked:upper`, then most probably you're faced with this [DRBD bug](https://lists.linbit.com/pipermail/drbd-user/2023-March/026373.html).
+          1. Login into the node with the problem:
+
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             ```
+
+          2. Check the drbd resource state:
+
+             ```
+             drbd status {{ $labels.name }}
+             ```
+
+             If all the connections are green (`Diskless` or `UpToDate`) but you see `quorum:no blocked:upper`, then most probably you're faced with this [DRBD bug](https://lists.linbit.com/pipermail/drbd-user/2023-March/026373.html).
              To fix this it should be enough to remove and create an additional diskless replica:
+
              ```
              linstor resource create some-node {{ $labels.name }} -d
              linstor resource delete some-node {{ $labels.name }}
              ```
 
-          3. Check the LINSTOR resource states: `linstor resource list -r {{ $labels.name }}`
-          4. Make sure if {{ $labels.node }} persists in output of above command
+          3. Check the LINSTOR resource states:
 
-          If non-persists:
-          5a. Try to remove the resource from the kernel: `drbdsetup down {{ $labels.name }}`
-          6a. If command has stuck consider rebooting the node {{ $labels.node }}
+             ```
+             linstor resource list -r {{ $labels.name }}
+             ```
 
-          If persists:
-          5b. Check the LINSTOR node and peer node states: `linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}`
-          6b. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
-          7b. View the status of the DRBD device on the node and try to figure out why it has no quorum:
-              ```
-              drbdsetup status --verbose {{ $labels.name }}
-              dmesg --color=always | grep 'drbd {{ $labels.name }}'
-              ```
-          8b. Consider recreating failed resources in LINSTOR
-              ```
-              linstor resource delete {{ $labels.node }} {{ $labels.name }}
-              linstor resource-definition auto-place {{ $labels.name }}
-              linstor resource-definition wait-sync {{ $labels.name }}
-              ```
+          4. Make sure that {{ $labels.node }} persists in the output of the above command.
+
+             If non-persists:
+             1. Try to remove the resource from the kernel: `drbdsetup down {{ $labels.name }}`
+             2. If command has stuck consider rebooting the node {{ $labels.node }}
+
+             If persists:
+             1. Check the LINSTOR node and peer node states:
+
+                ```
+                linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}
+                ```
+
+             2. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}.
+             3. View the status of the DRBD device on the node and try to figure out why it has no quorum:
+
+                ```
+                drbdsetup status --verbose {{ $labels.name }}
+                dmesg --color=always | grep 'drbd {{ $labels.name }}'
+                ```
+
+             4. Consider recreating failed resources in LINSTOR:
+
+                ```
+                linstor resource delete {{ $labels.node }} {{ $labels.name }}
+                linstor resource-definition auto-place {{ $labels.name }}
+                linstor resource-definition wait-sync {{ $labels.name }}
+                ```
 
     - alert: D8DrbdDeviceIsUnintentionalDiskless
       expr: max by (node, name) (drbd_device_unintentionaldiskless == 1)

--- a/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -16,10 +16,26 @@
           LINSTOR volume {{ $labels.resource }} on node {{ $labels.exported_node }} is not healthy
 
           The recommended course of action:
-          1. Login into node with the problem: `kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash`
-          2. Check the LINSTOR node state: `linstor node list -n {{ $labels.exported_node }}`
-          3. Check the LINSTOR resource states: `linstor resource list -r {{ $labels.resource }}`
+          1. Login into node with the problem:
+
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             ```
+
+          2. Check the LINSTOR node state:
+
+             ```
+             linstor node list -n {{ $labels.exported_node }}
+             ```
+
+          3. Check the LINSTOR resource states:
+
+             ```
+             linstor resource list -r {{ $labels.resource }}
+             ```
+
           4. View the status of the DRBD device and try to figure out why it is not UpToDate:
+
              ```
              drbdsetup status {{ $labels.name }} --verbose
              dmesg --color=always | grep 'drbd {{ $labels.name }}'
@@ -70,7 +86,12 @@
           4. Make sure that {{ $labels.node }} persists in the output of the above command.
 
              If non-persists:
-             1. Try to remove the resource from the kernel: `drbdsetup down {{ $labels.name }}`
+             1. Try to remove the resource from the kernel:
+
+                ```
+                drbdsetup down {{ $labels.name }}
+                ```
+
              2. If command has stuck consider rebooting the node {{ $labels.node }}
 
              If persists:
@@ -112,16 +133,39 @@
           DRBD device {{ $labels.name }} on node {{ $labels.node }} unintentionally switched to diskless mode
 
           The recommended course of action:
-          1. Login into node with the problem: `kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash`
-          2. Check the LINSTOR resource state on {{ $labels.node }}: `linstor resource list -r {{ $labels.name }}`
-          3. Check the LINSTOR storage-pools on {{ $labels.node }}: `linstor storage-pools list -r {{ $labels.name }}`
+          1. Login into node with the problem:
+
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             ```
+
+          2. Check the LINSTOR resource state on {{ $labels.node }}:
+
+             ```
+             linstor resource list -r {{ $labels.name }}
+             ```
+
+          3. Check the LINSTOR storage-pools on {{ $labels.node }}:
+
+             ```
+             linstor storage-pools list -r {{ $labels.name }}
+             ```
+
           4. View the status of the DRBD device:
+
              ```
              drbdsetup status {{ $labels.name }} --verbose
              dmesg --color=always | grep 'drbd {{ $labels.name }}'
              ```
-          5. Check the backing storage device: `lsblk`
-          6. Consider recreating failed resources in LINSTOR
+
+          5. Check the backing storage device:
+
+             ```
+             lsblk
+             ```
+
+          6. Consider recreating failed resources in LINSTOR:
+
              ```
              linstor resource delete {{ $labels.node }} {{ $labels.name }}
              linstor resource-definition auto-place {{ $labels.name }}
@@ -144,20 +188,40 @@
           DRBD device {{ $labels.name }} on node {{ $labels.node }} has out-of-sync data with {{ $labels.conn_name }}
 
           The recommended course of action:
-          1. Login into node with the problem: `kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash`
-          2. Check the LINSTOR peer node state: `linstor node list -n {{ $labels.conn_name }}`
-          3. Check the LINSTOR resource states: `linstor resource list -r {{ $labels.name }}`
+          1. Login into node with the problem:
+
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             ```
+
+          2. Check the LINSTOR peer node state:
+
+             ```
+             linstor node list -n {{ $labels.conn_name }}
+             ```
+
+          3. Check the LINSTOR resource states:
+
+             ```
+             linstor resource list -r {{ $labels.name }}
+             ```
+
           4. View the status of the DRBD device on the node and try to figure out why it has out-of-sync data with {{ $labels.conn_name }}:
+
              ```
              drbdsetup status {{ $labels.name }} --statistics
              dmesg --color=always | grep 'drbd {{ $labels.name }}'
              ```
+
           5. Consider reconnect resource with the peer node:
+
              ```
              drbdadm disconnect {{ $labels.name }}:{{ $labels.conn_name }}
              drbdadm connect {{ $labels.name }}:{{ $labels.conn_name }}
              ```
+
           6. Check if problem has solved, device should have no out-of-sync data:
+
              ```
              drbdsetup status {{ $labels.name }} --statistics
              ```
@@ -178,25 +242,47 @@
           DRBD device {{ $labels.name }} on node {{ $labels.node }} is not connected with {{ $labels.conn_name }}
 
           The recommended course of action:
-          1. Login into node with the problem: `kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash`
-          2. Check the LINSTOR resource states: `linstor resource list -r {{ $labels.name }}`
-          3. Make sure if {{ $labels.node }} persists in output of above command
+          1. Login into node with the problem:
 
-          If non-persists:
-          4a. Try to remove the resource from the kernel: `drbdsetup down {{ $labels.name }}`
-          5a. If command has stuck consider rebooting the node {{ $labels.node }}
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app=linstor-node -o name) -c linstor-satellite -- bash
+             ```
 
-          If persists:
-          4b. Check the LINSTOR node and peer node states: `linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}`
-          5b. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
-          6b. View the status of the DRBD device on the node and try to figure out why it is not connected:
-              ```
-              drbdadm status {{ $labels.name }}
-              dmesg --color=always | grep 'drbd {{ $labels.name }}'
-              ```
-          7b. Consider recreating failed resources in LINSTOR
-              ```
-              linstor resource delete {{ $labels.conn_name }} {{ $labels.name }}
-              linstor resource-definition auto-place {{ $labels.name }}
-              linstor resource-definition wait-sync {{ $labels.name }}
-              ```
+          2. Check the LINSTOR resource states:
+
+             ```
+             linstor resource list -r {{ $labels.name }}
+             ```
+
+          3. Make sure if {{ $labels.node }} persists in output of above command.
+
+             If non-persists:
+             1. Try to remove the resource from the kernel:
+
+                ```
+                drbdsetup down {{ $labels.name }}
+                ```
+             2. If command has stuck consider rebooting the node {{ $labels.node }}.
+
+             If persists:
+             1. Check the LINSTOR node and peer node states:
+
+                ```
+                linstor node list -n {{ $labels.node }} {{ $labels.conn_name }}
+                ```
+
+             2. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}.
+             3. View the status of the DRBD device on the node and try to figure out why it is not connected:
+
+                ```
+                drbdadm status {{ $labels.name }}
+                dmesg --color=always | grep 'drbd {{ $labels.name }}'
+                ```
+
+             4. Consider recreating failed resources in LINSTOR:
+
+                ```
+                linstor resource delete {{ $labels.conn_name }} {{ $labels.name }}
+                linstor resource-definition auto-place {{ $labels.name }}
+                linstor resource-definition wait-sync {{ $labels.name }}
+                ```


### PR DESCRIPTION
## Description

Update alerts and labels.

## Why do we need it, and what problem does it solve?

Simplify label selectors and update course of action in case of failures

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: chore
summary: Update alerts and labels.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
