### PR TITLE
[upmeter] Fix smoke-mini image generation.

### DIFF
--- a/modules/500-upmeter/hooks/smokemini/reschedule.go
+++ b/modules/500-upmeter/hooks/smokemini/reschedule.go
@@ -209,9 +209,9 @@ func parseBoolSnapshot(rs []go_hook.FilterResult) []bool {
 func getSmokeMiniImage(values *go_hook.PatchableValues) string {
 	var (
 		registry = values.Get("global.modulesImages.registry.base").String()
-		tag      = values.Get("global.modulesImages.digests.upmeter.smokeMini").String()
+		digest   = values.Get("global.modulesImages.digests.upmeter.smokeMini").String()
 	)
-	return registry + ":" + tag
+	return registry + "@" + digest
 }
 
 func getSmokeMiniStorageClass(values *go_hook.PatchableValues, storageClassSnap []go_hook.FilterResult) string {

--- a/modules/500-upmeter/hooks/smokemini/reschedule_test.go
+++ b/modules/500-upmeter/hooks/smokemini/reschedule_test.go
@@ -103,7 +103,7 @@ spec:
                   values:
                   - node-a-1
       containers:
-      - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini:whatever
+      - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini@whatever
         name: smoke-mini
 status:
   collisionCount: 0
@@ -120,7 +120,7 @@ metadata:
 spec:
   nodeName: node-a-1
   containers:
-  - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini:whatever
+  - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini@whatever
     name: smoke-mini
   affinity:
     nodeAffinity:
@@ -190,7 +190,7 @@ spec:
                   values:
                   - node-a-1
       containers:
-      - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini:whatever
+      - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini@whatever
         name: smoke-mini
 status:
   collisionCount: 0
@@ -207,7 +207,7 @@ metadata:
 spec:
   nodeName: node-a-1
   containers:
-  - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini:whatever
+  - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini@whatever
     name: smoke-mini
   affinity:
     nodeAffinity:
@@ -265,7 +265,7 @@ spec:
                   values:
                   - node-a-1
       containers:
-      - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini:whatever
+      - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini@whatever
         name: smoke-mini
 status:
   collisionCount: 0
@@ -282,7 +282,7 @@ metadata:
 spec:
   nodeName: ""
   containers:
-    - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini:whatever
+    - image: registry.deckhouse.io/deckhouse/ce/upmeter/smoke-mini@whatever
       name: smoke-mini
   affinity:
     nodeAffinity:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix smoke-mini image generation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After moving to pull images via sha256 digest there is a problem with smoke-mini image path generation

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Correct image

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: fix
summary: Fix smoke-mini image generation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
