### PR TITLE
[chore][node-manager] Update the default value of the allowedBundles parameter

### DIFF
--- a/ee/modules/040-node-manager/openapi/config-values.yaml
+++ b/ee/modules/040-node-manager/openapi/config-values.yaml
@@ -33,6 +33,7 @@ properties:
       - "redos"
       - "alteros"
       - "astra"
+      - "altlinux"
     x-examples:
       - ["ubuntu-lts"]
     items:


### PR DESCRIPTION
## Description
Add `altlinux` to the default values list of the [`allowedBundles`](https://deckhouse.io/documentation/latest/modules/040-node-manager/configuration.html#parameters-allowedbundles) parameter (EE edition).

## Why do we need it, and what problem does it solve?
Alt Linux support was added in Deckhouse EE 1.45. The `allowedBundles` parameters should include all possible bundles by default.

## Why do we need it in the patch release (if we do)?
It is a minor change and can be skipped in the patch.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: node-manager
type: chore
summary: Add `altlinux` to the default values list of the [`allowedBundles`](https://deckhouse.io/documentation/latest/modules/040-node-manager/configuration.html#parameters-allowedbundles) parameter (EE edition).
impact_level: default
```
