### PR TITLE
[log-shipper] Add vector backoff patch

### DIFF
--- a/modules/460-log-shipper/images/vector/Dockerfile
+++ b/modules/460-log-shipper/images/vector/Dockerfile
@@ -21,10 +21,11 @@ RUN apt-get update \
     && make install
 
 WORKDIR /vector
-COPY patches/match-speedup.patch /
+COPY patches/match-speedup.patch patches/kubernetes-backoff.patch /
 RUN git clone --depth 1 --branch v0.28.1 https://github.com/vectordotdev/vector.git \
     && cd vector \
-    && git apply /match-speedup.patch
+    && git apply /match-speedup.patch \
+    && git apply /kubernetes-backoff.patch
 
 # Download and cache dependencies
 WORKDIR /vector/vector

--- a/modules/460-log-shipper/images/vector/patches/README.md
+++ b/modules/460-log-shipper/images/vector/patches/README.md
@@ -5,3 +5,9 @@
 Precompile match VRL expressions with static regexes.
 
 Upstream PR - https://github.com/vectordotdev/vector/pull/16920
+
+### Kubernetes API backoff
+
+Slow down retries if Kubernetes API is unavailable.
+
+Upstream PR - https://github.com/vectordotdev/vector/pull/17009

--- a/modules/460-log-shipper/images/vector/patches/kubernetes-backoff.patch
+++ b/modules/460-log-shipper/images/vector/patches/kubernetes-backoff.patch
@@ -1,0 +1,43 @@
+diff --git a/src/sources/kubernetes_logs/mod.rs b/src/sources/kubernetes_logs/mod.rs
+index 25868df23035..a9ad17a0484f 100644
+--- a/src/sources/kubernetes_logs/mod.rs
++++ b/src/sources/kubernetes_logs/mod.rs
+@@ -23,7 +23,7 @@ use kube::{
+     config::{self, KubeConfigOptions},
+     runtime::{
+         reflector::{self},
+-        watcher,
++        watcher, WatchStreamExt,
+     },
+     Client, Config as ClientConfig,
+ };
+@@ -639,7 +639,8 @@ impl Source {
+                 label_selector: Some(label_selector),
+                 ..Default::default()
+             },
+-        );
++        )
++        .backoff(watcher::default_backoff());
+         let pod_store_w = reflector::store::Writer::default();
+         let pod_state = pod_store_w.as_reader();
+         let pod_cacher = MetaCache::new();
+@@ -660,7 +661,8 @@ impl Source {
+                 label_selector: Some(namespace_label_selector),
+                 ..Default::default()
+             },
+-        );
++        )
++        .backoff(watcher::default_backoff());
+         let ns_store_w = reflector::store::Writer::default();
+         let ns_state = ns_store_w.as_reader();
+         let ns_cacher = MetaCache::new();
+@@ -681,7 +683,8 @@ impl Source {
+                 field_selector: Some(node_selector),
+                 ..Default::default()
+             },
+-        );
++        )
++        .backoff(watcher::default_backoff());
+         let node_store_w = reflector::store::Writer::default();
+         let node_state = node_store_w.as_reader();
+         let node_cacher = MetaCache::new();


### PR DESCRIPTION
## Description
Add a patch

## Why do we need it, and what problem does it solve?
```
2023-03-29T17:28:32.024522Z  WARN vector::kubernetes::reflector: Watcher Stream received an error. Retrying. error=InitialListFailed(Service(Closed))
2023-03-29T17:28:32.024537Z  WARN vector::kubernetes::reflector: Watcher Stream received an error. Retrying. error=InitialListFailed(Service(Closed))
2023-03-29T17:28:32.024551Z  WARN vector::kubernetes::reflector: Watcher Stream received an error. Retrying. error=InitialListFailed(Service(Closed))
2023-03-29T17:28:32.024569Z  WARN vector::kubernetes::reflector: Watcher Stream received an error. Retrying. error=InitialListFailed(Service(Closed))
```
If there is a problem with API, vector immediately reties to requests.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Make vector retrying request on startup with backoff
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
