### PR TITLE
feat: command to enable/disable module via ModuleConfig

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -109,6 +109,7 @@ func main() {
 			if err != nil {
 				os.Exit(1)
 			}
+			debug.RegisterModuleEnableRoutes(operator.DebugServer, operator)
 			operator.Start()
 
 			// Init deckhouse-config service with ModuleManager instance.
@@ -131,6 +132,9 @@ func main() {
 	// Add debug commands from shell-operator and addon-operator
 	sh_debug.DefineDebugCommands(kpApp)
 	ad_app.DefineDebugCommands(kpApp)
+
+	// Add debug commands
+	debug.DefineModuleConfigDebugCommands(kpApp)
 
 	// deckhouse-controller helper subcommands
 	helpers.DefineHelperCommands(kpApp)

--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -1,0 +1,81 @@
+package debug
+
+import (
+	"fmt"
+	"net/http"
+
+	addon_operator "github.com/flant/addon-operator/pkg/addon-operator"
+	sh_app "github.com/flant/shell-operator/pkg/app"
+	sh_debug "github.com/flant/shell-operator/pkg/debug"
+	"github.com/go-chi/chi/v5"
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	deckhouse_config "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
+)
+
+func RegisterModuleEnableRoutes(dbgSrv *sh_debug.Server, op *addon_operator.AddonOperator) {
+	dbgSrv.RoutePOST("/module/{name}/{action:(disable|enable)}", func(r *http.Request) (interface{}, error) {
+		modName := chi.URLParam(r, "name")
+		if modName == "" {
+			return nil, fmt.Errorf("'name' parameter is required")
+		}
+
+		action := chi.URLParam(r, "action")
+		switch action {
+		case "enable":
+			err := deckhouse_config.SetModuleConfigEnabledFlag(op.KubeClient, modName, true)
+			if err != nil {
+				return nil, fmt.Errorf("Enable module failed: %v", err)
+			}
+			return "Module enabled", nil
+		case "disable":
+			err := deckhouse_config.SetModuleConfigEnabledFlag(op.KubeClient, modName, true)
+			if err != nil {
+				return nil, fmt.Errorf("Disable module failed: %v", err)
+			}
+			return "Module disabled", nil
+		}
+		return nil, fmt.Errorf("Unknown action '%s' for module '%s'", action, modName)
+	})
+}
+
+func DefineModuleConfigDebugCommands(kpApp *kingpin.Application) {
+	moduleCmd := kpApp.GetCommand("module")
+
+	var moduleName string
+	moduleEnableCmd := moduleCmd.Command("enable", "Enable module via spec.enabled flag in ModuleConfig resource.").
+		Action(func(c *kingpin.ParseContext) error {
+			response, err := ModuleEnable(sh_debug.DefaultClient(), moduleName)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(response))
+			return nil
+		})
+	moduleEnableCmd.Arg("module_name", "").Required().StringVar(&moduleName)
+	// --debug-unix-socket <file>
+	sh_app.DefineDebugUnixSocketFlag(moduleEnableCmd)
+
+	moduleDisableCmd := moduleCmd.Command("disable", "Enable module via spec.enabled flag in ModuleConfig resource.").
+		Action(func(c *kingpin.ParseContext) error {
+			response, err := ModuleDisable(sh_debug.DefaultClient(), moduleName)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(response))
+			return nil
+		})
+	moduleDisableCmd.Arg("module_name", "").Required().StringVar(&moduleName)
+	// --debug-unix-socket <file>
+	sh_app.DefineDebugUnixSocketFlag(moduleEnableCmd)
+}
+
+func ModuleEnable(client *sh_debug.Client, modName string) ([]byte, error) {
+	url := fmt.Sprintf("http://unix/module/%s/enable", modName)
+	return client.Post(url, nil)
+}
+
+func ModuleDisable(client *sh_debug.Client, modName string) ([]byte, error) {
+	url := fmt.Sprintf("http://unix/module/%s/disable", modName)
+	return client.Post(url, nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974
+	github.com/flant/addon-operator v1.1.3-0.20230328123006-e4887ca4cd1b
 	github.com/flant/kube-client v0.25.0
 	github.com/flant/shell-operator v1.1.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
@@ -29,7 +29,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/kyokomi/emoji v2.1.0+incompatible
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/mitchellh/mapstructure v1.4.1
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.2
@@ -62,6 +62,7 @@ require (
 )
 
 require (
+	github.com/go-chi/chi/v5 v5.0.7
 	k8s.io/cli-runtime v0.25.5
 	k8s.io/kubectl v0.25.5
 )
@@ -99,7 +100,6 @@ require (
 	github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a // indirect
 	github.com/flant/logboek v0.3.4 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-chi/chi/v5 v5.0.7 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.0.2 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974 h1:F1r5blw6uMXnE49GCNtqFUPsgpZzYpaK1i9vVLUpM6E=
-github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
+github.com/flant/addon-operator v1.1.3-0.20230328123006-e4887ca4cd1b h1:VztRVob8lN/Ld3PVeuqUdECl3y1AqnCEiimKuddgO9E=
+github.com/flant/addon-operator v1.1.3-0.20230328123006-e4887ca4cd1b/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.25.0 h1:7uwwbvGNl3d7jNk0nHM4VxNbTnhESXLTiv/gQaUb9A0=

--- a/go_lib/deckhouse-config/kube_helpers.go
+++ b/go_lib/deckhouse-config/kube_helpers.go
@@ -18,11 +18,15 @@ package deckhouse_config
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	d8cfg_v1alpha1 "github.com/deckhouse/deckhouse/go_lib/deckhouse-config/v1alpha1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
@@ -98,4 +102,55 @@ func GetAllConfigs(kubeClient k8s.Client) ([]*d8cfg_v1alpha1.ModuleConfig, error
 	}
 
 	return objs, nil
+}
+
+// SetModuleConfigEnabledFlag updates spec.enabled flag or creates a new ModuleConfig with spec.enabled flag.
+func SetModuleConfigEnabledFlag(kubeClient k8s.Client, name string, enabled bool) error {
+	// This should not happen, because DebugServer is started after Kubernetes client initialization, but check it anyway.
+	if kubeClient == nil {
+		return fmt.Errorf("kubernetes client not initialized, try again later")
+	}
+
+	gvr := d8cfg_v1alpha1.GroupVersionResource()
+	unstructuredObj, err := kubeClient.Dynamic().Resource(gvr).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil && !k8errors.IsNotFound(err) {
+		return err
+	}
+
+	if unstructuredObj != nil {
+		err := unstructured.SetNestedField(unstructuredObj.Object, pointer.Bool(enabled), "spec", "enabled")
+		if err != nil {
+			return err
+		}
+		_, err = kubeClient.Dynamic().Resource(gvr).Update(context.TODO(), unstructuredObj, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Create new ModuleConfig if absent.
+	newCfg := &d8cfg_v1alpha1.ModuleConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ModuleConfig",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: d8cfg_v1alpha1.ModuleConfigSpec{
+			Enabled: pointer.Bool(enabled),
+		},
+	}
+
+	obj, err := sdk.ToUnstructured(newCfg)
+	if err != nil {
+		return err
+	}
+
+	_, err = kubeClient.Dynamic().Resource(gvr).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -236,6 +236,7 @@ type releasePredictor struct {
 	skippedPatchesIndexes []int
 }
 
+// nolint: revive
 func NewReleasePredictor(releases []enqueueRelease) *releasePredictor {
 	return &releasePredictor{
 		ts:       time.Now().UTC(),


### PR DESCRIPTION

## Description

Add commands to deckhouse-controller binary:

- `deckhouse-controller module module-name enable`
- `deckhouse-controller module module-name enable`

Commands change `spec.enabled` flag or create new ModuleConfig resource.

Required exposing DebugServer from AddonOperator: https://github.com/flant/addon-operator/pull/369
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

This PR gives users a way to enable/disable module without YAML editing.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Add commands to enable/disable modules without YAML editing
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
