### PR TITLE
[prometheus] Fix time interval for prometheus longterm

### DIFF
--- a/modules/300-prometheus/templates/grafana/secret-datasources-list.yaml
+++ b/modules/300-prometheus/templates/grafana/secret-datasources-list.yaml
@@ -1,9 +1,14 @@
+{{- define "main_scrape_interval" }}
+    {{- $context := . }}
+{{- $context.Values.prometheus.scrapeInterval | default "30s" }}
+{{- end }}
+
 {{- define "authorization_config" }}
   {{- $context := index . 0 }}
   {{- $interval := index . 1 }}
 jsonData:
   httpMethod: POST
-  timeInterval: {{ $context.Values.prometheus.scrapeInterval | default $interval }}
+  timeInterval: {{ $interval }}
   httpHeaderName1: 'Authorization'
   tlsSkipVerify: true
 secureJsonData:
@@ -39,7 +44,7 @@ datasources:
   url: https://trickster.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}/trickster/main
   version: 1
   isDefault: true
-  {{- include "authorization_config" (list . "30s") | nindent 2 }}
+  {{- include "authorization_config" (list . (include "main_scrape_interval" . )) | nindent 2 }}
 
 
   {{- if ne (int .Values.prometheus.longtermRetentionDays) 0 }}
@@ -59,7 +64,7 @@ datasources:
   orgId: 1
   url: https://prometheus-main-0.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}:9090
   version: 1
-  {{- include "authorization_config" (list . "30s") | nindent 2 }}
+  {{- include "authorization_config" (list . (include "main_scrape_interval" . )) | nindent 2 }}
 
 - name: main-uncached-1
   type: prometheus
@@ -67,7 +72,7 @@ datasources:
   orgId: 1
   url: https://prometheus-main-1.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}:9090
   version: 1
-  {{- include "authorization_config" (list . "30s") | nindent 2 }}
+  {{- include "authorization_config" (list . (include "main_scrape_interval" . )) | nindent 2 }}
   {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## Description
Fix timeInterval for longterm Prometheus

## Why do we need it, and what problem does it solve?
Without this, all interval variables in Grafana are lower than 5 minutes, which leads to empty panels
![image](https://user-images.githubusercontent.com/32434187/226571389-166907f0-802e-4c37-b3ed-f85f32b33f1d.png)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix the time interval for Prometheus longterm.
```
