### PR TITLE
[extended-monitoring] fix cronjob listing

### DIFF
--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -217,7 +217,7 @@ class AnnotatedNode(Annotated):
 
 class AnnotatedCronJob(Annotated):
     kind = "CronJob"
-    api = kubernetes.client.BatchV1beta1Api()
+    api = kubernetes.client.BatchV1Api()
 
     @classmethod
     def list(cls, namespace, **kwargs):

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -1,1 +1,1 @@
-kubernetes==20.13.0
+kubernetes==22.6.0


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
In k8s version 1.25 there is no batch/v1beta1 version, so cronjob listing fails in extended monitoring

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Non-working extended-monitoring in k8s 1.25

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Proper working extended monitoring in all supported versions
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix
summary: Fix in extended monitoring module
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
