### PR TITLE
[cloud-data-crd] Minor doc fixes

### DIFF
--- a/docs/documentation/modules_menu_skip
+++ b/docs/documentation/modules_menu_skip
@@ -1,6 +1,6 @@
 000-common
 003-deckhouse-config
-010-cluster-autoscaler-crd
+010-cloud-data-crd
 010-operator-prometheus-crd
 010-prometheus-crd
 010-snapshot-controller-crd

--- a/modules/010-cloud-data-crd/docs/README.md
+++ b/modules/010-cloud-data-crd/docs/README.md
@@ -1,5 +1,5 @@
 ---
-title: "The cluster-autoscaler-crd module"
+title: "The cloud-data-crd module"
 searchable: false
 ---
 

--- a/modules/010-cloud-data-crd/docs/README_RU.md
+++ b/modules/010-cloud-data-crd/docs/README_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Модуль cluster-autoscaler-crd"
+title: "Модуль cloud-data-crd"
 searchable: false
 ---
 


### PR DESCRIPTION
Remove the `cloud-data-crd` module from the site.
