### PR TITLE
[global-hooks] Fix cluster dns address discovery

### DIFF
--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -100,7 +100,7 @@ func applyDNSServiceIPFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 // dnsAdress will be taken only from ClusterIP service in that order:
 // - from 'kube-dns' service
 // - from any other service selected by label 'k8s-app=kube-dns'
-//   if there are no more services with same label in namespace
+//   if there are no more ClusterIP services with same label in namespace
 
 func discoveryDNSAddress(input *go_hook.HookInput) error {
 	dnsAddress := ""
@@ -108,13 +108,13 @@ func discoveryDNSAddress(input *go_hook.HookInput) error {
 	for _, sRaw := range input.Snapshots["dns_cluster_ip"] {
 		s := sRaw.(ServiceAddr)
 
-		if s.Name == "kube-dns" && s.ClusterIP != "None" && s.ClusterIP != "" {
-			input.Values.Set("global.discovery.dnsAddress", s.ClusterIP)
-			return nil
-		}
-
 		if s.ClusterIP == "None" || s.ClusterIP == "" {
 			continue
+		}
+
+		if s.Name == "kube-dns" {
+			dnsAddress = s.ClusterIP
+			break
 		}
 
 		if dnsAddress != "" && dnsAddress != s.ClusterIP {

--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -85,6 +85,23 @@ func applyDNSServiceIPFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 	return ServiceAddr{service.Name, service.Spec.ClusterIP}, nil
 }
 
+// Providers are deploying node-local-dns to cluster in different ways
+// Here is services in 'kube-system' namespace for Deckhouse and GKE
+// when node-local-dns is deployed
+
+//      | .metadata.Name     |  .spec.Type   | .metadata.labels
+//  ----+--------------------+---------------+-------------------
+//  D8  | kube-dns           |  ClusterIP    |  k8s-app=kube-dns
+//      | kube-dns-upstream  |  ClusterIP    |  k8s-app=kube-dns
+//  ----+--------------------+---------------+-------------------
+//  GKE | kube-dns           |  ExternalName |  k8s-app=kube-dns
+//      | d8-kube-dns        |  ClusterIP    |  k8s-app=kube-dns
+
+// dnsAdress will be taken only from ClusterIP service in that order:
+// - from 'kube-dns' service
+// - from any other service selected by label 'k8s-app=kube-dns'
+//   if there are no more services with same label in namespace
+
 func discoveryDNSAddress(input *go_hook.HookInput) error {
 	dnsAddress := ""
 

--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -25,30 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const (
-	dnsAddressServiceSnapName = "kube_dns_cluster_ip"
-	dnsAddressByD8AppSnapName = "cluster_dns_address_by_d8s_app"
-)
-
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       dnsAddressServiceSnapName,
-			ApiVersion: "v1",
-			Kind:       "Service",
-			NameSelector: &types.NameSelector{
-				MatchNames: []string{"kube-dns"},
-			},
-			NamespaceSelector: &types.NamespaceSelector{
-				NameSelector: &types.NameSelector{
-					MatchNames: []string{"kube-system"},
-				},
-			},
-			FilterFunc: applyDNSServiceIPFilter,
-		},
-
-		{
-			Name:       dnsAddressByD8AppSnapName,
+			Name:       "dns_cluster_ip",
 			ApiVersion: "v1",
 			Kind:       "Service",
 			NamespaceSelector: &types.NamespaceSelector{

--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -25,10 +25,30 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const (
+	dnsAddressServiceSnapName = "kube_dns_cluster_ip"
+	dnsAddressByD8AppSnapName = "cluster_dns_address_by_d8s_app"
+)
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       "dns_cluster_ip",
+			Name:       dnsAddressServiceSnapName,
+			ApiVersion: "v1",
+			Kind:       "Service",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"kube-dns"},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			FilterFunc: applyDNSServiceIPFilter,
+		},
+
+		{
+			Name:       dnsAddressByD8AppSnapName,
 			ApiVersion: "v1",
 			Kind:       "Service",
 			NamespaceSelector: &types.NamespaceSelector{
@@ -50,6 +70,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, discoveryDNSAddress)
 
+type ServiceAddr struct {
+	Name      string
+	ClusterIP string
+}
+
 func applyDNSServiceIPFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var service v1core.Service
 	err := sdk.FromUnstructured(obj, &service)
@@ -57,24 +82,29 @@ func applyDNSServiceIPFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 		return "", err
 	}
 
-	return service.Spec.ClusterIP, nil
+	return ServiceAddr{service.Name, service.Spec.ClusterIP}, nil
 }
 
 func discoveryDNSAddress(input *go_hook.HookInput) error {
-	dnsAddressSnap := input.Snapshots["dns_cluster_ip"]
-
 	dnsAddress := ""
-	for _, addrRaw := range dnsAddressSnap {
-		addr := addrRaw.(string)
-		if addr == "None" || addr == "" {
+
+	for _, sRaw := range input.Snapshots["dns_cluster_ip"] {
+		s := sRaw.(ServiceAddr)
+
+		if s.Name == "kube-dns" && s.ClusterIP != "None" && s.ClusterIP != "" {
+			input.Values.Set("global.discovery.dnsAddress", s.ClusterIP)
+			return nil
+		}
+
+		if s.ClusterIP == "None" || s.ClusterIP == "" {
 			continue
 		}
 
-		if dnsAddress != "" && dnsAddress != addr {
-			return fmt.Errorf("ERROR: can't find a single kube-dns service, found %s %s", dnsAddress, addr)
+		if dnsAddress != "" && dnsAddress != s.ClusterIP {
+			return fmt.Errorf("ERROR: can't select a single service by 'k8s-app: kube-dns' label, found %s %s", dnsAddress, s.ClusterIP)
 		}
 
-		dnsAddress = addr
+		dnsAddress = s.ClusterIP
 	}
 
 	if dnsAddress == "" {

--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -66,15 +66,14 @@ func applyDNSServiceIPFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 }
 
 // Providers are deploying node-local-dns to cluster in different ways
-// Here is services in 'kube-system' namespace for Deckhouse and GKE
-// when node-local-dns is deployed
+// E.g.: services in 'kube-system' namespace for Deckhouse and GKE
 
 //      | .metadata.Name     |  .spec.Type   | .metadata.labels
 //  ----+--------------------+---------------+-------------------
-//  D8  | kube-dns           |  ClusterIP    |  k8s-app=kube-dns
+//  GKE | kube-dns           |  ClusterIP    |  k8s-app=kube-dns
 //      | kube-dns-upstream  |  ClusterIP    |  k8s-app=kube-dns
 //  ----+--------------------+---------------+-------------------
-//  GKE | kube-dns           |  ExternalName |  k8s-app=kube-dns
+//  D8  | kube-dns           |  ExternalName |  k8s-app=kube-dns
 //      | d8-kube-dns        |  ClusterIP    |  k8s-app=kube-dns
 
 // dnsAdress will be taken only from ClusterIP service in that order:


### PR DESCRIPTION
Take cluster dns address from service with `kube-dns` name if there are multiply clusterIp services labeled `k8s-app: kube-dns` in cluster.

E.g.:  enable node-local-dns plugin in GKE, to deploy two services with same labels `k8s-app: kube-dns` and selectors  named `kube-dns` and `kube-dns-upstream`,
after that cluster dns address fails with error `"ERROR: can't find a single kube-dns service`

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
[Issue 4520](https://github.com/deckhouse/deckhouse/issues/4520)
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix
summary:  Fix cluster dns address discovery
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
