### PR TITLE
[control-plane-manager] Add `-w table` parameters for `member list` and `endpoint status`

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -266,7 +266,7 @@ Repeat the steps below for **each master node one by one**, starting with the no
    --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
-Warning! The last parameter in the output table shows etcd member is in *learner* state, is not in _leader_ state.
+Warning! The last parameter in the output table shows etcd member is in [__learner__](https://etcd.io/docs/v3.5/learning/design-learner/) state, is not in _leader_ state.
 
 ### Option 2
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -263,7 +263,7 @@ Repeat the steps below for **each master node one by one**, starting with the no
 
    ```shell
    ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt \
-   --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list
+   --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
 ### Option 2
@@ -274,7 +274,8 @@ Example:
 
 ```shell
 $ ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt \  
-  --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ endpoint status
+  --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ endpoint status -w table
+
 https://10.2.1.101:2379, ade526d28b1f92f7, 3.5.3, 177 MB, false, false, 42007, 406566258, 406566258,
 https://10.2.1.102:2379, d282ac2ce600c1ce, 3.5.3, 182 MB, true, false, 42007, 406566258, 406566258,
 ```

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -266,7 +266,7 @@ Repeat the steps below for **each master node one by one**, starting with the no
    --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
-Warning! The last parameter in the output table shows etcd member is in [__learner__](https://etcd.io/docs/v3.5/learning/design-learner/) state, is not in _leader_ state.
+Warning! The last parameter in the output table shows etcd member is in [**learner**](https://etcd.io/docs/v3.5/learning/design-learner/) state, is not in *leader* state.
 
 ### Option 2
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -266,6 +266,8 @@ Repeat the steps below for **each master node one by one**, starting with the no
    --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
+Warning! The last parameter in the output table shows etcd member is in *learner* state, is not in _leader_ state.
+
 ### Option 2
 
 Use the `etcdctl endpoint status` command. The fith parameter in the output table will be `true` for the leader.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -266,6 +266,8 @@ title: "Управление control plane: FAQ"
    --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
+Внимание! Последний параметр в таблице вывода показывает, что член etcd находится в состоянии *learner*, а не в состоянии _leader_.
+
 ### Вариант 2
 
 Используйте команду `etcdctl endpoint status`. Пятый параметр в таблице вывода будет`true` у лидера.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -266,7 +266,7 @@ title: "Управление control plane: FAQ"
    --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
-Внимание! Последний параметр в таблице вывода показывает, что член etcd находится в состоянии *learner*, а не в состоянии _leader_.
+Внимание! Последний параметр в таблице вывода показывает, что член etcd находится в состоянии [__learner__](https://etcd.io/docs/v3.5/learning/design-learner/), а не в состоянии _leader_.
 
 ### Вариант 2
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -266,7 +266,7 @@ title: "Управление control plane: FAQ"
    --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
-Внимание! Последний параметр в таблице вывода показывает, что член etcd находится в состоянии [__learner__](https://etcd.io/docs/v3.5/learning/design-learner/), а не в состоянии _leader_.
+Внимание! Последний параметр в таблице вывода показывает, что член etcd находится в состоянии [**learner**](https://etcd.io/docs/v3.5/learning/design-learner/), а не в состоянии *leader*.
 
 ### Вариант 2
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -263,7 +263,7 @@ title: "Управление control plane: FAQ"
 
    ```shell
    ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt \
-   --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list
+   --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
 ### Вариант 2
@@ -274,7 +274,8 @@ title: "Управление control plane: FAQ"
 
 ```shell
 $ ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt \
-  --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ endpoint status
+  --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ endpoint status -w table
+
 https://10.2.1.101:2379, ade526d28b1f92f7, 3.5.3, 177 MB, false, false, 42007, 406566258, 406566258,
 https://10.2.1.102:2379, d282ac2ce600c1ce, 3.5.3, 182 MB, true, false, 42007, 406566258, 406566258,
 ```


### PR DESCRIPTION
## Description
Add `-w table` parameters for `member list` and `endpoint status`.
Now, commands output table with header.

## Why do we need it, and what problem does it solve?
Many clients are confused with `false` in last column.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: chore
summary: Add `-w table` parameters for `member list` and `endpoint status`.
impact_level: low
```
