### PR TITLE
[extended-monitoring] Migrate from annotation to labels

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -65,6 +65,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/300-prometheus/hooks/https"
 	_ "github.com/deckhouse/deckhouse/modules/301-prometheus-metrics-adapter/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/302-vertical-pod-autoscaler/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/340-extended-monitoring/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/340-monitoring-custom/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/340-monitoring-kubernetes/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/340-monitoring-ping/hooks"

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -395,9 +395,7 @@ func DeckhouseNamespace(name string) *apiv1.Namespace {
 			Name: name,
 			Labels: map[string]string{
 				"heritage": "deckhouse",
-			},
-			Annotations: map[string]string{
-				"extended-monitoring.flant.com/enabled": "",
+				"extended-monitoring.deckhouse.io/enabled": "",
 			},
 		},
 		Spec: apiv1.NamespaceSpec{

--- a/ee/fe/modules/500-basic-auth/templates/namespace.yaml
+++ b/ee/fe/modules/500-basic-auth/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "kube-%s" .Chart.Name)) }}

--- a/ee/modules/030-cloud-provider-openstack/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-openstack
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-openstack") }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-vsphere
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-vsphere") }}

--- a/ee/modules/110-istio/templates/ingress-gateway-controller/namespace.yaml
+++ b/ee/modules/110-istio/templates/ingress-gateway-controller/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-ingress-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-ingress-%s" .Chart.Name)) }}

--- a/ee/modules/110-istio/templates/namespace.yaml
+++ b/ee/modules/110-istio/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/380-metallb/templates/namespace.yaml
+++ b/ee/modules/380-metallb/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/450-keepalived/templates/namespace.yaml
+++ b/ee/modules/450-keepalived/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/450-network-gateway/templates/namespace.yaml
+++ b/ee/modules/450-network-gateway/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/600-flant-integration/templates/namespace.yaml
+++ b/ee/modules/600-flant-integration/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/002-deckhouse/hooks/enable_extended_monitoring_test.go
+++ b/modules/002-deckhouse/hooks/enable_extended_monitoring_test.go
@@ -31,6 +31,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-system
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
 `
 		d8SystemNS = `
 ---
