### PR TITLE
[node-manager] User draining

### DIFF
--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -39,9 +39,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:                         "nodes_for_draining",
-			WaitForSynchronization:       pointer.Bool(false),
-			ExecuteHookOnSynchronization: pointer.Bool(false),
-			ExecuteHookOnEvents:          pointer.Bool(false),
+			WaitForSynchronization:       pointer.Bool(true),
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			ExecuteHookOnEvents:          pointer.Bool(true),
 			ApiVersion:                   "v1",
 			Kind:                         "Node",
 			LabelSelector: &v1.LabelSelector{
@@ -57,12 +57,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 	Settings: &go_hook.HookConfigSettings{
 		ExecutionMinInterval: 30 * time.Second,
-	},
-	Schedule: []go_hook.ScheduleConfig{
-		{
-			Name:    "draining_schedule",
-			Crontab: "* * * * *",
-		},
 	},
 }, dependency.WithExternalDependencies(handleDraining))
 

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -124,14 +124,14 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 	for _, s := range snap {
 		dNode := s.(drainingNode)
 		if !dNode.isDraining() {
-			// if node has drained annotation (`user` source) and .spec.unscheduled == false - remove the annotation
+			// If the node became schedulable, but 'drained' annotation is still on it, remove the obsolete annotation
 			if !dNode.Unschedulable && dNode.DrainedSource == "user" {
 				input.PatchCollector.MergePatch(removeDrainedAnnotation, "v1", "Node", "", dNode.Name)
 			}
 			continue
 		}
 
-		// if node has drained annotation (`user` source) and new draining annotation - remove the 'drained' annotation
+		// If the node is marked for draining while is has been drained, remove the 'drained' annotation
 		if dNode.DrainedSource == "user" {
 			input.PatchCollector.MergePatch(removeDrainedAnnotation, "v1", "Node", "", dNode.Name)
 		}
@@ -176,7 +176,7 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 	return nil
 }
 
-func newDrainAnnotationPatch(source string) map[string]interface{} {
+func newDrainedAnnotationPatch(source string) map[string]interface{} {
 	return map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]interface{}{

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -55,8 +56,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 	},
 	Settings: &go_hook.HookConfigSettings{
-
-	}
+		ExecutionMinInterval: 30 * time.Second,
+	},
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "draining_schedule",

--- a/modules/040-node-manager/hooks/handle_draining_test.go
+++ b/modules/040-node-manager/hooks/handle_draining_test.go
@@ -30,14 +30,13 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Modules :: nodeManager :: hooks :: update_approval_draining ::", func() {
+var _ = Describe("Modules :: nodeManager :: hooks :: update_approval_draining ::", func() {
 	f := HookExecutionConfigInit(`{"nodeManager":{"internal":{}}}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 
 	Context("Empty cluster", func() {
 		BeforeEach(func() {
-			f.KubeStateSet(``)
-			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()
 		})
 
@@ -48,7 +47,7 @@ var _ = FDescribe("Modules :: nodeManager :: hooks :: update_approval_draining :
 
 	Context("Cluster node is draining", func() {
 		BeforeEach(func() {
-			f.KubeStateSet(`
+			st := f.KubeStateSet(`
 ---
 apiVersion: v1
 kind: Node
@@ -68,7 +67,7 @@ metadata:
   annotations:
     update.node.deckhouse.io/draining: "user"
 `)
-			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			f.BindingContexts.Set(st)
 			testMoveNodesToStaticClient(f)
 			f.RunHook()
 		})
@@ -88,7 +87,7 @@ metadata:
 		})
 	})
 
