### PR TITLE
[containerized-data-importer] Enable HonorWaitForFirstConsumer

### DIFF
--- a/modules/491-containerized-data-importer/templates/cdi.yaml
+++ b/modules/491-containerized-data-importer/templates/cdi.yaml
@@ -14,6 +14,8 @@ spec:
   {{- if .Values.global.modules.publicDomainTemplate }}
   config:
     uploadProxyURLOverride: {{ include "helm_lib_module_public_domain" (list . "cdi-uploadproxy") }}
+    featureGates:
+    - HonorWaitForFirstConsumer
   {{- end }}
   workload:
     nodeSelector:


### PR DESCRIPTION
## Description

Enable HonorWaitForFirstConsumer for CDI

## Why do we need it, and what problem does it solve?

This solves problem of correct provisioning PVs for virtual machines using WaitForFirstConsumer storage-class

## Why do we need it in the patch release (if we do)?

We already have clients using this feature

## What is the expected result?

CDI will wait until VM pod appears before scheduling importer pod

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: containerized-data-importer
type: fix
summary: Enable `HonorWaitForFirstConsumer`.
impact_level: low
```
