### PR TITLE
[cloud-provider-yandex] Use real InternalIPs for routes

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -228,7 +228,7 @@ k8s:
     bashible: *bashible_k8s_ge_1_22
     ccm:
       openstack: v1.26.1
-      yandex: v0.26.0
+      yandex: v0.26.1
       aws: v1.26.0
       vsphere: v1.26.0
       azure: v1.26.5

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/001-lock-route-table-operations.patch
@@ -1,4 +1,4 @@
-Subject: [PATCH] Added route table API locking
+Subject: [PATCH] 001
 ---
 Index: pkg/cloudprovider/yandex/routes.go
 IDEA additional info:
@@ -7,13 +7,15 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
 --- a/pkg/cloudprovider/yandex/routes.go	(revision 4355e41b39cb060df9aed3c13f50d2239caa1192)
-+++ b/pkg/cloudprovider/yandex/routes.go	(date 1674041456612)
-@@ -3,7 +3,9 @@
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1679489714548)
+@@ -2,8 +2,10 @@
+
  import (
  	"context"
- 	"fmt"
+-	"fmt"
 +	"sync"
 
++	"github.com/davecgh/go-spew/spew"
 +	"github.com/pkg/errors"
  	"github.com/yandex-cloud/go-genproto/yandex/cloud/operation"
  	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/002-use-real-internal-ip-for-routes.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/002-use-real-internal-ip-for-routes.patch
@@ -1,0 +1,84 @@
+Subject: [PATCH] 002
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision 4355e41b39cb060df9aed3c13f50d2239caa1192)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1679489714548)
+@@ -87,11 +87,22 @@
+ 	}
+
+ 	kubeNodeName := string(route.TargetNode)
+-	nextHop, err := yc.getInternalIpByNodeName(kubeNodeName)
++	addresses, err := yc.NodeAddresses(ctx, route.TargetNode)
+ 	if err != nil {
+ 		return err
+ 	}
+
++	var nextHop string
++	for _, address := range addresses {
++		if address.Type == v1.NodeInternalIP {
++			nextHop = address.Address
++			break
++		}
++	}
++	if len(nextHop) == 0 {
++		return spew.Errorf("could not determine InternalIP from list of IPs for VM %q: %v", route.TargetNode, addresses)
++	}
++
+ 	newStaticRoutes := filterStaticRoutes(rt.StaticRoutes, routeFilterTerm{
+ 		termType:        routeFilterAddOrUpdate,
+ 		nodeName:        kubeNodeName,
+@@ -137,25 +148,6 @@
+ 	return err
+ }
+
+-func (yc *Cloud) getInternalIpByNodeName(nodeName string) (string, error) {
+-	kubeNode, err := yc.nodeLister.Get(nodeName)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	var targetInternalIP string
+-	for _, address := range kubeNode.Status.Addresses {
+-		if address.Type == v1.NodeInternalIP {
+-			targetInternalIP = address.Address
+-		}
+-	}
+-	if len(targetInternalIP) == 0 {
+-		return "", fmt.Errorf("no InternalIPs found for Node %q", nodeName)
+-	}
+-
+-	return targetInternalIP, nil
+-}
+-
+ type routeFilterTerm struct {
+ 	termType        routeFilterTermType
+ 	nodeName        string
+Index: go.mod
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/go.mod b/go.mod
+--- a/go.mod	(revision 4355e41b39cb060df9aed3c13f50d2239caa1192)
++++ b/go.mod	(date 1679489725733)
+@@ -3,6 +3,7 @@
+ go 1.17
+
+ require (
++	github.com/davecgh/go-spew v1.1.1
+ 	github.com/deckarep/golang-set v1.7.1
+ 	github.com/golang/protobuf v1.5.2
+ 	github.com/pkg/errors v0.9.1
+@@ -29,7 +30,6 @@
+ 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+ 	github.com/coreos/go-semver v0.3.0 // indirect
+ 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+-	github.com/davecgh/go-spew v1.1.1 // indirect
+ 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+ 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+ 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/README.md
@@ -5,3 +5,9 @@
 Lock route tables operations, since we perform whole route table update on each call from cloud-provider controller.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/48)
+
+## 002-use-real-internal-ip-for-routes.patch
+
+Use real InternalIP for route table.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/53)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/001-lock-route-table-operations.patch
@@ -1,4 +1,4 @@
-Subject: [PATCH] Added route table API locking
+Subject: [PATCH] 001
 ---
 Index: pkg/cloudprovider/yandex/routes.go
 IDEA additional info:
@@ -7,13 +7,15 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
 --- a/pkg/cloudprovider/yandex/routes.go	(revision fd5725566d06883e6102499a1280982401be4432)
-+++ b/pkg/cloudprovider/yandex/routes.go	(date 1674041399136)
-@@ -3,7 +3,9 @@
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1679489787689)
+@@ -2,8 +2,10 @@
+
  import (
  	"context"
- 	"fmt"
+-	"fmt"
 +	"sync"
 
++	"github.com/davecgh/go-spew/spew"
 +	"github.com/pkg/errors"
  	"github.com/yandex-cloud/go-genproto/yandex/cloud/operation"
  	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/002-use-real-internal-ip-for-routes.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/002-use-real-internal-ip-for-routes.patch
@@ -1,0 +1,84 @@
+Subject: [PATCH] 002
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision fd5725566d06883e6102499a1280982401be4432)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1679489787689)
+@@ -87,11 +87,22 @@
+ 	}
+
+ 	kubeNodeName := string(route.TargetNode)
+-	nextHop, err := yc.getInternalIpByNodeName(kubeNodeName)
++	addresses, err := yc.NodeAddresses(ctx, route.TargetNode)
+ 	if err != nil {
+ 		return err
+ 	}
+
++	var nextHop string
++	for _, address := range addresses {
++		if address.Type == v1.NodeInternalIP {
++			nextHop = address.Address
++			break
++		}
++	}
++	if len(nextHop) == 0 {
++		return spew.Errorf("could not determine InternalIP from list of IPs for VM %q: %v", route.TargetNode, addresses)
++	}
++
+ 	newStaticRoutes := filterStaticRoutes(rt.StaticRoutes, routeFilterTerm{
+ 		termType:        routeFilterAddOrUpdate,
+ 		nodeName:        kubeNodeName,
+@@ -137,25 +148,6 @@
+ 	return err
+ }
+
+-func (yc *Cloud) getInternalIpByNodeName(nodeName string) (string, error) {
+-	kubeNode, err := yc.nodeLister.Get(nodeName)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	var targetInternalIP string
+-	for _, address := range kubeNode.Status.Addresses {
+-		if address.Type == v1.NodeInternalIP {
+-			targetInternalIP = address.Address
+-		}
+-	}
+-	if len(targetInternalIP) == 0 {
+-		return "", fmt.Errorf("no InternalIPs found for Node %q", nodeName)
+-	}
+-
+-	return targetInternalIP, nil
+-}
+-
+ type routeFilterTerm struct {
+ 	termType        routeFilterTermType
+ 	nodeName        string
+Index: go.mod
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/go.mod b/go.mod
+--- a/go.mod	(revision fd5725566d06883e6102499a1280982401be4432)
++++ b/go.mod	(date 1679489794445)
+@@ -3,6 +3,7 @@
+ go 1.18
+
+ require (
++	github.com/davecgh/go-spew v1.1.1
+ 	github.com/deckarep/golang-set v1.7.1
+ 	github.com/golang/protobuf v1.5.2
+ 	github.com/pkg/errors v0.9.1
+@@ -29,7 +30,6 @@
+ 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+ 	github.com/coreos/go-semver v0.3.0 // indirect
+ 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+-	github.com/davecgh/go-spew v1.1.1 // indirect
+ 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+ 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+ 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/README.md
@@ -5,3 +5,9 @@
 Lock route tables operations, since we perform whole route table update on each call from cloud-provider controller.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/48)
+
+## 002-use-real-internal-ip-for-routes.patch
+
+Use real InternalIP for route table.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/53)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/001-use-real-internal-ip-for-routes.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/001-use-real-internal-ip-for-routes.patch
@@ -1,0 +1,95 @@
+Subject: [PATCH] 001
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision c35e724eac6114ef570c1c5a2d45d4e8f38703f8)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1679489832746)
+@@ -2,9 +2,9 @@
+
+ import (
+ 	"context"
+-	"fmt"
+ 	"sync"
+
++	"github.com/davecgh/go-spew/spew"
+ 	"github.com/pkg/errors"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/operation"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
+@@ -77,11 +77,22 @@
+ 	}
+
+ 	kubeNodeName := string(route.TargetNode)
+-	nextHop, err := yc.getInternalIpByNodeName(kubeNodeName)
++	addresses, err := yc.NodeAddresses(ctx, route.TargetNode)
+ 	if err != nil {
+ 		return err
+ 	}
+
++	var nextHop string
++	for _, address := range addresses {
++		if address.Type == v1.NodeInternalIP {
++			nextHop = address.Address
++			break
++		}
++	}
++	if len(nextHop) == 0 {
++		return spew.Errorf("could not determine InternalIP from list of IPs for VM %q: %v", route.TargetNode, addresses)
++	}
++
+ 	newStaticRoutes := filterStaticRoutes(rt.StaticRoutes, routeFilterTerm{
+ 		termType:        routeFilterAddOrUpdate,
+ 		nodeName:        kubeNodeName,
+@@ -133,25 +144,6 @@
+ 	return err
+ }
+
+-func (yc *Cloud) getInternalIpByNodeName(nodeName string) (string, error) {
+-	kubeNode, err := yc.nodeLister.Get(nodeName)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	var targetInternalIP string
+-	for _, address := range kubeNode.Status.Addresses {
+-		if address.Type == v1.NodeInternalIP {
+-			targetInternalIP = address.Address
+-		}
+-	}
+-	if len(targetInternalIP) == 0 {
+-		return "", fmt.Errorf("no InternalIPs found for Node %q", nodeName)
+-	}
+-
+-	return targetInternalIP, nil
+-}
+-
+ type routeFilterTerm struct {
+ 	termType        routeFilterTermType
+ 	nodeName        string
+Index: go.mod
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/go.mod b/go.mod
+--- a/go.mod	(revision c35e724eac6114ef570c1c5a2d45d4e8f38703f8)
++++ b/go.mod	(date 1679489836846)
+@@ -3,6 +3,7 @@
+ go 1.18
+
+ require (
++	github.com/davecgh/go-spew v1.1.1
+ 	github.com/deckarep/golang-set v1.7.1
+ 	github.com/golang/protobuf v1.5.2
+ 	github.com/pkg/errors v0.9.1
+@@ -29,7 +30,6 @@
+ 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+ 	github.com/coreos/go-semver v0.3.0 // indirect
+ 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+-	github.com/davecgh/go-spew v1.1.1 // indirect
+ 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+ 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+ 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/README.md
@@ -1,0 +1,7 @@
+# Patches
+
+## 001-use-real-internal-ip-for-routes.patch
+
+Use real InternalIP for route table.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/53)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Use real InternalIP to avoid problematic routes in the route table.

https://github.com/deckhouse/yandex-cloud-controller-manager/pull/53

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Currently, CCM relies on InternalIP provided by the Node object in the Kubernetes API. This creates a race, since kubelet sets the IP earlier than CCM. This results in the wrong internalIP in the routing table.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Proper InternalIP is added to the routing table.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Proper InternalIPs are not added to the routing table. Those that are physically present on a VM in the cloud.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
