### PR TITLE
[monitoring] Fix image availability exporter

### DIFF
--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_ALPINE
-ARG BASE_GOLANG_17_ALPINE
+ARG BASE_GOLANG_19_ALPINE
 
 # Based on https://github.com/deckhouse/k8s-image-availability-exporter/blob/master/Dockerfile
-FROM $BASE_GOLANG_17_ALPINE as artifact
+FROM $BASE_GOLANG_19_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
 RUN wget https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.5.0 -O - | tar -xz --strip-components=1 && \

--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.4 -O - | tar -xz --strip-components=1 && \
+RUN wget https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.5.0 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 


### PR DESCRIPTION
## Description
Get a new `image-availability-exporter` docker image with `batchv1/CronJob` support.

Upstream PR: https://github.com/deckhouse/k8s-image-availability-exporter/pull/68

## Why do we need it, and what problem does it solve?
Kubernetes 1.25+ does not support `batch/v1beta1` anymore. So, `image-availability-exporter` is not able to start.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: fix
summary: Fix `image-availability-exporter` for Kubernetes 1.25+.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
