### PR TITLE
[deckhouse-config-webhook] temporary Recreate strategy for webhook

### DIFF
--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -37,6 +37,10 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 2
+  # Migration: temporary Recreate strategy in 1.44
+  strategy:
+    type: Recreate
+  # /Migration
   selector:
     matchLabels:
       heritage: deckhouse


### PR DESCRIPTION
## Description
Temporary Recreate strategy for deckhouse-config-webhook Deployment.

## Why do we need it, and what problem does it solve?
The new affinity in 1.44:
```
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app: deckhouse
        topologyKey: kubernetes.io/hostname
```
The old one:
```
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app: deckhouse-config-webhook
        topologyKey: kubernetes.io/hostname
```
So, the new Deployment version can't make it through RollingUpdate:
```
0/31 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 2 node(s) didn't match pod affinity rules
```

## What is the expected result?
deckhouse-config-webhook is being upgraded without problems.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-config-webhook
type: fix
summary: Temporary Recreate strategy for deckhouse-config-webhook Deployment.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
