### PR TITLE
[docs] add kube-rbac-proxy usage example

### DIFF
--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -132,13 +132,13 @@ spec:
 
 To enable secure access to metrics, we strongly recommend using **kube-rbac-proxy**.
 
-### An example of secure metrics collection from an application located outside a cluster
+### An example of collecting metrics securely from an application outside a cluster
 
-Suppose that there is an external server, which is accessible via the Internet and on which the `node-exporter` is running. By default, it listens on port `9100` and is available on all interfaces. It is necessary to provide access control to the `node-exporter` for the secure collection of metrics. Below is an example of such settings.
+Suppose there is a server exposed to the Internet on which the `node-exporter` is running. By default, the `node-exporter` listens on port `9100` and is available on all interfaces. One needs to ensure access control to the `node-exporter` so that metrics can be collected securely. Below is an example of how you can set this up.
 
 Requirements:
 - There must be network access from the cluster to the `kube-rbac-proxy` service running on the *remote server*.
-- Kubernetes API must be available from the *remote server*.
+- The *remote server* must have access to the Kubernetes API server.
 
 Follow these steps:
 1. Create a new **ServiceAccount** with the following permissions:
@@ -179,11 +179,11 @@ Follow these steps:
      namespace: d8-service-accounts
    ```
 
-2. Generate `kubeconfig` for the created `ServiceAccount` ([example of kubeconfig generation for `ServiceAccount`](https://deckhouse.io/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access)).
+2. Generate a `kubeconfig` file for the created `ServiceAccount` ([refer to the example on how to generate `kubeconfig` for `ServiceAccount`](https://deckhouse.io/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access)).
 
-3. Put the `kubeconfig` on the *remote server*. Later on you will need to specify the `kubeconfig` path to the `kube-rbac-proxy` (the example uses the path `${PWD}/.kube/config`).
+3. Copy the `kubeconfig` file to the *remote server*. You will also have to specify the `kubeconfig` path in the `kube-rbac-proxy` settings (our example uses `${PWD}/.kube/config`).
 
-4. Configure `node-exporter` on the *remote server* to be accessible only on the local interface and listen to `127.0.0.1:9100`.
+4. Configure `node-exporter` on the *remote server* to be accessible only on the local interface (i.e., listening on `127.0.0.1:9100`).
 5. Run `kube-rbac-proxy` on the *remote server*:
 
    ```shell
