### PR TITLE
[cni-cilium] fix virt cilium params for 1.11

### DIFF
--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -75,7 +75,13 @@ data:
   kube-proxy-replacement: "strict"
   kube-proxy-replacement-healthz-bind-address: "0.0.0.0:10256"
 
+  # remove this condition when virtCilium will be updated to v1.12
+  {{- if has "virtualization" .Values.global.enabledModules }}
+  enable-host-reachable-services: "true"
+  {{- else }}
   bpf-lb-sock: "true"
+  {{- end }}
+
   bpf-lb-sock-hostns-only: "true"
   enable-health-check-nodeport: "true"
   node-port-bind-protection: "true"


### PR DESCRIPTION
## Description
Bring back the `enable-host-reachable-services` parameter from version 1.11 for virtCilium.

## Why do we need it, and what problem does it solve?
virtCilium still based on cilium 1.11

## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: virtualization
type: fix
summary: Bring back the `enable-host-reachable-services` parameter from version 1.11 for virtCilium.
impact: Cilium pods will be restarted.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
