### PR TITLE
[tools] Change image for init container for deckhouse deployment with change-registry.sh 

### DIFF
--- a/tools/change-registry.sh
+++ b/tools/change-registry.sh
@@ -20,6 +20,7 @@ REGISTRY_SCHEME=""
 REGISTRY_ADDRESS=""
 REGISTRY_PATH=""
 REGISTRY_CAFILE=""
+DECKHOUSE_EXTERNAL_MODULES_IMAGE_TAG=""
 
 function usage() {
   printf "
@@ -87,6 +88,11 @@ function parse_args() {
   REGISTRY_SCHEME="$(sed "s/:\/\///" <<< "$REGISTRY_SCHEME")"
   DECKHOUSE_TAG="$(kubectl -n d8-system get deploy deckhouse -o json | jq '.spec.template.spec.containers[] | select(.name=="deckhouse") | .image | split(":")[-1]' -r)"
 
+  tmp_external_modules_tag="$(kubectl -n d8-system get deploy deckhouse -o json | jq '.spec.template.spec.initContainers[] | select(.name=="init-external-modules") | .image | split(":")[-1]' -r 2>/dev/null)"
+  if [[ "$tmp_external_modules_tag" != "" ]]; then
+    DECKHOUSE_EXTERNAL_MODULES_IMAGE_TAG="${tmp_external_modules_tag}"
+  fi
+
   if [[ "$REGISTRY_PATH" == "" ]]; then
     >&2 echo "Cannot parse path from registry url: $REGISTRY_URL. Registry url must have at least slash at the end. (for example, https://registry.example.com/ instead of https://registry.example.com)"
     exit 1
@@ -113,20 +119,30 @@ function parse_args() {
     exit 1
   fi
 
+
+  curl_image_by_tag "$DECKHOUSE_TAG"
+  if [[ "$DECKHOUSE_EXTERNAL_MODULES_IMAGE_TAG" != "" ]]; then
+    curl_image_by_tag "$DECKHOUSE_EXTERNAL_MODULES_IMAGE_TAG"
+  fi
+}
+
+function curl_image_by_tag() {
+  tag="$1"
+
   TOKEN="$(bb-rp-get-token)"
   if [[ "$TOKEN" == "" ]]; then
     >&2 echo "Cannot get Bearer token from registry $REGISTRY_URL"
     exit 1
   fi
 
-  URI="${REGISTRY_SCHEME}://${REGISTRY_ADDRESS}/v2${REGISTRY_PATH}/manifests/${DECKHOUSE_TAG}"
+  URI="${REGISTRY_SCHEME}://${REGISTRY_ADDRESS}/v2${REGISTRY_PATH}/manifests/${tag}"
   curl --retry 3 -fsSLq -o /dev/null \
        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
        -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
        -H "Authorization: Bearer $TOKEN" "$URI" 2>/dev/null
   RESULT=$?
   if [[ $RESULT -ne 0 ]]; then
-    >&2 echo "Cannot find image ${REGISTRY_ADDRESS}${REGISTRY_PATH}:${DECKHOUSE_TAG}."
+    >&2 echo "Cannot find image ${REGISTRY_ADDRESS}${REGISTRY_PATH}:${tag}."
     exit 1
   fi
 }
@@ -149,12 +165,28 @@ EOF
 parse_args "$@"
 
 DOCKERCONFIGJSON="$(create_dockerconfigjson | base64 -w0)"
-REGISTRY_ADDRESS="$(echo -n $REGISTRY_ADDRESS | base64 -w0)"
-REGISTRY_PATH="$(echo -n $REGISTRY_PATH | base64 -w0)"
-REGISTRY_SCHEME="$(echo -n $REGISTRY_SCHEME | base64 -w0)"
+REGISTRY_ADDRESS_B64="$(echo -n $REGISTRY_ADDRESS | base64 -w0)"
+REGISTRY_PATH_B64="$(echo -n $REGISTRY_PATH | base64 -w0)"
+REGISTRY_SCHEME_B64="$(echo -n $REGISTRY_SCHEME | base64 -w0)"
 
-kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\".dockerconfigjson\": \"${DOCKERCONFIGJSON}\", \"address\": \"${REGISTRY_ADDRESS}\", \"path\": \"${REGISTRY_PATH}\", \"scheme\": \"${REGISTRY_SCHEME}\"}}"
+kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\".dockerconfigjson\": \"${DOCKERCONFIGJSON}\", \"address\": \"${REGISTRY_ADDRESS_B64}\", \"path\": \"${REGISTRY_PATH_B64}\", \"scheme\": \"${REGISTRY_SCHEME_B64}\"}}"
 if  [[ "$REGISTRY_CAFILE" != "" ]]; then
-  REGISTRY_CA="$(base64 -w0 < ${REGISTRY_CAFILE})"
-  kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\"ca\": \"${REGISTRY_CA}\"}}"
+  REGISTRY_CA_B64="$(base64 -w0 < ${REGISTRY_CAFILE})"
+  kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\"ca\": \"${REGISTRY_CA_B64}\"}}"
+fi
+
+if [[ "$DECKHOUSE_EXTERNAL_MODULES_IMAGE_TAG" != "" ]]; then
+  temp_patch_file=$(mktemp /tmp/patch.XXXXXX.yaml)
+  cat <<EOF | tee "${temp_patch_file}"
+---
+op: replace
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: init-external-modules
+          image: ${REGISTRY_ADDRESS}${REGISTRY_PATH}:${DECKHOUSE_EXTERNAL_MODULES_IMAGE_TAG}
+EOF
+  kubectl patch -n d8-system deploy deckhouse --patch-file "${temp_patch_file}"
+  rm "${temp_patch_file}"
 fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
When using change-registry.sh script now, it doesn't change image for init container for deckhouse deployment. THis PR fixes this
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
fix #4056
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: change-registry.sh script changes deckhouse initContainer image 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
