### PR TITLE
[linstor] Disable auto-resync-after

### DIFF
--- a/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -91,6 +91,7 @@ spec:
     Autoplacer/Weights/MinReservedSpace: "1"
     Autoplacer/Weights/MinRscCount: "0"
     Autoplacer/Weights/MaxThroughput: "0"
+    DrbdOptions/auto-resync-after-disable: "true"
     DrbdOptions/Net/connect-int: "10"
     DrbdOptions/Net/ping-int: "15"
     DrbdOptions/Net/ping-timeout: "20"


### PR DESCRIPTION
## Description

Disable the `auto-resync-after` option on the cluster level.

## Why do we need it, and what problem does it solve?

It seems this is a new and currently unstable feature. At the moment, it's doing us more harm than good.

## What is the expected result?

The devices will not wait for each other to start syncing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: fix
summary: Disable the `auto-resync-after` option.
```
