### PR TITLE
[node-manager] Fix bashible altlinux docker containerd version

### DIFF
--- a/candi/bashible/bundles/altlinux/node-group/031_install_docker.sh.tpl
+++ b/candi/bashible/bundles/altlinux/node-group/031_install_docker.sh.tpl
@@ -77,7 +77,7 @@ if [[ "$should_install_containerd" == true ]]; then
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "altlinux" }}
   {{- $altlinuxVersion := toString $key }}
   if bb-is-altlinux-version? {{ $altlinuxVersion }} ; then
-    containerd_tag="{{- index $.images.registrypackages (printf "containerdAltlinux%s" ($value.containerd.desiredVersion | replace "containerd-" "" | replace "." "_" | replace "-" "_" | camelcase )) }}"
+    containerd_tag="{{- index $.images.registrypackages (printf "containerdAltlinux%s" ($value.docker.containerd.desiredVersion | replace "containerd-" "" | replace "." "_" | replace "-" "_" | camelcase )) }}"
   fi
 {{- end }}
 

--- a/modules/040-node-manager/images/bashible-apiserver/README.md
+++ b/modules/040-node-manager/images/bashible-apiserver/README.md
@@ -16,8 +16,8 @@ kubectl get -o json  nodegroupbundles  ubuntu-lts.master    # <os>.<nodegroup>
 or
 
 ```
-GET /api/bashible.deckhouse.io/v1alpha1/bashibles/ubuntu-lts.master
-GET /api/bashible.deckhouse.io/v1alpha1/nodegroupbundles/ubuntu-lts.master
+GET /apis/bashible.deckhouse.io/v1alpha1/bashibles/ubuntu-lts.master
+GET /apis/bashible.deckhouse.io/v1alpha1/nodegroupbundles/ubuntu-lts.master
 ```
 
 Example:


### PR DESCRIPTION
## Description
Without this fix, bashible-apiserver in kubernetes clusters with docker does not work

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

bashible apiserver log
```
I0503 06:57:23.560006       1 trace.go:205] Trace[734617307]: "Get" url:/apis/bashible.deckhouse.io/v1alpha1/bashibles/ubuntu-lts.master,user-agent:kubectl/v1.23.17 (linux/amd64) kubernetes/953be89,client:192.168.199.112 (03-May-2023 06:57:21.883) (total time: 1676ms):
Trace[734617307]: [1.676145184s] [1.676145184s] END
I0503 06:57:23.562712       1 context.go:350] Running context update. (Source: 'NodeUserConfiguration')
I0503 06:57:23.573584       1 trace.go:205] Trace[1809769494]: "Get" url:/apis/bashible.deckhouse.io/v1alpha1/bashibles/ubuntu-lts.system,user-agent:kubectl/v1.23.17 (linux/amd64) kubernetes/953be89,client:192.168.199.105 (03-May-2023 06:57:21.766) (total time: 1807ms):
Trace[1809769494]: [1.807051747s] [1.807051747s] END
W0503 06:57:27.711839       1 context.go:366] Context was saved without checksums. Bashible context hasn't been upgraded
W0503 06:57:27.712620       1 context.go:371] bundles checksums have errors:
	bundle-altlinux-alert-test-frontend: checksum calc failed: NG steps render failed: cannot render template "031_install_docker.sh.tpl" for bundle "altlinux": template: 031_install_docker.sh.tpl:80:145: executing "031_install_docker.sh.tpl" at <"">: invalid value; expected string
	bundle-altlinux-master: checksum calc failed: NG steps render failed: cannot render template "031_install_docker.sh.tpl" for bundle "altlinux": template: 031_install_docker.sh.tpl:80:145: executing "031_install_docker.sh.tpl" at <"">: invalid value; expected string
	bundle-altlinux-system: checksum calc failed: NG steps render failed: cannot render template "031_install_docker.sh.tpl" for bundle "altlinux": template: 031_install_docker.sh.tpl:80:145: executing "031_install_docker.sh.tpl" at <"">: invalid value; expected string
	bundle-altlinux-worker: checksum calc failed: NG steps render failed: cannot render template "031_install_docker.sh.tpl" for bundle "altlinux": template: 031_install_docker.sh.tpl:80:145: executing "031_install_docker.sh.tpl" at <"">: invalid value; expected string
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary:  Fix bashible-apiserver altlinux docker containerd version (otherwise, bashible-apiserver will not work).
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
