### PR TITLE
[cni-cilium] unprivileged mode

### DIFF
--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -30,9 +30,6 @@ spec:
       annotations:
         configmap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        # Set app AppArmor's profile to "unconfined". The value of this annotation
-        # can be modified as long users know which profiles they have available
-        # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
         container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
@@ -132,9 +129,6 @@ spec:
           privileged: false
           seLinuxOptions:
             level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
             type: 'spc_t'
           capabilities:
             add:
@@ -274,9 +268,6 @@ spec:
           privileged: false
           seLinuxOptions:
             level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
             type: 'spc_t'
           capabilities:
             drop:
@@ -320,9 +311,6 @@ spec:
           privileged: false
           seLinuxOptions:
             level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
             type: 'spc_t'
           capabilities:
             # Most of the capabilities here are the same ones used in the

--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -163,12 +163,6 @@ spec:
               #- BPF
               # Allow discretionary access control (e.g. required for package installation)
               - DAC_OVERRIDE
-              # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
-              - FOWNER
-              # Allow to execute program that changes GID (e.g. required for package installation)
-              - SETGID
-              # Allow to execute program that changes UID (e.g. required for package installation)
-              - SETUID
             drop:
               - ALL
           {{- end }}

--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -30,6 +30,12 @@ spec:
       annotations:
         configmap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        # Set app AppArmor's profile to "unconfined". The value of this annotation
+        # can be modified as long users know which profiles they have available
+        # in AppArmor.
+        container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
       labels:
         app: agent
         module: cni-cilium
@@ -119,11 +125,68 @@ spec:
           hostPort: 9092
           protocol: TCP
         securityContext:
+          # Remove this condition when virtCilium is ready to work in unprivileged mode
+          {{- if has "virtualization" .Values.global.enabledModules }}
           privileged: true
+          {{- else }}
+          privileged: false
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            add:
+              # Use to set socket permission
+              - CHOWN
+              # Used to terminate envoy child process
+              - KILL
+              # Used since cilium modifies routing tables, etc...
+              - NET_ADMIN
+              # Used since cilium creates raw sockets, etc...
+              - NET_RAW
+              # Used since cilium monitor uses mmap
+              - IPC_LOCK
+              # Used in iptables. Consider removing once we are iptables-free
+              - SYS_MODULE
+              # We need it for now but might not need it for >= 5.11 specially
+              # for the 'SYS_RESOURCE'.
+              # In >= 5.8 there's already BPF and PERMON capabilities
+              - SYS_ADMIN
+              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+              - SYS_RESOURCE
+              # Both PERFMON and BPF requires kernel 5.8, container runtime
+              # cri-o >= v1.22.0 or containerd >= v1.5.0.
+              # If available, SYS_ADMIN can be removed.
+              #- PERFMON
+              #- BPF
+              # Allow discretionary access control (e.g. required for package installation)
+              - DAC_OVERRIDE
+              # Allow to set Access Control Lists (ACLs) on arbitrary files (e.g. required for package installation)
+              - FOWNER
+              # Allow to execute program that changes GID (e.g. required for package installation)
+              - SETGID
+              # Allow to execute program that changes UID (e.g. required for package installation)
+              - SETUID
+            drop:
+              - ALL
+          {{- end }}
         volumeMounts:
+        # Remove this condition when virtCilium is ready to work in unprivileged mode
+        {{- if has "virtualization" .Values.global.enabledModules }}
         - name: bpf-maps
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
+        {{- else }}
+        - mountPath: /sys/fs/bpf
+          mountPropagation: HostToContainer
+          name: bpf-maps
+        - mountPath: /host/proc/sys/net
+          name: host-proc-sys-net
+        - mountPath: /host/proc/sys/kernel
+          name: host-proc-sys-kernel
+        {{- end }}
         - name: cilium-cgroup
           mountPath: "/run/cilium/cgroupv2"
         - name: cilium-run
@@ -210,7 +273,27 @@ spec:
         - name: cni-path
           mountPath: /hostbin
         securityContext:
+          # Remove this condition when virtCilium is ready to work in unprivileged mode
+          {{- if has "virtualization" .Values.global.enabledModules }}
           privileged: true
+          {{- else }}
+          privileged: false
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            drop:
+              - ALL
+            add:
+              # Only used for 'mount' cgroup
+              - SYS_ADMIN
+              # Used for nsenter
+              - SYS_CHROOT
+              - SYS_PTRACE
+          {{- end }}
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
@@ -236,7 +319,41 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "6445"
         securityContext:
+          # Remove this condition when virtCilium is ready to work in unprivileged mode
+          {{- if has "virtualization" .Values.global.enabledModules }}
           privileged: true
+          {{- else }}
+          privileged: false
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            # Most of the capabilities here are the same ones used in the
+            # cilium-agent's container because this container can be used to
+            # uninstall all Cilium resources, and therefore it is likely that
+            # will need the same capabilities.
+            add:
+              # Used since cilium modifies routing tables, etc...
+              - NET_ADMIN
+              # Used in iptables. Consider removing once we are iptables-free
+              - SYS_MODULE
+              # We need it for now but might not need it for >= 5.11 specially
+              # for the 'SYS_RESOURCE'.
+              # In >= 5.8 there's already BPF and PERMON capabilities
+              - SYS_ADMIN
+              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+              - SYS_RESOURCE
+              # Both PERFMON and BPF requires kernel 5.8, container runtime
+              # cri-o >= v1.22.0 or containerd >= v1.5.0.
+              # If available, SYS_ADMIN can be removed.
+              #- PERFMON
+              #- BPF
+            drop:
+              - ALL
+          {{- end }}
         volumeMounts:
         - name: bpf-maps
           mountPath: /sys/fs/bpf
@@ -252,6 +369,17 @@ spec:
       serviceAccountName: agent
       terminationGracePeriodSeconds: 1
       volumes:
+      # Remove this condition when virtCilium is ready to work in unprivileged mode
+      {{- if not (has "virtualization" .Values.global.enabledModules) }}
+      - name: host-proc-sys-net
+        hostPath:
+          type: Directory
+          path: /proc/sys/net
+      - name: host-proc-sys-kernel
+        hostPath:
+          type: Directory
+          path: /proc/sys/kernel
+      {{- end }}
       - name: cilium-run
         hostPath:
           path: "/var/run/cilium"

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -128,3 +128,9 @@ data:
   # disabled since they may generate absurd amount of requests in count and size
   # we've found no use for status field of CNP and CCNP
   disable-cnp-status-updates: "true"
+
+
+  # Remove this condition when virtCilium is ready to work in unprivileged mode
+{{- if not (has "virtualization" .Values.global.enabledModules) }}
+  procfs: "/host/proc"
+{{- end }}


### PR DESCRIPTION
## Description
Run CNI cilium in a non-privileged environment with the maximum permissions restriction.

## Why do we need it, and what problem does it solve?
Reduce the attack surface
Closes (https://github.com/deckhouse/deckhouse/issues/2961)

## What is the expected result?
The cilium agent runs in an unprivileged environment

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: cni-cilium
type: chore
summary: Run CNI cilium in a non-privileged environment with the maximum permissions restriction.
impact: All cilium pods will be restarted
impact_level: default
```