### PR TITLE
[log-shipper] fix typo for buffer settings

### DIFF
--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
@@ -45,6 +45,11 @@
       "healthcheck": {
         "enabled": false
       },
+      "buffer": {
+        "max_size": 268435488,
+        "type": "disk",
+        "when_full": "block"
+      },
       "encoding": {
         "only_fields": [
           "message"
@@ -69,12 +74,7 @@
         "stream": "{{ stream }}"
       },
       "remove_label_fields": true,
-      "out_of_order_action": "rewrite_timestamp",
-      "buffer": {
-        "type": "disk",
-        "max_bytes": 268435488,
-        "when_full": "block"
-      }
+      "out_of_order_action": "rewrite_timestamp"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_2.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_2.json
@@ -45,6 +45,11 @@
       "healthcheck": {
         "enabled": false
       },
+      "buffer": {
+        "max_size": 268435488,
+        "type": "disk",
+        "when_full": "block"
+      },
       "address": "192.168.0.1:9000",
       "encoding": {
         "codec": "json",
@@ -61,11 +66,6 @@
       },
       "keepalive": {
         "time_secs": 7200
-      },
-      "buffer": {
-        "type": "disk",
-        "max_bytes": 268435488,
-        "when_full": "block"
       }
     }
   }

--- a/modules/460-log-shipper/hooks/internal/vector/destination/common.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/common.go
@@ -70,7 +70,7 @@ type CommonTLS struct {
 }
 
 type Buffer struct {
-	MaxBytes  uint32 `json:"max_bytes,omitempty"`
+	MaxSize   uint32 `json:"max_size,omitempty"`
 	Type      string `json:"type,omitempty"`
 	MaxEvents uint32 `json:"max_events,omitempty"`
 	WhenFull  string `json:"when_full,omitempty"`
@@ -104,7 +104,7 @@ func buildVectorBufferNotNil(buffer *v1alpha1.Buffer) *Buffer {
 		}
 		return &Buffer{
 			Type:     toVectorValue(v1alpha1.BufferTypeDisk),
-			MaxBytes: maxBytes,
+			MaxSize:  maxBytes,
 			WhenFull: toVectorValue(buffer.WhenFull),
 		}
 	case v1alpha1.BufferTypeMemory:

--- a/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
@@ -193,6 +193,11 @@
       "healthcheck": {
         "enabled": false
       },
+      "buffer": {
+        "max_size": 270532608,
+        "type": "disk",
+        "when_full": "block"
+      },
       "endpoint": "http://192.168.1.1:9200",
       "encoding": {
         "timestamp_format": "rfc3339"
@@ -219,12 +224,7 @@
         "index": "logs-%F"
       },
       "mode": "bulk",
-      "suppress_type_name": true,
-      "buffer": {
-        "type": "disk",
-        "max_bytes": 270532608,
-        "when_full": "block"
-      }
+      "suppress_type_name": true
     },
     "destination/cluster/test-logstash-dest": {
       "type": "socket",
@@ -233,6 +233,11 @@
       ],
       "healthcheck": {
         "enabled": false
+      },
+      "buffer": {
+        "max_size": 536870912,
+        "type": "disk",
+        "when_full": "drop_newest"
       },
       "address": "192.168.199.252:9009",
       "encoding": {
@@ -250,11 +255,6 @@
       },
       "keepalive": {
         "time_secs": 7200
-      },
-      "buffer": {
-        "type": "disk",
-        "max_bytes": 536870912,
-        "when_full": "drop_newest"
       }
     },
     "destination/cluster/test-loki-dest": {
@@ -264,6 +264,11 @@
       ],
       "healthcheck": {
         "enabled": false
+      },
+      "buffer": {
+        "type": "memory",
+        "max_events": 4096,
+        "when_full": "drop_newest"
       },
       "encoding": {
         "only_fields": [
@@ -291,12 +296,7 @@
         "stream": "{{ stream }}"
       },
       "remove_label_fields": true,
-      "out_of_order_action": "rewrite_timestamp",
-      "buffer": {
-        "type": "memory",
-        "max_events": 4096,
-        "when_full": "drop_newest"
-      }
+      "out_of_order_action": "rewrite_timestamp"
     }
   }
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix typo from #4095 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: chore
summary: fix buffer settings typo
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
