### PR TITLE
[user-authz] Fix misleading enum

### DIFF
--- a/modules/140-user-authz/crds/crd.yaml
+++ b/modules/140-user-authz/crds/crd.yaml
@@ -145,7 +145,7 @@ spec:
                       kind:
                         type: string
                         description: 'Kind of the role.'
-                        enum: [ClusterRole, Role]
+                        enum: [ClusterRole]
                         example: 'ClusterRole'
                       name:
                         type: string

--- a/modules/140-user-authz/openapi/values.yaml
+++ b/modules/140-user-authz/openapi/values.yaml
@@ -117,7 +117,7 @@ properties:
                         minLength: 1
                       kind:
                         type: string
-                        enum: [ClusterRole, Role]
+                        enum: [ClusterRole]
                       name:
                         type: string
                         minLength: 1


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Fixing the doc.

## Why do we need it, and what problem does it solve?

No Roles can be used in `ClusterAuthorizationRule#spec.additionalRoles`, only ClusterRoles

## What is the expected result?

The doc renders correctly


## Changelog entries

```changes
section: user-authz
type: fix
summary: 'Removed possible value Role in `ClusterAuthorizationRule#spec.additionalRoles`'
impact_level: low
```
