### PR TITLE
[ci] Fix output only grey IP in e2e tests 

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -105,16 +105,16 @@ run: |
   echo "Full comment url for updating ${comment_url}"
 
   ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-  echo '::echo::on'
-  echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-  echo '::echo::off'
+  echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-  wait_bastion_ip="false"
+  bastion_ip_file=""
   if [[ "${PROVIDER}" == "Static" ]] ; then
-    wait_bastion_ip="true"
+    bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
   fi
 
-  $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+  echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+  $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 {!{ end }!}
 
   docker run --rm \
@@ -218,6 +218,7 @@ check_e2e_labels:
 {!{- end }!}
   outputs:
     ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+    ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
     run_id: ${{ github.run_id }}
     # need for find state in artifact
     cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -371,6 +372,7 @@ check_e2e_labels:
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       env:
         SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+        SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
       with:
         # it sets `should_run` output var if e2e/failed/stay label
         script: |

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -109,7 +109,12 @@ run: |
   echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
   echo '::echo::off'
 
-  $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+  wait_bastion_ip="false"
+  if [[ "${PROVIDER}" == "Static" ]] ; then
+    wait_bastion_ip="true"
+  fi
+
+  $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 {!{ end }!}
 
   docker run --rm \

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -112,7 +112,7 @@ run: |
     bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
   fi
 
-  echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+  echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
   $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 {!{ end }!}

