### PR TITLE
[linstor] add liveness container to check linstor nodes connectivity status

### DIFF
--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -195,5 +195,8 @@ EXPOSE 3366/tcp 3367/tcp
 RUN curl -Lfo /usr/bin/piraeus-entry.sh ${PIRAEUS_GITREPO}/raw/${PIRAEUS_COMMIT_REF}/dockerfiles/piraeus-server/entry.sh \
  && chmod +x /usr/bin/piraeus-entry.sh
 
+# Add liveness probe script
+COPY liveness.sh /liveness.sh
+
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/modules/041-linstor/images/linstor-server/liveness.sh
+++ b/modules/041-linstor/images/linstor-server/liveness.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Sometimes nodes can be shown as Online without established connection to them.
-# This is workaround for https://github.com/LINBIT/linstor-server/issues/331
+# This is a workaround for https://github.com/LINBIT/linstor-server/issues/331
 
 # Collect list of satellite nodes
 SATELLITES_ONLINE=$(linstor -m --output-version=v1 n l | jq -r '.[][] | select(.type == "SATELLITE" and .connection_status == "ONLINE").name' || true)

--- a/modules/041-linstor/images/linstor-server/liveness.sh
+++ b/modules/041-linstor/images/linstor-server/liveness.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Sometimes nodes can be shown as Online without established connection to them.
+# This is workaround for https://github.com/LINBIT/linstor-server/issues/331
+
+# Collect list of satellite nodes
+SATELLITES_ONLINE=$(linstor -m --output-version=v1 n l | jq -r '.[][] | select(.type == "SATELLITE" and .connection_status == "ONLINE").name' || true)
+if [ -z "$SATELLITES_ONLINE" ]; then
+  exit 0
+fi
+
+# Check online nodes with lost connection
+linstor -m --output-version=v1 sp l -s DfltDisklessStorPool -n $SATELLITES_ONLINE | jq '.[][].reports[]?.message' | grep 'No active connection to satellite'
+if [ $? -eq 0 ]; then
+  exit 1
+fi

--- a/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -3,6 +3,10 @@
 cpu: 30m
 memory: 300Mi
 {{- end }}
+{{- define "linstor_liveness_resources" }}
+cpu: 10m
+memory: 20Mi
+{{- end }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
@@ -123,4 +127,29 @@ spec:
         {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
         {{- end }}
-
+  - name: liveness
+    {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}
+    image: {{ include "helm_lib_module_image" (list . "linstorServer") }}
+    command: [ "/bin/sh", "-ec", "while sleep 60; do /liveness.sh > /dev/termination-log; done" ]
+    terminationMessagePath: "/dev/termination-log"
+    volumeMounts:
+    - mountPath: /etc/linstor
+      name: linstor-conf
+    - mountPath: /etc/linstor/https
+      name: linstor-https
+    - mountPath: /etc/linstor/https-pem
+      name: linstor-https-pem
+      readOnly: true
+    - mountPath: /etc/linstor/client
+      name: linstor-client
+    - mountPath: /etc/linstor/ssl
+      name: linstor-ssl
+    - mountPath: /etc/linstor/ssl-pem
+      name: linstor-ssl-pem
+      readOnly: true
+    resources:
+      requests:
+        {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 8 }}
+        {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+        {{- include "linstor_liveness_resources" . | nindent 6 }}
+        {{- end }}


### PR DESCRIPTION
Add liveness container to check linstor nodes connectivity status

## Description

fixes https://github.com/deckhouse/deckhouse/issues/4121

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Add liveness container to check linstor nodes connectivity status.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
