### PR TITLE
[operator-trivy] Add support for `kubernetes.io/dockercfg` secrets in `imagePullSecrets` pods field for scan jobs

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/patches/003-support-legacy-dockercfg.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/003-support-legacy-dockercfg.patch
@@ -1,0 +1,162 @@
+diff --git a/pkg/docker/config.go b/pkg/docker/config.go
+index 3f3c51e6..bc0fd656 100644
+--- a/pkg/docker/config.go
++++ b/pkg/docker/config.go
+@@ -55,9 +55,21 @@ type Config struct {
+ 	Auths map[string]Auth `json:"auths"`
+ }
+ 
+-func (c *Config) Read(contents []byte) error {
+-	if err := json.Unmarshal(contents, c); err != nil {
+-		return err
++func (c *Config) Read(contents []byte, isLegacy bool) error {
++	if isLegacy {
++		// Because ~/.dockercfg contents is "auths" field in ~/.docker/config.json
++		// we can simply pass it to "Auths" field of Config
++		auths := make(map[string]Auth)
++		if err := json.Unmarshal(contents, &auths); err != nil {
++			return err
++		}
++		*c = Config{
++			Auths: auths,
++		}
++	} else {
++		if err := json.Unmarshal(contents, c); err != nil {
++			return err
++		}
+ 	}
+ 	var err error
+ 	c.Auths, err = decodeAuths(c.Auths)
+diff --git a/pkg/docker/config_test.go b/pkg/docker/config_test.go
+index f7745890..b290e4d8 100644
+--- a/pkg/docker/config_test.go
++++ b/pkg/docker/config_test.go
+@@ -21,6 +21,8 @@ func TestConfig_Read(t *testing.T) {
+ 
+ 		expectedAuth  map[string]docker.Auth
+ 		expectedError error
++
++		isLegacy bool
+ 	}{
+ 		{
+ 			name:         "Should return empty credentials when content is empty JSON object",
+@@ -92,7 +94,7 @@ func TestConfig_Read(t *testing.T) {
+ 			givenJSON: `{
+ 						"auths": {
+ 						"https://index.docker.io/v1/": {
+-							
++
+ 						},
+ 						"harbor.domain": {
+ 							"auth": "YWRtaW46SGFyYm9yMTIzNDU="
+@@ -118,12 +120,36 @@ func TestConfig_Read(t *testing.T) {
+ 						}`,
+ 			expectedError: errors.New("expected username and password concatenated with a colon (:)"),
+ 		},
++		{
++			name:     "Should process legacy .dockercfg json",
++			isLegacy: true,
++			givenJSON: `{
++							"https://index.docker.io/v1/": {
++								"auth": "ZG9ja2VyOmh1Yg=="
++							},
++							"harbor.domain": {
++								"auth": "YWRtaW46SGFyYm9yMTIzNDU="
++							}
++						}`,
++			expectedAuth: map[string]docker.Auth{
++				"https://index.docker.io/v1/": {
++					Auth:     "ZG9ja2VyOmh1Yg==",
++					Username: "docker",
++					Password: "hub",
++				},
++				"harbor.domain": {
++					Auth:     "YWRtaW46SGFyYm9yMTIzNDU=",
++					Username: "admin",
++					Password: "Harbor12345",
++				},
++			},
++		},
+ 	}
+ 
+ 	for _, tc := range testCases {
+ 		t.Run(tc.name, func(t *testing.T) {
+ 			dockerConfig := &docker.Config{}
+-			err := dockerConfig.Read([]byte(tc.givenJSON))
++			err := dockerConfig.Read([]byte(tc.givenJSON), tc.isLegacy)
+ 			switch {
+ 			case tc.expectedError != nil:
+ 				assert.EqualError(t, err, tc.expectedError.Error())
+diff --git a/pkg/kube/secrets.go b/pkg/kube/secrets.go
+index 1fa612ef..99647cb7 100644
+--- a/pkg/kube/secrets.go
++++ b/pkg/kube/secrets.go
+@@ -53,22 +53,28 @@ func matchSubDomain(wildcardServers []string, subDomain string) string {
+ func MapDockerRegistryServersToAuths(imagePullSecrets []corev1.Secret, multiSecretSupport bool) (map[string]docker.Auth, error) {
+ 	auths := make(map[string]docker.Auth)
+ 	for _, secret := range imagePullSecrets {
+-		// Skip a deprecated secret of type "kubernetes.io/dockercfg" which contains a dockercfg file
+-		// that follows the same format rules as ~/.dockercfg
+-		// See https://docs.docker.com/engine/deprecated/#support-for-legacy-dockercfg-configuration-files
+-		if secret.Type != corev1.SecretTypeDockerConfigJson {
++		var data []byte
++		var hasRequiredData, isLegacy bool
++
++		switch secret.Type {
++		case corev1.SecretTypeDockerConfigJson:
++			data, hasRequiredData = secret.Data[corev1.DockerConfigJsonKey]
++		case corev1.SecretTypeDockercfg:
++			data, hasRequiredData = secret.Data[corev1.DockerConfigKey]
++			isLegacy = true
++		default:
+ 			continue
+ 		}
+-		data, hasRequiredData := secret.Data[corev1.DockerConfigJsonKey]
+-		// Skip a secrets of type "kubernetes.io/dockerconfigjson" which does not contain
+-		// the required ".dockerconfigjson" key.
++
++		// Skip a secrets of type "kubernetes.io/dockerconfigjson" or "kubernetes.io/dockercfg" which does not contain
++		// the required ".dockerconfigjson" or ".dockercfg" key.
+ 		if !hasRequiredData {
+ 			continue
+ 		}
+ 		dockerConfig := &docker.Config{}
+-		err := dockerConfig.Read(data)
++		err := dockerConfig.Read(data, isLegacy)
+ 		if err != nil {
+-			return nil, fmt.Errorf("reading %s field of %q secret: %w", corev1.DockerConfigJsonKey, secret.Namespace+"/"+secret.Name, err)
++			return nil, fmt.Errorf("reading %s or %s field of %q secret: %w", corev1.DockerConfigJsonKey, corev1.DockerConfigKey, secret.Namespace+"/"+secret.Name, err)
+ 		}
+ 		for authKey, auth := range dockerConfig.Auths {
+ 			server, err := docker.GetServerFromDockerAuthKey(authKey)
+diff --git a/pkg/kube/secrets_test.go b/pkg/kube/secrets_test.go
+index 412103e2..94050ad2 100644
+--- a/pkg/kube/secrets_test.go
++++ b/pkg/kube/secrets_test.go
+@@ -72,7 +72,13 @@ func TestMapDockerRegistryServersToAuths(t *testing.T) {
+ 		auths, err := kube.MapDockerRegistryServersToAuths([]corev1.Secret{
+ 			{
+ 				Type: corev1.SecretTypeDockercfg,
+-				Data: map[string][]byte{},
++				Data: map[string][]byte{
++					corev1.DockerConfigKey: []byte(`{
++  "quay.io": {
++	"auth": "dXNlcjpBZG1pbjEyMzQ1"
++  }
++}`),
++				},
+ 			},
+ 			{
+ 				Type: corev1.SecretTypeDockerConfigJson,
+@@ -96,6 +102,11 @@ func TestMapDockerRegistryServersToAuths(t *testing.T) {
+ 				Username: "root",
+ 				Password: "s3cret",
+ 			}),
++			"quay.io": Equal(docker.Auth{
++				Auth:     "dXNlcjpBZG1pbjEyMzQ1",
++				Username: "user",
++				Password: "Admin12345",
++			}),
+ 		}))
+ 	})
+ 

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -10,7 +10,7 @@ Skip some defseq checks for proper reports result for deckhouse installation.
 
 ## 003-support-legacy-dockercfg.patch
 
-Add support for `kubernetes.io/dockercfg`(legacy) secret type for `imagePullSecrets` field in scan jobs.
+Add support for `kubernetes.io/dockercfg` (legacy) secrets in `imagePullSecrets` pods field for scan jobs
 
 PR: https://github.com/aquasecurity/trivy-operator/pull/1183
 

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -8,3 +8,9 @@ This [issue](https://github.com/aquasecurity/trivy-operator/issues/695) covers b
 
 Skip some defseq checks for proper reports result for deckhouse installation.
 
+## 003-support-legacy-dockercfg.patch
+
+Add support for `kubernetes.io/dockercfg`(legacy) secret type for `imagePullSecrets` field in scan jobs.
+
+PR: https://github.com/aquasecurity/trivy-operator/pull/1183
+


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add support for `kubernetes.io/dockercfg` (legacy) secrets in `imagePullSecrets` pods field for scan jobs.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Some of the clusters have secrets with type `kubernetes.io/dockercfg` (legacy) that are used in `imagePullSecrets` field, so we should treat them in the operator to avoid 401 error in scan jobs

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Scan jobs for pods with secrets with type `kubernetes.io/dockercfg` in `imagePullSecrets` field are not failing
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: fix
summary: Add support for kubernetes.io/dockercfg secrets in imagePullSecrets pods field for scan jobs.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