-	FContext("draining_nodes", func() {
+	Context("draining_nodes", func() {
 		var initialState = `
 ---
 apiVersion: deckhouse.io/v1
@@ -129,8 +128,8 @@ data:
 					draining := gDraining
 					unschedulable := gUnschedulable
 					BeforeEach(func() {
-						f.KubeStateSet(initialState + generateStateToTestDrainingNodes(nodeNames, draining, unschedulable))
-						f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+						st := f.KubeStateSet(initialState + generateStateToTestDrainingNodes(nodeNames, draining, unschedulable))
+						f.BindingContexts.Set(st)
 						testMoveNodesToStaticClient(f)
 						f.RunHook()
 					})

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -347,7 +347,7 @@ func (ar *updateApprover) approveDisruptions(input *go_hook.HookInput) error {
 			patch = map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"annotations": map[string]interface{}{
-						"update.node.deckhouse.io/draining": "bashible",
+						drainingAnnotationKey: "bashible",
 					},
 				},
 			}
@@ -406,7 +406,7 @@ func (ar *updateApprover) processUpdatedNodes(input *go_hook.HookInput) error {
 					"update.node.deckhouse.io/waiting-for-approval": nil,
 					"update.node.deckhouse.io/disruption-required":  nil,
 					"update.node.deckhouse.io/disruption-approved":  nil,
-					"update.node.deckhouse.io/drained":              nil,
+					drainedAnnotationKey:                            nil,
 				},
 			},
 		}
@@ -515,7 +515,7 @@ func updateApprovalFilterNode(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if _, ok := node.Annotations["update.node.deckhouse.io/disruption-required"]; ok {
 		isDisruptionRequired = true
 	}
-	if v, ok := node.Annotations["update.node.deckhouse.io/draining"]; ok && v == "bashible" {
+	if v, ok := node.Annotations[drainingAnnotationKey]; ok && v == "bashible" {
 		isDraining = true
 	}
 	if _, ok := node.Annotations["update.node.deckhouse.io/disruption-approved"]; ok {
@@ -529,7 +529,7 @@ func updateApprovalFilterNode(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if !ok {
 		nodeGroup = ""
 	}
-	if v, ok := node.Annotations["update.node.deckhouse.io/drained"]; ok && v == "bashible" {
+	if v, ok := node.Annotations[drainedAnnotationKey]; ok && v == "bashible" {
 		isDrained = true
 	}
 

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -347,7 +347,7 @@ func (ar *updateApprover) approveDisruptions(input *go_hook.HookInput) error {
 			patch = map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"annotations": map[string]interface{}{
-						"update.node.deckhouse.io/draining": "",
+						"update.node.deckhouse.io/draining": "bashible",
 					},
 				},
 			}
@@ -515,7 +515,7 @@ func updateApprovalFilterNode(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if _, ok := node.Annotations["update.node.deckhouse.io/disruption-required"]; ok {
 		isDisruptionRequired = true
 	}
-	if _, ok := node.Annotations["update.node.deckhouse.io/draining"]; ok {
+	if v, ok := node.Annotations["update.node.deckhouse.io/draining"]; ok && v == "bashible" {
 		isDraining = true
 	}
 	if _, ok := node.Annotations["update.node.deckhouse.io/disruption-approved"]; ok {
@@ -529,7 +529,7 @@ func updateApprovalFilterNode(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if !ok {
 		nodeGroup = ""
 	}
-	if _, ok := node.Annotations["update.node.deckhouse.io/drained"]; ok {
+	if v, ok := node.Annotations["update.node.deckhouse.io/drained"]; ok && v == "bashible" {
 		isDrained = true
 	}
 

--- a/modules/040-node-manager/hooks/update_approval_test.go
+++ b/modules/040-node-manager/hooks/update_approval_test.go
@@ -1530,7 +1530,7 @@ metadata:
 
 		if drained {
 			state += `
-    update.node.deckhouse.io/drained: ""
+    update.node.deckhouse.io/drained: "bashible"
 `
 		}
 		state += `

--- a/modules/040-node-manager/hooks/update_approval_test.go
+++ b/modules/040-node-manager/hooks/update_approval_test.go
@@ -1474,7 +1474,7 @@ metadata:
 
 		if draining {
 			state += `
-    update.node.deckhouse.io/draining: ""
+    update.node.deckhouse.io/draining: "bashible"
 `
 		}
 		if unschedulable {

--- a/modules/040-node-manager/hooks/update_node_group_status_test.go
+++ b/modules/040-node-manager/hooks/update_node_group_status_test.go
@@ -1089,9 +1089,9 @@ status:
 				"update.node.deckhouse.io/approved",
 				"update.node.deckhouse.io/waiting-for-approval",
 				"update.node.deckhouse.io/disruption-required",
-				"update.node.deckhouse.io/draining",
+				drainingAnnotationKey,
 				"update.node.deckhouse.io/disruption-approved",
-				"update.node.deckhouse.io/drained",
+				drainedAnnotationKey,
 			}
 
 			for _, a := range annotations {


### PR DESCRIPTION
## Description
Add annotation for user-initiated node drain

## Why do we need it, and what problem does it solve?
We need to separate 2 draining sources:
- bashible
- user

Bashible drain is fully handled by deckhouse, so we don't need any manual operations here.
User drain is initiated via the annotation and then user have to uncordon node manually

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Add annotation `update.node.deckhouse.io/draining=user` for starting node drain process
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
