### PR TITLE
[ingress-nginx] Improve migration hook

### DIFF
--- a/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods.go
+++ b/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods.go
@@ -63,8 +63,20 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ExecuteHookOnEvents:          pointer.Bool(false),
 			NamespaceSelector:            internal.NsSelector(),
 			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "controller",
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "app",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"controller"},
+					},
+					{
+						Key:      "ingress.deckhouse.io/block-deleting",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
+					{
+						Key:      "lifecycle.apps.kruise.io/state",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
 				},
 			},
 			FilterFunc: applyIngressPodFilter,

--- a/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
+++ b/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Global hooks :: discovery :: migrate_daemonset ", func() {
+	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`
+	globalValuesString := `{}`
+	f := HookExecutionConfigInit(initValuesString, globalValuesString)
+	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
+
+	Context("Has incompatible ingress controllers", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: test
+spec:
+  controllerVersion: "1.1"
+  ingressClass: "test"
+  inlet: "HostWithFailover"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: test
+  name: controller-test-xxx
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - name: controller
+  nodeName: node-1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: test
+    ingress.deckhouse.io/block-deleting: "true"
+  name: controller-test-yyy
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - name: controller
+  nodeName: node-2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: test
+    lifecycle.apps.kruise.io/state: "PreparingDelete"
+  name: controller-test-zzz
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - name: controller
+  nodeName: node-3
+`)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should add label only to the controller-test-xxx pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			pod1 := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-xxx")
+			pod2 := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-yyy")
+			pod3 := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-zzz")
+
+			Expect(pod1.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").String()).To(Equal("true"))
+			Expect(pod2.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").String()).To(Equal("true"))
+			Expect(pod3.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Description
Migrate only old pods, without OpenKruise labels

## Why do we need it, and what problem does it solve?
Hook can act many times and set unneeded labels during the rollout process
We can avoid it with more strict labels selector

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Improve controller migration hook.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
