### PR TITLE
[admission-policy-engine] Fix requiredLabels operation policy

### DIFF
--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
@@ -62,6 +62,12 @@ spec:
         - memory
     disallowedImageTags:
       - latest
+    requiredLabels:
+      labels:
+      - allowedRegex: ^P\d{4}$
+        key: product-id
+      watchKinds:
+      - /Namespace
     requiredProbes:
       - livenessProbe
       - readinessProbe

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -44,7 +44,7 @@ type OperationPolicySpec struct {
 		} `json:"requiredResources,omitempty"`
 		DisallowedImageTags []string `json:"disallowedImageTags,omitempty"`
 		RequiredProbes      []string `json:"requiredProbes,omitempty"`
-		RequiredLabels      []struct {
+		RequiredLabels      struct {
 			Labels []struct {
 				Key          string `json:"key,omitempty"`
 				AllowedRegex string `json:"allowedRegex,omitempty"`

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"requiredLabels": {
 				"labels": [
 					{ "key": "foo" },
-					{ "key": "bar", "allowRegex": "^[a-zA-Z]+.agilebank.demo$" }
+					{ "key": "bar", "allowedRegex": "^[a-zA-Z]+.agilebank.demo$" }
 				],
 				"watchKinds": ["/Pod", "networking.k8s.io/Ingress"]
 			},


### PR DESCRIPTION
## Description
Fix struct for `requiredLabels` OperationPolicy

## Why do we need it, and what problem does it solve?
Wrong manual struct generation lead to the error:
```
filterFn: cannot restore slice from map
```

## What is the expected result?
Unmarshal correctly

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Fix `requiredLabels` OperationPolicy
impact: `requiredLabel` unmarshalling lead to an error
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
