### PR TITLE
[virtualization] Minor fixes

### DIFF
--- a/modules/490-virtualization/hooks/utils.go
+++ b/modules/490-virtualization/hooks/utils.go
@@ -159,6 +159,9 @@ func reducedDataVolumeSource2cdiDataVolumeSource(x *v1alpha1.ReducedDataVolumeSo
 }
 
 func reducedDataVolumeSourceRegistry2cdiDataVolumeSourceRegistry(x *v1alpha1.ReducedDataVolumeSourceRegistry) *cdiv1.DataVolumeSourceRegistry {
+	if x == nil {
+		return nil
+	}
 	pullNode := cdiv1.RegistryPullNode
 	return &cdiv1.DataVolumeSourceRegistry{
 		URL:           x.URL,

--- a/modules/490-virtualization/hooks/vm_handler.go
+++ b/modules/490-virtualization/hooks/vm_handler.go
@@ -611,7 +611,8 @@ func processKubevirtVM(input *go_hook.HookInput, d8vm *v1alpha1.VirtualMachine, 
 			}
 			err = setVMFields(d8vm, vm, ipAddress)
 			if err != nil {
-				return nil, err
+				input.LogEntry.Errorln(err)
+				return u, nil
 			}
 			return sdk.ToUnstructured(&vm)
 		}

--- a/modules/490-virtualization/hooks/vm_handler_test.go
+++ b/modules/490-virtualization/hooks/vm_handler_test.go
@@ -53,6 +53,17 @@ var _ = Describe("Modules :: virtualization :: hooks :: vm_handler ::", func() {
 				f.KubeStateSet(`
 ---
 apiVersion: deckhouse.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: 000-invalid
+  namespace: default
+spec:
+  cloudInit:
+    userDataSecretRef: my-vm-userdata
+    userData: |-
+      chpasswd: { expire: False }
+---
+apiVersion: deckhouse.io/v1alpha1
 kind: VirtualMachineIPAddressClaim
 metadata:
   name: vm10


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description


This PR includes two fixes:

hooks failing and stop processing other VMs in case of error of `setVMfields` for single VM:

```
2023-04-11T09:11:35Z [error][virtualization] - Module hook failed, requeue task to retry after delay. Failed count is 25. Error: 1 error occurred:
	* Filter object kubevirt.io/v1/VirtualMachine/infra/test-0: cloud-config variables can only be appended to userData section
```

nil pointer exception when creating VirtualMachineDisk not from registry source:
```
deckhouse-f84765c85-qfktk deckhouse {"binding":"onStartup","event.type":"OperatorStartup","hook":"490-virtualization/hooks/ensure_crds.go","hook.type":"module","level":"info","module":"virtualization","msg":"Module hook start virtualization/490-virtualization/hooks/ensure_crds.go","queue":"main","task.id":"0717457d-d021-4a31-99f5-264a0862517d","time":"2023-04-10T13:35:35Z"}
deckhouse-f84765c85-qfktk deckhouse panic: runtime error: invalid memory address or nil pointer dereference
deckhouse-f84765c85-qfktk deckhouse [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x36bcd97]
deckhouse-f84765c85-qfktk deckhouse 
deckhouse-f84765c85-qfktk deckhouse goroutine 11 [running]:
deckhouse-f84765c85-qfktk deckhouse github.com/deckhouse/deckhouse/modules/490-virtualization/hooks.reducedDataVolumeSourceRegistry2cdiDataVolumeSourceRegistry(...)
deckhouse-f84765c85-qfktk deckhouse 	/deckhouse/modules/490-virtualization/hooks/utils.go:164
deckhouse-f84765c85-qfktk deckhouse github.com/deckhouse/deckhouse/modules/490-virtualization/hooks.reducedDataVolumeSource2cdiDataVolumeSource(...)
deckhouse-f84765c85-qfktk deckhouse 	/deckhouse/modules/490-virtualization/hooks/utils.go:155
deckhouse-f84765c85-qfktk deckhouse github.com/deckhouse/deckhouse/modules/490-virtualization/hooks.applyClusterVirtualMachineImageFilter(0xc00adb6160?)
deckhouse-f84765c85-qfktk deckhouse 	/deckhouse/modules/490-virtualization/hooks/disk_handler.go:149 +0xd7
deckhouse-f84765c85-qfktk deckhouse github.com/flant/addon-operator/pkg/module_manager.NewHookConfigFromGoConfig.func1(0xc005682a70?)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/addon-operator@v1.1.3-0.20230209101344-0aaa96dbf974/pkg/module_manager/global_hook_config.go:313 +0x1d
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.ApplyFilter({0x0, 0x0}, 0xc0093563c0, 0xc005682a70)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/filter.go:32 +0x17e
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.(*resourceInformer).LoadExistedObjects.func1(0xc001c41c20, 0x20?, 0xc00a611ce8, 0xc00a611d20)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/resource_informer.go:236 +0xac
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.(*resourceInformer).LoadExistedObjects(0xc001c41c20)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/resource_informer.go:237 +0x709
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.(*resourceInformer).CreateSharedInformer(0xc001c41c20)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/resource_informer.go:160 +0xa46
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.(*monitor).CreateInformersForNamespace(0xc00b884e60, {0x0, 0x0})
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/monitor.go:261 +0x20b
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.(*monitor).CreateInformers(0xc00b884e60)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/monitor.go:115 +0x448
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/kube_events_manager.(*kubeEventsManager).AddMonitor(0xc000b81300, 0xc00b3d5440)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/kube_events_manager/kube_events_manager.go:81 +0x142
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/hook/controller.(*kubernetesBindingsController).EnableKubernetesBindings(0xc0095c8b10)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/hook/controller/kubernetes_bindings_controller.go:78 +0x110
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/hook/controller.(*hookController).HandleEnableKubernetesBindings(0xc00a612e38?, 0xc00bf2a2b8)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/hook/controller/hook_controller.go:170 +0x43
deckhouse-f84765c85-qfktk deckhouse github.com/flant/addon-operator/pkg/module_manager.(*moduleManager).HandleModuleEnableKubernetesBindings(0xc0007d71e0, {0xc00015fdd4?, 0x40abde4?}, 0xc0086f6100)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/addon-operator@v1.1.3-0.20230209101344-0aaa96dbf974/pkg/module_manager/module_manager.go:1112 +0x15f
deckhouse-f84765c85-qfktk deckhouse github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).HandleModuleRun(0xc000ad6fc0, {0x45940b8, 0xc000bdcd80}, 0xc000597440)
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/addon-operator@v1.1.3-0.20230209101344-0aaa96dbf974/pkg/addon-operator/operator.go:1243 +0xaf2
deckhouse-f84765c85-qfktk deckhouse github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).TaskHandler(0xc000ad6fc0, {0x45940b8, 0xc000bdcd80})
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/addon-operator@v1.1.3-0.20230209101344-0aaa96dbf974/pkg/addon-operator/operator.go:893 +0x24b
deckhouse-f84765c85-qfktk deckhouse github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1()
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/task/queue/task_queue.go:406 +0x35e
deckhouse-f84765c85-qfktk deckhouse created by github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start
deckhouse-f84765c85-qfktk deckhouse 	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/task/queue/task_queue.go:387 +0x6f
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: virtualization
type: fix
summary: Minor fixes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
