### PR TITLE
[user-authn][docs] Remove the "Integration with Kubernetes and Deckhouse" section

### DIFF
--- a/modules/150-user-authn/docs/README.md
+++ b/modules/150-user-authn/docs/README.md
@@ -27,16 +27,6 @@ You can use several external authentication providers simultaneously.
 
 ## Integration features
 
-### Integration with Kubernetes and Deckhouse
-
-The module generates [control-plane-manager](../../modules/040-control-plane-manager/) settings (based on the Kubernetes and Deckhouse versions).
-
-Thus, one of these modules configures the `kube-apiserver` so that it becomes the Dex OIDC client. Several other Deckhouse modules will also be configured to integrate with dex, including:
-- [prometheus](../300-prometheus/)
-- [dashboard](../500-dashboard/)
-- [openvpn](../500-openvpn/)
-- etc.
-
 ### Authenticating to the Kubernetes API using a login and password
 
 Currently, login and password-based authentication to the Kubernetes API is **only** available for the *Crowd* provider.

--- a/modules/150-user-authn/docs/README_RU.md
+++ b/modules/150-user-authn/docs/README_RU.md
@@ -27,16 +27,6 @@ webIfaces:
 
 ## Возможности интеграции
 
-### Интеграция с Kubernetes и Deckhouse
-
-Модуль генерирует настройки для модуля [control-plane-manager](../../modules/040-control-plane-manager/), в зависимости от версии Kubernetes и Deckhouse.
-
-Соответственно, один из этих модулей производит настройку `kube-apiserver` таким образом, что он становится OIDC-клиентом dex. В ряде других модулей Deckhouse также будет автоматически включена интеграция с dex, в том числе в модулях:
-- [prometheus](../../modules/300-prometheus/)
-- [dashboard](../../modules/500-dashboard/)
-- [openvpn](../../modules/500-openvpn/)
-- и других...
-
 ### Возможность аутентификации в API Kubernetes по логину и паролю
 
 Аутентификация по логину и паролю в API Kubernetes сейчас доступна **только** для провайдера *Crowd*.


### PR DESCRIPTION
## Description
Remove the "Integration with Kubernetes and Deckhouse" section from the documentation of the `user-authn` module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: chore
summary: 'Remove the "Integration with Kubernetes and Deckhouse" section from the documentation.'
impact_level: low
```