@@ -191,7 +191,7 @@ Follow these steps:
      --upstream=http://127.0.0.1:9100 --kubeconfig=/config --logtostderr=true --v=10
    ```
 
-6. Check, that port `8443` is accessible from the remote server's external address.
+6. Check that port `8443` is accessible at the remote server's external address.
 
 7. Create `Service` and `Endpoint`, specifying the external address of the *remote server* as `<server_ip_address>`:
 

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -132,6 +132,88 @@ spec:
 
 To enable secure access to metrics, we strongly recommend using **kube-rbac-proxy**.
 
+### An example of secure metrics collection from an application located outside a cluster
+
+Requirement: there must be network access from the cluster to kube-rbac-proxy service running on the remote server, and kubernetes api must be available from the remote server.
+
+Suppose that there is an external server which is accessible via the Internet and on which the **node-exporter** is running. By default, it listens on port 9100 and is available on all interfaces. We need to make the access controllable. We start by preparing some objects on the cluster side.
+We need a new **ServiceAccount** with certain permissions for which we will generate a **kubeconfig**:
+
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-external-endpoint-server-01
+  namespace: d8-service-accounts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-external-endpoint
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-external-endpoint-server-01
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-external-endpoint
+subjects:
+- kind: ServiceAccount
+  name: prometheus-external-endpoint-server-01
+  namespace: d8-service-accounts
+```
+
+How to generate **kubeconfig** for a created **ServiceAccount** can be seen [here](https://deckhouse.io/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access).
+
+Put the resulting **kubeconfig** on the remote machine. Later on we will need to specify **kube-rbac-proxy** path to it.
+
+Now configure **node-exporter** on the remote server to be accessible only on the local interface and listen to **127.0.0.1:9100**, and run **kube-rbac-proxy**.
+
+```bash
+docker run --network host -d -v ${PWD}/.kube/config:/config quay.io/brancz/kube-rbac-proxy:v0.14.0 --secure-listen-address=0.0.0.0:8443 --upstream=http://127.0.0.1:9100 --kubeconfig=/config --logtostderr=true --v=10
+```
+
+Check that port 8443 is accessible from the remote server's external address.
+
+Return to the cluster and create **Service** and **Endpoint**, specifying as **<server_ip_address>** the external address of the remote machine:
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-external-endpoint-server-01
+  labels:
+    prometheus.deckhouse.io/custom-target: prometheus-external-endpoint-server-01
+spec:
+  ports:
+  - name: https-metrics
+    port: 8443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: prometheus-external-endpoint-server-01
+subsets:
+  - addresses:
+    - ip: <server_ip_address>
+    ports:
+    - name: https-metrics
+      port: 8443
+```
+
 ## How do I add Alertmanager?
 
 Create a custom resource `CustomAlertmanager` with type `Internal`.
@@ -186,7 +268,7 @@ metadata:
   name: my-service-alertmanager
 spec:
   external:
-    service: 
+    service:
       namespace: myns
       name: my-alertmanager
       path: /myprefix/

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -141,7 +141,7 @@ Requirements:
 - The *remote server* must have access to the Kubernetes API server.
 
 Follow these steps:
-1. Create a new **ServiceAccount** with the following permissions:
+1. Create a new `ServiceAccount` with the following permissions:
 
    ```yaml
    ---

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -127,89 +127,95 @@ spec:
 
 ## Как обеспечить безопасный доступ к метрикам?
 
-Для обеспечения безопасности настоятельно рекомендуем использовать **kube-rbac-proxy**.
+Для обеспечения безопасности настоятельно рекомендуем использовать `kube-rbac-proxy`.
 
 ### Пример безопасного сбора метрик с приложения, расположенного вне кластера
 
-Требование: из кластера должен быть сетевой доступ до сервиса **kube-rbac-proxy**, запущенного на удалённом сервере, а с удалённого сервера должен быть доступен **kubernetes-api**.
+Предположим, что есть доступный через интернет сервер, на котором работает `node-exporter`. По умолчанию `node-exporter` слушает на порту `9100` и доступен на всех интерфейсах. Необходимо обеспечить контроль доступа к `node-exporter` для безопасного сбора метрик. Ниже приведен пример такой настройки.
 
-Предположим, что есть внешний сервер, который доступен через интернет и на котором работает **node-exporter**. По-умолчанию, он слушает порт 9100 и доступен на всех интерфейсах. Нам нужно сделать так, что бы доступ был контроллируемым. Начнём с подготовки некоторых объектов на стороне кластера.
-Нам нужен новый **ServiceAccount** с определёнными правами, для которого мы сгенерируем **kubeconfig**:
+Требования:
+- Из кластера должен быть доступ до сервиса `kube-rbac-proxy`, запущенного на *удалённом сервере*.
+- От *удалённого сервера* должен быть доступ до API-сервера кластера.
 
-```yaml
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: prometheus-external-endpoint-server-01
-  namespace: d8-service-accounts
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: prometheus-external-endpoint
-rules:
-- apiGroups: ["authentication.k8s.io"]
-  resources:
-  - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
-  resources:
-  - subjectaccessreviews
-  verbs: ["create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: prometheus-external-endpoint-server-01
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: prometheus-external-endpoint
-subjects:
-- kind: ServiceAccount
-  name: prometheus-external-endpoint-server-01
-  namespace: d8-service-accounts
-```
+Выполните следующие шаги:
+1. Создайте `ServiceAccount` с указанными ниже правами:
 
-Как сгенерировать **kubeconfig** для созданного **ServiceAccount** можно посмотреть [тут](https://deckhouse.ru/documentation/v1/modules/140-user-authz/usage.html#%D1%81%D0%BE%D0%B7%D0%B4%D0%B0%D0%BD%D0%B8%D0%B5-serviceaccount-%D0%B4%D0%BB%D1%8F-%D1%81%D0%B5%D1%80%D0%B2%D0%B5%D1%80%D0%B0-%D0%B8-%D0%BF%D1%80%D0%B5%D0%B4%D0%BE%D1%81%D1%82%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B5%D0%BC%D1%83-%D0%B4%D0%BE%D1%81%D1%82%D1%83%D0%BF%D0%B0).
+   ```yaml
+   ---
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: prometheus-external-endpoint-server-01
+     namespace: d8-service-accounts
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: prometheus-external-endpoint
+   rules:
+   - apiGroups: ["authentication.k8s.io"]
+     resources:
+     - tokenreviews
+     verbs: ["create"]
+   - apiGroups: ["authorization.k8s.io"]
+     resources:
+     - subjectaccessreviews
+     verbs: ["create"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: prometheus-external-endpoint-server-01
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: prometheus-external-endpoint
+   subjects:
+   - kind: ServiceAccount
+     name: prometheus-external-endpoint-server-01
+     namespace: d8-service-accounts
+   ```
 
-Положим получившийся **kubeconfig** на удалённую машину. В дальнейшем нам понадобится указать **kube-rbac-proxy** путь к нему.
+2. Сгенерируйте `kubeconfig` для созданного `ServiceAccount` ([пример генерации kubeconfig для `ServiceAccount`](https://deckhouse.ru/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-для-сервера-и-предоставление-ему-доступа)).
 
-Теперь настроим **node-exporter** на удалённом сервере, что бы он был доступен только на локальном интерфейсе и слушал **127.0.0.1:9100**, а так же, запустим **kube-rbac-proxy**.
+3. Положите получившийся `kubeconfig` на *удалённый сервер*. В дальнейшем понадобится указать путь к этому `kubeconfig` в настройках `kube-rbac-proxy` (в примере используется путь `${PWD}/.kube/config`).
 
-```bash
-docker run --network host -d -v ${PWD}/.kube/config:/config quay.io/brancz/kube-rbac-proxy:v0.14.0 --secure-listen-address=0.0.0.0:8443 --upstream=http://127.0.0.1:9100 --kubeconfig=/config --logtostderr=true --v=10
-```
+4. Настройте `node-exporter` на *удалённом сервере*, чтобы он был доступен только на локальном интерфейсе (слушал `127.0.0.1:9100`).
+5. Запустите `kube-rbac-proxy` на *удалённом сервере*:
 
-Проверьте, что порт 8443 доступен по внешнему адресу удалённого сервера.
+   ```shell
+   docker run --network host -d -v ${PWD}/.kube/config:/config quay.io/brancz/kube-rbac-proxy:v0.14.0 --secure-listen-address=0.0.0.0:8443 \
+     --upstream=http://127.0.0.1:9100 --kubeconfig=/config --logtostderr=true --v=10
+   ```
 
-Возвращаемся в кластер и создаём **Service** и **Endpoint**, указав в качестве **<server_ip_address>** внешний адрес удалённой машины:
+6. Проверьте, что порт `8443` доступен по внешнему адресу удалённого сервера.
 
-```yaml
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-external-endpoint-server-01
-  labels:
-    prometheus.deckhouse.io/custom-target: prometheus-external-endpoint-server-01
-spec:
-  ports:
-  - name: https-metrics
-    port: 8443
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: prometheus-external-endpoint-server-01
-subsets:
-  - addresses:
-    - ip: <server_ip_address>
-    ports:
-    - name: https-metrics
-      port: 8443
-```
+7. Создайте в кластере `Service` и `Endpoint`, указав в качестве `<server_ip_address>` внешний адрес *удалённого сервера*:
+
+   ```yaml
+   ---
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: prometheus-external-endpoint-server-01
+     labels:
+       prometheus.deckhouse.io/custom-target: prometheus-external-endpoint-server-01
+   spec:
+     ports:
+     - name: https-metrics
+       port: 8443
+   ---
+   apiVersion: v1
+   kind: Endpoints
+   metadata:
+     name: prometheus-external-endpoint-server-01
+   subsets:
+     - addresses:
+       - ip: <server_ip_address>
+       ports:
+       - name: https-metrics
+         port: 8443
+   ```
 
 ## Как добавить Alertmanager?
 


### PR DESCRIPTION
## Description
Add kube-rbac-proxy usage example

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add `kube-rbac-proxy` usage example.
impact_level: low
```
