### PR TITLE
[linstor] added secret generation for secureboot

### DIFF
--- a/modules/041-linstor/hooks/common.go
+++ b/modules/041-linstor/hooks/common.go
@@ -34,4 +34,9 @@ const (
 	spaasServiceHost = spaasServiceName + "." + linstorNamespace + ".svc"
 	spaasSecretName  = "spaas-certs"
 	spaasCertPath    = "linstor.internal.spaasCert"
+
+	secureBootSecretName     = "secureboot-cert"
+	secureBootKeyPath        = "linstor.internal.secretBootCerts.key"
+	secureBootDerPath        = "linstor.internal.secretBootCerts.der"
+	secureBootPassphrasePath = "linstor.internal.secretBootCerts.passphrase"
 )

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -113,7 +113,7 @@ func generateSecureBootCert(input *go_hook.HookInput) error {
 		derKey, err := x509.MarshalPKIXPublicKey(pub)
 
 		input.Values.Set(secureBootDerPath, string(derKey))
-		input.Values.Set(secureBootKeyPath, string(block.Bytes))
+		input.Values.Set(secureBootKeyPath, string(pem.EncodeToMemory(block)))
 		input.Values.Set(secureBootPassphrasePath, passphrase)
 	}
 

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -123,6 +123,10 @@ func generateSecureBootCert(input *go_hook.HookInput) error {
 		input.Values.Set(secureBootDerPath, string(derKey))
 		input.Values.Set(secureBootKeyPath, string(pem.EncodeToMemory(block)))
 		input.Values.Set(secureBootPassphrasePath, passphrase)
+	} else {
+		input.Values.Set(secureBootDerPath, cert.Der)
+		input.Values.Set(secureBootKeyPath, cert.Key)
+		input.Values.Set(secureBootPassphrasePath, cert.Passphrase)
 	}
 
 	return nil

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -109,11 +109,6 @@ func generateSecureBootCert(input *go_hook.HookInput) error {
 			Bytes: keyBytes,
 		}
 
-		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(passphrase), x509.PEMCipherAES256)
-		if err != nil {
-			return err
-		}
-
 		pub := key.Public()
 		derKey, err := x509.MarshalPKIXPublicKey(pub)
 		if err != nil {

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+/*
+We need to generate drbd module for each kernel version dynamically. In case of SecureBoot we need to sign module,
+and add our private key to secure store. This hook generate private key and passphrase.
+*/
+
+type SecureBootCertSnapshotContent struct {
+	Der        string
+	Key        string
+	Passphrase string
+}
+
+type SecureBootCertSnapshot struct {
+	Name string
+	Data SecureBootCertSnapshotContent
+}
+
+func applySecureBootCertsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert certificate secret to secret: %v", err)
+	}
+
+	return &SecureBootCertSnapshot{
+		Name: secret.Name,
+		Data: SecureBootCertSnapshotContent{
+			Der:        string(secret.Data["secureboot.der"]),
+			Key:        string(secret.Data["secureboot.key"]),
+			Passphrase: string(secret.Data["passphrase"]),
+		}}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "certs",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{linstorNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{secureBootSecretName},
+			},
+			FilterFunc: applySecureBootCertsFilter,
+		},
+	},
+}, generateSecureBootCert)
+
+func generateSecureBootCert(input *go_hook.HookInput) error {
+	var cert SecureBootCertSnapshotContent
+
+	snaps := input.Snapshots["certs"]
+	for _, snap := range snaps {
+		s := snap.(*SecureBootCertSnapshot)
+		cert = s.Data
+	}
+
+	if cert.Passphrase == "" {
+		bitSize := 2048
+		passphrase := tools.RandomString("", 16)
+		key, err := rsa.GenerateKey(rand.Reader, bitSize)
+		if err != nil {
+			return err
+		}
+
+		block := &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		}
+
+		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(passphrase), x509.PEMCipherAES256)
+		if err != nil {
+			return err
+		}
+
+		pub := key.Public()
+		derKey, err := x509.MarshalPKIXPublicKey(pub)
+
+		input.Values.Set(secureBootDerPath, string(derKey))
+		input.Values.Set(secureBootKeyPath, string(block.Bytes))
+		input.Values.Set(secureBootPassphrasePath, passphrase)
+	}
+
+	return nil
+}

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -91,7 +91,7 @@ func generateSecureBootCert(input *go_hook.HookInput) error {
 		cert = s.Data
 	}
 
