### PR TITLE
[deckhouse] Remove Helm binary from Deckhouse image

### DIFF
--- a/werf.yaml
+++ b/werf.yaml
@@ -57,15 +57,6 @@ gitWorktree:
       dest: /usr/local/bin/kubectl
       mode: +x
 
-  - name: "Install helm 3"
-    unarchive:
-      extra_opts:
-        - linux-amd64/helm
-        - --strip-components=1
-      src: https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz
-      remote_src: yes
-      dest: /usr/local/bin
-
   # TODO: checksum
   - name: "Install semver"
     unarchive:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR removes Helm binary from Deckhouse image.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Having Helm binary in Deckhouse image carries only debugging purpose.
But keeping it in sync with Helm lib in go.mod requires addition effort, and sometimes it'll get out of sync, causing inability to use Helm for debugging.
Deckhouse pod doesn't force read-only, so it's easy to download it manually.

This PR closes #4277.

Well, as a bonus, we will save 40MB.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Helm binary is removed from Deckhouse image:
![image](https://user-images.githubusercontent.com/111346521/231779086-257ea353-b6e7-4964-8d9d-bd44474cc135.png)


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Remove Helm binary from Deckhouse image
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
