### PR TITLE
[ci] Schedule e2e-daily test on 1:00 UTC (was 3:00 UTC)

### DIFF
--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -17,7 +17,7 @@
 name: '{!{ $workflowName }!}'
 on:
   schedule:
-  - cron: '0 3 * * 1-5'
+  - cron: '0 1 * * 1-5'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -17,7 +17,7 @@
 # limitations under the License.name: 'Daily e2e tests'
 on:
   schedule:
-  - cron: '0 3 * * 1-5'
+  - cron: '0 1 * * 1-5'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

Run daily e2e tests at 1 am UTC, as 3 am UTC is too late.

## Changelog entries
```changes
section: ci
type: chore
summary: Run daily e2e tests at 1 am UTC.
impact_level: low
```
