### PR TITLE
[deckhouse] Remove Deckhouse release naming transformation

### DIFF
--- a/modules/002-deckhouse/docs/USAGE.md
+++ b/modules/002-deckhouse/docs/USAGE.md
@@ -94,7 +94,7 @@ In this mode, it will be necessary to confirm each minor Deckhouse updates (excl
 Manual confirmation of the update to the version `v1.43.2`:
 
 ```shell
-kubectl patch DeckhouseRelease v1-43-2 --type=merge -p='{"approved": true}'
+kubectl patch DeckhouseRelease v1.43.2 --type=merge -p='{"approved": true}'
 ```
 
 ### Manual disruption update confirmation
@@ -119,7 +119,7 @@ In this mode, it will be necessary to confirm each minor disruptive update with 
 An example of confirmation of a potentially dangerous Deckhouse minor update `v1.36.4`:
 
 ```shell
-kubectl annotate DeckhouseRelease v1-36-4 release.deckhouse.io/disruption-approved=true
+kubectl annotate DeckhouseRelease v1.36.4 release.deckhouse.io/disruption-approved=true
 ```
 
 ### Deckhouse update notification

--- a/modules/002-deckhouse/docs/USAGE_RU.md
+++ b/modules/002-deckhouse/docs/USAGE_RU.md
@@ -94,7 +94,7 @@ spec:
 Пример подтверждения обновления на версию `v1.43.2`:
 
 ```shell
-kubectl patch DeckhouseRelease v1-43-2 --type=merge -p='{"approved": true}'
+kubectl patch DeckhouseRelease v1.43.2 --type=merge -p='{"approved": true}'
 ```
 
 ### Ручное подтверждение потенциально опасных (disruptive) обновлений
@@ -119,7 +119,7 @@ spec:
 Пример подтверждения минорного потенциально опасного обновления Deckhouse `v1.36.4`:
 
 ```shell
-kubectl annotate DeckhouseRelease v1-36-4 release.deckhouse.io/disruption-approved=true
+kubectl annotate DeckhouseRelease v1.36.4 release.deckhouse.io/disruption-approved=true
 ```
 
 ### Оповещение об обновлении Deckhouse

--- a/modules/002-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"path"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -102,8 +101,6 @@ func checkReleases(input *go_hook.HookInput, dc dependency.Container) error {
 	if newImageHash == "" {
 		return nil
 	}
-
-	releaseName := strings.ReplaceAll(releaseChecker.releaseMetadata.Version, ".", "-")
 
 	// run only if it's a canary release
 	var (
@@ -208,7 +205,7 @@ releaseLoop:
 			APIVersion: "deckhouse.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        releaseName,
+			Name:        releaseChecker.releaseMetadata.Version,
 			Annotations: make(map[string]string),
 		},
 		Spec: v1alpha1.DeckhouseReleaseSpec{

--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Modules :: deckhouse :: hooks :: check deckhouse release ::", 
 		})
 		It("Release should be created", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-3").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-3").Field("spec.version").String()).To(BeEquivalentTo("v1.25.3"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.3").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.3").Field("spec.version").String()).To(BeEquivalentTo("v1.25.3"))
 		})
 	})
 
@@ -89,9 +89,9 @@ var _ = Describe("Modules :: deckhouse :: hooks :: check deckhouse release ::", 
 		})
 		It("Release should be created without ApplyAfter (wave 0)", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("spec.version").String()).To(BeEquivalentTo("v1.25.0"))
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("spec.applyAfter").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("spec.version").String()).To(BeEquivalentTo("v1.25.0"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("spec.applyAfter").Exists()).To(BeFalse())
 		})
 	})
 
@@ -109,9 +109,9 @@ var _ = Describe("Modules :: deckhouse :: hooks :: check deckhouse release ::", 
 		})
 		It("Release should be created with ApplyAfter (wave 4)", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-5").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-5").Field("spec.applyAfter").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-5").Field("spec.applyAfter").Time()).To(BeTemporally("~", time.Now().UTC().Add(60*time.Minute), time.Minute))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.5").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.5").Field("spec.applyAfter").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.5").Field("spec.applyAfter").Time()).To(BeTemporally("~", time.Now().UTC().Add(60*time.Minute), time.Minute))
 		})
 	})
 
