### PR TITLE
[linstor] Reconcile LVM pool updates

### DIFF
--- a/modules/041-linstor/images/linstor-pools-importer/main.go
+++ b/modules/041-linstor/images/linstor-pools-importer/main.go
@@ -163,10 +163,10 @@ func provisionStoragePools(ctx context.Context, lc *lclient.Client, kc kclient.C
 					return
 				}
 				for _, cand := range candidates {
-					if _, yes := seen[cand.UUID]; yes {
+					if _, yes := seen[cand.UUID+"+"+cand.StoragePool.StoragePoolName]; yes {
 						continue
 					}
-					seen[cand.UUID] = struct{}{}
+					seen[cand.UUID+"+"+cand.StoragePool.StoragePoolName] = struct{}{}
 					candiCh <- cand
 				}
 			case <-ctx.Done():


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description

This change fixes the case when linstor-pools-importer not reconciling seen pools which have tags updated

## Why do we need it, and what problem does it solve?

fixes https://github.com/deckhouse/deckhouse/issues/2728
and possible fixes https://github.com/deckhouse/deckhouse/issues/3142

## What is the expected result?

linstor-pools-importer will start reconciling any changes in tags for the existing VGs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Reconcile LVM pool updates
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
