### PR TITLE
[cloud-provider-vsphere] Add zones to provider cloud discovery data

### DIFF
--- a/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/outputs.tf
+++ b/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/outputs.tf
@@ -3,9 +3,10 @@
 
 output "cloud_discovery_data" {
   value = {
-    "apiVersion" = "deckhouse.io/v1"
-    "kind" = "VsphereCloudDiscoveryData"
-    "vmFolderPath" = vsphere_folder.main.path
+    "apiVersion"       = "deckhouse.io/v1"
+    "kind"             = "VsphereCloudDiscoveryData"
+    "vmFolderPath"     = vsphere_folder.main.path
     "resourcePoolPath" = local.use_nested_resource_pool == true ? (local.base_resource_pool != "" ? join("/", [local.base_resource_pool, local.prefix]) : local.prefix) : ""
+    "zones"            = var.providerClusterConfiguration.zones
   }
 }

--- a/ee/candi/cloud-providers/vsphere/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cloud_discovery_data.yaml
@@ -17,3 +17,7 @@ apiVersions:
         minLength: 1
       resourcePoolPath:
         type: string
+      zones:
+        type: array
+        items:
+          type: string

--- a/ee/modules/030-cloud-provider-vsphere/hooks/internal/v1/cloud_discovery_data.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/internal/v1/cloud_discovery_data.go
@@ -6,8 +6,9 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package v1
 
 type VsphereCloudDiscoveryData struct {
-	APIVersion       *string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
-	Kind             *string `json:"kind,omitempty" yaml:"kind,omitempty"`
-	VMFolderPath     *string `json:"vmFolderPath,omitempty" yaml:"vmFolderPath,omitempty"`
-	ResourcePoolPath *string `json:"resourcePoolPath,omitempty" yaml:"resourcePoolPath,omitempty"`
+	APIVersion       *string  `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind             *string  `json:"kind,omitempty" yaml:"kind,omitempty"`
+	VMFolderPath     *string  `json:"vmFolderPath,omitempty" yaml:"vmFolderPath,omitempty"`
+	ResourcePoolPath *string  `json:"resourcePoolPath,omitempty" yaml:"resourcePoolPath,omitempty"`
+	Zones            []string `json:"zones,omitempty" yaml:"zones,omitempty"`
 }

--- a/ee/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
@@ -78,7 +78,8 @@ cloudProviderVsphere:
   "apiVersion":"deckhouse.io/v1",
   "kind":"VsphereCloudDiscoveryData",
   "vmFolderPath":"test",
-  "resourcePoolPath": "test"
+  "resourcePoolPath": "test",
+  "zones": ["test"]
 }
 `
 		stateAClusterConfiguration1 = `

--- a/ee/modules/030-cloud-provider-vsphere/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/openapi/values.yaml
@@ -391,6 +391,10 @@ properties:
             type: string
           resourcePoolPath:
             type: string
+          zones:
+            type: array
+            items:
+              type: string
       vsphereDiscoveryData:
         type: object
         additionalProperties: false


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add zones to vsphere provider cloud discovery data for uniformity with another cloud providers
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #4109 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Added zones to vsphere provider cloud discovery data
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: feature
summary: Add zones list to cloud discovery data
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