@@ -129,7 +129,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: check deckhouse release ::", 
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -140,8 +140,8 @@ status:
 		})
 		It("Release should be marked with annotation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").String()).To(Equal("true"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").String()).To(Equal("true"))
 		})
 	})
 
@@ -159,7 +159,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -170,8 +170,8 @@ status:
 		})
 		It("Release should not be marked with annotation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
 		})
 	})
 
@@ -191,8 +191,8 @@ status:
 		})
 		It("Release should be marked with annotation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").String()).To(Equal("true"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").String()).To(Equal("true"))
 		})
 	})
 
@@ -210,7 +210,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
   annotations:
     release.deckhouse.io/suspended: "true"
 spec:
@@ -223,10 +223,10 @@ status:
 		})
 		It("Release should be marked with annotation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("status.phase").String()).To(Equal("Pending"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("status.phase").String()).To(Equal("Pending"))
 		})
 	})
 
@@ -247,7 +247,7 @@ status:
 		})
 		It("Release should not be created", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeFalse())
 		})
 	})
 
@@ -267,8 +267,8 @@ status:
 		})
 		It("Release should be created with requirements", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-0").Exists()).To(BeTrue())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-0")
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.0").Exists()).To(BeTrue())
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.0")
 			Expect(rl.Field("spec.requirements").String()).To(Equal(`{"k8s":"1.19","req1":"dep1"}`))
 		})
 	})
@@ -289,8 +289,8 @@ status:
 		})
 		It("Release should be created with requirements", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0").Exists()).To(BeTrue())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0")
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0").Exists()).To(BeTrue())
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0")
 			Expect(rl.Field("spec.applyAfter").Exists()).To(BeTrue())
 		})
 	})
@@ -318,8 +318,8 @@ status:
 		})
 		It("Release should be created with cooldown", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0").Exists()).To(BeTrue())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0")
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0").Exists()).To(BeTrue())
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0")
 			Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).Exists()).To(BeTrue())
 			Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).String()).To(Equal("2026-06-06T16:16:16Z"))
 		})
@@ -340,8 +340,8 @@ status:
 			})
 			It("Release should inherit cooldown from previous one", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-1").Exists()).To(BeTrue())
-				rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-1")
+				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.1").Exists()).To(BeTrue())
+				rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.1")
 				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).Exists()).To(BeTrue())
 				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).String()).To(Equal("2026-06-06T16:16:16Z"))
 			})
@@ -370,8 +370,8 @@ status:
 			})
 			It("Release should not inherit cooldown from previous one", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-2").Exists()).To(BeTrue())
-				rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-2")
+				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.2").Exists()).To(BeTrue())
+				rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.2")
 				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).Exists()).To(BeTrue())
 				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).String()).To(Equal("2030-05-05T15:15:15Z"))
 			})
@@ -394,8 +394,8 @@ status:
 		})
 		It("Release should be created with requirements", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-32-0").Exists()).To(BeTrue())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-32-0")
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.32.0").Exists()).To(BeTrue())
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.32.0")
 			Expect(rl.Field("spec.disruptions").Array()).To(HaveLen(1))
 			Expect(rl.Field("spec.disruptions").Array()[0].String()).To(Equal("ingressNginx"))
 		})
@@ -449,8 +449,8 @@ global:
 		})
 		It("Release should be created with requirements", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0").Exists()).To(BeTrue())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0")
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0").Exists()).To(BeTrue())
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0")
 
 			// global changelog is added
 			globalChangelog := rl.Field("spec.changelog.global")
@@ -498,7 +498,7 @@ global:
 		})
 		It("Manual release creation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-666-0")
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.666.0")
 			fmt.Println("\n" + rl.ToYaml())
 			time.Sleep(300 * time.Millisecond)
 		})

--- a/modules/002-deckhouse/hooks/cleanup_deckhouse_releases_test.go
+++ b/modules/002-deckhouse/hooks/cleanup_deckhouse_releases_test.go
@@ -42,13 +42,13 @@ var _ = Describe("Modules :: deckhouse :: hooks :: cleanup deckhouse releases ::
 		})
 		It("Wrong deployed releases should be Superseded", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			rl1 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-0")
+			rl1 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.28.0")
 			Expect(rl1.Field("status.phase").String()).Should(Equal("Superseded"))
-			rl2 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-1")
+			rl2 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.28.1")
 			Expect(rl2.Field("status.phase").String()).Should(Equal("Superseded"))
-			rl3 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-2")
+			rl3 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.28.2")
 			Expect(rl3.Field("status.phase").String()).Should(Equal("Superseded"))
-			rl4 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-3")
+			rl4 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.28.3")
 			Expect(rl4.Field("status.phase").String()).Should(Equal("Deployed"))
 		})
 	})
