### PR TITLE
[descheduler] Restored migration hook

### DIFF
--- a/global-hooks/migrate/migrate_descheduler.go
+++ b/global-hooks/migrate/migrate_descheduler.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(deschedulerConfigMigration))
+
+func deschedulerConfigMigration(input *go_hook.HookInput, dc dependency.Container) error {
+	kubeCl, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("cannot init Kubernetes client: %v", err)
+	}
+
+	mcGVR := schema.ParseGroupResource("moduleconfigs.deckhouse.io").WithVersion("v1alpha1")
+
+	moduleConfig, err := kubeCl.Dynamic().Resource(mcGVR).Get(context.TODO(), "descheduler", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		input.LogEntry.Info("ModuleConfig for descheduler does not exists, nothing to migrate")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	mcVersion, exists, err := unstructured.NestedInt64(moduleConfig.UnstructuredContent(), "spec", "version")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("moduleConfig does not exists, that should not be happening")
+	}
+	if mcVersion != 1 {
+		input.LogEntry.Infof("moduleConfig is not version 1, skipping migration")
+		return nil
+	}
+
+	moduleEnabled, exists, err := unstructured.NestedBool(moduleConfig.UnstructuredContent(), "spec", "enabled")
+	if err != nil {
+		return err
+	}
+	if exists && !moduleEnabled {
+		input.LogEntry.Infof("module explicitly disabled, skipping migration")
+		return nil
+	}
+
+	deschedulerSettings, exists, err := unstructured.NestedMap(moduleConfig.UnstructuredContent(), "spec", "settings")
+	if err != nil {
+		return err
+	}
+
+	deschedulerConfigJSON := []byte("{}")
+	if exists && len(deschedulerSettings) > 0 {
+		deschedulerConfigJSON, err = json.Marshal(deschedulerSettings)
+		if err != nil {
+			return err
+		}
+	} else {
+		input.LogEntry.Info("Config for descheduler is empty, but module is enabled, migrating without config")
+	}
+
+	_, err = kubeCl.CoreV1().ConfigMaps("d8-system").Create(context.TODO(), &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "descheduler-config-migration",
+			Namespace: "d8-system",
+		},
+		Data: map[string]string{"config": string(deschedulerConfigJSON)},
+	}, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		input.LogEntry.Infof("CM already existis, skipping migration: %s", err)
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Restored descheduler config-to-CR migration hook.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


Has been deleted in https://github.com/deckhouse/deckhouse/pull/4016/files#diff-86dc37896afb6eceaa9b1da3da51da09170dee0531cb2e3b89473b98c20f7ac1L17

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Current releases are silently disable descheduler configuration.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Descheduler config is correctly migrated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: fix
summary: Restored descheduler migration hook
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
