### PR TITLE
fix shell executable

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -82,6 +82,8 @@ You can automate the bootstrap process with any automation platform you prefer. 
          when: bootstrapped.stat.exists == False
        - name: Run bootstrap.sh
          shell: "{{ bootstrap_secret.json.data['bootstrap.sh'] | b64decode }}"
+         args:
+           executable: /bin/bash
          ignore_errors: yes
          when: bootstrapped.stat.exists == False
        - name: wait

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -82,6 +82,8 @@ search: добавить ноду в кластер, добавить узел �
          when: bootstrapped.stat.exists == False
        - name: Run bootstrap.sh
          shell: "{{ bootstrap_secret.json.data['bootstrap.sh'] | b64decode }}"
+         args:
+           executable: /bin/bash
          ignore_errors: yes
          when: bootstrapped.stat.exists == False
        - name: wait


### PR DESCRIPTION
## Description
Fix shell binary using by ansible in FAQ example. Ansible shell module use /bin/sh by default, but the script is written on bash.

## Why do we need it, and what problem does it solve?
Correct example in documentation without syntax error in shell during execution.

## What is the expected result?
Try to add node, using ansible script in documentation without syntax errors.

## Checklist
- [X] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix the Ansible script example for adding a node.
impact: documentation
impact_level: low
```