### PR TITLE
[candi] refactor bootstrap scripts to fit 16kb limit of cloud-data

### DIFF
--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -39,10 +39,12 @@ if [ "${VERSION_ID}" == "8" ] ; then
   yum install python3 -y
   alternatives --set python /usr/bin/python3
 fi
-
+{{- /*
+Description of problem with XFS https://www.suse.com/support/kb/doc/?id=000020068
+*/}}
 for FS_NAME in $(mount -l -t xfs | awk '{ print $1 }'); do
   if command -v xfs_info >/dev/null && xfs_info $FS_NAME | grep -q ftype=0; then
-     >&2 echo "XFS file system with ftype=0 was found ($FS_NAME). This may cause problems (https://www.suse.com/support/kb/doc/?id=000020068), please fix it and try again."
+     >&2 echo "ERROR: XFS file system with ftype=0 was found ($FS_NAME)."
      exit 1
   fi
 done

--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -13,6 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+function name_is_not_supported() {
+    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
+    exit 1
+}
+
+function try_bundle(){
+  >&2 echo "WARNING: Trying to use ${1} bundle as default for: ${PRETTY_NAME}"
+  echo "${1}"
+  exit 0
+
 */}}
 if [ ! -e /etc/os-release ]; then
   >&2 echo "ERROR: Can't determine OS! /etc/os-release is not found."
@@ -25,29 +35,25 @@ case "$ID" in
     case "$VERSION_ID" in 7|7.*|8|8.*|9|9.*)
       echo "centos" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   ubuntu)
     case "$VERSION_ID" in 18.04|20.04|22.04)
       echo "ubuntu-lts" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   debian)
     case "$VERSION_ID" in 9|10|11)
       echo "debian" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   altlinux)
     case "$VERSION_ID" in p10)
       echo "altlinux" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   "")
     >&2 echo "ERROR: Can't determine OS! No ID in /etc/os-release."
@@ -60,16 +66,13 @@ esac
 for ID in $ID_LIKE; do
   case "$ID" in
     centos|rhel)
-      >&2 echo "WARNING: Trying to use centos bundle as default for: ${PRETTY_NAME}"
-      echo "centos" && exit 0
+      try_bundle "centos"
     ;;
     debian)
-      >&2 echo "WARNING: Trying to use debian bundle as default for: ${PRETTY_NAME}"
-      echo "debian" && exit 0
+      try_bundle "debian"
     ;;
     altlinux)
-      >&2 echo "WARNING: Trying to use altlinux bundle as default for: ${PRETTY_NAME}"
-      echo "altlinux" && exit 0
+      try_bundle "altlinux"
     ;;
   esac
 done
@@ -80,5 +83,4 @@ bundle="debian"
 if yum -q --version >/dev/null 2>/dev/null; then
   bundle="centos"
 fi
->&2 echo "WARNING: Trying to use ${bundle} bundle as default for: ${PRETTY_NAME}"
-echo "${bundle}"
+try_bundle "${bundle}"

--- a/ee/candi/bashible/bundles/alteros/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/alteros/bootstrap.sh.tpl
@@ -27,9 +27,12 @@ until yum install nc curl wget jq -y; do
   sleep 10
 done
 
+{{- /*
+Description of problem with XFS https://www.suse.com/support/kb/doc/?id=000020068
+*/}}
 for FS_NAME in $(mount -l -t xfs | awk '{ print $1 }'); do
   if command -v xfs_info >/dev/null && xfs_info $FS_NAME | grep -q ftype=0; then
-     >&2 echo "XFS file system with ftype=0 was found ($FS_NAME). This may cause problems (https://www.suse.com/support/kb/doc/?id=000020068), please fix it and try again."
+     >&2 echo "ERROR: XFS file system with ftype=0 was found ($FS_NAME)."
      exit 1
   fi
 done