-	if cert.Passphrase == "" {
+	if cert.Passphrase == "" || cert.Der == "" || cert.Key == "" {
 		bitSize := 2048 // 4096 bit not supported!
 		passphrase := tools.RandomString("", 16)
 		key, err := rsa.GenerateKey(rand.Reader, bitSize)

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -109,10 +109,10 @@ func generateSecureBootCert(input *go_hook.HookInput) error {
 			Bytes: keyBytes,
 		}
 
-		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(passphrase), x509.PEMCipherAES256)
-		if err != nil {
-			return err
-		}
+		//block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(passphrase), x509.PEMCipherAES256)
+		//if err != nil {
+		//	return err
+		//}
 
 		pub := key.Public()
 		derKey, err := x509.MarshalPKIXPublicKey(pub)

--- a/modules/041-linstor/hooks/generate_secureboot_key.go
+++ b/modules/041-linstor/hooks/generate_secureboot_key.go
@@ -109,6 +109,11 @@ func generateSecureBootCert(input *go_hook.HookInput) error {
 			Bytes: keyBytes,
 		}
 
+		block, err = x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte(passphrase), x509.PEMCipherAES256)
+		if err != nil {
+			return err
+		}
+
 		pub := key.Public()
 		derKey, err := x509.MarshalPKIXPublicKey(pub)
 		if err != nil {

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 # Using source code from GitHub repository
 RUN git clone ${DRBD_GITREPO} /drbd \
  && cd /drbd \
- && git checkout test-dkms-sign \
+ && git checkout test-sign \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -16,6 +16,8 @@ RUN git clone ${DRBD_GITREPO} /drbd \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 
+RUN echo 1
+
 # # Using source code provided by LINBIT
 # RUN DRBD_PKG=https://pkg.linbit.com//downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz \
 #  && wget -O /drbd.tar.gz ${DRBD_PKG}

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_UBUNTU
 
 FROM $BASE_UBUNTU as builder
-ARG DRBD_GITREPO=https://gitlab.lv426.tech/ext/drbd
+ARG DRBD_GITREPO=https://github.com/duckhawk/drbd
 ARG DRBD_VERSION=9.2.2
 
 RUN apt-get update \

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 # Using source code from GitHub repository
 RUN git clone ${DRBD_GITREPO} /drbd \
  && cd /drbd \
- && git checkout test-sign \
+ && git checkout test-dkms-sign \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_UBUNTU
 
 FROM $BASE_UBUNTU as builder
 ARG DRBD_GITREPO=https://github.com/duckhawk/drbd
-ARG DRBD_VERSION=9.2.2
+ARG DRBD_VERSION=9.2.3
 
 RUN apt-get update \
  && apt-get install -y make git \

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_UBUNTU
 
 FROM $BASE_UBUNTU as builder
-ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
+ARG DRBD_GITREPO=https://gitlab.lv426.tech/ext/drbd
 ARG DRBD_VERSION=9.2.2
 
 RUN apt-get update \
@@ -12,7 +12,7 @@ RUN apt-get update \
 # Using source code from GitHub repository
 RUN git clone ${DRBD_GITREPO} /drbd \
  && cd /drbd \
- && git reset --hard drbd-${DRBD_VERSION} \
+ && git reset --hard test-dkms-sign \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 
@@ -26,7 +26,7 @@ RUN tar xvf /drbd.tar.gz --strip-components=2 --wildcards 'drbd-*/docker/entry.s
 FROM $BASE_UBUNTU
 
 RUN apt-get update \
- && apt-get install -y kmod gnupg wget make gcc patch curl libelf-dev \
+ && apt-get install -y kmod gnupg wget make gcc patch curl libelf-dev mokutil \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -16,8 +16,6 @@ RUN git clone ${DRBD_GITREPO} /drbd \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 
-RUN echo 1
-
 # # Using source code provided by LINBIT
 # RUN DRBD_PKG=https://pkg.linbit.com//downloads/drbd/9/drbd-${DRBD_VERSION}.tar.gz \
 #  && wget -O /drbd.tar.gz ${DRBD_PKG}

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 # Using source code from GitHub repository
 RUN git clone ${DRBD_GITREPO} /drbd \
  && cd /drbd \
- && git reset --hard test-dkms-sign \
+ && git checkout test-dkms-sign \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 

--- a/modules/041-linstor/images/spaas/Dockerfile
+++ b/modules/041-linstor/images/spaas/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_GOLANG_19_BULLSEYE as builder
 ARG SPAAS_GITREPO=https://github.com/LINBIT/saas
 ARG SPAAS_COMMIT_REF=7bef2e7976a455550bce2533487c635f20390ccf
 ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
-ARG DRBD_VERSION=9.2.2
+ARG DRBD_VERSION=9.2.3
 
 RUN git clone ${SPAAS_GITREPO} /usr/local/go/spaas \
  && cd /usr/local/go/spaas \

--- a/modules/041-linstor/openapi/values.yaml
+++ b/modules/041-linstor/openapi/values.yaml
@@ -81,6 +81,23 @@ properties:
           ca:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+      secretBootCerts:
+        type: object
+        default: {}
+        x-required-for-helm:
+        - der
+        - key
+        - passphrase
+        properties:
+          cert:
+            type: string
+            x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+          key:
+            type: string
+            x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+          ca:
+            type: string
+            x-examples: ["YjY0ZW5jX3N0cmluZwo="]
       spaasCert:
         type: object
         default: {}

--- a/modules/041-linstor/openapi/values.yaml
+++ b/modules/041-linstor/openapi/values.yaml
@@ -89,13 +89,13 @@ properties:
         - key
         - passphrase
         properties:
-          cert:
+          der:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
           key:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
-          ca:
+          passphrase:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
       spaasCert:

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -78,7 +78,7 @@ spec:
       subPath: ca.crt
       readOnly: true
     - name: secureboot
-      mountPath: /opt/linstor/secureboot/
+      mountPath: /var/lib/shim-signed/mok
       readOnly: true
   additionalEnv:
   - name: SPAAS_URL

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -77,6 +77,9 @@ spec:
       mountPath: /etc/spaas/certs/ca.crt
       subPath: ca.crt
       readOnly: true
+    - name: secureboot
+      mountPath: /opt/linstor/secureboot/
+      readOnly: true
   additionalEnv:
   - name: SPAAS_URL
     value: "https://spaas.d8-linstor.svc:2020"
@@ -84,6 +87,9 @@ spec:
   - name: spaas-certs
     secret:
       secretName: spaas-certs
+  - name: secureboot
+    secret:
+      secretName: secureboot-cert
   logLevel: info
   sidecars:
   - name: kube-rbac-proxy

--- a/modules/041-linstor/templates/secret-secureboot.yaml
+++ b/modules/041-linstor/templates/secret-secureboot.yaml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 data:
   {{- with .Values.linstor.internal.secretBootCerts }}
-  secureboot.der: {{ b64enc .der }}
-  secureboot.key: {{ b64enc .key }}
+  MOK.der: {{ b64enc .der }}
+  MOK.priv: {{ b64enc .key }}
   passphrase: {{ b64enc .passphrase }}
   {{- end }}

--- a/modules/041-linstor/templates/secret-secureboot.yaml
+++ b/modules/041-linstor/templates/secret-secureboot.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secureboot-cert
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+type: kubernetes.io/tls
+data:
+  {{- with .Values.linstor.internal.secretBootCerts }}
+  secureboot.der: {{ b64enc .der }}
+  secureboot.key: {{ b64enc .key }}
+  passphrase: {{ b64enc .passphrase }}
+  {{- end }}

--- a/modules/041-linstor/templates/secret-secureboot.yaml
+++ b/modules/041-linstor/templates/secret-secureboot.yaml
@@ -5,7 +5,7 @@ metadata:
   name: secureboot-cert
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-type: kubernetes.io/tls
+type: Opaque
 data:
   {{- with .Values.linstor.internal.secretBootCerts }}
   secureboot.der: {{ b64enc .der }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
