### PR TITLE
[node-manager] Fix error node group condition

### DIFF
--- a/modules/040-node-manager/hooks/update_node_group_status_test.go
+++ b/modules/040-node-manager/hooks/update_node_group_status_test.go
@@ -1402,6 +1402,24 @@ status:
 		})
 
 		Context("Error condition", func() {
+			const machines = `
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: Machine
+metadata:
+  name: machine-ng1-aaa
+  namespace: d8-cloud-instance-manager
+  labels:
+    instance-group: ng1
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: Machine
+metadata:
+  name: machine-ng1-bbb
+  namespace: d8-cloud-instance-manager
+  labels:
+    instance-group: ng1
+`
 			const ngWithError = `
 ---
 apiVersion: deckhouse.io/v1
@@ -1458,31 +1476,218 @@ status:
       type: Create
     name: machine-ng-2-bbb
     ownerRef: korker-3e52ee98-8649499f7
----
-apiVersion: machine.sapcloud.io/v1alpha1
-kind: Machine
-metadata:
-  name: machine-ng1-aaa
-  namespace: d8-cloud-instance-manager
-  labels:
-    instance-group: ng1
----
-apiVersion: machine.sapcloud.io/v1alpha1
-kind: Machine
-metadata:
-  name: machine-ng1-bbb
-  namespace: d8-cloud-instance-manager
-  labels:
-    instance-group: ng1
 `
 				BeforeEach(func() {
 					f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(
-						ngWithError+machineDeploymentErr+stateCloudProviderSecret+configurationChecksums, 2))
+						ngWithError+machineDeploymentErr+machines+stateCloudProviderSecret+configurationChecksums, 2))
 					f.RunHook()
 				})
 
 				It("Sets to True and sets message from ng error and machine deployment error", func() {
 					assertCondition(f, ngv1.NodeGroupConditionTypeError, ngv1.ConditionTrue, nowTime, "Node group error|Cloud provider message - rpc error: code = FailedPrecondition desc = Image not found #2.")
+				})
+			})
+
+			Context("Machine deployment has `Started Machine creation process` error but ng is not in error condition", func() {
+				const machineDeploymentErr = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ng1
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    maxPerZone: 5
+    minPerZone: 1
+status:
+  conditions:
+  - status: "False"
+    type: Error
+    lastTransitionTime: "2023-03-03T16:47:40Z"
+    message: ""
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: md-failed-ng
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: ng1
+spec:
+  replicas: 2
+status:
+  failedMachines:
+  - lastOperation:
+      description: 'Started Machine creation process'
+      lastUpdateTime: "2020-05-15T15:01:13Z"
+      state: Failed
+      type: Create
+    name: machine-ng-2-bbb
+    ownerRef: korker-3e52ee98-8649499f7
+
+`
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(
+						machineDeploymentErr+machines+stateCloudProviderSecret+configurationChecksums, 2))
+					f.RunHook()
+				})
+
+				It("Sets to True and sets message from machine deployment error", func() {
+					assertCondition(f, ngv1.NodeGroupConditionTypeError, ngv1.ConditionTrue, nowTime, "Started Machine creation process")
+				})
+			})
+
+			Context("Machine deployment has `Started Machine creation process` error and ng is in error condition", func() {
+				const machineDeploymentErr = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ng1
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    maxPerZone: 5
+    minPerZone: 1
+status:
+  conditions:
+  - status: "True"
+    type: Error
+    lastTransitionTime: "2023-03-03T19:47:40+03:00"
+    message: "Some error"
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: md-failed-ng
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: ng1
+spec:
+  replicas: 2
+status:
+  failedMachines:
+  - lastOperation:
+      description: 'Started Machine creation process'
+      lastUpdateTime: "2020-05-15T15:01:13Z"
+      state: Failed
+      type: Create
+    name: machine-ng-2-bbb
+    ownerRef: korker-3e52ee98-8649499f7
+
+`
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(
+						machineDeploymentErr+machines+stateCloudProviderSecret+configurationChecksums, 2))
+					f.RunHook()
+				})
+
+				It("Sets to True and sets message from machine deployment error", func() {
+					assertCondition(f, ngv1.NodeGroupConditionTypeError, ngv1.ConditionTrue, "2023-03-03T19:47:40+03:00", "Some error")
+				})
+			})
+
+			Context("Machine deployment is in the frozen state ng is in error condition", func() {
+				const machineDeploymentErr = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ng1
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    maxPerZone: 5
+    minPerZone: 1
+status:
+  conditions:
+  - status: "True"
+    type: Error
+    lastTransitionTime: "2023-03-03T19:47:40+03:00"
+    message: "Some error"
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: md-failed-ng
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: ng1
+spec:
+  replicas: 2
+status:
+  conditions:
+  - lastTransitionTime: "2023-04-06T15:15:07Z"
+    lastUpdateTime: "2023-04-06T15:15:07Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2023-04-11T12:03:02Z"
+    lastUpdateTime: "2023-04-11T12:03:02Z"
+    message: 'The number of machines backing MachineSet: sandbox-stage-8ef4a622-5f76f
+      is 4 >= 4 which is the Max-ScaleUp-Limit'
+    reason: OverShootingReplicaCount
+    status: "True"
+    type: Frozen
+`
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(
+						machineDeploymentErr+machines+stateCloudProviderSecret+configurationChecksums, 2))
+					f.RunHook()
+				})
+
+				It("Sets to True and sets message from machine deployment error", func() {
+					assertCondition(f, ngv1.NodeGroupConditionTypeError, ngv1.ConditionTrue, "2023-03-03T19:47:40+03:00", "Some error")
+				})
+			})
+
+			Context("Machine deployment unfroze and has not error, ng is in error condition", func() {
+				const machineDeploymentErr = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ng1
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    maxPerZone: 5
+    minPerZone: 1
+status:
+  conditions:
+  - status: "True"
+    type: Error
+    lastTransitionTime: "2023-03-03T19:47:40+03:00"
+    message: "Some error"
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: md-failed-ng
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: ng1
+spec:
+  replicas: 2
+status:
+  conditions:
+  - lastTransitionTime: "2023-04-06T15:15:07Z"
+    lastUpdateTime: "2023-04-06T15:15:07Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+`
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(
+						machineDeploymentErr+machines+stateCloudProviderSecret+configurationChecksums, 2))
+					f.RunHook()
+				})
+
+				It("Sets to False and clear error message", func() {
+					assertCondition(f, ngv1.NodeGroupConditionTypeError, ngv1.ConditionFalse, nowTime, "")
 				})
 			})
 


### PR DESCRIPTION
## Description
Stabilize node group error condition.

## Why do we need it, and what problem does it solve?
Often we see `Started Machine creation process` or we do not see error when node group is in error.
See [this](https://github.com/deckhouse/deckhouse/pull/4367/files#diff-9e81af91baf05718041369f0cbc3133f589d2664f2ab94e0567a37a18044d2ceR161) comment for more information 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix error node group condition
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