--- a/ee/candi/bashible/bundles/redos/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/bootstrap.sh.tpl
@@ -27,9 +27,12 @@ until yum install nc curl wget jq -y; do
   sleep 10
 done
 
+{{- /*
+Description of problem with XFS https://www.suse.com/support/kb/doc/?id=000020068
+*/}}
 for FS_NAME in $(mount -l -t xfs | awk '{ print $1 }'); do
   if command -v xfs_info >/dev/null && xfs_info $FS_NAME | grep -q ftype=0; then
-     >&2 echo "XFS file system with ftype=0 was found ($FS_NAME). This may cause problems (https://www.suse.com/support/kb/doc/?id=000020068), please fix it and try again."
+     >&2 echo "ERROR: XFS file system with ftype=0 was found ($FS_NAME)."
      exit 1
   fi
 done

--- a/ee/candi/bashible/detect_bundle.sh
+++ b/ee/candi/bashible/detect_bundle.sh
@@ -3,6 +3,17 @@
 # Copyright 2022 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */}}
+function name_is_not_supported() {
+    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
+    exit 1
+}
+
+function try_bundle(){
+  >&2 echo "WARNING: Trying to use ${1} bundle as default for: ${PRETTY_NAME}"
+  echo "${1}"
+  exit 0
+}
+
 if [ ! -e /etc/os-release ]; then
   >&2 echo "ERROR: Can't determine OS! /etc/os-release is not found."
   exit 1
@@ -14,36 +25,31 @@ case "$ID" in
     case "$VERSION_ID" in 7|7.*|8|8.*|9|9.*)
       echo "centos" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   redos)
     case "$VERSION_ID" in 7|7.*)
       echo "redos" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   alteros)
     case "$VERSION_ID" in 7|7.*)
       echo "alteros" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   ubuntu)
     case "$VERSION_ID" in 18.04|20.04|22.04)
       echo "ubuntu-lts" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   debian)
     case "$VERSION_ID" in 9|10|11)
       echo "debian" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   astra)
     case "$VERSION_ID" in
@@ -52,15 +58,13 @@ case "$ID" in
       2.12|2.12.*)
         echo "debian" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   altlinux)
     case "$VERSION_ID" in p10)
       echo "altlinux" && exit 0 ;;
     esac
-    >&2 echo "ERROR: ${PRETTY_NAME} is not supported."
-    exit 1
+    name_is_not_supported
   ;;
   "")
     >&2 echo "ERROR: Can't determine OS! No ID in /etc/os-release."
@@ -73,16 +77,13 @@ esac
 for ID in $ID_LIKE; do
   case "$ID" in
     centos|rhel)
-      >&2 echo "WARNING: Trying to use centos bundle as default for: ${PRETTY_NAME}"
-      echo "centos" && exit 0
+      try_bundle "centos"
     ;;
     debian)
-      >&2 echo "WARNING: Trying to use debian bundle as default for: ${PRETTY_NAME}"
-      echo "debian" && exit 0
+      try_bundle "debian"
     ;;
     altlinux)
-      >&2 echo "WARNING: Trying to use altlinux bundle as default for: ${PRETTY_NAME}"
-      echo "altlinux" && exit 0
+      try_bundle "altlinux"
     ;;
   esac
 done
@@ -93,5 +94,4 @@ bundle="debian"
 if yum -q --version >/dev/null 2>/dev/null; then
   bundle="centos"
 fi
->&2 echo "WARNING: Trying to use ${bundle} bundle as default for: ${PRETTY_NAME}"
-echo "${bundle}"
+try_bundle "${bundle}"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Refactor bootstrap scripts to fit 16kb limit of cloud-data. Backport of https://github.com/deckhouse/deckhouse/pull/4580.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
In AWS cloud provider size of bootstrap scripts is limited to 16kb. We need to precisely write the bash bootstrap code to avoid exceeding the limit.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Refactor bootstrap scripts to fit 16kb limit of cloud-data.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
