### PR TITLE
[runtime-audit-engine] Fix K8sAudit -> k8s_audit source convert action

### DIFF
--- a/ee/modules/650-runtime-audit-engine/hack/far-converter/main.go
+++ b/ee/modules/650-runtime-audit-engine/hack/far-converter/main.go
@@ -159,7 +159,7 @@ func convert(path string, rules []RawRule) FalcoAuditRule {
 
 			if source, ok := r["source"]; ok {
 				switch strings.ToLower(source.(string)) {
-				case "k8saudit":
+				case "k8s_audit":
 					ruleToAdd.Source = "K8sAudit"
 				case "syscall":
 					ruleToAdd.Source = "Syscall"

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/rules/hook.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/rules/hook.py
@@ -6,6 +6,7 @@
 from os import remove, walk
 
 from shell_operator import hook
+from stringcase import snakecase
 from yaml import dump
 
 _FALCO_RULES_DIR = '/etc/falco/rules.d'
@@ -41,7 +42,7 @@ def convert_spec(spec: dict) -> list:
 
             source = item["rule"].get("source")
             if source is not None:
-                converted_item["source"] = source.lower()
+                converted_item["source"] = snakecase(source)
 
             result.append(converted_item)
             continue

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/rules/test.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/rules/test.py
@@ -58,6 +58,16 @@ class TestConvertSpec(unittest.TestCase):
                         "tags": ["filesystem", "mitre_persistence"],
                         "source": "Syscall",
                     }
+                },
+                {
+                    "rule": {
+                        "name": "Test name",
+                        "desc": "Alert about test",
+                        "condition": "ka.user.name == \"test\"",
+                        "output": "Test output %ka.user.name",
+                        "priority": "Error",
+                        "source": "K8sAudit",
+                    }
                 }
             ]
         })
@@ -75,6 +85,14 @@ class TestConvertSpec(unittest.TestCase):
                 "priority": "Error",
                 "tags": ["filesystem", "mitre_persistence"],
                 "source": "syscall",
+            },
+            {
+                "desc": "Alert about test",
+                "condition": 'ka.user.name == "test"',
+                "output": "Test output %ka.user.name",
+                "priority": "Error",
+                "source": "k8s_audit",
+                "rule": "Test name",
             }
         ]
         self.assertListEqual(res, expect)

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/requirements.txt
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/requirements.txt
@@ -2,3 +2,4 @@ dictdiffer==0.9.0
 dotmap==1.3.30
 PyYAML==6.0
 shell-operator==0.0.8
+stringcase==1.2.0


### PR DESCRIPTION
## Description
Add the stringcase library to convert camel case to string case.

## Why do we need it, and what problem does it solve?
The plugin's name is `k8saudit`, but the source's name is `k8s_audit`. Without it, `K8sAudit` source type rules are ignored now.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: Fix `K8sAudit` -> `k8s_audit` source convert action.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
