### PR TITLE
[linstor] DRBD 9.2.3

### DIFF
--- a/modules/041-linstor/hack/update.sh
+++ b/modules/041-linstor/hack/update.sh
@@ -17,12 +17,16 @@
 # This helper script is looking for *_GITREPO *_VERSION and *_COMMIT_REF variables
 # on Dockerfiles and updating them to the latest versions from GitHub
 #
-# Usage: hack/update.sh [./images]
+# Usage: [DRBDONLY=1] hack/update.sh [./images]
 
 sed_regex=""
 targets="$(grep -rl '^ARG [A-Z_]*_\(VERSION\|COMMIT_REF\)=' $@)"
 versions=$(grep -r '^ARG [A-Z_]*_\(VERSION\|COMMIT_REF\)=' $targets | awk '{print $NF}' | sort -u)
 gitrepos=$(grep -r '^ARG [A-Z_]*_GITREPO=' $targets | awk '{print $NF}' | sort -u)
+
+if [ "$DRBDONLY" = 1 ]; then
+  gitrepos=$(echo "$gitrepos" | grep '\(DRBD_GITREPO\|UTILS_GITREPO\|SPAAS_GITREPO\)')
+fi
 
 while read name repo; do
   shortrepo=$(echo "$repo" | awk -F/ '{print $(NF-1) "/" $NF}')

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_UBUNTU
 
 FROM $BASE_UBUNTU as builder
 ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
-ARG DRBD_VERSION=9.2.2
+ARG DRBD_VERSION=9.2.3
 
 RUN apt-get update \
  && apt-get install -y make git \

--- a/modules/041-linstor/images/spaas/Dockerfile
+++ b/modules/041-linstor/images/spaas/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_GOLANG_19_BULLSEYE as builder
 ARG SPAAS_GITREPO=https://github.com/LINBIT/saas
 ARG SPAAS_COMMIT_REF=7bef2e7976a455550bce2533487c635f20390ccf
 ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
-ARG DRBD_VERSION=9.2.2
+ARG DRBD_VERSION=9.2.3
 
 RUN git clone ${SPAAS_GITREPO} /usr/local/go/spaas \
  && cd /usr/local/go/spaas \


### PR DESCRIPTION
## Description

Update DRBD to 9.2.3

## Why do we need it, and what problem does it solve?

Bug fixes

## Why do we need it in the patch release (if we do)?

We already use it in production and sometimes facing with bugs.

## What is the expected result?

DRBD updated to 9.2.3

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Update DRBD to `9.2.3`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