@@ -38,6 +40,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-system
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
 `
 	)
 
@@ -49,18 +53,22 @@ metadata:
 			f.RunHook()
 		})
 
-		It("Annotation should be present on both namespaces", func() {
+		It("Label should be present on both namespaces", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			annotation := f.KubernetesGlobalResource("Namespace", "d8-system").
-				Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`)
-			Expect(annotation.Exists()).To(BeTrue())
-			Expect(annotation.String()).To(Equal(""))
+			label := f.KubernetesGlobalResource("Namespace", "d8-system").
+				Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`)
+			Expect(label.Exists()).To(BeTrue())
+			Expect(label.String()).To(Equal(""))
+			Expect(f.KubernetesGlobalResource("Namespace", "d8-system").
+				Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
 
-			annotation = f.KubernetesGlobalResource("Namespace", "kube-system").
-				Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`)
-			Expect(annotation.Exists()).To(BeTrue())
-			Expect(annotation.String()).To(Equal(""))
+			label = f.KubernetesGlobalResource("Namespace", "kube-system").
+				Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`)
+			Expect(label.Exists()).To(BeTrue())
+			Expect(label.String()).To(Equal(""))
+			Expect(f.KubernetesGlobalResource("Namespace", "kube-system").
+				Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -3,21 +3,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-monitoring
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-service-accounts
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-system") }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-monitoring") }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-service-accounts") }}
-

--- a/modules/021-cni-cilium/templates/namespace.yaml
+++ b/modules/021-cni-cilium/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{ include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{ include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/030-cloud-provider-aws/templates/namespace.yaml
+++ b/modules/030-cloud-provider-aws/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/030-cloud-provider-azure/templates/namespace.yaml
+++ b/modules/030-cloud-provider-azure/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-azure") }}

--- a/modules/030-cloud-provider-gcp/templates/namespace.yaml
+++ b/modules/030-cloud-provider-gcp/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-gcp
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/030-cloud-provider-yandex/templates/namespace.yaml
+++ b/modules/030-cloud-provider-yandex/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-yandex
-  {{- include "helm_lib_module_labels" (list . "prometheus.deckhouse.io/monitor-watcher-enabled" "true") | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/031-local-path-provisioner/templates/namespace.yaml
+++ b/modules/031-local-path-provisioner/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/035-cni-flannel/templates/namespace.yaml
+++ b/modules/035-cni-flannel/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/035-cni-simple-bridge/templates/namespace.yaml
+++ b/modules/035-cni-simple-bridge/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/040-node-manager/templates/namespace.yaml
+++ b/modules/040-node-manager/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-instance-manager
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-instance-manager") }}

--- a/modules/040-node-manager/templates/standby-holder/deployment.yaml
+++ b/modules/040-node-manager/templates/standby-holder/deployment.yaml
@@ -3,11 +3,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    extended-monitoring.flant.com/enabled: "false"
   name: standby-holder-{{ $ng.name }}
   namespace: d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "standby-holder")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "standby-holder" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 spec:
   selector:
     matchLabels:

--- a/modules/041-linstor/templates/namespace.yaml
+++ b/modules/041-linstor/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/045-snapshot-controller/templates/namespace.yaml
+++ b/modules/045-snapshot-controller/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/101-cert-manager/templates/namespace.yaml
+++ b/modules/101-cert-manager/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cert-manager
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list . (dict "cert-manager.io/disable-validation" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "cert-manager.io/disable-validation" "true" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cert-manager") }}

--- a/modules/140-user-authz/templates/namespace.yaml
+++ b/modules/140-user-authz/templates/namespace.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}
 {{- end }}

--- a/modules/150-user-authn/templates/dex/ingress.yaml
+++ b/modules/150-user-authn/templates/dex/ingress.yaml
@@ -39,9 +39,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
     # Send alert only if dex doesn't work at all (resolves issue #204).
     # We use 101% here to switch off warnings because this threshold value is out of the range.
-    threshold.extended-monitoring.flant.com/5xx-warning: "101"
-    threshold.extended-monitoring.flant.com/5xx-critical: "100"
-  {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "dex" "threshold.extended-monitoring.deckhouse.io/5xx-warning" "101" "threshold.extended-monitoring.deckhouse.io/5xx-critical" "100")) | nindent 2 }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}

--- a/modules/150-user-authn/templates/namespace.yaml
+++ b/modules/150-user-authn/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/200-operator-prometheus/templates/namespace.yaml
+++ b/modules/200-operator-prometheus/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-operator-prometheus
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-operator-prometheus") }}

--- a/modules/300-prometheus/templates/grafana/deployment.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment.yaml
@@ -56,12 +56,12 @@ spec:
     metadata:
       labels:
         app: grafana
+        threshold.extended-monitoring.deckhouse.io/container-throttling-warning: "40"
       annotations:
         checksum/datasources: {{ include (print $.Template.BasePath "/grafana/secret-datasources-list.yaml") . | sha256sum }}
         checksum/dashboards-list-custom: {{ include (print $.Template.BasePath "/grafana/cm-dashboards-list-custom.yaml") . | sha256sum }}
         checksum/alerts-channels: {{ include (print $.Template.BasePath "/grafana/grafana-alerts-channels.yaml") . | sha256sum }}
         checksum/kube-rbac-proxy: {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "") | sha256sum }}
-        threshold.extended-monitoring.flant.com/container-throttling-warning: "40"
     spec:
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -130,9 +130,10 @@ spec:
     fsGroup: 2000
   serviceAccountName: prometheus
   podMetadata:
+    labels:
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-warning: "97"
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-critical: "99"
     annotations:
-      threshold.extended-monitoring.flant.com/disk-bytes-warning: "97"
-      threshold.extended-monitoring.flant.com/disk-bytes-critical: "99"
       checksum/kube-rbac-proxy: {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "") | sha256sum }}
   secrets:
   - prometheus-api-client-tls

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -151,9 +151,10 @@ spec:
     matchLabels:
       heritage: deckhouse
   podMetadata:
+    labels:
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-warning: "97"
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-critical: "99"
     annotations:
-      threshold.extended-monitoring.flant.com/disk-bytes-warning: "97"
-      threshold.extended-monitoring.flant.com/disk-bytes-critical: "99"
       checksum/kube-rbac-proxy: {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "") | sha256sum }}
   serviceMonitorSelector:
     matchLabels:

--- a/modules/303-prometheus-pushgateway/templates/namespace.yaml
+++ b/modules/303-prometheus-pushgateway/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-{{ .Chart.Name }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "kube-%s" .Chart.Name)) }}

--- a/modules/340-extended-monitoring/docs/CONFIGURATION.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION.md
@@ -7,26 +7,26 @@ force_searchable: true
 
 ## How to use `extended-monitoring-exporter`
 
-Attach the `extended-monitoring.flant.com/enabled` annotation to the Namespace to enable the export of extended monitoring metrics. You can do it by:
+Attach the `extended-monitoring.deckhouse.io/enabled` label to the Namespace to enable the export of extended monitoring metrics. You can do it by:
 - adding the appropriate helm-chart to the project (recommended method);
 - adding it to `.gitlab-ci.yml` (kubectl patch/create);
-- attaching it manually (`kubectl annotate namespace my-app-production extended-monitoring.flant.com/enabled=""`).
+- attaching it manually (`kubectl label namespace my-app-production extended-monitoring.deckhouse.io/enabled=""`).
 - configuring via [namespace-configurator](/documentation/v1/modules/600-namespace-configurator/) module.
 
-Any of the methods above would result in the emergence of the default metrics (+ any custom metrics with the `threshold.extended-monitoring.flant.com/` prefix) for all supported Kubernetes objects in the target Namespace. Note that monitoring and standard annotations are enabled automatically for a number of [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes objects described below.
+Any of the methods above would result in the emergence of the default metrics (+ any custom metrics with the `threshold.extended-monitoring.deckhouse.io/` prefix) for all supported Kubernetes objects in the target Namespace. Note that monitoring and standard annotations are enabled automatically for a number of [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes objects described below.
 
-You can also add custom annotations with the specified value to `threshold.extended-monitoring.flant.com/something` Kubernetes objects, e.g., `kubectl annotate pod test threshold.extended-monitoring.flant.com/disk-inodes-warning-threshold=30`.
+You can also add custom annotations with the specified value to `threshold.extended-monitoring.deckhouse.io/something` Kubernetes objects, e.g., `kubectl annotate pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning-threshold=30`.
 In this case, the annotation value will replace the default one.
 
-You can disable monitoring on a per-object basis by adding the `extended-monitoring.flant.com/enabled=false` annotation to it. Thus, the default annotations will also be disabled (as well as annotation-based alerts).
+You can disable monitoring on a per-object basis by adding the `extended-monitoring.deckhouse.io/enabled=false` label to it. Thus, the default annotations will also be disabled (as well as annotation-based alerts).
 
 ### Standard annotations and supported Kubernetes objects
 
 Below is the list of annotations used in Prometheus Rules and their default values.
 
 **Caution!** All annotations:
-1. Start with a `threshold.extended-monitoring.flant.com/` prefix;
-2. Have an integer value (except for the `extended-monitoring.flant.com/enabled` Namespace-annotation — its value can be omitted). The specified value defines the alert threshold.
+1. Start with a `threshold.extended-monitoring.deckhouse.io/` prefix;
+2. Have an integer value. The specified value defines the alert threshold.
 
 #### Non-namespaced Kubernetes objects
 
@@ -95,7 +95,7 @@ The threshold implies the number of unavailable replicas **in addition** to [max
 
 ##### CronJob
 
-Note that only the deactivation using the `extended-monitoring.flant.com/enabled=false` annotation is supported.
+Note that only the deactivation using the `extended-monitoring.deckhouse.io/enabled=false` annotation is supported.
 
 ### How does it work?
 

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -7,26 +7,26 @@ force_searchable: true
 
 ## Как использовать `extended-monitoring-exporter`
 
-Чтобы включить экспортирование extended-monitoring метрик, нужно навесить на Namespace аннотацию `extended-monitoring.flant.com/enabled` любым удобным способом, например:
+Чтобы включить экспортирование extended-monitoring метрик, нужно навесить на Namespace лейбл `extended-monitoring.deckhouse.io/enabled` любым удобным способом, например:
 - добавить в проект соответствующий helm-чарт (рекомендуемый)
 - добавить в описание `.gitlab-ci.yml` (kubectl patch/create)
-- поставить руками (`kubectl annotate namespace my-app-production extended-monitoring.flant.com/enabled=""`).
+- поставить руками (`kubectl label namespace my-app-production extended-monitoring.deckhouse.io/enabled=""`).
 - настроить через [namespace-configurator](/documentation/v1/modules/600-namespace-configurator/) модуль.
 
-Сразу же после этого, для всех поддерживаемых Kubernetes объектов в данном Namespace в Prometheus появятся default метрики + любые кастомные с префиксом `threshold.extended-monitoring.flant.com/`. Для ряда [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes объектов, описанных ниже, мониторинг и стандартные аннотации включаются автоматически.
+Сразу же после этого, для всех поддерживаемых Kubernetes объектов в данном Namespace в Prometheus появятся default метрики + любые кастомные с префиксом `threshold.extended-monitoring.deckhouse.io/`. Для ряда [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes объектов, описанных ниже, мониторинг и стандартные аннотации включаются автоматически.
 
-К Kubernetes объектам `threshold.extended-monitoring.flant.com/что-то своё` можно добавить любые другие аннотации с указанным значением. Пример: `kubectl annotate pod test threshold.extended-monitoring.flant.com/disk-inodes-warning-threshold=30`.
+К Kubernetes объектам `threshold.extended-monitoring.deckhouse.io/что-то своё` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl annotate pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning-threshold=30`.
 В таком случае, значение из аннотации заменит значение по умолчанию.
 