@@ -76,7 +76,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: cleanup deckhouse releases ::
 		})
 		It("Shouldn't touch releases", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			rl1 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-0")
+			rl1 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.28.0")
 			Expect(rl1.Field("status.phase").String()).Should(Equal("Deployed"))
 
 			ll, _ := f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{Resource: "deckhousereleases", Group: "deckhouse.io", Version: "v1alpha1"}).List(context.TODO(), v1.ListOptions{})
@@ -91,7 +91,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-30-16
+  name: v1.30.16
 spec:
   requirements:
     k8s: 1.19.0
@@ -105,7 +105,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-30-17
+  name: v1.30.17
 spec:
   applyAfter: "2022-03-22T16:39:01.017873947Z"
   requirements:
@@ -120,7 +120,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-30-18
+  name: v1.30.18
 spec:
   requirements:
     k8s: 1.19.0
@@ -135,7 +135,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-30-19
+  name: v1.30.19
 spec:
   applyAfter: "2022-03-24T12:20:02.146704455Z"
   requirements:
@@ -150,7 +150,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-30-9
+  name: v1.30.9
 spec:
   version: v1.30.9
 status:
@@ -165,9 +165,9 @@ status:
 		})
 		It("Should keep last release in order", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			rl19 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-19")
-			rl18 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-18")
-			rl17 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-17")
+			rl19 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.19")
+			rl18 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.18")
+			rl17 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.17")
 			Expect(rl17.Field("status.phase").String()).Should(Equal("Skipped"))
 			Expect(rl18.Field("status.phase").String()).Should(Equal("Deployed"))
 			Expect(rl19.Field("status.phase").String()).Should(Equal("Pending"))
@@ -184,7 +184,7 @@ func generateReleases(deployedReleasesCount, outdatedReleasesCount int) string {
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-28-%d
+  name: v1.28.%d
 spec:
   version: "v1.28.%d"
 status:
@@ -199,7 +199,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-27-%d
+  name: v1.27.%d
 spec:
   version: "v1.27.%d"
 status:

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 			Expect(f).To(ExecuteSuccessfully())
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.0"))
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.26.0")
 			Expect(rl.Field("status.message").String()).To(Equal("Release is waiting for the update window: 02 Jan 21 08:00 UTC"))
 		})
 	})
@@ -144,7 +144,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 			Expect(f).To(ExecuteSuccessfully())
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.1"))
-			patchRelease := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1")
+			patchRelease := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1")
 			Expect(patchRelease.Field("status.approved").Bool()).To(Equal(true))
 		})
 	})
@@ -279,7 +279,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should update deckhouse deployment", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1").Field("status.phase").String()).To(Equal("Deployed"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1").Field("status.phase").String()).To(Equal("Deployed"))
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.1"))
 		})
@@ -296,7 +296,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should update deckhouse deployment", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1").Field("status.phase").String()).To(Equal("Deployed"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1").Field("status.phase").String()).To(Equal("Deployed"))
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.1"))
 		})
@@ -311,10 +311,10 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should update deckhouse deployment for latest patch", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-3").Field("status.phase").String()).To(Equal("Deployed"))
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-2").Field("status.phase").String()).To(Equal("Skipped"))
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-1").Field("status.phase").String()).To(Equal("Skipped"))
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-32-0").Field("status.phase").String()).To(Equal("Pending"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.3").Field("status.phase").String()).To(Equal("Deployed"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.2").Field("status.phase").String()).To(Equal("Skipped"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.1").Field("status.phase").String()).To(Equal("Skipped"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.32.0").Field("status.phase").String()).To(Equal("Pending"))
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.31.3"))
 		})
