### PR TITLE
[tools] d8 pull fix for tagged images

### DIFF
--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -161,7 +161,7 @@ pull_image() {
   fi
 
   delim="@"
-  if [[ $# -ne $2 ]] && [[ "$3" == "by_tag" ]]; then
+  if [[ $# -ne $2 ]] && [[ "$3" == "use_tag" ]]; then
     delim=":"
   fi
   #using tarball, because dhctl bootstrap doesn't support oci format
@@ -185,9 +185,9 @@ REGISTRY_PATH="$REGISTRY/$EDITION"
 IMAGES=$(docker run --pull=always -ti --rm "$REGISTRY_PATH:$RELEASE" cat /deckhouse/modules/images_digests.json | jq '. | to_entries | .[].value | to_entries | .[].value' -r | sort -rn | uniq)
 trap pull_image_clean_up ERR SIGINT SIGTERM SIGHUP SIGQUIT
 #saving Deckhouse image
-pull_image "$RELEASE" "" "by_tag"
+pull_image "$RELEASE" "" "use_tag"
 #saving Deckhouse install image
-pull_image "$RELEASE" "install"
+pull_image "$RELEASE" "install" "use_tag"
 #saving uniq images from images_digests.json
 l=$(echo "$IMAGES" | wc -l)
 count=1

--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -161,7 +161,7 @@ pull_image() {
   fi
 
   delim="@"
-  if [[ $# -ne $2 ]] && [[ "$3" == "use_tag" ]]; then
+  if [[ $# -ne 2 ]] && [[ "$3" == "use_tag" ]]; then
     delim=":"
   fi
   #using tarball, because dhctl bootstrap doesn't support oci format

--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -161,7 +161,7 @@ pull_image() {
   fi
 
   delim="@"
-  if [[ $# -ne 2 ]] && [[ "$3" == "use_tag" ]]; then
+  if [[ $# -gt 2 ]] && [[ "$3" == "use_tag" ]]; then
     delim=":"
   fi
   #using tarball, because dhctl bootstrap doesn't support oci format

--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -159,8 +159,13 @@ pull_image() {
   if [[ -s "$IMAGE" ]]; then
     return 0
   fi
+
+  delim="@"
+  if [[ $# -ne $2 ]] && [[ "$3" == "by_tag" ]]; then
+    delim=":"
+  fi
   #using tarball, because dhctl bootstrap doesn't support oci format
-  crane pull "$registry_full_path@$1" --format tarball "$IMAGE"
+  crane pull "$registry_full_path${delim}${1}" --format tarball "$IMAGE"
 }
 
 pull_trivy_db() {
@@ -180,7 +185,7 @@ REGISTRY_PATH="$REGISTRY/$EDITION"
 IMAGES=$(docker run --pull=always -ti --rm "$REGISTRY_PATH:$RELEASE" cat /deckhouse/modules/images_digests.json | jq '. | to_entries | .[].value | to_entries | .[].value' -r | sort -rn | uniq)
 trap pull_image_clean_up ERR SIGINT SIGTERM SIGHUP SIGQUIT
 #saving Deckhouse image
-pull_image "$RELEASE"
+pull_image "$RELEASE" "" "by_tag"
 #saving Deckhouse install image
 pull_image "$RELEASE" "install"
 #saving uniq images from images_digests.json


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
After #4390 `d8-pull.sh` script fails to pull tagged images (like release image). This PR adds additional argument for pull_image func 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix `d8-pull.sh` script
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: Fix d8-pull.sh script for tagged images
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
