### PR TITLE
[monitoring-custom] Set by default limit 5000

### DIFF
--- a/modules/340-monitoring-custom/docs/README.md
+++ b/modules/340-monitoring-custom/docs/README.md
@@ -41,7 +41,7 @@ To enable the `monitoring-custom` module to collect application metrics, you mus
 
       For example, `prometheus.deckhouse.io/query-param-foo=bar` & `prometheus.deckhouse.io/query-param-bar=zxc` annotations will be converted to the `http://...?foo=bar&bar=zxc` query;
   * `prometheus.deckhouse.io/allow-unready-pod` — enables collecting metrics for Pods in any state (by default, Prometheus scrapes metrics from the Ready Pods only). Note that this option is rarely helpful. For example, it can come in handy if it takes a long time to start your application (e.g., some data are loaded into the database at startup or some caching activity occurs), but valuable metrics are supplied during the startup process, helping to monitor it;
-  * `prometheus.deckhouse.io/sample-limit` — sample limit for a Pod (1000 by default). The default value prevents a situation when the application suddenly starts to supply too many metrics, disrupting the entire monitoring process. This annotation must be attached to the resource with the `prometheus.deckhouse.io/custom-target` label;
+  * `prometheus.deckhouse.io/sample-limit` — sample limit for a Pod (5000 by default). The default value prevents a situation when the application suddenly starts to supply too many metrics, disrupting the entire monitoring process. This annotation must be attached to the resource with the `prometheus.deckhouse.io/custom-target` label;
 
 ### An example: Service
 
@@ -58,7 +58,7 @@ metadata:
     prometheus.deckhouse.io/path: "/my_app/metrics"           # /metrics by default
     prometheus.deckhouse.io/query-param-format: "prometheus"  # '' by default
     prometheus.deckhouse.io/allow-unready-pod: "true"         # by default, NON-ready Pods are ignored
-    prometheus.deckhouse.io/sample-limit: "5000"              # by default, the sample is limited to 1000 metrics for a single Pod
+    prometheus.deckhouse.io/sample-limit: "5000"              # by default, the sample is limited to 5000 metrics for a single Pod
 spec:
   ports:
   - name: my-app
@@ -89,7 +89,7 @@ spec:
         app: my-app
         prometheus.deckhouse.io/custom-target: my-app
       annotations:
-        prometheus.deckhouse.io/sample-limit: "5000"  # by default, the sample is limited to 1000 metrics for a single Pod
+        prometheus.deckhouse.io/sample-limit: "5000"  # by default, the sample is limited to 5000 metrics for a single Pod
     spec:
       containers:
       - name: my-app

--- a/modules/340-monitoring-custom/docs/README_RU.md
+++ b/modules/340-monitoring-custom/docs/README_RU.md
@@ -42,7 +42,7 @@ search: prometheus
 
       Например: `prometheus.deckhouse.io/query-param-foo=bar` и `prometheus.deckhouse.io/query-param-bar=zxc` будут преобразованы в query: `http://...?foo=bar&bar=zxc`
   * `prometheus.deckhouse.io/allow-unready-pod` — разрешает сбор метрик с Pod'ов в любом состоянии (по умолчанию метрики собираются только с Pod'ов в состоянии Ready). Эта опция полезна в очень редких случаях. Например, если ваше приложение запускается очень долго (при старте загружаются данные в базу или прогреваются кеши), но в процессе запуска уже отдаются полезные метрики, которые помогают следить за запуском приложения.
-  * `prometheus.deckhouse.io/sample-limit` — сколько семплов разрешено собирать с Pod'а (по умолчанию 1000). Значение по умолчанию защищает от ситуации, когда приложение внезапно начинает отдавать слишком большое количество метрик, что может нарушить работу всего мониторинга. Эту аннотацию надо вешать на тот же ресурс, на котором висит лейбл  `prometheus.deckhouse.io/custom-target`.
+  * `prometheus.deckhouse.io/sample-limit` — сколько семплов разрешено собирать с Pod'а (по умолчанию 5000). Значение по умолчанию защищает от ситуации, когда приложение внезапно начинает отдавать слишком большое количество метрик, что может нарушить работу всего мониторинга. Эту аннотацию надо вешать на тот же ресурс, на котором висит лейбл  `prometheus.deckhouse.io/custom-target`.
 
 ### Пример: Service
 