@@ -329,9 +329,9 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should update deckhouse even on suspended forced release", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-1").Field("status.phase").String()).To(Equal("Deployed"))
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-1").Field("metadata.annotations.release\\.deckhouse\\.io/force").Exists()).To(BeFalse())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-31-0").Field("status.phase").String()).To(Equal("Superseded"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.1").Field("status.phase").String()).To(Equal("Deployed"))
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.1").Field("metadata.annotations.release\\.deckhouse\\.io/force").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0").Field("status.phase").String()).To(Equal("Superseded"))
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.31.1"))
 		})
@@ -346,8 +346,8 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should keep deckhouse deployment", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			r1250 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0")
-			r1251 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1")
+			r1250 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0")
+			r1251 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1")
 			Expect(r1250.Field("status.phase").String()).To(Equal("Deployed"))
 			Expect(r1251.Field("status.phase").String()).To(Equal("Pending"))
 			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
@@ -364,8 +364,8 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 			It("Should upgrade deckhouse deployment", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				r1250 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0")
-				r1251 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1")
+				r1250 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0")
+				r1251 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1")
 				Expect(r1250.Field("status.phase").String()).To(Equal("Superseded"))
 				Expect(r1251.Field("status.phase").String()).To(Equal("Deployed"))
 				dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
@@ -383,9 +383,9 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should update deckhouse deployment", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			r1250 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0")
-			r1251 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1")
-			r1252 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-2")
+			r1250 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0")
+			r1251 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1")
+			r1252 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.2")
 			Expect(r1250.Field("status.phase").String()).To(Equal("Superseded"))
 			Expect(r1251.Field("status.phase").String()).To(Equal("Suspended"))
 			Expect(r1251.Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
@@ -413,7 +413,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should not update deckhouse deployment", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			r130 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-0")
+			r130 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.0")
 			Expect(r130.Field("status.phase").String()).To(Equal("Pending"))
 			Expect(r130.Field("status.message").String()).To(Equal(`"k8s" requirement for DeckhouseRelease "1.30.0" not met: min k8s version failed`))
 			Expect(f.MetricsCollector.CollectedMetrics()[2].Name).To(Equal("d8_release_blocked"))