-Слежение за объектом можно отключить индивидуально, поставив на него аннотацию `extended-monitoring.flant.com/enabled=false`. Соответственно, отключатся и аннотации по умолчанию, а также все алерты, привязанные к аннотациям.
+Слежение за объектом можно отключить индивидуально, поставив на него лейбл `extended-monitoring.deckhouse.io/enabled=false`. Соответственно, отключатся и аннотации по умолчанию, а также все алерты, привязанные к аннотациям.
 
 ### Стандартные аннотации и поддерживаемые Kubernetes объекты
 
 Далее приведён список используемых в Prometheus Rules аннотаций, а также их стандартные значения.
 
 **Внимание!** Все аннотации:
-1. Начинаются с префикса `threshold.extended-monitoring.flant.com/`;
-2. Имеют целочисленное значение в качестве value, за исключением Namespace-аннотации `extended-monitoring.flant.com/enabled` (в которой value можно опустить). Указанное в value значение устанавливает порог срабатывания алерта.
+1. Начинаются с префикса `threshold.extended-monitoring.deckhouse.io/`;
+2. Имеют целочисленное значение в качестве value. Указанное в value значение устанавливает порог срабатывания алерта.
 
 #### Non-namespaced Kubernetes objects
 
@@ -95,7 +95,7 @@ force_searchable: true
 
 ##### CronJob
 
