### PR TITLE
[ingress-nginx] Add detailed default backend metrics

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -211,11 +211,6 @@ local function fill_buffer()
   -- For older versions we just cut of the asterisk from vhost
   local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
 
-  if var_server_name == "_" then
-    _increment("c22", {}, 22)
-    return
-  end
-
   local content_kind
   local var_upstream_x_content_kind = ngx.var.upstream_x_content_kind
   local var_upstream_addr = ngx.var.upstream_addr

--- a/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -211,11 +211,6 @@ local function fill_buffer()
   -- For older versions we just cut of the asterisk from vhost
   local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
 
-  if var_server_name == "_" then
-    _increment("c22", {}, 22)
-    return
-  end
-
   local content_kind
   local var_upstream_x_content_kind = ngx.var.upstream_x_content_kind
   local var_upstream_addr = ngx.var.upstream_addr

--- a/modules/402-ingress-nginx/images/protobuf-exporter/rootfs/etc/protobuf_exporter/mappings.yaml
+++ b/modules/402-ingress-nginx/images/protobuf-exporter/rootfs/etc/protobuf_exporter/mappings.yaml
@@ -119,7 +119,3 @@
   type: Counter
   labels: [content_kind, namespace, vhost, geohash, place]
   ttl: 1h
-#22
-- name: ingress_nginx_default_backend_requests_total
-  type: Counter
-  ttl: 1h

--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/namespace/namespace_detail.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/namespace/namespace_detail.json
@@ -10167,14 +10167,36 @@
         "useTags": false
       },
       {
-        "description": null,
-        "error": null,
-        "hide": 2,
+        "current": {
+          "selected": true,
+          "text": "without default backend",
+          "value": "[^_]*"
+        },
+        "hide": 0,
+        "includeAll": false,
         "label": "VHost",
+        "multi": false,
         "name": "vhost",
-        "query": ".*",
+        "options": [
+          {
+            "selected": true,
+            "text": "without default backend",
+            "value": "[^_]*"
+          },
+          {
+            "selected": false,
+            "text": "all",
+            "value": ".*"
+          },
+          {
+            "selected": false,
+            "text": "default backend",
+            "value": "_"
+          }
+        ],
+        "query": "[^_]*,.*,_",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "custom"
       },
       {
         "description": null,

--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/namespace/namespaces.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/namespace/namespaces.json
@@ -8089,14 +8089,36 @@
         "type": "constant"
       },
       {
-        "description": null,
-        "error": null,
-        "hide": 2,
+        "current": {
+          "selected": true,
+          "text": "without default backend",
+          "value": "[^_]*"
+        },
+        "hide": 0,
+        "includeAll": false,
         "label": "VHost",
+        "multi": false,
         "name": "vhost",
-        "query": ".*",
+        "options": [
+          {
+            "selected": true,
+            "text": "without default backend",
+            "value": "[^_]*"
+          },
+          {
+            "selected": false,
+            "text": "all",
+            "value": ".*"
+          },
+          {
+            "selected": false,
+            "text": "default backend",
+            "value": "_"
+          }
+        ],
+        "query": "[^_]*,.*,_",
         "skipUrlSync": false,
-        "type": "constant"
+        "type": "custom"
       },
       {
         "description": null,

--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/kubernetes-cluster/controller-detail.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/kubernetes-cluster/controller-detail.json
@@ -1017,7 +1017,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\"}[$__interval_sx4]))",
+          "expr": "sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\", vhost=~\"_\"}[$__interval_sx4]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1027,7 +1027,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\"}[$__interval_sx4])) by (controller)",
+          "expr": "sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\", vhost=~\"_\"}[$__interval_sx4])) by (controller)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1144,7 +1144,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\"}[$__interval_sx4])) by (controller)\n/ scalar(sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\"}[$__interval_sx4])))",
+          "expr": "sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\", vhost=~\"_\"}[$__interval_sx4])) by (controller)\n/ scalar(sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\".*\", app=~\".*\", node=~\".*\", vhost=~\"_\"}[$__interval_sx4])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/kubernetes-cluster/controllers.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/kubernetes-cluster/controllers.json
@@ -1008,7 +1008,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\"}[$__interval_sx4]))",
+          "expr": "sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\", vhost=~\"_\"}[$__interval_sx4]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Total",
@@ -1016,7 +1016,7 @@
           "step": 10
         },
         {
-          "expr": "sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\"}[$__interval_sx4])) $by",
+          "expr": "sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\", vhost=~\"_\"}[$__interval_sx4])) $by",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$legend_format",
@@ -1120,7 +1120,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\"}[$__interval_sx4])) $by\n/ scalar(sum(rate(ingress_nginx_default_backend_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\"}[$__interval_sx4])))",
+          "expr": "sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\", vhost=~\"_\"}[$__interval_sx4])) $by\n/ scalar(sum(rate(ingress_nginx_detail_requests_total{job=\"nginx-ingress-controller\", controller=~\"$controller\", app=~\"$app\", node=~\"$node\", vhost=~\"_\"}[$__interval_sx4])))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$legend_format",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add labels to the default backend request metric: ingress, service, location.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The default backend can handle requests to different locations. We need to split metric for different locations. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
ingress_nginx_default_backend_requests_total metric MUST contain 3 new labels - ingress, service, location

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: feature
summary: The default backend request metric contain ingress, service, and location labels
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
