### PR TITLE
[virtualization] Fix AdmissionReview

### DIFF
--- a/modules/490-virtualization/images/artifact/patches/008-fix-admissionreview.patch
+++ b/modules/490-virtualization/images/artifact/patches/008-fix-admissionreview.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/virt-controller/services/template.go b/pkg/virt-controller/services/template.go
+index e23c9a0b0..601f01778 100644
+--- a/pkg/virt-controller/services/template.go
++++ b/pkg/virt-controller/services/template.go
+@@ -511,6 +511,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
+ 	pod := k8sv1.Pod{
+ 		ObjectMeta: metav1.ObjectMeta{
+ 			GenerateName: "virt-launcher-" + domain + "-",
++			Namespace:    vmi.GetNamespace(),
+ 			Labels:       podLabels(vmi, hostName),
+ 			Annotations:  podAnnotations,
+ 			OwnerReferences: []metav1.OwnerReference{

--- a/modules/490-virtualization/images/artifact/patches/README.md
+++ b/modules/490-virtualization/images/artifact/patches/README.md
@@ -41,3 +41,9 @@ There is a problem when all nodes in cluster have taints, KubeVirt can't run vir
 The provided fix will always run the job in same place where virt-operator runs
 
 - https://github.com/kubevirt/kubevirt/pull/9360
+
+#### `008-fix-admissionreview.patch`
+
+Fixes admission review for creating pods
+
+- https://github.com/kubevirt/kubevirt/pull/9579


### PR DESCRIPTION
## Description

This PR adds patch to fix AdmissionReview for KubeVirt

## Why do we need it, and what problem does it solve?

When VM pods are created they does not pass admission review due to KubeVirt bug.
Thus linstor-scheduler-admission can't assign correct `schedulerName: linstor` for the VM pods

## What is the expected result?

All the VM pods on linstor will have `schedulerName: linstor` specified

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: virtualization
type: fix
summary: Fix AdmissionReview for KubeVirt virtual machines
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
