### PR TITLE
[node-manager] Restrict changing `nodeType` for node groups and fix stale status fields

### DIFF
--- a/modules/040-node-manager/hooks/util.go
+++ b/modules/040-node-manager/hooks/util.go
@@ -110,6 +110,14 @@ func conditionsToPatch(conditions []ngv1.NodeGroupCondition) []map[string]interf
 	return res
 }
 
+const (
+	minStatusField                 = "min"
+	maxStatusField                 = "max"
+	desiredStatusField             = "desired"
+	instancesStatusField           = "instances"
+	lastMachineFailuresStatusField = "lastMachineFailures"
+)
+
 func buildUpdateStatusPatch(
 	nodesNum, readyNodesNum, uptodateNodesCount, minPerZone, maxPerZone, desiredMax, instancesNum int32,
 	nodeType ngv1.NodeType, statusMsg string,
@@ -122,19 +130,24 @@ func buildUpdateStatusPatch(
 	}
 
 	patch := map[string]interface{}{
-		"nodes":    nodesNum,
-		"ready":    readyNodesNum,
-		"upToDate": uptodateNodesCount,
+		"nodes":                        nodesNum,
+		"ready":                        readyNodesNum,
+		"upToDate":                     uptodateNodesCount,
+		minStatusField:                 nil,
+		maxStatusField:                 nil,
+		desiredStatusField:             nil,
+		instancesStatusField:           nil,
+		lastMachineFailuresStatusField: nil,
 	}
 	if nodeType == ngv1.NodeTypeCloudEphemeral {
-		patch["min"] = minPerZone
-		patch["max"] = maxPerZone
-		patch["desired"] = desiredMax
-		patch["instances"] = instancesNum
-		patch["lastMachineFailures"] = lastMachineFailures
+		patch[minStatusField] = minPerZone
+		patch[maxStatusField] = maxPerZone
+		patch[desiredStatusField] = desiredMax
+		patch[instancesStatusField] = instancesNum
+		patch[lastMachineFailuresStatusField] = lastMachineFailures
 
 		if len(lastMachineFailures) == 0 {
-			patch["lastMachineFailures"] = make([]interface{}, 0) // to make [] array in json result
+			patch[lastMachineFailuresStatusField] = make([]interface{}, 0) // to make [] array in json result
 		}
 	}
 

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -180,7 +180,7 @@ EOF
     oldNodeType="$(context::jq -r '.review.request.oldObject.spec.nodeType')"
     if [[ "${oldNodeType}" != "${newNodeType}" ]]; then
         cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup"}
+{"allowed":false, "message":".spec.nodeType field is immutable"}
 EOF
         return 0
     fi

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -172,13 +172,18 @@ EOF
     return 0
   fi
 
-  newNodeType="$(context::jq -r '.review.request.object.spec.nodeType')"
-  oldNodeType="$(context::jq -r --arg nt "${newNodeType}" '.review.request.oldObject.spec.nodeType // $nt')"
-  if [[ "${oldNodeType}" != "${newNodeType}" ]]; then
-      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup (from ${oldNodeType} to ${newNodeType})"}
+  # Only update operation checks
+  operationType="$(context::jq -r '.review.request.operation')"
+  if [[ "${operationType}" == "UPDATE" ]]; then
+    # Forbid changing nodeType
+    newNodeType="$(context::jq -r '.review.request.object.spec.nodeType')"
+    oldNodeType="$(context::jq -r '.review.request.oldObject.spec.nodeType')"
+    if [[ "${oldNodeType}" != "${newNodeType}" ]]; then
+        cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup"}
 EOF
-      return 0
+        return 0
+    fi
   fi
 
   cat <<EOF > "$VALIDATING_RESPONSE_PATH"

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -176,7 +176,7 @@ EOF
   newNodeType="$(context::jq -r '.review.request.object.spec.nodeType')"
   if [[ "${oldNodeType}" != "${newNodeType}" ]]; then
       cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup"}
+{"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup (from ${oldNodeType} to ${newNodeType})"}
 EOF
       return 0
   fi

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -172,7 +172,16 @@ EOF
     return 0
   fi
 
-    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+  oldNodeType="$(context::jq -r '.review.request.oldObject.spec.nodeType')"
+  newNodeType="$(context::jq -r '.review.request.object.spec.nodeType')"
+  if [[ "${oldNodeType}" != "${newNodeType}" ]]; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup"}
+EOF
+      return 0
+  fi
+
+  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true}
 EOF
 }

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -172,8 +172,8 @@ EOF
     return 0
   fi
 
-  oldNodeType="$(context::jq -r '.review.request.oldObject.spec.nodeType')"
   newNodeType="$(context::jq -r '.review.request.object.spec.nodeType')"
+  oldNodeType="$(context::jq -r --arg nt "${newNodeType}" '.review.request.oldObject.spec.nodeType // $nt')"
   if [[ "${oldNodeType}" != "${newNodeType}" ]]; then
       cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"it is forbidden to change nodeType for NodeGroup (from ${oldNodeType} to ${newNodeType})"}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Restrict changing `nodeType` for node groups by validating webhook and fix stale status fields
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #4236 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Users can't change `nodeType` in the node group spec and removed stale status fields from static NGs
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: restrict changing nodeType for node groups and remove stale status fields from static node groups
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
