### PR TITLE
[deckhouse] changes in deckhouse module manifest and dhctl to fix installation in managed clusters

### DIFF
--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
 {{- end }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
       initContainers:
         - name: init-external-modules
           image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
@@ -104,6 +105,7 @@ spec:
           volumeMounts:
             - mountPath: /deckhouse/external-modules
               name: external-modules
+{{- end }}
       containers:
         - name: deckhouse
           {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 10 }}
@@ -156,10 +158,15 @@ spec:
               value: "yes"
             - name: HELM_HISTORY_MAX
               value: "3"
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
             - name: MODULES_DIR
               value: "/deckhouse/modules:/deckhouse/external-modules/modules"
             - name: EXTERNAL_MODULES_DIR
               value: "/deckhouse/external-modules/"
+{{- else }}
+            - name: MODULES_DIR
+              value: "/deckhouse/modules"
+{{- end }}
             - name: DEBUG_UNIX_SOCKET
               value: /tmp/shell-operator-debug.socket
             - name: HISTFILE
@@ -190,8 +197,10 @@ spec:
             name: tmp
           - mountPath: /.kube
             name: kube
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
           - mountPath: /deckhouse/external-modules
             name: external-modules
+{{- end }}
       hostNetwork: true
 {{- if .Values.global.clusterIsBootstrapped }}
       dnsPolicy: ClusterFirstWithHostNet
@@ -206,7 +215,9 @@ spec:
       - emptyDir:
           medium: Memory
         name: kube
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
       - name: external-modules
         hostPath:
           path: /var/lib/deckhouse/external-modules
           type: DirectoryOrCreate
+{{- end}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR removes external module directory volume mount and init container if external module manager disabled. Also it adds init container in dhctl manifest to fix installation in managed clusters

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In case of disabled external module manager we have Deckhouse stucked because of non-existent external modules directory. Also, we have problem with installation in managed clusters.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Correct work of Deckhouse pod, and successful installation in managed clusters

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Changes in deckhouse module manifest and dhctl to fix installation in managed clusters (and also in minimal bundle).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
