### PR TITLE
[prometheus] Update to 2.43.0

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -12,7 +12,7 @@ ansible:
       unarchive:
         extra_opts:
           # The promtool version should match prometheus version from the 300-prometheus module.
-         {{- $promVersion := "2.37.0" }}
+         {{- $promVersion := "2.43.0+stringlabels" }}
           - prometheus-{{ $promVersion }}.linux-amd64/promtool
           - --strip-components=1
         src: https://github.com/prometheus/prometheus/releases/download/v{{ $promVersion }}/prometheus-{{ $promVersion }}.linux-amd64.tar.gz

--- a/modules/300-prometheus/images/prometheus/Dockerfile
+++ b/modules/300-prometheus/images/prometheus/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_NODE_16_ALPINE
 ARG BASE_ALPINE
 
 FROM $BASE_GOLANG_18_BULLSEYE as artifact
-ENV PROMETHEUS_VERSION=v2.37.0
+ENV PROMETHEUS_VERSION=v2.43.0+stringlabels
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - &&  \
   apt install -y nodejs && \

--- a/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
+++ b/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
@@ -1,32 +1,40 @@
 diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
-index 2e55dce78..e84fa50b0 100644
+index 396720c22..faf28654a 100644
 --- a/discovery/kubernetes/pod.go
 +++ b/discovery/kubernetes/pod.go
-@@ -279,6 +279,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+@@ -299,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+ 			// The user has to add a port manually.
+ 			tg.Targets = append(tg.Targets, model.LabelSet{
+ 				model.AddressLabel:     lv(pod.Status.PodIP),
++				"__sample_limit__":     lv(""),
+ 				podContainerNameLabel:  lv(c.Name),
+ 				podContainerIDLabel:    lv(cID),
+ 				podContainerImageLabel: lv(c.Image),
+@@ -313,6 +314,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:            lv(addr),
 +				"__sample_limit__":            lv(""),
  				podContainerNameLabel:         lv(c.Name),
- 				podContainerPortNumberLabel:   lv(ports),
- 				podContainerPortNameLabel:     lv(port.Name),
+ 				podContainerIDLabel:           lv(cID),
+ 				podContainerImageLabel:        lv(c.Image),
 diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
-index 4b3c4de51..6b8ee4772 100644
+index a19f06e7d..f19f6e3bb 100644
 --- a/discovery/kubernetes/service.go
 +++ b/discovery/kubernetes/service.go
-@@ -188,6 +188,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
+@@ -193,6 +193,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 
  		labelSet := model.LabelSet{
  			model.AddressLabel:       lv(addr),
 +			"__sample_limit__":       lv(""),
  			servicePortNameLabel:     lv(port.Name),
+ 			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
  			servicePortProtocolLabel: lv(string(port.Protocol)),
- 			serviceType:              lv(string(svc.Spec.Type)),
 diff --git a/scrape/scrape.go b/scrape/scrape.go
-index 9304baecd..3e59cc738 100644
+index f38527ff3..e8a14a2a0 100644
 --- a/scrape/scrape.go
 +++ b/scrape/scrape.go
-@@ -297,6 +297,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
+@@ -305,6 +305,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
  		}
  		opts.target.SetMetadataStore(cache)
 
@@ -38,7 +46,7 @@ index 9304baecd..3e59cc738 100644
  		return newScrapeLoop(
  			ctx,
  			opts.scraper,
-@@ -310,7 +315,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
+@@ -318,7 +323,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
  			cache,
  			jitterSeed,
  			opts.honorTimestamps,
@@ -48,7 +56,7 @@ index 9304baecd..3e59cc738 100644
  			opts.interval,
  			opts.timeout,
 diff --git a/scrape/target.go b/scrape/target.go
-index e017a4584..f3f7352ec 100644
+index f250910c1..1c505d0a4 100644
 --- a/scrape/target.go
 +++ b/scrape/target.go
 @@ -18,6 +18,7 @@ import (
@@ -59,7 +67,7 @@ index e017a4584..f3f7352ec 100644
  	"strings"
  	"sync"
  	"time"
-@@ -492,3 +493,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
+@@ -517,3 +518,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
  	}
  	return targets, failures
  }

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -52,7 +52,7 @@ spec:
   retention: {{ .Values.prometheus.longtermRetentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusLongterm.retentionGigabytes }}GB
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.36.2
+  version: v2.43.0
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -51,7 +51,7 @@ spec:
   retention: {{ .Values.prometheus.retentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusMain.retentionGigabytes }}GB
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.36.2
+  version: v2.43.0
   enableRemoteWriteReceiver: true
   enableFeatures:
   - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/


### PR DESCRIPTION
## Description
Bump Prometheus

## Why do we need it, and what problem does it solve?
Better performance, less bugs.

## What is the expected result?

Prometheus will be restarted.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: promtheus
type: fix
summary: Update Prometheus to 2.43.0 (bug and security fixes, performance improvements)
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
