### PR TITLE
[candi] Add ALT Linux 10.1 support

### DIFF
--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -43,7 +43,7 @@ case "$ID" in
     exit 1
   ;;
   altlinux)
-    case "$VERSION_ID" in p10)
+    case "$VERSION_ID" in p10|10.1)
       echo "altlinux" && exit 0 ;;
     esac
     >&2 echo "ERROR: ${PRETTY_NAME} is not supported."

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -68,7 +68,14 @@ bashible: &bashible
   altlinux:
     'p10':
       docker:
-        desiredVersion: "docker-engine=20.10.21-alt1.x86_64"
+        desiredVersion: "docker-engine=23.0.1-alt1.x86_64"
+        allowedPattern: ""
+        containerd:
+          desiredVersion: "containerd-1.6.19"
+          allowedPattern: ""
+    '10.1':
+      docker:
+        desiredVersion: "docker-engine=23.0.1-alt1.x86_64"
         allowedPattern: ""
         containerd:
           desiredVersion: "containerd-1.6.19"

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -355,7 +355,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"crictl126":                           "imageHash-registrypackages-crictl126",
 		"d8Curl801":                           "imageHash-registrypackages-d8Curl801",
 		"dockerAlteros1903153El7X866473":      "imageHash-registrypackages-dockerAlteros1903153El7X866473",
-		"dockerAltlinux201021Alt1X8664":       "imageHash-registrypackages-dockerAltlinux201021Alt1X8664",
+		"dockerAltlinux2301Alt1X8664":         "imageHash-registrypackages-dockerAltlinux2301Alt1X8664",
 		"dockerAstra520101230DebianBuster":    "imageHash-registrypackages-dockerAstra520101230DebianBuster",
 		"dockerCentos1903153El7X86647":        "imageHash-registrypackages-dockerCentos1903153El7X86647",
 		"dockerCentos1903153El8X86648":        "imageHash-registrypackages-dockerCentos1903153El8X86648",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added ALT Linux 10.1 support

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Added ALT Linux 10.1 support
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