@@ -431,7 +431,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 			It("Should update deckhouse deployment", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				r130 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-30-0")
+				r130 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.30.0")
 				Expect(r130.Field("status.phase").String()).To(Equal("Deployed"))
 				Expect(r130.Field("status.message").String()).To(Equal(``))
 				dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
@@ -458,9 +458,9 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 		It("Should block the release", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			r136 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-36-0")
+			r136 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.36.0")
 			Expect(r136.Field("status.phase").String()).To(Equal("Pending"))
-			Expect(r136.Field("status.message").String()).To(Equal("Release requires disruption approval (`kubectl annotate DeckhouseRelease v1-36-0 release.deckhouse.io/disruption-approved=true`): some test reason"))
+			Expect(r136.Field("status.message").String()).To(Equal("Release requires disruption approval (`kubectl annotate DeckhouseRelease v1.36.0 release.deckhouse.io/disruption-approved=true`): some test reason"))
 		})
 
 		Context("Disruption release approved", func() {
@@ -473,7 +473,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 
 			It("Should deploy the release", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				r136 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-36-0")
+				r136 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.36.0")
 				Expect(r136.Field("status.phase").String()).To(Equal("Deployed"))
 				Expect(r136.Field("status.message").String()).To(Equal(""))
 			})
@@ -503,7 +503,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(httpBody).To(ContainSubstring("New Deckhouse Release 1.26 is available. Release will be applied at: Friday, 01-Jan-21 14:30:00 UTC"))
 			Expect(httpBody).To(ContainSubstring(`"version":"1.26"`))
-			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
+			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.26.0")
 			cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
 			Expect(cm.Field("data.notified").Bool()).To(BeTrue())
 			Expect(r126.Field("status.phase").String()).To(Equal("Pending"))
@@ -519,7 +519,7 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -528,7 +528,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-26-0
+  name: v1.26.0
 spec:
   applyAfter: "2019-01-01T01:01:00Z"
   version: v1.26.0
@@ -551,7 +551,7 @@ metadata:
 		It("Release should be deployed", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
-			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
+			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.26.0")
 			Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
 			Expect(cm.Field("data.isUpdating").Bool()).To(BeTrue())
 			Expect(cm.Field("data.notified").Bool()).To(BeFalse())
@@ -565,7 +565,7 @@ metadata:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-26-0
+  name: v1.26.0
 spec:
   version: "v1.26.0"
 status:
@@ -585,7 +585,7 @@ metadata:
 		})
 		It("IsUpdating flag should be reset", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
+			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.26.0")
 			Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
 			cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
 			Expect(cm.Field("data.isUpdating").Bool()).To(BeFalse())
@@ -620,7 +620,7 @@ metadata:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(httpBody).To(ContainSubstring("New Deckhouse Release 1.36 is available. Release will be applied at: Monday, 11-Nov-22 23:23:23 UTC"))
 			Expect(httpBody).To(ContainSubstring(`"version":"1.36"`))
-			r136 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-36-0")
+			r136 := f.KubernetesGlobalResource("DeckhouseRelease", "v1.36.0")
 			cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
 			Expect(cm.Field("data.notified").Bool()).To(BeTrue())
 			Expect(r136.Field("status.phase").String()).To(Equal("Pending"))
@@ -767,7 +767,7 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -776,7 +776,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-26-0
+  name: v1.26.0
 spec:
   version: "v1.26.0"
 `
@@ -786,7 +786,7 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -795,7 +795,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-26-0
+  name: v1.26.0
 spec:
   version: "v1.26.0"
 approved: true
@@ -807,7 +807,7 @@ approved: true
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-1
+  name: v1.25.1
 spec:
   version: "v1.25.1"
 `
@@ -818,7 +818,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-26-2
+  name: v1.26.2
 spec:
   version: v1.26.2
 status:
@@ -830,7 +830,7 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  name: v1-27-0
+  name: v1.27.0
 spec:
   version: v1.27.0
 ---
@@ -844,7 +844,7 @@ metadata:
 spec:
   containers:
     - name: deckhouse
-      image: dev-registry.deckhouse.io/sys/deckhouse-oss:1-26-2
+      image: dev-registry.deckhouse.io/sys/deckhouse-oss:1.26.2
 status:
   containerStatuses:
     - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
@@ -869,7 +869,7 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -878,7 +878,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-1
+  name: v1.25.1
   annotations:
     release.deckhouse.io/suspended: "true"
 spec:
@@ -889,7 +889,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-2
+  name: v1.25.2
 spec:
   version: "v1.25.2"
 status:
@@ -901,7 +901,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-0
+  name: v1.25.0
 spec:
   version: "v1.25.0"
 status:
@@ -910,7 +910,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-25-1
+  name: v1.25.1
 spec:
   version: "v1.25.1"
   applyAfter: "2222-11-11T23:23:23Z"
@@ -923,7 +923,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-35-0
+  name: v1.35.0
 spec:
   version: "v1.35.0"
 status:
@@ -932,7 +932,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-36-0
+  name: v1.36.0
 spec:
   version: "v1.36.0"
   applyAfter: "2222-11-11T23:23:23Z"
@@ -945,7 +945,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-29-0
+  name: v1.29.0
 spec:
   version: "v1.29.0"
 status:
@@ -954,7 +954,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-30-0
+  name: v1.30.0
 spec:
   version: "v1.30.0"
   requirements:
@@ -967,7 +967,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-31-0
+  name: v1.31.0
 spec:
   version: "v1.31.0"
 status:
@@ -976,7 +976,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-31-1
+  name: v1.31.1
 spec:
   version: "v1.31.1"
 status:
@@ -985,7 +985,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-31-2
+  name: v1.31.2
 spec:
   version: "v1.31.2"
 status:
@@ -994,7 +994,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-31-3
+  name: v1.31.3
 spec:
   version: "v1.31.3"
 status:
@@ -1003,7 +1003,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-32-0
+  name: v1.32.0
 spec:
   version: "v1.32.0"
 status:
@@ -1014,7 +1014,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-31-0
+  name: v1.31.0
 spec:
   version: "v1.31.0"
 status:
@@ -1023,7 +1023,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-31-1
+  name: v1.31.1
   annotations:
     release.deckhouse.io/force: "true"
 spec:
@@ -1037,7 +1037,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-36-0
+  name: v1.36.0
 spec:
   version: "v1.36.0"
   disruptions:
@@ -1050,7 +1050,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1-36-0
+  name: v1.36.0
   annotations:
     release.deckhouse.io/disruption-approved: "true"
 spec:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove Deckhouse release naming transformation

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Remove Deckhouse release naming transformation.
impact: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