-Работает только выключение через аннотацию `extended-monitoring.flant.com/enabled=false`.
+Работает только выключение через аннотацию `extended-monitoring.deckhouse.io/enabled=false`.
 
 ### Как работает
 

--- a/modules/340-extended-monitoring/docs/README.md
+++ b/modules/340-extended-monitoring/docs/README.md
@@ -4,7 +4,7 @@ title: "The extended-monitoring module"
 
 Contains the following Prometheus exporters:
 
-- `extended-monitoring-exporter` — implements extended scraping of metrics (free space and inode-related) and [alerts](configuration.html#non-namespaced-kubernetes-objects); also, it enables the "extended monitoring" of objects in the Namespaces with the `extended-monitoring.flant.com/enabled=””` annotation.
+- `extended-monitoring-exporter` — implements extended scraping of metrics (free space and inode-related) and [alerts](configuration.html#non-namespaced-kubernetes-objects); also, it enables the "extended monitoring" of objects in the Namespaces with the `extended-monitoring.deckhouse.io/enabled=””` label.
 - `image-availability-exporter` — adds metrics (and send alerts) for tracking the availability of the container image specified in the `image` field in the Pod's spec in `Deployments`, `StatefulSets`, `DaemonSets`, `CronJobs`.
 - `events-exporter` — collects Kubernetes cluster events end exposes them as metrics.
 - `cert-exporter`— scans Kubernetes Secrets and generates metrics about certificates expiration in them.

--- a/modules/340-extended-monitoring/docs/README_RU.md
+++ b/modules/340-extended-monitoring/docs/README_RU.md
@@ -4,7 +4,7 @@ title: "Модуль extended-monitoring"
 
 Содержит следующие Prometheus exporter'ы:
 
-- `extended-monitoring-exporter` — включает расширенный сбор метрик и отправку [алертов](configuration.html#non-namespaced-kubernetes-objects) по свободному месту и inode на узлах, плюс включает «расширенный мониторинг» объектов в Namespace, у которых есть аннотация `extended-monitoring.flant.com/enabled=””`.
+- `extended-monitoring-exporter` — включает расширенный сбор метрик и отправку [алертов](configuration.html#non-namespaced-kubernetes-objects) по свободному месту и inode на узлах, плюс включает «расширенный мониторинг» объектов в Namespace, у которых есть лейбл `extended-monitoring.deckhouse.io/enabled=””`.
 - `image-availability-exporter` — добавляет метрики и включает отправку алертов, позволяющих узнать о проблемах с доступностью образа контейнера в registry, прописанному в поле `image` из spec Pod’а в `Deployments`, `StatefulSets`, `DaemonSets`, `CronJobs`.
 - `events-exporter` — собирает события в кластере Kubernetes и отдает их в виде метрик.
 - `cert-exporter`— сканирует Secret'ы кластера Kubernetes и генерирует метрики об истечении срока действия сертификатов в них.

--- a/modules/340-extended-monitoring/hooks/alert_old_annotation.go
+++ b/modules/340-extended-monitoring/hooks/alert_old_annotation.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const extendedMonitoringAnnotationKey = "extended-monitoring.flant.com/enabled"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "namespaces",
+			ApiVersion: "v1",
+			Kind:       "Namespace",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+		{
+			Name:       "deployments",
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+		{
+			Name:       "statefulsets",
+			ApiVersion: "apps/v1",
+			Kind:       "StatefulSet",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+		{
+			Name:       "daemonsets",
+			ApiVersion: "apps/v1",
+			Kind:       "DaemonSet",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+		{
+			Name:       "cronjobs",
+			ApiVersion: "batch/v1beta1",
+			Kind:       "CronJob",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+		{
+			Name:       "ingresses",
+			ApiVersion: "networking.k8s.io/v1",
+			Kind:       "Ingress",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+		{
+			Name:       "nodes",
+			ApiVersion: "v1",
+			Kind:       "Node",
+			FilterFunc: applyNameNamespaceFilter,
+		},
+	},
+}, handleLegacyAnnotatedResource)
+
+type ObjectNameNamespaceKind struct {
+	Name      string
+	Namespace string
+	Kind      string
+}
+
+func applyNameNamespaceFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	if _, ok := obj.GetAnnotations()[extendedMonitoringAnnotationKey]; !ok {
+		return nil, nil
+	}
+
+	return &ObjectNameNamespaceKind{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      obj.GetKind(),
+	}, nil
+}
+
+func handleLegacyAnnotatedResource(input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire("d8_deprecated_legacy_annotation")
+
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["nodes"])
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["namespaces"])
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["deployments"])
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["statefulsets"])
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["daemonsets"])
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["cronjobs"])
+	iterateOverSnapshotsAndSetMetric(input.MetricsCollector, input.Snapshots["ingresses"])
+
+	return nil
+}
+
+func iterateOverSnapshotsAndSetMetric(collector go_hook.MetricsCollector, filterResults []go_hook.FilterResult) {
+	for _, obj := range filterResults {
+		if obj == nil {
+			continue
+		}
+
+		objMeta := obj.(*ObjectNameNamespaceKind)
+
+		collector.Set("d8_deprecated_legacy_annotation", 1, map[string]string{"kind": objMeta.Kind, "namespace": objMeta.Namespace, "name": objMeta.Name}, metrics.WithGroup("d8_deprecated_legacy_annotation"))
+	}
+}

