### PR TITLE
[linstor] Fix multiple requisites

### DIFF
--- a/modules/041-linstor/images/linstor-csi/Dockerfile
+++ b/modules/041-linstor/images/linstor-csi/Dockerfile
@@ -7,9 +7,13 @@ ARG LINSTOR_CSI_VERSION=1.0.0
 ARG LINSTOR_WAIT_UNTIL_GITREPO=https://github.com/LINBIT/linstor-wait-until
 ARG LINSTOR_WAIT_UNTIL_VERSION=0.2.1
 
+# Copy patches
+COPY ./patches /patches
+
 RUN git clone ${LINSTOR_CSI_GITREPO} /usr/local/go/linstor-csi/ \
  && cd /usr/local/go/linstor-csi \
  && git reset --hard v${LINSTOR_CSI_VERSION} \
+ && git apply /patches/*.patch \
  && cd cmd/linstor-csi \
  && go build -ldflags="-X github.com/piraeusdatastore/linstor-csi/pkg/driver.Version=v${LINSTOR_CSI_VERSION}" \
  && mv ./linstor-csi /

--- a/modules/041-linstor/images/linstor-csi/patches/README.md
+++ b/modules/041-linstor/images/linstor-csi/patches/README.md
@@ -1,0 +1,8 @@
+## Patches
+
+### Fix multiple requisites
+
+Sometimes Kubernetes may request multiple requisites in topology in CreateVolume request.
+This patch considers just the first one as the requested node.
+
+- https://github.com/piraeusdatastore/linstor-csi/pull/196

--- a/modules/041-linstor/images/linstor-csi/patches/requisites.patch
+++ b/modules/041-linstor/images/linstor-csi/patches/requisites.patch
@@ -1,0 +1,33 @@
+diff --git a/pkg/linstor/highlevelclient/high_level_client.go b/pkg/linstor/highlevelclient/high_level_client.go
+index 645599c..2f7c3f9 100644
+--- a/pkg/linstor/highlevelclient/high_level_client.go
++++ b/pkg/linstor/highlevelclient/high_level_client.go
+@@ -27,7 +27,6 @@ import (
+ 	"github.com/container-storage-interface/spec/lib/go/csi"
+ 
+ 	"github.com/piraeusdatastore/linstor-csi/pkg/linstor/util"
+-	"github.com/piraeusdatastore/linstor-csi/pkg/slice"
+ 	"github.com/piraeusdatastore/linstor-csi/pkg/topology"
+ 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
+ )
+@@ -104,18 +103,8 @@ func (c *HighLevelClient) GetAllTopologyNodes(ctx context.Context, remoteAccessP
+ 		accessibleSegments = []map[string]string{{}}
+ 	}
+ 
+-	var allNodes []string
+-
+-	for _, segment := range accessibleSegments {
+-		nodes, err := c.NodesForTopology(ctx, segment)
+-		if err != nil {
+-			return nil, err
+-		}
+-
+-		allNodes = slice.AppendUnique(allNodes, nodes...)
+-	}
+-
+-	return allNodes, nil
++	// schedulded node of the pod is the first entry in the accessible segment
++	return c.NodesForTopology(ctx, accessibleSegments[0])
+ }
+ 
+ // NodesForTopology finds all matching nodes for the given topology segment.


### PR DESCRIPTION
## Description

Sometimes Kubernetes may request multiple requisites in topology in CreateVolume request.
This patch considers just the first one as the requested node.

upstream: https://github.com/piraeusdatastore/linstor-csi/pull/196

## Why do we need it, and what problem does it solve?

fixes https://github.com/piraeusdatastore/linstor-csi/issues/195

## Why do we need it in the patch release (if we do)?

Some of our clients already using this feature

## What is the expected result?

Some scheduling errors will gone

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: fix
summary: Fix multiple requisites in volume placement request
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
