### PR TITLE
Add prometheus.deckhouse.io/rules-watcher-enabled label

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-openstack
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-openstack") }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-vsphere
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-vsphere") }}

--- a/ee/modules/110-istio/templates/ingress-gateway-controller/namespace.yaml
+++ b/ee/modules/110-istio/templates/ingress-gateway-controller/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-ingress-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-ingress-%s" .Chart.Name)) }}

--- a/ee/modules/110-istio/templates/namespace.yaml
+++ b/ee/modules/110-istio/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/380-metallb/templates/namespace.yaml
+++ b/ee/modules/380-metallb/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/450-keepalived/templates/namespace.yaml
+++ b/ee/modules/450-keepalived/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/450-network-gateway/templates/namespace.yaml
+++ b/ee/modules/450-network-gateway/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/500-operator-trivy/templates/namespace.yaml
+++ b/ee/modules/500-operator-trivy/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/502-delivery/templates/namespace.yaml
+++ b/ee/modules/502-delivery/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-delivery") }}

--- a/ee/modules/600-flant-integration/templates/namespace.yaml
+++ b/ee/modules/600-flant-integration/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/650-runtime-audit-engine/templates/namespace.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -3,13 +3,13 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-service-accounts
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-system") }}
 ---

--- a/modules/015-admission-policy-engine/templates/namespace.yaml
+++ b/modules/015-admission-policy-engine/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/021-cni-cilium/templates/namespace.yaml
+++ b/modules/021-cni-cilium/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{ include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{ include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/030-cloud-provider-aws/templates/namespace.yaml
+++ b/modules/030-cloud-provider-aws/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/030-cloud-provider-azure/templates/namespace.yaml
+++ b/modules/030-cloud-provider-azure/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-azure") }}

--- a/modules/030-cloud-provider-gcp/templates/namespace.yaml
+++ b/modules/030-cloud-provider-gcp/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-gcp
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/030-cloud-provider-yandex/templates/namespace.yaml
+++ b/modules/030-cloud-provider-yandex/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-yandex
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/031-ceph-csi/templates/namespace.yaml
+++ b/modules/031-ceph-csi/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+{{ include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | indent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/031-local-path-provisioner/templates/namespace.yaml
+++ b/modules/031-local-path-provisioner/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/035-cni-flannel/templates/namespace.yaml
+++ b/modules/035-cni-flannel/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/035-cni-simple-bridge/templates/namespace.yaml
+++ b/modules/035-cni-simple-bridge/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/040-node-manager/templates/namespace.yaml
+++ b/modules/040-node-manager/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-instance-manager") }}

--- a/modules/041-linstor/templates/namespace.yaml
+++ b/modules/041-linstor/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/045-snapshot-controller/templates/namespace.yaml
+++ b/modules/045-snapshot-controller/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/101-cert-manager/templates/namespace.yaml
+++ b/modules/101-cert-manager/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cert-manager
-  {{- include "helm_lib_module_labels" (list . (dict "cert-manager.io/disable-validation" "true" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "cert-manager.io/disable-validation" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cert-manager") }}

--- a/modules/140-user-authz/templates/namespace.yaml
+++ b/modules/140-user-authz/templates/namespace.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}
 {{- end }}

--- a/modules/150-user-authn/templates/namespace.yaml
+++ b/modules/150-user-authn/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/200-operator-prometheus/templates/namespace.yaml
+++ b/modules/200-operator-prometheus/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-operator-prometheus
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-operator-prometheus") }}

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -688,6 +688,22 @@ spec:
     - port: web
 ```
 
+## How do I set up a PrometheusRules to work with Prometheus?
+
+Add the label `prometheus.deckhouse.io/rules-watcher-enabled: "true"` to the namespace where the PrometheusRules was created.
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/rules-watcher-enabled: "true"
+```
+
 ## How to expand disk size
 
 1. To request a larger volume for a PVC, edit the PVC object and specify a larger size in `spec.resources.requests.storage` field.

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -685,6 +685,22 @@ spec:
     - port: web
 ```
 
+## Как настроить PrometheusRules для работы с Prometheus?
+
+Добавьте в namespace, в котором находятся PrometheusRules, лейбл `prometheus.deckhouse.io/rules-watcher-enabled: "true"`.
+
+Пример:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/rules-watcher-enabled: "true"
+```
+
 ## Как увеличить размер диска
 
 1. Для увеличения размера отредактируйте PersistentVolumeClaim, указав новый размер в поле `spec.resources.requests.storage`.

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -146,7 +146,7 @@ spec:
       prometheus.deckhouse.io/monitor-watcher-enabled: "true"
   ruleNamespaceSelector:
     matchLabels:
-      heritage: deckhouse
+      prometheus.deckhouse.io/rules-watcher-enabled: "true"
   probeNamespaceSelector:
     matchLabels:
       heritage: deckhouse

--- a/modules/400-descheduler/templates/namespace.yaml
+++ b/modules/400-descheduler/templates/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   name: d8-descheduler
   annotations:
     extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-descheduler") }}

--- a/modules/402-ingress-nginx/templates/namespace.yaml
+++ b/modules/402-ingress-nginx/templates/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   name: d8-ingress-nginx
   annotations:
     extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.flant.com/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.flant.com/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/460-log-shipper/templates/namespace.yaml
+++ b/modules/460-log-shipper/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/465-pod-reloader/templates/namespace.yaml
+++ b/modules/465-pod-reloader/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/470-chrony/templates/namespace.yaml
+++ b/modules/470-chrony/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/490-virtualization/templates/namespace.yaml
+++ b/modules/490-virtualization/templates/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
   name: d8-virtualization
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}

--- a/modules/491-containerized-data-importer/templates/namespace.yaml
+++ b/modules/491-containerized-data-importer/templates/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
   name: d8-cdi
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cdi") }}

--- a/modules/500-dashboard/templates/namespace.yaml
+++ b/modules/500-dashboard/templates/namespace.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}

--- a/modules/500-okmeter/templates/namespace.yaml
+++ b/modules/500-okmeter/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "okmeter")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "okmeter" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/500-openvpn/templates/namespace.yaml
+++ b/modules/500-openvpn/templates/namespace.yaml
@@ -4,6 +4,6 @@ kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
   annotations:
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/500-upmeter/templates/namespace.yaml
+++ b/modules/500-upmeter/templates/namespace.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add `prometheus.deckhouse.io/rules-watcher-enabled` label to all namespaces with the prefix 'd8-'. Add a rule for the Helm resources linter.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Provide users the ability to extend namespaces to read prometheus rules.
Close #4335 

## What is the expected result?
Prometheus resource has the `ruleNamespaceSelector.matchLabels.prometheus.deckhouse.io/rules-watcher-enabled` field.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
---
section:
type: cloud-provider-openstack
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cloud-provider-vsphere
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: istio
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: metallb
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: keepalived
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: network-gateway
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section:  operator-trivy
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: delivery
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: flant-integration
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: runtime-audit-engine
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: deckhouse
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: admission-policy-engine
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cni-cilium
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cloud-provider-aws
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cloud-provider-azure
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cloud-provider-gcp
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cloud-provider-yandex
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: ceph-csi
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: local-path-provisioner
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cni-flannel
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cni-simple-bridge
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: node-manager
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: linstor
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: snapsnot-controller
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: cert-manager
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: user-authz
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: user-authn
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: operator-prometheus
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: prometheus
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: descheduler
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: ingress-nginx
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: log-shipper
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: pod-reloader
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: chrony
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: virtualization
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: containerized-data-importer
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: dashboard
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: okmeter
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: openvpn
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
---
section: upmeter
type: feature
summary: Add support for `PrometheusRule`.
impact_level: default
```
