### PR TITLE
[containerized-data-importer] Enable static build to avoid glibc error on old CPUs

### DIFF
--- a/modules/491-containerized-data-importer/images/artifact/patches/002-static-build.patch
+++ b/modules/491-containerized-data-importer/images/artifact/patches/002-static-build.patch
@@ -1,0 +1,84 @@
+diff --git a/cmd/cdi-apiserver/BUILD.bazel b/cmd/cdi-apiserver/BUILD.bazel
+index 4ac2f795e..6e78ba7ce 100644
+--- a/cmd/cdi-apiserver/BUILD.bazel
++++ b/cmd/cdi-apiserver/BUILD.bazel
+@@ -26,6 +26,7 @@ go_library(
+ go_binary(
+     name = "cdi-apiserver",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 
+diff --git a/cmd/cdi-cloner/BUILD.bazel b/cmd/cdi-cloner/BUILD.bazel
+index 098bff0a1..e6eb5839a 100644
+--- a/cmd/cdi-cloner/BUILD.bazel
++++ b/cmd/cdi-cloner/BUILD.bazel
+@@ -21,6 +21,7 @@ go_library(
+ go_binary(
+     name = "cdi-cloner",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 
+diff --git a/cmd/cdi-controller/BUILD.bazel b/cmd/cdi-controller/BUILD.bazel
+index 1a92595e7..78f5dca3b 100644
+--- a/cmd/cdi-controller/BUILD.bazel
++++ b/cmd/cdi-controller/BUILD.bazel
+@@ -57,6 +57,7 @@ go_library(
+ go_binary(
+     name = "cdi-controller",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 
+diff --git a/cmd/cdi-importer/BUILD.bazel b/cmd/cdi-importer/BUILD.bazel
+index 316b37840..ee6b78f95 100644
+--- a/cmd/cdi-importer/BUILD.bazel
++++ b/cmd/cdi-importer/BUILD.bazel
+@@ -23,6 +23,7 @@ go_library(
+ go_binary(
+     name = "cdi-importer",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 
+diff --git a/cmd/cdi-operator/BUILD.bazel b/cmd/cdi-operator/BUILD.bazel
+index e07f0ff04..42fb80b11 100644
+--- a/cmd/cdi-operator/BUILD.bazel
++++ b/cmd/cdi-operator/BUILD.bazel
+@@ -27,6 +27,7 @@ go_library(
+ go_binary(
+     name = "cdi-operator",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 
+diff --git a/cmd/cdi-uploadproxy/BUILD.bazel b/cmd/cdi-uploadproxy/BUILD.bazel
+index 859dcc5b8..2be032360 100644
+--- a/cmd/cdi-uploadproxy/BUILD.bazel
++++ b/cmd/cdi-uploadproxy/BUILD.bazel
+@@ -24,6 +24,7 @@ go_library(
+ go_binary(
+     name = "cdi-uploadproxy",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 
+diff --git a/cmd/cdi-uploadserver/BUILD.bazel b/cmd/cdi-uploadserver/BUILD.bazel
+index ac257d2aa..3a99f3131 100755
+--- a/cmd/cdi-uploadserver/BUILD.bazel
++++ b/cmd/cdi-uploadserver/BUILD.bazel
+@@ -18,6 +18,7 @@ go_library(
+ go_binary(
+     name = "cdi-uploadserver",
+     embed = [":go_default_library"],
++    static = "on",
+     visibility = ["//visibility:public"],
+ )
+ 

--- a/modules/491-containerized-data-importer/images/artifact/patches/002-static-build.patch
+++ b/modules/491-containerized-data-importer/images/artifact/patches/002-static-build.patch
@@ -1,15 +1,3 @@
-diff --git a/cmd/cdi-apiserver/BUILD.bazel b/cmd/cdi-apiserver/BUILD.bazel
-index 4ac2f795e..6e78ba7ce 100644
---- a/cmd/cdi-apiserver/BUILD.bazel
-+++ b/cmd/cdi-apiserver/BUILD.bazel
-@@ -26,6 +26,7 @@ go_library(
- go_binary(
-     name = "cdi-apiserver",
-     embed = [":go_default_library"],
-+    static = "on",
-     visibility = ["//visibility:public"],
- )
- 
 diff --git a/cmd/cdi-cloner/BUILD.bazel b/cmd/cdi-cloner/BUILD.bazel
 index 098bff0a1..e6eb5839a 100644
 --- a/cmd/cdi-cloner/BUILD.bazel

--- a/modules/491-containerized-data-importer/images/artifact/patches/README.md
+++ b/modules/491-containerized-data-importer/images/artifact/patches/README.md
@@ -11,6 +11,12 @@ Internal patch which adds deckhouse ImagePullSecrets to kubevirt VMs
 - https://github.com/kubevirt/containerized-data-importer/issues/2395
 - https://kubernetes.slack.com/archives/C0163DT0R8X/p1660319072512309
 
+#### `002-static-build.patch`
+
+Enable static build to avoid glibc error on old CPUs
+
+- https://github.com/kubevirt/containerized-data-importer/issues/2652
+
 #### `003-apiserver-node-selector-and-tolerations.patch`
 
 Allow to override nodeSelector and tolerations for cdi-apiserver


### PR DESCRIPTION
## Description

fix https://github.com/kubevirt/containerized-data-importer/issues/2652

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