--- a/modules/340-extended-monitoring/hooks/alert_old_annotation_test.go
+++ b/modules/340-extended-monitoring/hooks/alert_old_annotation_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/shell-operator/pkg/metric_storage/operation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	state = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: test
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  namespace: default
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test
+  namespace: default
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test
+  namespace: default
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: test
+  namespace: default
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test
+  namespace: default
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
+`
+)
+
+var _ = Describe("Extended Monitoring hooks :: alert_old_annotation ::", func() {
+	f := HookExecutionConfigInit(``, ``)
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should have no metrics regarding deprecated annotation", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "expire",
+			}))
+		})
+	})
+
+	Context("Cluster with old annotated Node", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(state))
+			f.RunHook()
+		})
+
+		It("Metrics should be created for all deprecated objects", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(7))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "expire",
+			}))
+			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_deprecated_legacy_annotation",
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"kind":      "Node",
+					"namespace": "",
+					"name":      "test",
+				},
+			}))
+			Expect(m[2]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_deprecated_legacy_annotation",
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"kind":      "Deployment",
+					"namespace": "default",
+					"name":      "test",
+				},
+			}))
+			Expect(m[3]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_deprecated_legacy_annotation",
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"kind":      "StatefulSet",
+					"namespace": "default",
+					"name":      "test",
+				},
+			}))
+			Expect(m[4]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_deprecated_legacy_annotation",
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"kind":      "DaemonSet",
+					"namespace": "default",
+					"name":      "test",
+				},
+			}))
+			Expect(m[5]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_deprecated_legacy_annotation",
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"kind":      "CronJob",
+					"namespace": "default",
+					"name":      "test",
+				},
+			}))
+			Expect(m[6]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_deprecated_legacy_annotation",
+				Group:  "d8_deprecated_legacy_annotation",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"kind":      "Ingress",
+					"namespace": "default",
+					"name":      "test",
+				},
+			}))
+		})
+	})
+})

--- a/modules/340-extended-monitoring/hooks/common_test.go
+++ b/modules/340-extended-monitoring/hooks/common_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -266,7 +266,7 @@ def _get_metrics():
         if
         (ns.metadata.labels and EXTENDED_MONITORING_ENABLED_LABEL in ns.metadata.labels)
         or
-        (ns.metadata.labels and DEPRECATED_EXTENDED_MONITORING_ENABLED_ANNOTATION in ns.metadata.annotations)
+        (ns.metadata.annotations and DEPRECATED_EXTENDED_MONITORING_ENABLED_ANNOTATION in ns.metadata.annotations)
     )
 
     response = """# HELP extended_monitoring_annotations Extended monitoring annotations

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -49,7 +49,7 @@ class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
 def is_monitoring_enabled(labels, annotations):
     if annotations and annotations.get(DEPRECATED_EXTENDED_MONITORING_ENABLED_ANNOTATION, "false") != "false":
         return True
-    if labels or labels.get(EXTENDED_MONITORING_ENABLED_LABEL, "false") != "false":
+    if labels and labels.get(EXTENDED_MONITORING_ENABLED_LABEL, "false") != "false":
         return True
 
     return False
@@ -57,17 +57,16 @@ def is_monitoring_enabled(labels, annotations):
 
 def parse_thresholds(labels, annotations, default_thresholds):
     thresholds = copy.deepcopy(default_thresholds)
-    if not labels:
-        return thresholds
-    for name, value in labels.items():
-        if name.startswith(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX):
-            unprefixed_name = name.replace(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX, "")
-            thresholds[unprefixed_name] = value
-
-    for name, value in annotations.items():
-        if name.startswith(DEPRECATED_EXTENDED_MONITORING_ANNOTATION_THRESHOLD_PREFIX):
-            unprefixed_name = name.replace(DEPRECATED_EXTENDED_MONITORING_ANNOTATION_THRESHOLD_PREFIX, "")
-            thresholds[unprefixed_name] = value
+    if annotations:
+        for name, value in annotations.items():
+            if name.startswith(DEPRECATED_EXTENDED_MONITORING_ANNOTATION_THRESHOLD_PREFIX):
+                unprefixed_name = name.replace(DEPRECATED_EXTENDED_MONITORING_ANNOTATION_THRESHOLD_PREFIX, "")
+                thresholds[unprefixed_name] = value
+    if labels:
+        for name, value in labels.items():
+            if name.startswith(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX):
+                unprefixed_name = name.replace(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX, "")
+                thresholds[unprefixed_name] = value
 
     return thresholds
 

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -47,11 +47,12 @@ class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def is_monitoring_enabled(labels, annotations):
-    if not labels and not annotations:
-        return False
-    # The absense of the label and "false" value mean the same
-    return labels.get(EXTENDED_MONITORING_ENABLED_LABEL, "false") == "" or annotations.get(DEPRECATED_EXTENDED_MONITORING_ENABLED_ANNOTATION,
-                                                                                      "false") == ""
+    if annotations and annotations.get(DEPRECATED_EXTENDED_MONITORING_ENABLED_ANNOTATION, "false") != "false":
+        return True
+    if labels or labels.get(EXTENDED_MONITORING_ENABLED_LABEL, "false") != "false":
+        return True
+
+    return False
 
 
 def parse_thresholds(labels, annotations, default_thresholds):

--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,9 +5,11 @@ ARG BASE_GOLANG_19_ALPINE
 FROM $BASE_GOLANG_19_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
+RUN apk add patch
+COPY patches/001-support-legacy-annotation.patch /src/
 RUN wget https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.5.0 -O - | tar -xz --strip-components=1 && \
-    go get -d -v ./... && \
-    CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
+    patch -p1 < 001-support-legacy-annotation.patch && \
+    CGO_ENABLED=0 go build -a -ldflags '-s -w -extldflags "-static"' -o /k8s-image-availability-exporter main.go
 
 FROM $BASE_ALPINE
 COPY --from=artifact /k8s-image-availability-exporter /k8s-image-availability-exporter

--- a/modules/340-extended-monitoring/images/image-availability-exporter/patches/001-support-legacy-annotation.patch
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/patches/001-support-legacy-annotation.patch
@@ -1,0 +1,26 @@
+diff --git a/pkg/registry_checker/indexers.go b/pkg/registry_checker/indexers.go
+--- a/pkg/registry_checker/indexers.go	(revision 2f9c6e0cad7662a42ca4953c4c191b270995c7f0)
++++ b/pkg/registry_checker/indexers.go	(date 1681283516269)
+@@ -18,6 +18,8 @@
+ const (
+ 	imageIndexName     = "image"
+ 	labeledNSIndexName = "labeledNS"
++
++	deprecatedExtendedMonitoringNamespaceAnnotationKey = "extended-monitoring.flant.com/enabled"
+ )
+
+ type ControllerIndexers struct {
+@@ -75,6 +77,13 @@
+ 					return []string{ns.GetName()}, nil
+ 				}
+ 			}
++
++			annotations := ns.GetAnnotations()
++			if len(annotations) > 0 {
++				if _, ok := annotations[deprecatedExtendedMonitoringNamespaceAnnotationKey]; ok {
++					return []string{ns.GetName()}, nil
++				}
++			}
+
+ 			return nil, nil
+ 		},

--- a/modules/340-extended-monitoring/images/image-availability-exporter/patches/README.md
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/patches/README.md
@@ -1,0 +1,3 @@
+# 001-support-legacy-annotation.patch
+
+Support extended-monitoring legacy annotation for now. Upstream project has an option to use label Namespace selector only.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/deprecated-annotation.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/deprecated-annotation.yaml
@@ -1,0 +1,15 @@
+- name: kubernetes.extended-monitoring.deprecated-annotation
+  rules:
+  - alert: ExtendedMonitoringDeprecatatedAnnotation
+    expr: >-
+      group by (kind,namespace,name) (d8_deprecated_legacy_annotation == 1)
+    labels:
+      severity_level: "4"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_extended_monitoring_deprecated_annotation: "D8ExtendedMonitoringDeprecatedAnnotation,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_extended_monitoring_deprecated_annotation: "D8ExtendedMonitoringDeprecatedAnnotation,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: >
+        There is a deprecated `extended-monitoring.flant.com/enabled` annotation on {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }}.
+        Migrate to `extended-monitoring.deckhouse.io/enabled` label ASAP.

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -72,6 +72,7 @@ spec:
           {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}
         {{- end }}
         - '--ignored-images={{ $ignoredImages | join "~" }}'
+        - --namespace-label=extended-monitoring.deckhouse.io/enabled
         {{- if .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         - --skip-registry-cert-verification={{ .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         {{- end }}

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
@@ -29,6 +29,7 @@ rules:
 - apiGroups: [""]
   resources:
   - serviceaccounts
+  - namespaces
   verbs:
   - get
   - list

--- a/modules/402-ingress-nginx/templates/namespace.yaml
+++ b/modules/402-ingress-nginx/templates/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   name: d8-ingress-nginx
   annotations:
     extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.flant.com/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/465-pod-reloader/templates/namespace.yaml
+++ b/modules/465-pod-reloader/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/470-chrony/templates/namespace.yaml
+++ b/modules/470-chrony/templates/namespace.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/500-dashboard/templates/namespace.yaml
+++ b/modules/500-dashboard/templates/namespace.yaml
@@ -3,6 +3,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}

--- a/modules/500-openvpn/templates/namespace.yaml
+++ b/modules/500-openvpn/templates/namespace.yaml
@@ -4,7 +4,6 @@ kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
   annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/600-namespace-configurator/docs/EXAMPLES.md
+++ b/modules/600-namespace-configurator/docs/EXAMPLES.md
@@ -4,7 +4,7 @@ title: "The namespace-configurator module: examples"
 
 ## Example
 
-This example will add `extended-monitoring.flant.com/enabled=true` annotation and `foo=bar` label to every namespace starting with `prod-` and `infra-`, except `infra-test`.
+This example will add `extended-monitoring.deckhouse.io/enabled=true` label and `foo=bar` annotation to every namespace starting with `prod-` and `infra-`, except `infra-test`.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -17,9 +17,9 @@ spec:
   settings:
     configurations:
     - annotations:
-        extended-monitoring.flant.com/enabled: "true"
-      labels:
         foo: bar
+      labels:
+        extended-monitoring.deckhouse.io/enabled: "true"
       includeNames:
       - "^prod"
       - "^infra"

--- a/modules/600-namespace-configurator/docs/EXAMPLES_RU.md
+++ b/modules/600-namespace-configurator/docs/EXAMPLES_RU.md
@@ -4,7 +4,7 @@ title: "Модуль namespace-configurator: примеры"
 
 ## Пример
 
-Этот пример добавит аннотацию `extended-monitoring.flant.com/enabled=true` и label `foo=bar` к каждому Namespace, начинающемуся с `prod-` или `infra-`, за исключением `infra-test`.
+Этот пример добавит лейбл `extended-monitoring.deckhouse.io/enabled=true` и аннотацию `foo=bar` к каждому Namespace, начинающемуся с `prod-` или `infra-`, за исключением `infra-test`.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -17,9 +17,9 @@ spec:
   settings:
     configurations:
     - annotations:
-        extended-monitoring.flant.com/enabled: "true"
-      labels:
         foo: bar
+      labels:
+        extended-monitoring.deckhouse.io/enabled: "true"
       includeNames:
       - "^prod"
       - "^infra"

--- a/modules/600-namespace-configurator/docs/README.md
+++ b/modules/600-namespace-configurator/docs/README.md
@@ -4,7 +4,7 @@ title: "The namespace-configurator module"
 
 This module allows to assign annotations and labels to namespaces automatically.
 
-It facilitates to enable new namespaces to monitoring system by adding `extended-monitoring.flant.com/enabled=true` annotation.
+It facilitates to enable new namespaces to monitoring system by adding `extended-monitoring.deckhouse.io/enabled=true` label.
 
 ### How does it work?
 

--- a/modules/600-namespace-configurator/docs/README_RU.md
+++ b/modules/600-namespace-configurator/docs/README_RU.md
@@ -4,7 +4,7 @@ title: "Модуль namespace-configurator"
 
 Позволяет автоматически управлять аннотациями и label'ами на Namespace'ах.
 
-Модуль полезен тем, что помогает автоматически включать новые Namespace'ы в мониторинг, посредством добавления аннотации `extended-monitoring.flant.com/enabled=true`.
+Модуль полезен тем, что помогает автоматически включать новые Namespace'ы в мониторинг, посредством добавления лейбла `extended-monitoring.deckhouse.io/enabled=true`.
 
 ### Как работает
 

--- a/modules/600-namespace-configurator/hooks/handler_test.go
+++ b/modules/600-namespace-configurator/hooks/handler_test.go
@@ -39,8 +39,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test2
-  annotations:
-    extended-monitoring.flant.com/enabled: "true"
+  labels:
+    extended-monitoring.deckhouse.io/enabled: "true"
 `)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
