### PR TITLE
[cloud-provider-aws][monitoring] Document missing IAM permissions in corresponding alerts for Deckhouse >= 1.45

### DIFF
--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -175,7 +175,7 @@
         Probably, it occurred because Terraform-state-exporter had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 {{ if and (.Values.global.enabledModules | has "cloud-provider-aws") (semverCompare ">=1.45" .Values.global.deckhouseVersion) }}
-        Also, it can occur because of missing permissions for the following actions in configured AWS IAM policy that were first used in Deckhouse v1.45:
+        Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
         1. `ec2:DescribeInstanceTypes`,
         2. `ec2:DescribeSecurityGroupRules`.
 {{ end -}}
@@ -201,7 +201,7 @@
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 {{ if and (.Values.global.enabledModules | has "cloud-provider-aws") (semverCompare ">=1.45" .Values.global.deckhouseVersion) }}
-        Also, it can occur because of missing permissions for the following actions in configured AWS IAM policy that were first used in Deckhouse v1.45:
+        Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
         1. `ec2:DescribeInstanceTypes`,
         2. `ec2:DescribeSecurityGroupRules`.
 {{ end -}}

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -128,7 +128,7 @@
       plk_create_group_if_not_exists__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       description: |
-        Real Kubernetes cluster state is `{{ $labels.status }}` comparing to Terraform state.
+        Real Kubernetes cluster state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
@@ -149,7 +149,7 @@
       plk_create_group_if_not_exists__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       description: |
-        Real Node "{{ $labels.node_group }}/{{ $labels.name }}" state is `{{ $labels.status }}` comparing to Terraform state.
+        Real Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
@@ -196,7 +196,7 @@
       plk_create_group_if_not_exists__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       description: |
-        Terraform-state-exporter can't check difference between Node "{{ $labels.node_group }}/{{ $labels.name }}" state and Terraform state.
+        Terraform-state-exporter can't check difference between Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state and Terraform state.
 
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
@@ -222,8 +222,8 @@
       plk_create_group_if_not_exists__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_terraform_state_exporter_malfunctioning: "D8TerraformStateExporterMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       description: |
-        Terraform-state-exporter found difference between node template from cluster provider configuration and from NodeGroup {{ $labels.name }}.
-        Node template is `{{ $labels.status }}`.
+        Terraform-state-exporter found difference between node template from cluster provider configuration and from NodeGroup `{{`{{ $labels.name }}`}}`.
+        Node template is `{{`{{ $labels.status }}`}}`.
 
         Use `dhctl converge` command or manually adjust NodeGroup settings to fix the issue.
       summary: Terraform-state-exporter node template changed

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -174,11 +174,12 @@
 
         Probably, it occurred because Terraform-state-exporter had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
-{{ if and (.Values.global.enabledModules | has "cloud-provider-aws") (semverCompare ">=1.45" .Values.global.deckhouseVersion) }}
+
+{{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
         Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
         1. `ec2:DescribeInstanceTypes`,
         2. `ec2:DescribeSecurityGroupRules`.
-{{ end -}}
+{{- end }}
       summary: Terraform-state-exporter cluster state error
 
   - alert: D8TerraformStateExporterNodeStateError
@@ -200,11 +201,12 @@
 
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
-{{ if and (.Values.global.enabledModules | has "cloud-provider-aws") (semverCompare ">=1.45" .Values.global.deckhouseVersion) }}
+
+{{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
         Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
         1. `ec2:DescribeInstanceTypes`,
         2. `ec2:DescribeSecurityGroupRules`.
-{{ end -}}
+{{- end }}
       summary: Terraform-state-exporter node state error
 
   - alert: D8TerraformStateExporterNodeTemplateChanged

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -174,6 +174,11 @@
 
         Probably, it occurred because Terraform-state-exporter had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
+{{ if and (.Values.global.enabledModules | has "cloud-provider-aws") (semverCompare ">=1.45" .Values.global.deckhouseVersion) }}
+        Also, it can occur because of missing permissions for the following actions in configured AWS IAM policy that were first used in Deckhouse v1.45:
+        1. `ec2:DescribeInstanceTypes`,
+        2. `ec2:DescribeSecurityGroupRules`.
+{{ end -}}
       summary: Terraform-state-exporter cluster state error
 
   - alert: D8TerraformStateExporterNodeStateError
@@ -195,6 +200,11 @@
 
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
+{{ if and (.Values.global.enabledModules | has "cloud-provider-aws") (semverCompare ">=1.45" .Values.global.deckhouseVersion) }}
+        Also, it can occur because of missing permissions for the following actions in configured AWS IAM policy that were first used in Deckhouse v1.45:
+        1. `ec2:DescribeInstanceTypes`,
+        2. `ec2:DescribeSecurityGroupRules`.
+{{ end -}}
       summary: Terraform-state-exporter node state error
 
   - alert: D8TerraformStateExporterNodeTemplateChanged


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR adds following note in `D8TerraformStateExporterClusterStateError` and `D8TerraformStateExporterNodeStateError` if  `cloud-provider-aws` is enabled:
```
Also, it can occur because of missing permissions for the following actions in configured AWS IAM policy that were first used in Deckhouse v1.45:
1. `ec2:DescribeInstanceTypes`,
2. `ec2:DescribeSecurityGroupRules`.
```
This PR was tested manually on AWS cluster with corresponding permissions missing:
![image1](https://user-images.githubusercontent.com/111346521/233207370-271df751-9f5d-40a6-8f46-ff231e42e35e.png)
![image2](https://user-images.githubusercontent.com/111346521/233207430-585f3c69-8b22-42b6-ab85-ec2bab025a94.png)


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Since https://github.com/deckhouse/deckhouse/pull/4256 the permissions above are essential for AWS Terraform Provider to function correctly, but there is a common case when this permission are missing on existing cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We need to inform CE users of existing AWS clusters of the newly required permissions.

## What is the expected result?
<!---
  How can one check these changes after applying?

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Information about possibility of missing permissions added to corresponding alerts of `terraform-manager`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: terraform-manager
type: chore
summary: Document missing IAM permissions in corresponding alerts for Deckhouse >= 1.45
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
