### PR TITLE
[tools] Fix `d8-push.sh` and `d8-pull.sh` scripts

### DIFF
--- a/tools/release/d8-pull-tarball.sh
+++ b/tools/release/d8-pull-tarball.sh
@@ -20,6 +20,7 @@ help() {
 echo "
 Usage: $0
 
+  HINT: Use this script only for image scanning, if you want to push images to another registry - use d8-pull.sh script
   Command pulls all images to a local directory for the selected Deckhouse release.
   Accepted cli arguments are:
     --release

--- a/tools/release/d8-pull-tarball.sh
+++ b/tools/release/d8-pull-tarball.sh
@@ -45,13 +45,13 @@ Usage: $0
 EDITION="ee"
 HAS_DOCKER="$(type "docker" &> /dev/null && echo true || echo false)"
 HAS_JQ="$(type "jq" &> /dev/null && echo true || echo false)"
-HAS_GNU_READLINK=$(type "readlink" &> /dev/null && readlink --version | grep -qi GNU && echo true || echo false)
+HAS_CRANE="$(type "crane" &> /dev/null && echo true || echo false)"
 LICENSE=""
 OUTPUT_DIR=""
-D8_DOCKER_CONFIG_DIR=~/.docker/deckhouse
 REGISTRY_ROOT="registry.deckhouse.io"
 REGISTRY="${REGISTRY_ROOT}/deckhouse"
 RELEASE=$(curl -fsL https://api.github.com/repos/deckhouse/deckhouse/tags | jq -r ".[0].name")
+IMAGE=""
 PULL_RELEASE_METADATA_IMAGES="yes"
 
 parse_args() {
@@ -63,7 +63,7 @@ parse_args() {
       --release)
         shift
         if [[ $# -ne 0 ]]; then
-          RELEASE="${1}"
+          export RELEASE="${1}"
         else
           echo "Please provide the desired Deckhouse release. Last available releases are:"
           curl -fsL https://api.github.com/repos/deckhouse/deckhouse/tags | jq -r ".[].name"
@@ -73,13 +73,13 @@ parse_args() {
       --edition)
         shift
         if [[ $# -ne 0 ]]; then
-          EDITION="${1}"
+          export EDITION="${1}"
         fi
         ;;
       --output-dir)
         shift
         if [[ $# -ne 0 ]]; then
-          OUTPUT_DIR=$(readlink -f "${1}")
+          export OUTPUT_DIR="${1}"
         else
           echo "Please provide a directory name."
           return 1
@@ -88,7 +88,7 @@ parse_args() {
       --license)
         shift
         if [[ $# -ne 0 ]]; then
-          LICENSE="${1}"
+          export LICENSE="${1}"
         else
           echo "Please provide a license key for registry.deckhouse.io."
           return 1
@@ -117,8 +117,8 @@ check_requirements() {
     exit 1
   fi
 
-  if [[ "${HAS_GNU_READLINK}" != "true" ]]; then
-    echo "GNU readlink is required. If you are on Mac, check: https://formulae.brew.sh/formula/coreutils"
+  if [ "${HAS_CRANE}" != "true" ]; then
+    echo "Crane is required. Please, check https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation."
     exit 1
   fi
 
@@ -137,16 +137,8 @@ check_requirements() {
       echo "License is required to download Deckhouse Enterprise Edition. Please provide it with CLI argument --license."
       return 1
     else
-      # Docker Desktop stores creds in Desktop store, this hack helps to avoid it and save creds to file
-      mkdir -p "$D8_DOCKER_CONFIG_DIR"
-      cat <<EOF > "$D8_DOCKER_CONFIG_DIR/config.json"
-{
-  "auths": {
-    "$REGISTRY_ROOT": {}
-  }
-}
-EOF
-      docker --config "$D8_DOCKER_CONFIG_DIR" login -u license-token -p "$LICENSE" $REGISTRY_ROOT
+      docker login -u license-token -p "$LICENSE" $REGISTRY_ROOT
+      crane auth login $REGISTRY_ROOT -u license-token -p "$LICENSE"
     fi
   fi
 
@@ -155,49 +147,16 @@ EOF
   rm "$OUTPUT_DIR/test"
 }
 
-function cleanup() {
-  rm -rf "$D8_DOCKER_CONFIG_DIR"
-}
-
-trap cleanup ERR SIGINT SIGTERM SIGHUP SIGQUIT
-
-parse_args "$@"
-check_requirements
-
-echo "Saving Deckhouse $EDITION $RELEASE."
-REGISTRY_PATH="$REGISTRY/$EDITION"
-IMAGES=$(docker run --pull=always -ti --rm "$REGISTRY_PATH:$RELEASE" cat /deckhouse/modules/images_digests.json | jq '. | to_entries | .[].value | to_entries | .[].value' -r | sort -rn | uniq)
-
-
-docker run \
-  -v /etc/hosts:/etc/hosts \
-  -v /etc/resolv.conf:/etc/resolv.conf \
-  -v "$OUTPUT_DIR:$OUTPUT_DIR" \
-  -v "$D8_DOCKER_CONFIG_DIR:/root/.docker" \
-  -e "IMAGES=$IMAGES" \
-  -e "REGISTRY_PATH=$REGISTRY_PATH" \
-  -e "OUTPUT_DIR=$OUTPUT_DIR" \
-  -e "RELEASE=$RELEASE" \
-  -e "PULL_RELEASE_METADATA_IMAGES=$PULL_RELEASE_METADATA_IMAGES" \
-  -e "RUNNING_USER=$UID" \
-  -e "RUNNING_GROUP=$(id -g $UID)" \
-  --network host -ti --rm \
-  --entrypoint /bin/bash \
-  "quay.io/skopeo/stable:v1.11.2" -c '
-
-set -Eeuo pipefail
-
-IMAGE_PATH=""
 
 pull_image() {
   local registry_full_path="$REGISTRY_PATH"
   if [[ $# -ne 1 ]] && [[ -n $2 ]]; then
     registry_full_path="$registry_full_path/$2"
-    IMAGE_PATH="$OUTPUT_DIR/$2:$1"
+    IMAGE="$OUTPUT_DIR/$2:$1"
   else
-    IMAGE_PATH="$OUTPUT_DIR/$1"
+    IMAGE="$OUTPUT_DIR/$1"
   fi
-  if [[ -s "$IMAGE_PATH" ]]; then
+  if [[ -s "$IMAGE" ]]; then
     return 0
   fi
 
@@ -205,24 +164,26 @@ pull_image() {
   if [[ $# -gt 2 ]] && [[ "$3" == "use_tag" ]]; then
     delim=":"
   fi
-
-  # using dir to save digests of images
-  skopeo copy --authfile /root/.docker/config.json --preserve-digests "docker://$registry_full_path${delim}${1}" "dir:$IMAGE_PATH" >/dev/null
-  chown -R "$RUNNING_USER:$RUNNING_GROUP" "$IMAGE_PATH"
+  #using tarball, because dhctl bootstrap doesn't support oci format
+  crane pull "$registry_full_path${delim}${1}" --format tarball "$IMAGE"
 }
 
-
 pull_trivy_db() {
-  IMAGE_PATH="$OUTPUT_DIR/trivy-db"
-  skopeo copy --authfile /root/.docker/config.json --preserve-digests "docker://$REGISTRY_PATH/security/trivy-db:2" "dir:$IMAGE_PATH" >/dev/null
-  chown -R "$RUNNING_USER:$RUNNING_GROUP" "$IMAGE_PATH"
+  IMAGE="$OUTPUT_DIR/trivy-db"
+  crane pull "$REGISTRY_PATH/security/trivy-db:2" --format tarball "$IMAGE"
 }
 
 function pull_image_clean_up {
-  rm -rf "$IMAGE_PATH"
+  rm -rf "$IMAGE"
 }
-trap pull_image_clean_up ERR SIGINT SIGTERM SIGHUP SIGQUIT
 
+parse_args "$@"
+check_requirements
+
+echo "Saving Deckhouse $EDITION $RELEASE."
+REGISTRY_PATH="$REGISTRY/$EDITION"
+IMAGES=$(docker run --pull=always -ti --rm "$REGISTRY_PATH:$RELEASE" cat /deckhouse/modules/images_digests.json | jq '. | to_entries | .[].value | to_entries | .[].value' -r | sort -rn | uniq)
+trap pull_image_clean_up ERR SIGINT SIGTERM SIGHUP SIGQUIT
 #saving Deckhouse image
 pull_image "$RELEASE" "" "use_tag"
 #saving Deckhouse install image
@@ -232,7 +193,7 @@ l=$(echo "$IMAGES" | wc -l)
 count=1
 for i in $IMAGES; do
   pull_image "$i"
-  printf '"'"'\rImages downloaded %s out of %s'"'"' "$count" "$l"
+  printf '\rImages downloaded %s out of %s' "$count" "$l"
   count=$((count + 1))
 done
 
@@ -251,6 +212,3 @@ pull_trivy_db
 
 echo ""
 echo "Operation is complete."
-'
-
-cleanup

--- a/tools/release/d8-pull-tarball.sh
+++ b/tools/release/d8-pull-tarball.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022 Flant JSC
+# Copyright 2023 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -237,6 +237,7 @@ for i in $IMAGES; do
 done
 
 if [[ "$PULL_RELEASE_METADATA_IMAGES" == "yes" ]]; then
+  echo ""
   echo "Pull metadata images"
   #saving metadata about release channel
   pull_image "alpha" "release-channel" "use_tag"

--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -45,6 +45,7 @@ Usage: $0
 EDITION="ee"
 HAS_DOCKER="$(type "docker" &> /dev/null && echo true || echo false)"
 HAS_JQ="$(type "jq" &> /dev/null && echo true || echo false)"
+HAS_GNU_READLINK=$(type "readlink" &> /dev/null && readlink --version | grep -qi GNU && echo true || echo false)
 LICENSE=""
 OUTPUT_DIR=""
 D8_DOCKER_CONFIG_DIR=~/.docker/deckhouse
@@ -78,7 +79,7 @@ parse_args() {
       --output-dir)
         shift
         if [[ $# -ne 0 ]]; then
-          OUTPUT_DIR=$(cd "$(dirname "${1}")" && pwd -P)/$(basename "${1}")
+          OUTPUT_DIR=$(readlink -f "${1}")
         else
           echo "Please provide a directory name."
           return 1
@@ -113,6 +114,11 @@ check_requirements() {
 
   if [ "${HAS_JQ}" != "true" ]; then
     echo "Jq is required. Please, check https://stedolan.github.io/jq/download/."
+    exit 1
+  fi
+
+  if [[ "${HAS_GNU_READLINK}" != "true" ]]; then
+    echo "GNU readlink is required. If you are on Mac, check: https://formulae.brew.sh/formula/coreutils"
     exit 1
   fi
 

--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -45,7 +45,6 @@ Usage: $0
 EDITION="ee"
 HAS_DOCKER="$(type "docker" &> /dev/null && echo true || echo false)"
 HAS_JQ="$(type "jq" &> /dev/null && echo true || echo false)"
-HAS_GNU_READLINK=$(type "readlink" &> /dev/null && readlink --version | grep -qi GNU && echo true || echo false)
 LICENSE=""
 OUTPUT_DIR=""
 D8_DOCKER_CONFIG_DIR=~/.docker/deckhouse
@@ -79,7 +78,7 @@ parse_args() {
       --output-dir)
         shift
         if [[ $# -ne 0 ]]; then
-          OUTPUT_DIR=$(readlink -f "${1}")
+          OUTPUT_DIR=$(cd "$(dirname "${1}")" && pwd -P)/$(basename "${1}")
         else
           echo "Please provide a directory name."
           return 1
@@ -114,11 +113,6 @@ check_requirements() {
 
   if [ "${HAS_JQ}" != "true" ]; then
     echo "Jq is required. Please, check https://stedolan.github.io/jq/download/."
-    exit 1
-  fi
-
-  if [[ "${HAS_GNU_READLINK}" != "true" ]]; then
-    echo "GNU readlink is required. If you are on Mac, check: https://formulae.brew.sh/formula/coreutils"
     exit 1
   fi
 

--- a/tools/release/d8-push.sh
+++ b/tools/release/d8-push.sh
@@ -132,7 +132,7 @@ check_requirements() {
   }
 }
 EOF
-    docker --config "$D8_DOCKER_CONFIG_DIR" login -u license-token -p "$LICENSE" "$REGISTRY"
+    docker --config "$D8_DOCKER_CONFIG_DIR" login -u "$USERNAME" -p "$PASSWORD" "$REGISTRY"
   fi
 }
 

--- a/tools/release/d8-push.sh
+++ b/tools/release/d8-push.sh
@@ -43,6 +43,7 @@ Usage: $0
 }
 
 HAS_DOCKER="$(type "docker" &> /dev/null && echo true || echo false)"
+HAS_GNU_READLINK=$(type "readlink" &> /dev/null && readlink --version | grep -qi GNU && echo true || echo false)
 D8_DOCKER_CONFIG_DIR=~/.docker/deckhouse
 SOURCE_DIR=""
 REGISTRY_PATH=""
@@ -72,7 +73,7 @@ parse_args() {
       --source-dir)
         shift
         if [[ $# -ne 0 ]]; then
-          SOURCE_DIR=$(cd "$(dirname "${1}")" && pwd -P)/$(basename "${1}")
+          SOURCE_DIR=$(readlink -f "${1}")
         else
           echo "Please provide a directory name."
           return 1
@@ -102,6 +103,11 @@ parse_args() {
 check_requirements() {
   if [ "${HAS_DOCKER}" != "true" ]; then
     echo "Docker is required."
+    exit 1
+  fi
+
+  if [[ "${HAS_GNU_READLINK}" != "true" ]]; then
+    echo "GNU readlink is required. If you are on Mac, check: https://formulae.brew.sh/formula/coreutils"
     exit 1
   fi
 

--- a/tools/release/d8-push.sh
+++ b/tools/release/d8-push.sh
@@ -168,9 +168,9 @@ l=$(echo "$PATHS" | wc -l)
 count=1
 for path in $PATHS; do
   image="$(basename "$path")"
-  if [[ "$image" == *"trivy-db" ]]; then
+  if [[ "$image" == "trivy-db" ]]; then
     push_image "$SOURCE_DIR/trivy-db" "$REGISTRY_PATH/security/trivy-db:2"
-  elif [[ "$image" == *"sha256:"* ]]; then
+  elif [[ "$image" == "sha256:"* ]]; then
     push_image "$path" "$REGISTRY_PATH@$image"
   elif [[ "$image" == *":"* ]]; then
     push_image "$path" "$REGISTRY_PATH/$image"

--- a/tools/release/d8-push.sh
+++ b/tools/release/d8-push.sh
@@ -43,7 +43,6 @@ Usage: $0
 }
 
 HAS_DOCKER="$(type "docker" &> /dev/null && echo true || echo false)"
-HAS_GNU_READLINK=$(type "readlink" &> /dev/null && readlink --version | grep -qi GNU && echo true || echo false)
 D8_DOCKER_CONFIG_DIR=~/.docker/deckhouse
 SOURCE_DIR=""
 REGISTRY_PATH=""
@@ -73,7 +72,7 @@ parse_args() {
       --source-dir)
         shift
         if [[ $# -ne 0 ]]; then
-          SOURCE_DIR=$(readlink -f "${1}")
+          SOURCE_DIR=$(cd "$(dirname "${1}")" && pwd -P)/$(basename "${1}")
         else
           echo "Please provide a directory name."
           return 1
@@ -103,11 +102,6 @@ parse_args() {
 check_requirements() {
   if [ "${HAS_DOCKER}" != "true" ]; then
     echo "Docker is required."
-    exit 1
-  fi
-
-  if [[ "${HAS_GNU_READLINK}" != "true" ]]; then
-    echo "GNU readlink is required. If you are on Mac, check: https://formulae.brew.sh/formula/coreutils"
     exit 1
   fi
 

--- a/tools/release/d8-push.sh
+++ b/tools/release/d8-push.sh
@@ -34,37 +34,46 @@ Usage: $0
     --username
         Username for the registry.
 
+    --insecure
+        Use http instead of https while connecting to registry
+
     --help|-h
         Print this message.
 "
 }
 
-HAS_CRANE="$(type "crane" &> /dev/null && echo true || echo false)"
+HAS_DOCKER="$(type "docker" &> /dev/null && echo true || echo false)"
+HAS_GNU_READLINK=$(type "readlink" &> /dev/null && readlink --version | grep -qi GNU && echo true || echo false)
+D8_DOCKER_CONFIG_DIR=~/.docker/deckhouse
 SOURCE_DIR=""
 REGISTRY_PATH=""
 REGISTRY=""
 USERNAME=""
 PASSWORD=""
+USE_HTTPS="true"
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      --insecure)
+        USE_HTTPS="false"
+        ;;
       --password)
         shift
         if [[ $# -ne 0 ]]; then
-          export PASSWORD="${1}"
+          PASSWORD="${1}"
         fi
         ;;
       --username)
         shift
         if [[ $# -ne 0 ]]; then
-          export USERNAME="${1}"
+          USERNAME="${1}"
         fi
         ;;
       --source-dir)
         shift
         if [[ $# -ne 0 ]]; then
-          export SOURCE_DIR="${1}"
+          SOURCE_DIR=$(readlink -f "${1}")
         else
           echo "Please provide a directory name."
           return 1
@@ -73,7 +82,7 @@ parse_args() {
       --path)
         shift
         if [[ $# -ne 0 ]]; then
-          export REGISTRY_PATH="${1}"
+          REGISTRY_PATH="${1}"
         else
           echo "Please provide the registry path to push images"
           return 1
@@ -92,8 +101,13 @@ parse_args() {
 }
 
 check_requirements() {
-  if [ "${HAS_CRANE}" != "true" ]; then
-    echo "Crane is required. Please, check https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation."
+  if [ "${HAS_DOCKER}" != "true" ]; then
+    echo "Docker is required."
+    exit 1
+  fi
+
+  if [[ "${HAS_GNU_READLINK}" != "true" ]]; then
+    echo "GNU readlink is required. If you are on Mac, check: https://formulae.brew.sh/formula/coreutils"
     exit 1
   fi
 
@@ -109,22 +123,66 @@ check_requirements() {
   REGISTRY=$(echo "$REGISTRY_PATH" | cut -d/ -f1)
 
   if [[ "$PASSWORD" != "" ]] && [[ "$USERNAME" != "" ]]; then
-    crane auth login "$REGISTRY" -u "$USERNAME" -p "$PASSWORD"
+    # Docker Desktop stores creds in Desktop store, this hack helps to avoid it and save creds to file
+    mkdir -p "$D8_DOCKER_CONFIG_DIR"
+    cat <<EOF > "$D8_DOCKER_CONFIG_DIR/config.json"
+{
+  "auths": {
+    "$REGISTRY": {}
+  }
+}
+EOF
+    docker --config "$D8_DOCKER_CONFIG_DIR" login -u license-token -p "$LICENSE" "$REGISTRY"
   fi
 }
+
+function cleanup() {
+  rm -rf "$D8_DOCKER_CONFIG_DIR"
+}
+
+trap cleanup ERR SIGINT SIGTERM SIGHUP SIGQUIT
 
 parse_args "$@"
 check_requirements
 
-for i in "$SOURCE_DIR"/*; do
-  image="$(basename "$i")"
-  if [[ "$image" == *":"* ]]; then
-    crane push "$i" "$REGISTRY_PATH/$image"
+docker run \
+  -v /etc/hosts:/etc/hosts \
+  -v /etc/resolv.conf:/etc/resolv.conf \
+  -v "$SOURCE_DIR:$SOURCE_DIR" \
+  -v "$D8_DOCKER_CONFIG_DIR:/root/.docker" \
+  -e "SOURCE_DIR=$SOURCE_DIR" \
+  -e "REGISTRY_PATH=$REGISTRY_PATH" \
+  -e "USE_HTTPS=$USE_HTTPS" \
+  --network host -ti --rm \
+  --entrypoint /bin/bash \
+  "quay.io/skopeo/stable:v1.11.2" -c '
+
+set -Eeuo pipefail
+
+function push_image() {
+  skopeo copy --dest-tls-verify="$USE_HTTPS" --authfile /root/.docker/config.json --preserve-digests "dir:${1}" "docker://${2}" >/dev/null
+}
+
+PATHS=$(find "$SOURCE_DIR" -maxdepth 1 -mindepth 1 -type d)
+l=$(echo "$PATHS" | wc -l)
+count=1
+for path in $PATHS; do
+  image="$(basename "$path")"
+  if [[ "$image" == *"trivy-db" ]]; then
+    push_image "$SOURCE_DIR/trivy-db" "$REGISTRY_PATH/security/trivy-db:2"
+  elif [[ "$image" == *"sha256:"* ]]; then
+    push_image "$path" "$REGISTRY_PATH@$image"
+  elif [[ "$image" == *":"* ]]; then
+    push_image "$path" "$REGISTRY_PATH/$image"
   else
-    crane push "$i" "$REGISTRY_PATH:$image"
+    push_image "$path" "$REGISTRY_PATH:$image"
   fi
+  printf '"'"'\rImages pushed %s out of %s'"'"' "$count" "$l"
+  count=$((count + 1))
 done
 
-crane push "$SOURCE_DIR/trivy-db" "$REGISTRY_PATH/security/trivy-db:2"
-
+echo ""
 echo "Operation is complete."
+'
+
+cleanup


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix d8-push.sh and d8-pull.sh scripts to proper evaluate digests. Save previous d8-pull.sh to d8-pull-tarball.sh for trivy scanning. 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After move from tags to digests d8-pull.sh script can't be used, because it saves images in taballs with different digests. This PR is fixing this.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Proper pushing images to registry
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: Fix d8-push.sh and d8-pull.sh scripts
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
