### PR TITLE
[descheduler] Provided a proper migration

### DIFF
--- a/global-hooks/migrate/migrate_descheduler.go
+++ b/global-hooks/migrate/migrate_descheduler.go
@@ -56,12 +56,12 @@ func deschedulerConfigMigration(input *go_hook.HookInput, dc dependency.Containe
 
 	mcGVR := schema.ParseGroupResource("moduleconfigs.deckhouse.io").WithVersion("v1alpha1")
 
-	mCM, err := kubeCl.CoreV1().ConfigMaps(migrationNS).Get(context.TODO(), migrationCM, metav1.GetOptions{})
+	_, err = kubeCl.CoreV1().ConfigMaps(migrationNS).Get(context.TODO(), migrationCM, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	if mCM != nil {
-		input.LogEntry.Info("Migration cm %s already exists, skipping migration", migrationCM)
+	if !errors.IsNotFound(err) {
+		input.LogEntry.Infof("Migration cm %s already exists, skipping migration", migrationCM)
 		return nil
 	}
 

--- a/modules/400-descheduler/hooks/migrate_from_cm.go
+++ b/modules/400-descheduler/hooks/migrate_from_cm.go
@@ -155,6 +155,7 @@ func createFirstDeschedulerCR(input *go_hook.HookInput, dc dependency.Container)
 	}
 
 	input.PatchCollector.Create(object, object_patch.IgnoreIfExists())
+	input.PatchCollector.Delete("deckhouse.io/v1alpha1", "ModuleConfig", "", "descheduler")
 	input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", "descheduler-config-migration")
 
 	return nil

--- a/modules/400-descheduler/hooks/migrate_from_cm.go
+++ b/modules/400-descheduler/hooks/migrate_from_cm.go
@@ -171,7 +171,6 @@ func createFirstDeschedulerCR(input *go_hook.HookInput, dc dependency.Container)
 		if annotations == nil {
 			objCopy.SetAnnotations(map[string]string{migratedKey: ""})
 			return objCopy, nil
-
 		}
 		annotations[migratedKey] = ""
 		objCopy.SetAnnotations(annotations)

--- a/modules/400-descheduler/hooks/migrate_from_cm_test.go
+++ b/modules/400-descheduler/hooks/migrate_from_cm_test.go
@@ -59,7 +59,7 @@ data:
 `
 )
 
-var _ = FDescribe("Modules :: descheduler :: hooks :: migrate_from_cm ::", func() {
+var _ = Describe("Modules :: descheduler :: hooks :: migrate_from_cm ::", func() {
 	f := HookExecutionConfigInit(`{"descheduler":{"internal":{}}}`, ``)
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "Descheduler", false)
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)

--- a/modules/400-descheduler/hooks/migrate_from_cm_test.go
+++ b/modules/400-descheduler/hooks/migrate_from_cm_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -39,14 +38,16 @@ metadata:
 data:
   version: 1
 `
-	emptyConfigMap = `---
+	annotatedConfigMap = `---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: descheduler-config-migration
+  annotations:
+    cm-migrated: ""
   namespace: d8-system
 data:
-  "config": "{}"
+  "config": '{"removePodsViolatingTopologySpreadConstraint": true}'
 `
 	configMap = `---
 apiVersion: v1
@@ -64,16 +65,22 @@ var _ = Describe("Modules :: descheduler :: hooks :: migrate_from_cm ::", func()
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "Descheduler", false)
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 
-	cm := &corev1.ConfigMap{}
-	Expect(yaml.Unmarshal([]byte(emptyConfigMap), &cm)).To(Succeed())
+	annotatedCM := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal([]byte(annotatedConfigMap), &annotatedCM.Object)).To(Succeed())
+	cm := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal([]byte(configMap), &cm.Object)).To(Succeed())
 	mc := &unstructured.Unstructured{}
 	Expect(yaml.Unmarshal([]byte(moduleConfig), &mc)).To(Succeed())
 
-	Context("Cluster with enabled, but unconfigured descheduler", func() {
+	Context("Unmigrated cluster", func() {
 		BeforeEach(func() {
 
 			f.KubeStateSet("")
-			_, err := f.KubeClient().CoreV1().ConfigMaps("d8-system").Create(context.TODO(), cm, v1.CreateOptions{})
+			_, err := f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "configmaps",
+			}).Namespace("d8-system").Create(context.TODO(), mc, v1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err = f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{
 				Group:    "deckhouse.io",
@@ -87,31 +94,20 @@ var _ = Describe("Modules :: descheduler :: hooks :: migrate_from_cm ::", func()
 
 		It("Should create the default Descheduler CR", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ModuleConfig", "descheduler").Exists()).To(BeFalse())
 
-			legacyCR := f.KubernetesGlobalResource("Descheduler", "legacy")
-			Expect(legacyCR.ToYaml()).To(MatchYAML(`
-apiVersion: deckhouse.io/v1alpha1
-kind: Descheduler
-metadata:
-  name: legacy
-spec:
-  deschedulerPolicy:
-    strategies:
-      removePodsViolatingInterPodAntiAffinity:
-        enabled: true
-      removePodsViolatingNodeAffinity:
-        enabled: true
-`))
 		})
 	})
 
-	Context("Cluster with configured descheduler", func() {
+	Context("Migrated cluster", func() {
 		BeforeEach(func() {
-			cm := &corev1.ConfigMap{}
-			Expect(yaml.Unmarshal([]byte(configMap), &cm)).To(Succeed())
 
 			f.KubeStateSet("")
-			_, err := f.KubeClient().CoreV1().ConfigMaps("d8-system").Create(context.TODO(), cm, v1.CreateOptions{})
+			_, err := f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "configmaps",
+			}).Namespace("d8-system").Create(context.TODO(), annotatedCM, v1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err = f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{
 				Group:    "deckhouse.io",
@@ -123,26 +119,10 @@ spec:
 			f.RunHook()
 		})
 
-		It("Should create the default Descheduler CR", func() {
+		It("Should not create the default Descheduler CR", func() {
 			Expect(f).To(ExecuteSuccessfully())
-
 			Expect(f.KubernetesGlobalResource("ModuleConfig", "descheduler").Exists()).To(BeFalse())
-			legacyCR := f.KubernetesGlobalResource("Descheduler", "legacy")
-			Expect(legacyCR.ToYaml()).To(MatchYAML(`
-apiVersion: deckhouse.io/v1alpha1
-kind: Descheduler
-metadata:
-  name: legacy
-spec:
-  deschedulerPolicy:
-    strategies:
-      removePodsViolatingInterPodAntiAffinity:
-        enabled: true
-      removePodsViolatingNodeAffinity:
-        enabled: true
-      removePodsViolatingTopologySpreadConstraint:
-        enabled: true
-`))
+			Expect(f.KubernetesGlobalResource("Descheduler", "legacy").Exists()).To(BeFalse())
 		})
 	})
 
@@ -159,7 +139,7 @@ spec:
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("Should create the default Descheduler CR", func() {
+		It("Should not create the default Descheduler CR", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
 			Expect(f.KubernetesGlobalResource("ModuleConfig", "descheduler").Exists()).To(BeFalse())


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Create a default Descheduler instance even if no config is present.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Descheduler instance was configured automatically if `descheduler` module is enabled. Continue this fine tradition.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Deschedulers are disabled by default. This is a breaking change.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Default descheduler instance is created with the following config:

```yaml
"removePodsViolatingInterPodAntiAffinity": true,
"removePodsViolatingNodeAffinity": true
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: fix
summary: Create a default Descheduler instance.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
