### PR TITLE
[node-manager] Create event if node drain failed

### DIFF
--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -22,16 +22,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flant/shell-operator/pkg/kube/object_patch"
-	eventsv1 "k8s.io/api/events/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"

--- a/modules/040-node-manager/hooks/handle_draining_test.go
+++ b/modules/040-node-manager/hooks/handle_draining_test.go
@@ -18,7 +18,10 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	eventsv1 "k8s.io/api/events/v1"
 
 	"github.com/flant/addon-operator/sdk"
 	. "github.com/onsi/ginkgo"
@@ -166,6 +169,37 @@ data:
 				})
 			}
 		}
+	})
+
+	Context("simulate error", func() {
+		var event *eventsv1.Event
+
+		BeforeEach(func() {
+
+			st := f.KubeStateSet("")
+			f.BindingContexts.Set(st)
+
+			dnode := drainedNodeRes{
+				NodeName:            "foo-1",
+				NodeUID:             "111-222-333",
+				NodeResourceVersion: "123123123123",
+				DrainingSource:      "bashible",
+				Err:                 errors.New("foo-bar-error"),
+			}
+
+			event = dnode.buildEvent()
+			unst, _ := sdk.ToUnstructured(event)
+			f.BindingContextController.FakeCluster().Client.Dynamic().Resource(schema.GroupVersionResource{Resource: "events", Group: "events.k8s.io", Version: "v1"}).Namespace("default").Create(context.Background(), unst, v1.CreateOptions{})
+		})
+
+		It("Should generate event", func() {
+			ev := f.KubernetesResource("Event", "default", event.Name)
+			Expect(ev.Field("note").String()).To(Equal("foo-bar-error"))
+			Expect(ev.Field("reason").String()).To(Equal("DrainFailed"))
+			Expect(ev.Field("type").String()).To(Equal("Warning"))
+			Expect(ev.Field("regarding.kind").String()).To(Equal("Node"))
+			Expect(ev.Field("regarding.name").String()).To(Equal("foo-1"))
+		})
 	})
 })
 

--- a/modules/040-node-manager/hooks/handle_draining_test.go
+++ b/modules/040-node-manager/hooks/handle_draining_test.go
@@ -21,12 +21,11 @@ import (
 	"errors"
 	"fmt"
 
-	eventsv1 "k8s.io/api/events/v1"
-
 	"github.com/flant/addon-operator/sdk"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -189,7 +188,7 @@ data:
 
 			event = dnode.buildEvent()
 			unst, _ := sdk.ToUnstructured(event)
-			f.BindingContextController.FakeCluster().Client.Dynamic().Resource(schema.GroupVersionResource{Resource: "events", Group: "events.k8s.io", Version: "v1"}).Namespace("default").Create(context.Background(), unst, v1.CreateOptions{})
+			_, _ = f.BindingContextController.FakeCluster().Client.Dynamic().Resource(schema.GroupVersionResource{Resource: "events", Group: "events.k8s.io", Version: "v1"}).Namespace("default").Create(context.Background(), unst, v1.CreateOptions{})
 		})
 
 		It("Should generate event", func() {


### PR DESCRIPTION
## Description
Create event when node drain was failed

## Why do we need it, and what problem does it solve?
This event will bind to a Node object and we will be able to find drain failure reason easily

## Why do we need it in the patch release (if we do)?

It's hard to figure out drain failure reason from deckhouse logs

## What is the expected result?
Event will be created in the `default` namespace:
```bash
# kubectl get event -o yaml

apiVersion: v1
items:
- action: Binding
  apiVersion: v1
  eventTime: "2023-05-03T19:22:20.036930Z"
  firstTimestamp: null
  involvedObject:
    apiVersion: deckhouse.io/v1
    kind: Node
    name: ndev-worker-5e11c78a-5f688-zmmjb
    resourceVersion: "106354301"
    uid: 5dbe53d3-3d6d-4074-a807-5faa130fee45
  kind: Event
  lastTimestamp: null
  message: "drain failure reason"
  metadata:
    creationTimestamp: "2023-05-03T19:23:52Z"
    generateName: node-ndev-worker-5e11c78a-
    name: ndev-worker-5e11c78a-5f688-zmmjb
    namespace: default
    resourceVersion: "106354767"
    uid: 3a698dbf-f7d7-4215-b328-4a908cf7e7cd
  reason: DrainFailed
  reportingComponent: deckhouse
  reportingInstance: deckhouse
  source: {}
  type: Warning
kind: List
metadata:
  resourceVersion: ""
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Create an event bound to a Node object if node drain was failed during the bashible update.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