@@ -59,7 +59,7 @@ metadata:
     prometheus.deckhouse.io/path: "/my_app/metrics"           # по умолчанию /metrics
     prometheus.deckhouse.io/query-param-format: "prometheus"  # по умолчанию ''
     prometheus.deckhouse.io/allow-unready-pod: "true"         # по умолчанию Pod'ы НЕ в Ready игнорируются
-    prometheus.deckhouse.io/sample-limit: "5000"              # по умолчанию принимается не больше 1000 метрик от одного Pod'а
+    prometheus.deckhouse.io/sample-limit: "5000"              # по умолчанию принимается не больше 5000 метрик от одного Pod'а
 spec:
   ports:
   - name: my-app
@@ -90,7 +90,7 @@ spec:
         app: my-app
         prometheus.deckhouse.io/custom-target: my-app
       annotations:
-        prometheus.deckhouse.io/sample-limit: "5000"  # по умолчанию принимается не больше 1000 метрик от одного Pod'а
+        prometheus.deckhouse.io/sample-limit: "5000"  # по умолчанию принимается не больше 5000 метрик от одного Pod'а
     spec:
       containers:
       - name: my-app

--- a/modules/340-monitoring-custom/templates/pod-monitor.yaml
+++ b/modules/340-monitoring-custom/templates/pod-monitor.yaml
@@ -6,15 +6,15 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
-  sampleLimit: 1000
+  sampleLimit: 5000
   podMetricsEndpoints:
-  # HTTP target with samples limited to 1000
+  # HTTP target with samples limited to 5000
   - relabelings:
     {{- include "keep_targets_for_schema" (list "pod" "http") | nindent 4 }}
     {{- include "endpoint_by_container_port_name" "http" | nindent 4 }}
     {{- include "base_relabeling" "pod" | nindent 4 }}
 
-  # HTTPS target with samples limited to 1000
+  # HTTPS target with samples limited to 5000
   - scheme: https
     {{- include "tls_config" "" | nindent 4 }}
     relabelings:
@@ -23,7 +23,7 @@ spec:
     {{- include "base_relabeling" "pod" | nindent 4 }}
 
     {{- if .Values.monitoringCustom.internal.prometheusScraperIstioMTLSEnabled }}
-  # HTTPS Istio mTLS target with samples limited to 1000
+  # HTTPS Istio mTLS target with samples limited to 5000
   - scheme: https
     {{- include "tls_config" "prometheus-scraper-istio-mtls" | nindent 4 }}
     relabelings:
@@ -31,7 +31,6 @@ spec:
     {{- include "endpoint_by_container_port_name" "http" | nindent 4 }}
     {{- include "base_relabeling" "pod" | nindent 4 }}
     {{- end }}
-
 
   namespaceSelector:
     any: true

--- a/modules/340-monitoring-custom/templates/service-monitor.yaml
+++ b/modules/340-monitoring-custom/templates/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
-  sampleLimit: 1000
+  sampleLimit: 5000
   endpoints:
   # HTTP target with samples limited to 1000
   - relabelings:
@@ -15,7 +15,7 @@ spec:
     {{- include "endpoint_by_service_port_name" "http" | nindent 4 }}
     {{- include "base_relabeling" "service" | nindent 4 }}
 
-  # HTTPS target with samples limited to 1000
+  # HTTPS target with samples limited to 5000
   - scheme: https
     {{- include "tls_config" "" | nindent 4 }}
     relabelings:
@@ -25,7 +25,7 @@ spec:
     {{- include "base_relabeling" "service" | nindent 4 }}
 
     {{- if .Values.monitoringCustom.internal.prometheusScraperIstioMTLSEnabled }}
-  # Istio mTLS target with samples limited to 1000
+  # Istio mTLS target with samples limited to 5000
   - scheme: https
     {{- include "tls_config" "prometheus-scraper-istio-mtls" | nindent 4 }}
     relabelings:


### PR DESCRIPTION
## Description

Set a new default value for services and Pods.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The current value is too low and permanently causes application metrics to be unavailable.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-custom
type:  chore
summary: Set a new default value for services and Pods.
impact_level: default 
```

