### PR TITLE
[virtualization] fix disks processing

### DIFF
--- a/modules/490-virtualization/hooks/disk_handler.go
+++ b/modules/490-virtualization/hooks/disk_handler.go
@@ -238,6 +238,8 @@ func handleVirtualMachineDisks(input *go_hook.HookInput) error {
 
 		// DataVolume not found, needs to create a new one
 		var source *v1alpha1.TypedObjectReference
+
+		// TODO: should we allow copy across namespaces?
 		if disk.Source != nil {
 			source = &v1alpha1.TypedObjectReference{
 				TypedLocalObjectReference: corev1.TypedLocalObjectReference{
@@ -245,6 +247,9 @@ func handleVirtualMachineDisks(input *go_hook.HookInput) error {
 					Kind:     disk.Source.Kind,
 					Name:     disk.Source.Name,
 				},
+			}
+			if disk.Source.Kind != "ClusterVirtualMachineImage" {
+				source.Namespace = disk.Namespace
 			}
 		}
 

--- a/modules/490-virtualization/hooks/disk_handler_test.go
+++ b/modules/490-virtualization/hooks/disk_handler_test.go
@@ -200,7 +200,30 @@ metadata:
 spec:
   storageClassName: linstor-thindata-r2
   size: 10Gi
-
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: VirtualMachineDisk
+metadata:
+  name: mydata6
+  namespace: ns1
+spec:
+  source:
+    kind: VirtualMachineDisk
+    name: mydata3
+  storageClassName: linstor-thindata-r2
+  size: 10Gi
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: VirtualMachineDisk
+metadata:
+  name: mydata7
+  namespace: ns2
+spec:
+  source:
+    kind: VirtualMachineDisk
+    name: mydata3
+  storageClassName: linstor-thindata-r2
+  size: 10Gi
 `),
 			)
 			f.RunHook()
@@ -231,6 +254,15 @@ spec:
 			dataVolume = f.KubernetesResource("DataVolume", "ns1", "disk-mydata5")
 			Expect(dataVolume).To(Not(BeEmpty()))
 			Expect(dataVolume.Field(`spec.source.blank`).String()).To(Equal("{}"))
+
+			By("Should create DataVolume with source of other DataVolume")
+			dataVolume = f.KubernetesResource("DataVolume", "ns1", "disk-mydata6")
+			Expect(dataVolume).To(Not(BeEmpty()))
+			Expect(dataVolume.Field(`spec.source.pvc`).String()).To(Equal("{\"name\":\"disk-mydata3\",\"namespace\":\"ns1\"}"))
+
+			By("Should create DataVolume with source of non existing DataVolume")
+			dataVolume = f.KubernetesResource("DataVolume", "ns2", "disk-mydata7")
+			Expect(dataVolume).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
## Description
This PR fixes some cases of processing VirtualMachineDisks

## Why do we need it, and what problem does it solve?

- Releasing disk lease when VM is not removed but disk is not attached
- Copying VirtualMachineDisk from VirtualMachineDisk

## Why do we need it in the patch release (if we do)?

Fix already existing cases, I checked cherry-pick works fine

## What is the expected result?

The above problems fixed

## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: virtualization
type: fix
summary: fix releasing disk lease when VM is not removed but disk is not attached
impact: low
---
section: virtualization
type: fix
summary: fix copying VirtualMachineDisk from VirtualMachineDisk
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
