### PR TITLE
[monitoring] Fix rbac rules for image-availability-exporter

### DIFF
--- a/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
@@ -22,9 +22,17 @@ rules:
   - get
 - apiGroups: [""]
   resources:
+    - namespaces
+  verbs:
+    - list
+    - watch
+- apiGroups: [""]
+  resources:
   - serviceaccounts
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - extensions
   - apps


### PR DESCRIPTION
## Description
Fix RBAC ClusterRole for exporter

## Why do we need it, and what problem does it solve?
We have an error:
```
W0410 08:03:53.965246       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: failed to list *v1.ServiceAccount: serviceaccounts is forbidden: User "system:serviceaccount:d8-monitoring:image-availability-exporter" cannot list resource "serviceaccounts" in API group "" at the cluster scope
E0410 08:03:53.965289       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1.ServiceAccount: failed to list *v1.ServiceAccount: serviceaccounts is forbidden: User "system:serviceaccount:d8-monitoring:image-availability-exporter" cannot list resource "serviceaccounts" in API group "" at the cluster scope
W0410 08:04:22.904852       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:d8-monitoring:image-availability-exporter" cannot list resource "namespaces" in API group "" at the cluster scope
E0410 08:04:22.904936       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:d8-monitoring:image-availability-exporter" cannot list resource "namespaces" in API group "" at the cluster scope
```

New image-availability-exporter have to have more wide permissions to act

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: fix 
summary: Fix RBAC rules for image-availability-exporter
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
