### PR TITLE
[user-authz] Disable NetworkPolicy editing for Editor role

### DIFF
--- a/modules/140-user-authz/templates/cluster-roles.yaml
+++ b/modules/140-user-authz/templates/cluster-roles.yaml
@@ -106,9 +106,14 @@
   - networking.k8s.io
   resources:
   - ingresses
-  - networkpolicies
   verbs:
   {{- include "user_authz_verbs" $mode }}
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+{{- include "user_authz_verbs" "r" }}
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -258,6 +263,12 @@
   - deckhouse.io
   resources:
   - clusterauthorizationrules
+  verbs:
+{{- include "user_authz_verbs" "rw" }}
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
   verbs:
 {{- include "user_authz_verbs" "rw" }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disabled NetworkPolicy editing for Editors.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Editor can't edit native NetworkPolicy. This is important for security reasons. All egress traffic have to be denied by default. And only cluster admin decides where application can route egress traffic outside of namespace.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Only ClusterAdmins can edit NetworkPolicy.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: Disabled NetworkPolicy editing for Editors.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
