### PR TITLE
[node-manager] Fix links in node-unmanaged rule for Prometheus

### DIFF
--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -21,7 +21,7 @@
     {{- else }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
         description: |
-          The {{`{{ $labels.node }}`}} Node is not managed by the `node-manager` module.
+          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
 
           The recommended actions are as follows:
           - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -11,15 +11,9 @@
         plk_protocol_version: "1"
         plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-    {{- if .Values.global.modules.publicDomainTemplate }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
         description: |
           The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-put-an-existing-cluster-node-under-the-node-managers-control) module.
-    {{- else }}
-        summary: The {{`{{ $labels.node }}`}} Node is not managed by the `node-manager`.
-        description: |
-          The {{`{{ $labels.node }}`}} Node is not managed by the `node-manager`.
-    {{- end }}
 
           The recommended actions are as follows:
           - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -14,7 +14,7 @@
     {{- if .Values.global.modules.publicDomainTemplate }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
         description: |
-          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
+          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-put-an-existing-cluster-node-under-the-node-managers-control) module.
     {{- else }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the `node-manager`.
         description: |

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -11,9 +11,9 @@
         plk_protocol_version: "1"
         plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
+        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/) module.
         description: |
-          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-put-an-existing-cluster-node-under-the-node-managers-control) module.
+          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-to-put-an-existing-cluster-node-under-the-node-managers-control) module.
 
           The recommended actions are as follows:
-          - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
+          - Follow these instructions to clean up the node and add it to the cluster: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -12,9 +12,9 @@
         plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
     {{- if .Values.global.modules.publicDomainTemplate }}
-        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/040-node-manager/) module.
+        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
         description: |
-          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/040-node-manager/) module.
+          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
     {{- else }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the `node-manager`.
         description: |
@@ -22,5 +22,4 @@
     {{- end }}
 
           The recommended actions are as follows:
-          - Follow these instructions to clean up the node before adding it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
-          - Follow these instructions to add the Node to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-do-i-add-a-static-node-to-a-cluster
+          - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -11,9 +11,18 @@
         plk_protocol_version: "1"
         plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+    {{- if .Values.global.modules.publicDomainTemplate }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/) module.
         description: |
-          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-to-put-an-existing-cluster-node-under-the-node-managers-control) module.
+          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/) module.
 
           The recommended actions are as follows:
           - Follow these instructions to clean up the node and add it to the cluster: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
+    {{- else }}
+        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.
+        description: |
+          The {{`{{ $labels.node }}`}} Node is not managed by the `node-manager` module.
+
+          The recommended actions are as follows:
+          - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
+    {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix links to docs in node-unmanaged rule for Prometheus
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The links to the documents in the node-unmanaged rule for Prometheus were pointing to different sources, one to the official site and the other to the internal Deckhouse site.  This may caused confusion for the users, so we fixed the links to point to the official site.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix links in node-unmanaged rule for Prometheus.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
