### PR TITLE
[prometheus] Fix AlertmanagerConfig Heml template

### DIFF
--- a/modules/300-prometheus/template_tests/multiple_custom_alert_managers_test.go
+++ b/modules/300-prometheus/template_tests/multiple_custom_alert_managers_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: prometheus :: helm template :: AlertmanagerConfig", func() {
+	f := SetupHelmConfig(``)
+
+	const prometheusValues = `
+auth: {}
+vpa: {}
+grafana: {}
+https:
+  mode: CustomCertificate
+internal:
+  vpa: {}
+  prometheusMain: {}
+  grafana: {}
+  customCertificateData:
+    tls.crt: CRTCRTCRT
+    tls.key: KEYKEYKEY
+  alertmanagers: {}
+  prometheusAPIClientTLS:
+    certificate: CRTCRTCRT
+    key: KEYKEYKEY
+  prometheusScraperIstioMTLS:
+    certificate: CRTCRTCRT
+    key: KEYKEYKEY
+  prometheusScraperTLS:
+    certificate: CRTCRTCRT
+    key: KEYKEYKEY
+  auth: {}
+`
+
+	const values = `
+- name: test-alert-emailer
+  receivers:
+    - emailConfigs:
+        - from: test
+          requireTLS: false
+          sendResolved: false
+          smarthost: test
+          to: test@test.ru
+      name: test-alert-emailer
+  route:
+    groupBy:
+      - job
+    groupInterval: 5m
+    groupWait: 30s
+    receiver: test-alert-emailer
+    repeatInterval: 4h
+    routes:
+      - matchers:
+          - name: namespace
+            regex: false
+            value: app-airflow
+        receiver: test-alert-emailer
+- name: airflow-alert-emailer
+  receivers:
+    - emailConfigs:
+        - from: test
+          requireTLS: false
+          sendResolved: false
+          smarthost: test
+          to: test@test.ru
+      name: airflow-alert-emailer
+  route:
+    groupBy:
+      - job
+    groupInterval: 5m
+    groupWait: 30s
+    receiver: airflow-alert-emailer
+    repeatInterval: 4h
+    routes:
+      - matchers:
+          - name: namespace
+            regex: false
+            value: app-airflow
+        receiver: airflow-alert-emailer
+`
+	var tests = []struct {
+		name         string
+		expectedYaml string
+	}{
+		{
+			name: "test-alert-emailer",
+			expectedYaml: `apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  labels:
+    alertmanagerConfig: test-alert-emailer
+    app: alertmanager
+    heritage: deckhouse
+    module: prometheus
+  name: test-alert-emailer
+  namespace: d8-monitoring
+spec:
+  receivers:
+  - emailConfigs:
+    - from: test
+      requireTLS: false
+      sendResolved: false
+      smarthost: test
+      to: test@test.ru
+    name: test-alert-emailer
+  route:
+    groupBy:
+    - job
+    groupInterval: 5m
+    groupWait: 30s
+    receiver: test-alert-emailer
+    repeatInterval: 4h
+    routes:
+    - matchers:
+      - name: namespace
+        regex: false
+        value: app-airflow
+      receiver: test-alert-emailer
+`,
+		},
+		{
+			name: "airflow-alert-emailer",
+			expectedYaml: `apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  labels:
+    alertmanagerConfig: airflow-alert-emailer
+    app: alertmanager
+    heritage: deckhouse
+    module: prometheus
+  name: airflow-alert-emailer
+  namespace: d8-monitoring
+spec:
+  receivers:
+  - emailConfigs:
+    - from: test
+      requireTLS: false
+      sendResolved: false
+      smarthost: test
+      to: test@test.ru
+    name: airflow-alert-emailer
+  route:
+    groupBy:
+    - job
+    groupInterval: 5m
+    groupWait: 30s
+    receiver: airflow-alert-emailer
+    repeatInterval: 4h
+    routes:
+    - matchers:
+      - name: namespace
+        regex: false
+        value: app-airflow
+      receiver: airflow-alert-emailer
+`,
+		},
+	}
+
+	Context("Default", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("prometheus", prometheusValues)
+			f.ValuesSetFromYaml("prometheus.internal.alertmanagers.internal", values)
+			f.HelmRender()
+		})
+
+		It("AlertmanagerConfig must render properly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			for _, test := range tests {
+				resource := f.KubernetesResource("AlertmanagerConfig", "d8-monitoring", test.name)
+				Expect(resource.Exists()).To(BeTrue())
+				Expect(resource.ToYaml()).To(MatchYAML(test.expectedYaml))
+			}
+		})
+	})
+})

--- a/modules/300-prometheus/templates/alertmanager/internal/alertmanagerconfig.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/alertmanagerconfig.yaml
@@ -1,5 +1,6 @@
 {{- if (hasKey .Values.prometheus.internal.alertmanagers "internal") }}
   {{- range .Values.prometheus.internal.alertmanagers.internal }}
+---
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add three dashes `---` to separate resources in alertmanagerconfig.yaml Helm template. Add tests.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In Helm templates you MUST separate resources with three dashes `---`.
Close #3369 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Fixed creation of multiple CustomAlertmanager resources.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fixed creation of multiple CustomAlertmanager resources.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
