### PR TITLE
[candi] include patch version in common kubernetes image artifact name

### DIFF
--- a/modules/000-common/images/kubernetes/werf.inc.yaml
+++ b/modules/000-common/images/kubernetes/werf.inc.yaml
@@ -2,8 +2,9 @@
   {{- $version := toString $key }}
   {{- $patch := toString $value.patch }}
   {{- $v := semver $version }}
+  {{- $full_version := printf "%s.%s" $version $patch }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $full_version | replace "." "-" }}
     {{- if semverCompare ">=1.25" $version }}
 from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
     {{- else if semverCompare ">=1.24" $version }}
@@ -27,11 +28,11 @@ shell:
   - apk add --no-cache make bash git mercurial patch rsync gcc musl-dev
   install:
   - mkdir /src
-  - wget https://github.com/kubernetes/kubernetes/archive/v{{ printf "%s.%s" $version $patch }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/
+  - wget https://github.com/kubernetes/kubernetes/archive/v{{ $full_version }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/
   - cd /src
   - |
     cat <<EOF > .kube-version
-    KUBE_GIT_VERSION='v{{ printf "%s.%s" $version $patch }}'
+    KUBE_GIT_VERSION='v{{ $full_version }}'
     KUBE_GIT_MAJOR='{{ $v.Major }}'
     KUBE_GIT_MINOR='{{ $v.Minor }}'
     KUBE_GIT_COMMIT='0000000000000000000000000000000000000000'

--- a/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
@@ -29,7 +29,7 @@ git:
     setup:
     - '**/*'
 import:
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubeadm
   to: /kubeadm
   before: setup

--- a/modules/007-registrypackages/images/kubectl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubectl/werf.inc.yaml
@@ -29,7 +29,7 @@ git:
     setup:
     - '**/*'
 import:
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubectl
   to: /kubectl
   before: setup

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -31,7 +31,7 @@ git:
     setup:
     - '**/*'
 import:
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubelet
   to: /kubelet
   before: setup

--- a/modules/021-kube-proxy/images/kube-proxy/werf.inc.yaml
+++ b/modules/021-kube-proxy/images/kube-proxy/werf.inc.yaml
@@ -2,6 +2,7 @@
   {{- $version := toString $key }}
   {{- $patch := $value.patch | toString }}
   {{- $v := semver $version }}
+  {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
@@ -9,7 +10,7 @@ git:
 - add: /modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/iptables-wrapper-installer.sh
   to: /iptables-wrapper-installer.sh
 import:
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-proxy
   to: /usr/local/bin/kube-proxy
   before: setup

--- a/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
@@ -1,11 +1,12 @@
 {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- $patch := $value.patch | toString }}
+  {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin
   to: /
   includePaths:

--- a/modules/040-control-plane-manager/images/kube-apiserver/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-apiserver/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- $patch := toString $value.patch }}
+  {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
@@ -9,7 +10,7 @@ import:
   add: /pause
   to: /pause
   before: setup
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-apiserver
   to: /usr/bin/kube-apiserver
   before: setup

--- a/modules/040-control-plane-manager/images/kube-controller-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- $patch := toString $value.patch }}
+  {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_UBUNTU }}
@@ -9,7 +10,7 @@ import:
   add: /pause
   to: /pause
   before: setup
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-controller-manager
   to: /usr/bin/kube-controller-manager
   before: setup

--- a/modules/040-control-plane-manager/images/kube-scheduler/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-scheduler/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- $patch := $value.patch | toString }}
+  {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
@@ -9,7 +10,7 @@ import:
   add: /pause
   to: /pause
   before: setup
-- artifact: common/kubernetes-artifact-{{ $version | replace "." "-" }}
+- artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-scheduler
   to: /usr/bin/kube-scheduler
   before: setup


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Include patch version in common kubernetes image artifact name.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Before this PR common kubernetes artifact name was something like`common/kubernetes-artifact-1-24`.
Now it is include patch version of kubernetes, so name is `common/kubernetes-artifact-1-24-3`.
It allows us to avoid permanent rebuild via branches during the kubernetes patch version bump
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: include patch version in common kubernetes image artifact name
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
