### PR TITLE
[bashible] fix cleanup flannel used ips on migration from docker to containerd

### DIFF
--- a/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
@@ -50,6 +50,7 @@ if bb-yum-package? docker-ce; then
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
   rm -rf /var/lib/docker/ /var/run/docker.sock
+  rm -f /var/lib/cni/networks/cbr0/*
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "centos" }}

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -50,6 +50,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
   rm -rf /var/lib/docker/ /var/run/docker.sock
+  rm -f /var/lib/cni/networks/cbr0/*
 fi
 
 # set default

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
@@ -51,6 +51,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
   rm -rf /var/lib/docker/ /var/run/docker.sock
+  rm -f /var/lib/cni/networks/cbr0/*
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "ubuntu" }}

--- a/ee/candi/bashible/bundles/alteros/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/alteros/node-group/031_install_containerd.sh.tpl
@@ -39,6 +39,7 @@ if bb-yum-package? docker-ce; then
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
   rm -rf /var/lib/docker/ /var/run/docker.sock
+  rm -f /var/lib/cni/networks/cbr0/*
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "alteros" }}

--- a/ee/candi/bashible/bundles/astra/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/node-group/031_install_containerd.sh.tpl
@@ -39,6 +39,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
   rm -rf /var/lib/docker/ /var/run/docker.sock
+  rm -f /var/lib/cni/networks/cbr0/*
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "astra" }}

--- a/ee/candi/bashible/bundles/redos/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/node-group/031_install_containerd.sh.tpl
@@ -39,6 +39,7 @@ if bb-yum-package? docker-ce; then
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
   rm -rf /var/lib/docker/ /var/run/docker.sock
+  rm -f /var/lib/cni/networks/cbr0/*
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "redos" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove /var/lib/cni/networks/cbr0/* on docker->containerd migration.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Flannel has dir to store used pod ip addresses (/var/lib/cni/networks/cbr0). If node has many pods, after migration to containerd pods are restarted and flannel tries to assign new ip addresses to pods. But almost all of pod ip addresses marked as used, because we cannot clean /var/lib/cni/networks/cbr0 directory on docker->containerd migration.
Pods fail to start with message 
```
Warning  FailedCreatePodSandBox  9m55s (x475 over 117m)  kubelet  (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "27160a7396731fab0b66773efde66e8b570f33d3aeb64967bdc12b0726d40cee": plugin type="flannel" failed (add): failed to delegate add: failed to allocate for range 0: no IP addresses available in range set: 10.111.20.1-10.111.20.254
```
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-flannel
type: fix
summary: fix cleanup flannel used ips on migration from docker to containerd
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
