### PR TITLE
[linstor] Enforce data locality

### DIFF
--- a/modules/041-linstor/docs/ADVANCED_USAGE.md
+++ b/modules/041-linstor/docs/ADVANCED_USAGE.md
@@ -130,6 +130,7 @@ metadata:
 parameters:
   linstor.csi.linbit.com/storagePool: lvmthin
   linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
   property.linstor.csi.linbit.com/DrbdOptions/Net/rr-conflict: retry-connect
   property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible: suspend-io
   property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary

--- a/modules/041-linstor/docs/ADVANCED_USAGE_RU.md
+++ b/modules/041-linstor/docs/ADVANCED_USAGE_RU.md
@@ -130,6 +130,7 @@ metadata:
 parameters:
   linstor.csi.linbit.com/storagePool: lvmthin
   linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
   property.linstor.csi.linbit.com/DrbdOptions/Net/rr-conflict: retry-connect
   property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible: suspend-io
   property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary

--- a/modules/041-linstor/images/linstor-pools-importer/main.go
+++ b/modules/041-linstor/images/linstor-pools-importer/main.go
@@ -542,7 +542,7 @@ func newKubernetesEvent(nodeName string, involvedObject v1.ObjectReference, even
 }
 
 func newKubernetesStorageClass(sp *lclient.StoragePool, r int) storagev1.StorageClass {
-	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
+	volBindMode := storagev1.VolumeBindingImmediate
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 	return storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -568,9 +568,6 @@ func newKubernetesStorageClass(sp *lclient.StoragePool, r int) storagev1.Storage
 }
 
 func allParametersAreSet(sc, oldSC *storagev1.StorageClass) bool {
-	if oldSC.VolumeBindingMode != sc.VolumeBindingMode {
-		return false
-	}
 	for k := range sc.Parameters {
 		if oldSC.Parameters[k] != sc.Parameters[k] {
 			return false

--- a/modules/041-linstor/images/linstor-pools-importer/main_test.go
+++ b/modules/041-linstor/images/linstor-pools-importer/main_test.go
@@ -196,7 +196,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 	}
 	got := newKubernetesStorageClass(&tp, 2)
 
-	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
+	volBindMode := storagev1.VolumeBindingImmediate
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	expected := storagev1.StorageClass{
@@ -227,7 +227,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 }
 
 func TestAllParametersAreSet(t *testing.T) {
-	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
+	volBindMode := storagev1.VolumeBindingImmediate
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	oldSC := &storagev1.StorageClass{
@@ -277,8 +277,7 @@ func TestAllParametersAreSet(t *testing.T) {
 }
 
 func TestAppendOldParameters(t *testing.T) {
-	oldVolBindMode := storagev1.VolumeBindingImmediate
-	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
+	volBindMode := storagev1.VolumeBindingImmediate
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	oldSC := &storagev1.StorageClass{
@@ -292,7 +291,7 @@ func TestAppendOldParameters(t *testing.T) {
 			},
 		},
 		Provisioner:          "linstor.csi.linbit.com",
-		VolumeBindingMode:    &oldVolBindMode,
+		VolumeBindingMode:    &volBindMode,
 		AllowVolumeExpansion: pointer.BoolPtr(true),
 		ReclaimPolicy:        &reclaimPolicy,
 		Parameters: map[string]string{

--- a/modules/041-linstor/images/linstor-pools-importer/main_test.go
+++ b/modules/041-linstor/images/linstor-pools-importer/main_test.go
@@ -196,7 +196,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 	}
 	got := newKubernetesStorageClass(&tp, 2)
 
-	volBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	expected := storagev1.StorageClass{
@@ -213,6 +213,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 		Parameters: map[string]string{
 			"linstor.csi.linbit.com/storagePool":                                                 "ssd",
 			"linstor.csi.linbit.com/placementCount":                                              "2",
+			"linstor.csi.linbit.com/allowRemoteVolumeAccess":                                     "false",
 			"property.linstor.csi.linbit.com/DrbdOptions/auto-quorum":                            "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible":         "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated": "force-secondary",
@@ -226,7 +227,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 }
 
 func TestAllParametersAreSet(t *testing.T) {
-	volBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	oldSC := &storagev1.StorageClass{
@@ -257,6 +258,7 @@ func TestAllParametersAreSet(t *testing.T) {
 		Parameters: map[string]string{
 			"linstor.csi.linbit.com/storagePool":                                                 "ssd",
 			"linstor.csi.linbit.com/placementCount":                                              "2",
+			"linstor.csi.linbit.com/allowRemoteVolumeAccess":                                     "false",
 			"property.linstor.csi.linbit.com/DrbdOptions/auto-quorum":                            "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible":         "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated": "force-secondary",
@@ -275,7 +277,8 @@ func TestAllParametersAreSet(t *testing.T) {
 }
 
 func TestAppendOldParameters(t *testing.T) {
-	volBindMode := storagev1.VolumeBindingImmediate
+	oldVolBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	oldSC := &storagev1.StorageClass{
@@ -289,7 +292,7 @@ func TestAppendOldParameters(t *testing.T) {
 			},
 		},
 		Provisioner:          "linstor.csi.linbit.com",
-		VolumeBindingMode:    &volBindMode,
+		VolumeBindingMode:    &oldVolBindMode,
 		AllowVolumeExpansion: pointer.BoolPtr(true),
 		ReclaimPolicy:        &reclaimPolicy,
 		Parameters: map[string]string{
@@ -313,6 +316,7 @@ func TestAppendOldParameters(t *testing.T) {
 		Parameters: map[string]string{
 			"linstor.csi.linbit.com/storagePool":                                                 "ssd",
 			"linstor.csi.linbit.com/placementCount":                                              "2",
+			"linstor.csi.linbit.com/allowRemoteVolumeAccess":                                     "false",
 			"property.linstor.csi.linbit.com/DrbdOptions/auto-quorum":                            "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible":         "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated": "force-secondary",
@@ -338,6 +342,7 @@ func TestAppendOldParameters(t *testing.T) {
 		Parameters: map[string]string{
 			"linstor.csi.linbit.com/storagePool":                                                 "ssd",
 			"linstor.csi.linbit.com/placementCount":                                              "2",
+			"linstor.csi.linbit.com/allowRemoteVolumeAccess":                                     "false",
 			"property.linstor.csi.linbit.com/DrbdOptions/auto-quorum":                            "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible":         "suspend-io",
 			"property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated": "force-secondary",

--- a/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             - --leader-election-id=$(NAME)
             - --lease-lock-namespace=$(NAMESPACE)
             - --lease-lock-name=linstor-affinity-controller
-            - --v=2
+            - --v=5
           env:
             - name: LEASE_LOCK_NAME
               value: linstor-affinity-controller

--- a/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             - --leader-election-id=$(NAME)
             - --lease-lock-namespace=$(NAMESPACE)
             - --lease-lock-name=linstor-affinity-controller
-            - --v=5
+            - --v=2
           env:
             - name: LEASE_LOCK_NAME
               value: linstor-affinity-controller


### PR DESCRIPTION
## Description

This pull request will prohibit the use of configurations with remotely accessible replicas. Instead, physical volumes will be reconfigured to be tied to specific nodes containing their data. The binding of volumes will now occur on-demand using the WaitForFirstConsumer method

However, DRBD diskless replicas can still be used as a tiebreaker to achieve quorum.

Although we have limited the use cases by no longer supporting data storage separate from workloads, the enforced data locality ensures improved disk subsystem performance.

Users can manually relocate replicas to nodes. The nodeAffinity rules in PVs will be automatically updated by the `linstor-affinity-controller`.

Users still have the ability to create custom storage classes where the use of DRBD diskless primaries will be allowed

## Why do we need it, and what problem does it solve?

As practice has shown, DRBD diskless primaries are unstable and still have some unpleasant bugs, which can only be solved by rebooting the nodes or manually editing the Linstor database.

On the other hand, diskful DRBD technology has been stable in the kernel for over the past 10 years. The recovery logic of diskful DRBD works much more predictably because such resources have state. They are better able to survive in case of an unstable network connection or slow disks.

## What is the expected result?

- StorageClasses will be reconfigured to allow run only on diskful replicas
- The nodeAffinity rules will be assigned the existing and new PVs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Enforce data locality.
impact: All the newly created persistent volumes will force to run workloads only on nodes with diskfull DRBD replicas, meaning that diskless primaries are no longer allowed. 
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
