### PR TITLE
[candi] Remove from first control-plane node `node-role.kubernetes.io/master` taint during bootstrap.

### DIFF
--- a/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
@@ -43,3 +43,21 @@ if [ ! -f /root/.kube/config ]; then
   mkdir -p /root/.kube
   ln -s /etc/kubernetes/admin.conf /root/.kube/config
 fi
+
+{{- if semverCompare "<1.24" .kubernetesVersion }}
+# add node-role.kubernetes.io/control-plane taint
+# kubeadm < 1.24 taint node only with add node-role.kubernetes.io/master taint
+if ! bb-kubectl --kubeconfig=/etc/kubernetes/admin.conf taint node "$(hostname)" node-role.kubernetes.io/control-plane=:NoSchedule; then
+  echo "Cannot add 'node-role.kubernetes.io/control-plane' taint to node" 1>&2
+  exit 1
+fi
+{{- end }}
+
+{{- if semverCompare "<1.25" .kubernetesVersion }}
+# remove node-role.kubernetes.io/master taint because we start use node-role.kubernetes.io/control-plane
+# and node-role.kubernetes.io/master keeps only first master node
+if ! bb-kubectl --kubeconfig=/etc/kubernetes/admin.conf taint node "$(hostname)" node-role.kubernetes.io/master-; then
+  echo "Cannot remove 'node-role.kubernetes.io/master' taint from node" 1>&2
+  exit 1
+fi
+{{- end }}


### PR DESCRIPTION
## Description
Remove from first control-plane node `node-role.kubernetes.io/master` taint during bootstrap.

## Why do we need it, and what problem does it solve?
Deprecated taint `node-role.kubernetes.io/master` keeps on first control-plane node.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Remove from first control-plane node `node-role.kubernetes.io/master` taint during bootstrap.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