--- a/.github/scripts/js/e2e/cleanup.js
+++ b/.github/scripts/js/e2e/cleanup.js
@@ -36,6 +36,7 @@ function buildFailedE2eTestAdditionalInfo({ needsContext, core, context }){
 
         // ci_commit_branch
         const connectStr = outputs['ssh_master_connection_string'] || '';
+        const bastionStr = outputs['ssh_bastion_connection_string'] || '';
         const ranFor = outputs['ran_for'] || '';
         const runId = outputs['run_id'] || '';
         const clusterPrefix = needsContext[key].outputs['cluster_prefix'] || '';
@@ -62,8 +63,13 @@ function buildFailedE2eTestAdditionalInfo({ needsContext, core, context }){
         // connection string is not required
         argv.push(connectStr)
 
+        let bastionPart = ''
+        if(!bastionStr){
+          bastionPart = `-J ${bastionStr}`
+        }
+
         const splitRunFor = ranFor.replace(';', ' ');
-        const outConnectStr = connectStr ? `\`ssh -i ~/.ssh/e2e-id-rsa ${connectStr}\` - connect for debugging;` : '';
+        const outConnectStr = connectStr ? `\`ssh -i ~/.ssh/e2e-id-rsa ${bastionPart} ${connectStr}\` - connect for debugging;` : '';
 
         return `
 <!--- failed_clusters_start ${ranFor} -->
@@ -91,6 +97,7 @@ E2e for ${splitRunFor} was failed. Use:
 
 async function readConnectionScript({core, github, context}){
   core.debug(`SSH_CONNECT_STR_FILE ${process.env.SSH_CONNECT_STR_FILE}`);
+  core.debug(`SSH_BASTION_STR_FILE ${process.env.SSH_BASTION_STR_FILE}`);
 
   try {
     const data = fs.readFileSync(process.env.SSH_CONNECT_STR_FILE, 'utf8');
@@ -98,6 +105,19 @@ async function readConnectionScript({core, github, context}){
   } catch (err) {
     // this file can be not created
     core.warning(`Cannot read ssh connection file ${err.name}: ${err.message}`);
+  }
+
+  if(process.env.SSH_BASTION_STR_FILE) {
+    try {
+      const data = fs.readFileSync(process.env.SSH_BASTION_STR_FILE, 'utf8');
+      core.setOutput('ssh_bastion_connection_string', data);
+    } catch (err) {
+      // this file can be not created
+      core.warning(`Cannot read ssh connection file ${err.name}: ${err.message}`);
+      core.setOutput('ssh_bastion_connection_string', '');
+    }
+  } else {
+    core.setOutput('ssh_bastion_connection_string', '');
   }
 
   core.setOutput('failed_cluster_stayed', 'true');

--- a/.github/scripts/js/e2e/cleanup.js
+++ b/.github/scripts/js/e2e/cleanup.js
@@ -64,7 +64,7 @@ function buildFailedE2eTestAdditionalInfo({ needsContext, core, context }){
         argv.push(connectStr)
 
         let bastionPart = ''
-        if(!bastionStr){
+        if(bastionStr){
           bastionPart = `-J ${bastionStr}`
         }
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -452,7 +452,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -886,7 +891,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1320,7 +1330,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1754,7 +1769,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2188,7 +2208,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2622,7 +2647,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3056,7 +3086,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3490,7 +3525,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3924,7 +3964,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4358,7 +4403,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -456,7 +456,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -897,7 +897,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1338,7 +1338,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1779,7 +1779,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2220,7 +2220,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2661,7 +2661,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3102,7 +3102,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3543,7 +3543,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3984,7 +3984,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4425,7 +4425,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -448,16 +449,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -491,6 +492,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -644,6 +646,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -887,16 +890,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -930,6 +933,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1083,6 +1087,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1326,16 +1331,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1369,6 +1374,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1522,6 +1528,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1765,16 +1772,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1808,6 +1815,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1961,6 +1969,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2204,16 +2213,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2247,6 +2256,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2400,6 +2410,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2643,16 +2654,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2686,6 +2697,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2839,6 +2851,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3082,16 +3095,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3125,6 +3138,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3278,6 +3292,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3521,16 +3536,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3564,6 +3579,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3717,6 +3733,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3960,16 +3977,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4003,6 +4020,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4156,6 +4174,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4399,16 +4418,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4442,6 +4461,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -454,7 +454,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -896,7 +901,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1338,7 +1348,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1780,7 +1795,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2222,7 +2242,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2664,7 +2689,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3106,7 +3136,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3548,7 +3583,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3990,7 +4030,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4432,7 +4477,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -458,7 +458,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -907,7 +907,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1356,7 +1356,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1805,7 +1805,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2254,7 +2254,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2703,7 +2703,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3152,7 +3152,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3601,7 +3601,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4050,7 +4050,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4499,7 +4499,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -450,16 +451,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -495,6 +496,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -652,6 +654,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -897,16 +900,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -942,6 +945,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1099,6 +1103,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1344,16 +1349,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1389,6 +1394,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1546,6 +1552,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1791,16 +1798,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1836,6 +1843,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1993,6 +2001,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2238,16 +2247,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2283,6 +2292,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2440,6 +2450,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2685,16 +2696,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2730,6 +2741,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2887,6 +2899,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3132,16 +3145,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3177,6 +3190,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3334,6 +3348,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3579,16 +3594,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3624,6 +3639,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3781,6 +3797,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4026,16 +4043,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4071,6 +4088,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4228,6 +4246,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4473,16 +4492,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4518,6 +4537,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -137,6 +137,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -552,6 +553,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -975,6 +977,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1386,6 +1389,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1805,6 +1809,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2216,6 +2221,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2631,6 +2637,7 @@ jobs:
       - git_info
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -451,7 +451,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -881,7 +886,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1311,7 +1321,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1741,7 +1756,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2171,7 +2191,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2601,7 +2626,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3031,7 +3061,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3461,7 +3496,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3891,7 +3931,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4321,7 +4366,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -447,16 +448,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -489,6 +490,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -640,6 +642,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -882,16 +885,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -924,6 +927,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1075,6 +1079,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1317,16 +1322,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1359,6 +1364,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1510,6 +1516,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1752,16 +1759,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1794,6 +1801,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1945,6 +1953,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2187,16 +2196,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2229,6 +2238,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2380,6 +2390,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2622,16 +2633,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2664,6 +2675,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2815,6 +2827,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3057,16 +3070,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3099,6 +3112,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3250,6 +3264,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3492,16 +3507,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3534,6 +3549,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3685,6 +3701,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3927,16 +3944,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3969,6 +3986,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4120,6 +4138,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4362,16 +4381,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4404,6 +4423,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -455,7 +455,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -892,7 +892,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1329,7 +1329,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1766,7 +1766,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2203,7 +2203,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2640,7 +2640,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3077,7 +3077,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3514,7 +3514,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3951,7 +3951,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4388,7 +4388,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -451,7 +451,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -881,7 +886,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1311,7 +1321,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1741,7 +1756,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2171,7 +2191,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2601,7 +2626,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3031,7 +3061,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3461,7 +3496,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3891,7 +3931,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4321,7 +4366,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -447,16 +448,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -489,6 +490,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -640,6 +642,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -882,16 +885,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -924,6 +927,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1075,6 +1079,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1317,16 +1322,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1359,6 +1364,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1510,6 +1516,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1752,16 +1759,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1794,6 +1801,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1945,6 +1953,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2187,16 +2196,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2229,6 +2238,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2380,6 +2390,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2622,16 +2633,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2664,6 +2675,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2815,6 +2827,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3057,16 +3070,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3099,6 +3112,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3250,6 +3264,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3492,16 +3507,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3534,6 +3549,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3685,6 +3701,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3927,16 +3944,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3969,6 +3986,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4120,6 +4138,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4362,16 +4381,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4404,6 +4423,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -455,7 +455,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -892,7 +892,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1329,7 +1329,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1766,7 +1766,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2203,7 +2203,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2640,7 +2640,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3077,7 +3077,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3514,7 +3514,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3951,7 +3951,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4388,7 +4388,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -451,7 +451,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -881,7 +886,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1311,7 +1321,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1741,7 +1756,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2171,7 +2191,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2601,7 +2626,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3031,7 +3061,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3461,7 +3496,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3891,7 +3931,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4321,7 +4366,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -447,16 +448,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -489,6 +490,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -640,6 +642,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -882,16 +885,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -924,6 +927,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1075,6 +1079,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1317,16 +1322,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1359,6 +1364,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1510,6 +1516,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1752,16 +1759,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1794,6 +1801,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1945,6 +1953,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2187,16 +2196,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2229,6 +2238,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2380,6 +2390,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2622,16 +2633,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2664,6 +2675,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2815,6 +2827,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3057,16 +3070,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3099,6 +3112,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3250,6 +3264,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3492,16 +3507,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3534,6 +3549,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3685,6 +3701,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3927,16 +3944,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3969,6 +3986,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4120,6 +4138,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4362,16 +4381,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4404,6 +4423,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -455,7 +455,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -892,7 +892,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1329,7 +1329,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1766,7 +1766,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2203,7 +2203,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2640,7 +2640,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3077,7 +3077,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3514,7 +3514,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3951,7 +3951,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4388,7 +4388,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -452,7 +452,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -886,7 +891,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1320,7 +1330,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1754,7 +1769,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2188,7 +2208,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2622,7 +2647,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3056,7 +3086,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3490,7 +3525,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3924,7 +3964,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4358,7 +4403,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -456,7 +456,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -897,7 +897,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1338,7 +1338,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1779,7 +1779,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2220,7 +2220,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2661,7 +2661,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3102,7 +3102,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3543,7 +3543,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3984,7 +3984,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4425,7 +4425,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -448,16 +449,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -491,6 +492,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -644,6 +646,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -887,16 +890,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -930,6 +933,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1083,6 +1087,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1326,16 +1331,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1369,6 +1374,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1522,6 +1528,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1765,16 +1772,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1808,6 +1815,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1961,6 +1969,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2204,16 +2213,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2247,6 +2256,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2400,6 +2410,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2643,16 +2654,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2686,6 +2697,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2839,6 +2851,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3082,16 +3095,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3125,6 +3138,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3278,6 +3292,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3521,16 +3536,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3564,6 +3579,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3717,6 +3733,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3960,16 +3977,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4003,6 +4020,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4156,6 +4174,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4399,16 +4418,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4442,6 +4461,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -453,7 +453,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -891,7 +896,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1329,7 +1339,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1767,7 +1782,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2205,7 +2225,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2643,7 +2668,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3081,7 +3111,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3519,7 +3554,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3957,7 +3997,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4395,7 +4440,12 @@ jobs:
           echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
           echo '::echo::off'
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" > "${dhctl_log_file}-wait-log" 2>&1 &
+          wait_bastion_ip="false"
+          if [[ "${PROVIDER}" == "Static" ]] ; then
+            wait_bastion_ip="true"
+          fi
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -457,7 +457,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -902,7 +902,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1347,7 +1347,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -1792,7 +1792,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2237,7 +2237,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -2682,7 +2682,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3127,7 +3127,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -3572,7 +3572,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4017,7 +4017,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
@@ -4462,7 +4462,7 @@ jobs:
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+          echo "ssh_bastion_str_file=${bastion_ip_file}" >> $GITHUB_OUTPUT
 
           $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -205,6 +205,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -449,16 +450,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -493,6 +494,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -648,6 +650,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -892,16 +895,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -936,6 +939,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1091,6 +1095,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1335,16 +1340,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1379,6 +1384,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1534,6 +1540,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -1778,16 +1785,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -1822,6 +1829,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -1977,6 +1985,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_docker_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2221,16 +2230,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2265,6 +2274,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2420,6 +2430,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_22 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -2664,16 +2675,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -2708,6 +2719,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -2863,6 +2875,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3107,16 +3120,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3151,6 +3164,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3306,6 +3320,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_24 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3550,16 +3565,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -3594,6 +3609,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -3749,6 +3765,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_25 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -3993,16 +4010,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4037,6 +4054,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |
@@ -4192,6 +4210,7 @@ jobs:
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
+      ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
@@ -4436,16 +4455,16 @@ jobs:
           echo "Full comment url for updating ${comment_url}"
 
           ssh_connect_str_file="${DHCTL_LOG_FILE}-ssh-connect_str-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          echo '::echo::on'
-          echo "::set-output name=ssh_connection_str_file::${ssh_connect_str_file}"
-          echo '::echo::off'
+          echo "ssh_connection_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
 
-          wait_bastion_ip="false"
+          bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
-            wait_bastion_ip="true"
+            bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
-          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$wait_bastion_ip" > "${dhctl_log_file}-wait-log" 2>&1 &
+          echo "ssh_bastion_str_file=${ssh_connect_str_file}" >> $GITHUB_OUTPUT
+
+          $(pwd)/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh "$dhctl_log_file" "$comment_url" "$ssh_connect_str_file" "$bastion_ip_file" > "${dhctl_log_file}-wait-log" 2>&1 &
 
 
           docker run --rm \
@@ -4480,6 +4499,7 @@ jobs:
         uses: actions/github-script@v5.0.0
         env:
           SSH_CONNECT_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_connection_str_file }}
+          SSH_BASTION_STR_FILE: ${{ steps.e2e_test_run.outputs.ssh_bastion_str_file }}
         with:
           # it sets `should_run` output var if e2e/failed/stay label
           script: |

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -350,6 +350,7 @@ function prepare_environment() {
   esac
 
   echo -e "\nmaster_user_name_for_ssh = $ssh_user\n" >> "$bootstrap_log"
+  echo -e "\nbastion_user_name_for_ssh = $ssh_user\n" >> "$bootstrap_log"
 
   set_common_ssh_parameters
 
@@ -395,6 +396,7 @@ function bootstrap_static() {
   fi
 
   echo -e "\nmaster_ip_address_for_ssh = $master_ip\n" >> "$bootstrap_log"
+  echo -e "\nbastion_ip_address_for_ssh = $bastion_ip\n" >> "$bootstrap_log"
 
   # Add key to access to hosts thru bastion
   eval "$(ssh-agent -s)"

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -398,6 +398,9 @@ function bootstrap_static() {
   echo -e "\nmaster_ip_address_for_ssh = $master_ip\n" >> "$bootstrap_log"
   echo -e "\nbastion_ip_address_for_ssh = $bastion_ip\n" >> "$bootstrap_log"
 
+  sleep 30
+  exit 1
+
   # Add key to access to hosts thru bastion
   eval "$(ssh-agent -s)"
   ssh-add "$ssh_private_key_path"

--- a/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh
+++ b/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh
@@ -17,7 +17,7 @@
 log_file="$1"
 comment_url="$2"
 connection_str_out_file="$3"
-wait_bastion_ip="$4"
+bastion_out_file="$4"
 
 if [ -z "$log_file" ]; then
   echo "Log file is required"
@@ -36,11 +36,6 @@ fi
 
 if [ -z "$connection_str_out_file" ]; then
   echo "Connection string output file is required"
-  exit 1
-fi
-
-if [ -z "$wait_bastion_ip" ]; then
-  echo "Wait bastion ip is required"
   exit 1
 fi
 
@@ -211,7 +206,7 @@ if [[ "$master_ip" == "" || "$master_user" == "" ]]; then
   exit 1
 fi
 
-if [[ "$wait_bastion_ip" == "true" ]]; then
+if [ -n "$bastion_out_file" ]; then
   # wait bastion ip and user. 10 minutes 60 cycles wit 10 second sleep
   sleep_second=0
   for (( i=1; i<=60; i++ )); do
@@ -228,6 +223,9 @@ if [[ "$wait_bastion_ip" == "true" ]]; then
     echo "Timeout waiting bastion ip and bastion user"
     exit 1
   fi
+
+  bastion_connection_str="${bastion_ip}@${bastion_user}"
+  echo -n "$bastion_connection_str" > "$bastion_out_file"
 fi
 
 connection_str="${master_user}@${master_ip}"

--- a/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh
+++ b/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh
@@ -224,7 +224,7 @@ if [ -n "$bastion_out_file" ]; then
     exit 1
   fi
 
-  bastion_connection_str="${bastion_ip}@${bastion_user}"
+  bastion_connection_str="${bastion_user}@${bastion_ip}"
   echo -n "$bastion_connection_str" > "$bastion_out_file"
 fi
 


### PR DESCRIPTION
## Description
Fix output only grey IP in e2e tests.

## Why do we need it, and what problem does it solve?
Close #3992

## What is the expected result?
e2e should output bastion `user@ip` in e2e tests (static).

Tested [here](https://github.com/deckhouse/deckhouse-test-2/pull/299).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix output only grey IP in e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
