### PR TITLE
[ci] Fix build-and-test_pre-release.yml, cve-daily.yml and e2e-daily.yml workflow name rendering

### DIFF
--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {!{- $ctx := . -}!}
-{!{- $jobNames := dict -}!}
+{!{- $jobNames := dict }!}
 
 name: Build and test for release branches
 

--- a/.github/workflow_templates/cve-daily.yml
+++ b/.github/workflow_templates/cve-daily.yml
@@ -56,7 +56,7 @@ steps:
 {!{- end -}!}
 
 
-{!{- $ctx := . -}!}
+{!{- $ctx := . }!}
 
 name: '{!{ $workflowName }!}'
 on:

--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {!{- $enableWorkflowOnTestRepos := false -}!}
-{!{- $workflowName := "Daily e2e tests" -}!}
+{!{- $workflowName := "Daily e2e tests" }!}
 name: '{!{ $workflowName }!}'
 on:
   schedule:

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -14,7 +14,9 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.name: Build and test for release branches
+# limitations under the License.
+
+name: Build and test for release branches
 
 # On every push to relese branches.
 on:

--- a/.github/workflows/cve-daily.yml
+++ b/.github/workflows/cve-daily.yml
@@ -14,7 +14,9 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.name: 'Daily CVE tests'
+# limitations under the License.
+
+name: 'Daily CVE tests'
 on:
   schedule:
   - cron: '0 23 * * 1-5'

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -14,7 +14,8 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.name: 'Daily e2e tests'
+# limitations under the License.
+name: 'Daily e2e tests'
 on:
   schedule:
   - cron: '0 1 * * 1-5'


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR fixes incorrect name rendering for following workflows:
* `build-and-test_pre-release.yml`
* `cve-daily.yml`
* `e2e-daily.yml`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Workflow names mentioned above don't render correctly:

![image](https://user-images.githubusercontent.com/111346521/226313187-e201ba57-2361-462b-ab83-3bc584432e91.png)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Workflow names render correctly now (tested on `deckhouse-test-1` repo):

![image](https://user-images.githubusercontent.com/111346521/226313917-fb196119-298c-4868-83dd-772edc9a8584.png)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix build-and-test_pre-release.yml, cve-daily.yml and e2e-daily.yml workflow name rendering
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
