### PR TITLE
[virtualization] Set bus for diskAttachments

### DIFF
--- a/modules/490-virtualization/hooks/internal/v1alpha1/virtualmachine_types.go
+++ b/modules/490-virtualization/hooks/internal/v1alpha1/virtualmachine_types.go
@@ -80,7 +80,7 @@ type BootDisk struct {
 	// The type of disk device to emulate.
 	//
 	// Supported values: `virtio`, `sata`, `scsi`, `usb`.
-	Bus string `json:"bus,omitempty"`
+	Bus virtv1.DiskBus `json:"bus,omitempty"`
 }
 
 // The source of existing disk.

--- a/modules/490-virtualization/hooks/vm_handler.go
+++ b/modules/490-virtualization/hooks/vm_handler.go
@@ -258,6 +258,10 @@ func setVMFields(d8vm *v1alpha1.VirtualMachine, vm *virtv1.VirtualMachine, ipAdd
 
 	// attach boot disk
 	if d8vm.Spec.BootDisk != nil {
+		bus := d8vm.Spec.BootDisk.Bus
+		if bus == "" {
+			bus = virtv1.DiskBusVirtio
+		}
 		bootVirtualMachineDiskName := d8vm.Spec.BootDisk.Name
 		if bootVirtualMachineDiskName == "" {
 			bootVirtualMachineDiskName = d8vm.Name + "-boot"
@@ -266,7 +270,7 @@ func setVMFields(d8vm *v1alpha1.VirtualMachine, vm *virtv1.VirtualMachine, ipAdd
 			Name: "boot",
 			DiskDevice: virtv1.DiskDevice{
 				Disk: &virtv1.DiskTarget{
-					Bus: "virtio",
+					Bus: bus,
 				},
 			},
 		})
@@ -286,9 +290,7 @@ func setVMFields(d8vm *v1alpha1.VirtualMachine, vm *virtv1.VirtualMachine, ipAdd
 		vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, virtv1.Disk{
 			Name: "cloudinit",
 			DiskDevice: virtv1.DiskDevice{
-				Disk: &virtv1.DiskTarget{
-					Bus: "virtio",
-				},
+				Disk: &virtv1.DiskTarget{},
 			},
 		})
 		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
@@ -306,11 +308,15 @@ func setVMFields(d8vm *v1alpha1.VirtualMachine, vm *virtv1.VirtualMachine, ipAdd
 	if d8vm.Spec.DiskAttachments != nil {
 		for i, disk := range *d8vm.Spec.DiskAttachments {
 			diskName := "disk-" + strconv.Itoa(i+1)
+			bus := disk.Bus
+			if bus == "" {
+				bus = virtv1.DiskBusVirtio
+			}
 			vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, virtv1.Disk{
 				Name: diskName,
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: disk.Bus,
+						Bus: bus,
 					},
 				},
 			})


### PR DESCRIPTION
## Description

- Set default bus to `virtio` for diskAttachments
- Unset `virtio` bus for cloud-init drive

## Why do we need it, and what problem does it solve?

Virtio is faster by default. Let's use it by default for all drives.
While cloud-init does not require to be virtio due to better compatibility with various OSes 

## What is the expected result?

All VMs will use virtio by default for disk attachments and use no virtio for cloud init drive

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: virtualization
type: fix
summary: Set default bus to `virtio` for diskAttachments
impact_level: low
---
section: virtualization
type: fix
summary: Unset `virtio` bus for cloud-init drive
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