@@ -48,9 +48,9 @@ metadata:
 
 		It("Expected patch", func() {
 			ns := f.KubernetesResource("Namespace", "", "test1")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeFalse())
 			ns = f.KubernetesResource("Namespace", "", "test2")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 		})
 
 		Context("Adding new config", func() {
@@ -58,8 +58,8 @@ metadata:
 				f.ValuesSetFromYaml("namespaceConfigurator", []byte(`
 ---
 configurations:
-  - annotations:
-      extended-monitoring.flant.com/enabled: "true"
+  - labels:
+      extended-monitoring.deckhouse.io/enabled: "true"
     includeNames: ["test1"]
 `))
 				f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -67,9 +67,9 @@ configurations:
 			})
 			It("Expected patch", func() {
 				ns := f.KubernetesResource("Namespace", "", "test1")
-				Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+				Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 				ns = f.KubernetesResource("Namespace", "", "test2")
-				Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+				Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 			})
 
 		})
@@ -191,8 +191,8 @@ metadata:
 			f.ValuesSetFromYaml("namespaceConfigurator", []byte(`
 ---
 configurations:
-  - annotations:
-      extended-monitoring.flant.com/enabled: "true"
+  - labels:
+      extended-monitoring.deckhouse.io/enabled: "true"
     includeNames: ["prod-.*","infra-.*"]
     excludeNames: ["infra-test"]
 `))
