### PR TITLE
[bashible-api-server] Prevent changing bashible checksum if scale/downscale nodegroup

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/go.mod
+++ b/modules/040-node-manager/images/bashible-apiserver/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/flant/kube-client v0.0.6
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-openapi/spec v0.20.2
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1

--- a/modules/040-node-manager/images/bashible-apiserver/go.sum
+++ b/modules/040-node-manager/images/bashible-apiserver/go.sum
@@ -376,6 +376,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -455,6 +455,7 @@ func (bc *bashibleContext) AddToChecksum(checksumCollector hash.Hash) error {
 			delete(cloudInstances, "maxSurgePerZone")
 			delete(cloudInstances, "maxUnavailablePerZone")
 			delete(cloudInstances, "minPerZone")
+			delete(cloudInstances, "zones")
 		}
 	}
 

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -235,8 +235,6 @@ func (cb *ContextBuilder) generateBashibleChecksum(checksumCollector hash.Hash, 
 		return errors.Wrap(err, "marshal bashibleContext failed")
 	}
 
-	checksumCollector.Write(bcData)
-
 	var res map[string]interface{}
 
 	err = yaml.Unmarshal(bcData, &res)

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder_test.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestBashibleChecksum(t *testing.T) {
+	hash := func(t *testing.T, bc *bashibleContext) string {
+		h := sha256.New()
+
+		bcDataExpected, err := yaml.Marshal(bc)
+		if err != nil {
+			t.Fatal("cannot marshal bashible context")
+		}
+
+		err = bc.AddToChecksum(h)
+		if err != nil {
+			t.Fatalf("Add to checksum error: %v", err)
+		}
+
+		bcDataAfter, err := yaml.Marshal(bc)
+		if err != nil {
+			t.Fatal("cannot marshal bashible context")
+		}
+
+		if string(bcDataExpected) != string(bcDataAfter) {
+			t.Fatal("AddToChecksum should not change object")
+		}
+
+		return fmt.Sprintf("%x", h.Sum(nil))
+	}
+
+	clusterMasterAddresses := []string{
+		"10.0.0.1",
+	}
+
+	const ngYaml = `
+cloudInstances:
+  classReference:
+    kind: OpenStackInstanceClass
+    name: pico
+  maxPerZone: 0
+  maxSurgePerZone: 0
+  maxUnavailablePerZone: 0
+  minPerZone: 0
+  zones:
+  - nova
+cri:
+  type: Docker
+disruptions:
+  approvalMode: Manual
+instanceClass:
+  flavorName: nm1.small
+  imageName: ubuntu-18-04-cloud-amd64
+  mainNetwork: sandbox
+kubelet:
+  containerLogMaxFiles: 4
+  containerLogMaxSize: 50Mi
+  maxPods: 13
+kubernetesVersion: "1.23"
+manualRolloutID: ""
+name: stage
+nodeTemplate:
+  labels:
+    node-role.aaaaa.io/staging: ""
+nodeType: CloudEphemeral
+updateEpoch: "1680009541"
+`
+	ng := make(map[string]interface{})
+
+	err := yaml.Unmarshal([]byte(ngYaml), &ng)
+	if err != nil {
+		t.Errorf("unmarshal error: %v", err)
+		return
+	}
+
+	bc := bashibleContext{
+		KubernetesVersion: "1.26",
+		Bundle:            "bundle",
+		Normal:            map[string][]string{"apiserverEndpoints": clusterMasterAddresses},
+		NodeGroup:         ng,
+		RunType:           "Normal",
+
+		Images: map[string]map[string]string{
+			"common": {
+				"pause": "c5120536ab49040dbbff34be987469227fd9c241a6fd73da694c13c1-1654517843943",
+			},
+		},
+
+		Registry: &registry{
+			Address: "registry.deckhouse.io",
+			Path:    "/deckhouse/ce",
+		},
+
+		Proxy: map[string]interface{}{
+			"httpProxy": "proxy.example.com:444",
+		},
+	}
+
+	expectedHash := hash(t, &bc)
+
+	t.Run("changing counter in cloudInstances object does not affect checksum", func(t *testing.T) {
+		bc.NodeGroup["cloudInstances"].(map[string]interface{})["maxPerZone"] = 2
+		bc.NodeGroup["cloudInstances"].(map[string]interface{})["maxSurgePerZone"] = 1
+		bc.NodeGroup["cloudInstances"].(map[string]interface{})["maxUnavailablePerZone"] = 1
+		bc.NodeGroup["cloudInstances"].(map[string]interface{})["minPerZone"] = 1
+
+		newHash := hash(t, &bc)
+
+		if expectedHash != newHash {
+			t.Errorf("%s != %s", expectedHash, newHash)
+			return
+		}
+	})
+}

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder_test.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder_test.go
@@ -124,6 +124,7 @@ updateEpoch: "1680009541"
 		bc.NodeGroup["cloudInstances"].(map[string]interface{})["maxSurgePerZone"] = 1
 		bc.NodeGroup["cloudInstances"].(map[string]interface{})["maxUnavailablePerZone"] = 1
 		bc.NodeGroup["cloudInstances"].(map[string]interface{})["minPerZone"] = 1
+		bc.NodeGroup["cloudInstances"].(map[string]interface{})["zones"] = []string{"aaaaaa"}
 
 		newHash := hash(t, &bc)
 


### PR DESCRIPTION
## Description
Prevent changing bashible checksum if scale/downscale nodegroup.

## Why do we need it, and what problem does it solve?
When we scale/downscale node group all nodes in nodegroup start updating.
Need for Deckhouse UI. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Prevent changing bashible checksum if scale/downscale nodegroup.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
