### PR TITLE
[user-authn] Add check for unique of userID and email in User object

### DIFF
--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetes:
+  - name: users
+    apiVersion: deckhouse.io/v1
+    kind: User
+    queue: "users"
+    group: main
+    executeHookOnEvent: []
+    executeHookOnSynchronization: false
+    keepFullObjectsInMemory: false
+    jqFilter: |
+      {
+        "name": .metadata.name,
+        "email": .spec.email,
+        "userID": .spec.userID
+      }
+kubernetesValidating:
+- name: users-unique.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["users"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+  userName=$(context::jq -r '.review.request.object.metadata.name')
+  email=$(context::jq -r '.review.request.object.spec.email')
+  userID=$(context::jq -r '.review.request.object.spec.userID')
+
+  if context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email)' >/dev/null 2>&1; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"Email must be unique '$newEmail'" }
+EOF
+  fi
+
+  if context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid)' >/dev/null 2>&1; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"UserID must be unique '$userID'" }
+EOF
+  fi
+
+}
+
+hook::run "$@"

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -51,16 +51,16 @@ function __main__() {
   email=$(context::jq -r '.review.request.object.spec.email')
   userID=$(context::jq -r '.review.request.object.spec.userID')
 
-  if context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email)' >/dev/null 2>&1; then
+  if userWithTheSameEmail="$(context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"Email must be unique '$newEmail'" }
+{"allowed":false, "message":"Email must be unique. User '$userWithTheSameEmail' is already using email '$email'" }
 EOF
     return 0
   fi
 
-  if context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid)' >/dev/null 2>&1; then
+  if userWithTheSameUserID="$(context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid) | .name' >/dev/null 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"UserID must be unique '$userID'" }
+{"allowed":false, "message":"UserID must be unique.  User '$userWithTheSameUserID' is already using userID '$userID'" }
 EOF
     return 0
   fi

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -51,14 +51,14 @@ function __main__() {
   email=$(context::jq -r '.review.request.object.spec.email')
   userID=$(context::jq -r '.review.request.object.spec.userID')
 
-  if userWithTheSameEmail="$(context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email) | .name' 2>&1)"; then
+  if userWithTheSameEmail="$(context::jq -er --arg name "$userName" --arg email "$email" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"Email must be unique. User '$userWithTheSameEmail' is already using email '$email'" }
 EOF
     return 0
   fi
 
-  if userWithTheSameUserID="$(context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid) | .name' >/dev/null 2>&1)"; then
+  if userWithTheSameUserID="$(context::jq -er --arg name "$userName" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"UserID must be unique.  User '$userWithTheSameUserID' is already using userID '$userID'" }
 EOF

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -55,13 +55,19 @@ function __main__() {
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"Email must be unique '$newEmail'" }
 EOF
+    return 0
   fi
 
   if context::jq -er --arg name "$userName" --arg email "$email" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid)' >/dev/null 2>&1; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"UserID must be unique '$userID'" }
 EOF
+    return 0
   fi
+
+  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
 
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added validating webhook to check for unique userID and email in User object

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
userID and email must be unique for all static users

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Added validating webhook to check for unique userID and email in User object
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