@@ -222,8 +222,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: infra-test2
-  annotations:
-    extended-monitoring.flant.com/enabled: "true"
+  labels:
+    extended-monitoring.deckhouse.io/enabled: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -236,28 +236,28 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: prod-ns2
-  annotations:
-    extended-monitoring.flant.com/enabled: "true"
+  labels:
+    extended-monitoring.deckhouse.io/enabled: "true"
 `))
 			f.RunHook()
 		})
 
 		It("Expected patch", func() {
 			ns := f.KubernetesResource("Namespace", "", "prod-ns1")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 			ns = f.KubernetesResource("Namespace", "", "infra-ns1")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 
 			ns = f.KubernetesResource("Namespace", "", "foo")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeFalse())
 			ns = f.KubernetesResource("Namespace", "", "infra-test")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeFalse())
 			ns = f.KubernetesResource("Namespace", "", "infra-test2")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 			ns = f.KubernetesResource("Namespace", "", "prod-ns2")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
 			ns = f.KubernetesResource("Namespace", "", "infra-test3")
-			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/600-namespace-configurator/openapi/config-values.yaml
+++ b/modules/600-namespace-configurator/openapi/config-values.yaml
@@ -13,7 +13,7 @@ properties:
           description: |
             A list of annotations in the `key: "value"` format.
           x-examples:
-            extended-monitoring.flant.com/enabled: "true"
+            example: "true"
           additionalProperties:
             type: string
             nullable: true

--- a/modules/600-namespace-configurator/openapi/doc-ru-config-values.yaml
+++ b/modules/600-namespace-configurator/openapi/doc-ru-config-values.yaml
@@ -12,7 +12,7 @@ properties:
           description: |
             Список аннотаций в формате `ключ: "значение"`.
           x-examples:
-            extended-monitoring.flant.com/enabled: "true"
+            example: "true"
           additionalProperties:
             type: string
             nullable: true

--- a/modules/600-namespace-configurator/openapi/openapi-case-tests.yaml
+++ b/modules/600-namespace-configurator/openapi/openapi-case-tests.yaml
@@ -2,7 +2,7 @@ positive:
   configValues:
   - configurations:
     - annotations:
-        extended-monitoring.flant.com/enabled: "true"
+        test: "true"
       labels:
         foo: bar
       includeNames:
@@ -12,7 +12,7 @@ positive:
       - "infra-test"
   - configurations:
     - annotations:
-        extended-monitoring.flant.com/enabled: null
+        test: null
       labels:
         foo: null
       includeNames:
@@ -23,10 +23,10 @@ negative:
     - []
   - configurations:
     - annotations:
-      - "extended-monitoring.flant.com/enabled=true"
+      - "test=true"
       includeNames:
       - "abc"
   - configurations:
     - annotations:
-      - "extended-monitoring.flant.com/enabled": "true"
+      - "test": "true"
       includeNames: []


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. All Deckhouse machinery now subscribes to extended-monitoring.deckhouse.io/enabled: "" label.
2. image-availability exporter now monitors only extended-monitoring.deckhouse.io/enabled: "" labeled Namespaces.
3. Threshold annotations are deprecated. Use the new `threshold.extended-monitoring.deckhouse.io/` label.

Enhances previously reverted https://github.com/deckhouse/deckhouse/pull/3797

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: chore
summary: Starting the process of migration from extended-monitoring annotations to labels
impact: An alert will be generated for each instance of an object with a deprecated `extended-monitoring.flant.com`. Change it to `extended-monitoring.deckhouse.io` ASAP.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
