### PR TITLE
[node-manager] Disable `instances`, `desired`, `min` and `max` status fields for static nodes

### DIFF
--- a/modules/040-node-manager/hooks/chaos_monkey.go
+++ b/modules/040-node-manager/hooks/chaos_monkey.go
@@ -222,7 +222,7 @@ func chaosFilterNodeGroup(obj *unstructured.Unstructured) (go_hook.FilterResult,
 
 	isReadyForChaos := false
 	if ng.Spec.NodeType == ngv1.NodeTypeCloudEphemeral {
-		if ng.Status.Desired > 1 && ng.Status.Desired == ng.Status.Ready {
+		if ng.Status.Desired != nil && *ng.Status.Desired > 1 && *ng.Status.Desired == ng.Status.Ready {
 			isReadyForChaos = true
 		}
 	} else {

--- a/modules/040-node-manager/hooks/internal/v1/nodegroup.go
+++ b/modules/040-node-manager/hooks/internal/v1/nodegroup.go
@@ -348,19 +348,19 @@ type NodeGroupStatus struct {
 	Instances int32 `json:"instances,omitempty"`
 
 	// Number of desired machines in the group.
-	Desired int32 `json:"desired,omitempty"`
+	Desired *int32 `json:"desired"`
 
 	// Minimal amount of instances in the group.
-	Min int32 `json:"min,omitempty"`
+	Min *int32 `json:"min"`
 
 	// Maximum amount of instances in the group.
-	Max int32 `json:"max,omitempty"`
+	Max *int32 `json:"max"`
+
+	// Number of overprovisioned instances in the group.
+	Standby *int32 `json:"standby"`
 
 	// Number of up-to-date nodes in the group.
 	UpToDate int32 `json:"upToDate,omitempty"`
-
-	// Number of overprovisioned instances in the group.
-	Standby int32 `json:"standby,omitempty"`
 
 	// Error message about possible problems with the group handling.
 	Error string `json:"error,omitempty"`

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -202,8 +202,13 @@ func (ar *updateApprover) approveUpdates(input *go_hook.HookInput) error {
 
 		approvedNodeNames := make(map[string]struct{}, countToApprove)
 
+		// This is because when Status.Desired was a value (not a pointer) - it would be the value "0"
+		// refer to test `Modules :: nodeManager :: hooks :: update_approval :: approve_updates ->  [It] Works as expected `
+		if ng.Status.Desired == nil {
+			ng.Status.Desired = pointer.Int32(0)
+		}
 		//     Allow one node, if 100% nodes in NodeGroup are ready
-		if ng.Status.Desired == ng.Status.Ready || ng.NodeType != ngv1.NodeTypeCloudEphemeral {
+		if *ng.Status.Desired == ng.Status.Ready || ng.NodeType != ngv1.NodeTypeCloudEphemeral {
 			var allReady = true
 			for _, ngn := range nodeGroupNodes {
 				if !ngn.IsReady {

--- a/modules/040-node-manager/hooks/update_node_group_status.go
+++ b/modules/040-node-manager/hooks/update_node_group_status.go
@@ -390,9 +390,8 @@ func handleUpdateNGStatus(input *go_hook.HookInput) error {
 		newConditions := conditions.CalculateNodeGroupConditions(ngForConditions, nodesForCalcConditions, nodeGroup.Conditions, errors)
 
 		patch := buildUpdateStatusPatch(
-			nodesNum, readyNodesNum, uptodateNodesCount,
-			minPerZone, maxPerZone,
-			desiredMax, instancesCount,
+			nodesNum, readyNodesNum, uptodateNodesCount, instancesCount,
+			pointer.Int32(minPerZone), pointer.Int32(maxPerZone), pointer.Int32(desiredMax),
 			nodeGroup.NodeType, statusMsg,
 			lastMachineFailures, newConditions,
 		)

--- a/modules/040-node-manager/hooks/util.go
+++ b/modules/040-node-manager/hooks/util.go
@@ -111,7 +111,8 @@ func conditionsToPatch(conditions []ngv1.NodeGroupCondition) []map[string]interf
 }
 
 func buildUpdateStatusPatch(
-	nodesNum, readyNodesNum, uptodateNodesCount, minPerZone, maxPerZone, desiredMax, instancesNum int32,
+	nodesNum, readyNodesNum, uptodateNodesCount, instancesNum int32,
+	minPerZone, maxPerZone, desiredMax *int32,
 	nodeType ngv1.NodeType, statusMsg string,
 	lastMachineFailures []*v1alpha1.MachineSummary,
 	newConditions []ngv1.NodeGroupCondition,


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
