### PR TITLE
[bashible] update ec2_describe_tags binary version to support IMDSv2

### DIFF
--- a/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
@@ -17,7 +17,7 @@
 mkdir -p /opt/deckhouse/bin
 
 if [ ! -f /var/lib/bashible/hosname-set-as-in-aws ]; then
-  curl -L -o /opt/deckhouse/bin/ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.1/ec2_describe_tags
+  curl -L -o /opt/deckhouse/bin/ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.2/ec2_describe_tags
   chmod +x /opt/deckhouse/bin/ec2_describe_tags
   instance_name=$(/opt/deckhouse/bin/ec2_describe_tags -query_meta | grep -Po '(?<=Name=).+')
   hostnamectl set-hostname "$instance_name"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bashible script for network bootstrap in AWS has been updated to use the new version of [ec2_describe_tags](https://github.com/flant/go-ec2-describe-tags/releases/tag/v0.0.1-flant.2) binary, supporting AWS IMDSv2. 

## Why do we need it, and what problem does it solve?
Current implementation of bashible networking bootstrap in AWS cloud uses AWS IMDSv1 that fails to bootstrap a node in case IMDSv1 is disabled (by policies or/and there is IMDSv2=required setting in the AMI that is used for VM creation).
Switching to the new version of the binary overcomes the bootstrapping issue for the IMDSv2-required nodes and doesn't affect the nodes where IMDSv2 isn't mandatory as IMDSv2 is also available on such nodes.
Close #4583
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
An AWS node bootstrap process should be successfully regardless of the version of IMDS set for the node.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: bashible
type: fix
summary: Update bashible network bootstrap in AWS cloud to use IMDSv2 for obtaining an instance metadata.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
