### PR TITLE
[admission-policy-engine] update grafana dashboard definition

### DIFF
--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -109,7 +109,7 @@ spec:
                           minItems: 1
                           items:
                             type: string
-                            pattern: '^[a-z]?/[a-zA-Z]+$'
+                            pattern: '^[a-z]*/[a-zA-Z]+$'
                             example: ["apps/Deployment", "/Pod", "networking.k8s.io/Ingress"]
                     requiredProbes:
                       type: array

--- a/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
+++ b/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
@@ -298,7 +298,9 @@
       "type": "row"
     },
     {
-      "datasource": "$ds_prometheus",
+      "datasource": {
+        "uid": "$ds_prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -307,7 +309,8 @@
           "custom": {
             "align": "left",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -345,7 +348,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 108
+                "value": 50
               }
             ]
           },
@@ -393,7 +396,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 55
+                "value": 108
               }
             ]
           },
@@ -408,6 +411,30 @@
                 "value": 400
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 205
+              }
+            ]
           }
         ]
       },
@@ -419,16 +446,18 @@
       },
       "id": 34,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "frameIndex": 10,
         "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Time"
-          }
-        ]
+        "sortBy": []
       },
-      "pluginVersion": "8.2.3",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": false,
@@ -442,8 +471,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "OPA Violations",
       "transformations": [
         {
@@ -453,11 +480,11 @@
               "names": [
                 "Time",
                 "kind",
-                "name",
+                "violating_kind",
                 "violating_name",
                 "violation_enforcement",
-                "violating_kind",
-                "violation_msg"
+                "violation_msg",
+                "violating_namespace"
               ]
             }
           }
@@ -465,13 +492,24 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": {},
-            "indexByName": {},
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "kind": 1,
+              "violating_kind": 3,
+              "violating_name": 4,
+              "violating_namespace": 2,
+              "violation_enforcement": 5,
+              "violation_msg": 6
+            },
             "renameByName": {
               "Time": "",
               "kind": "Policy",
               "violating_kind": "Kind",
-              "violating_name": "Pod name",
+              "violating_name": "Name",
+              "violating_namespace": "Namespace",
               "violation_enforcement": "Enforcement",
               "violation_msg": "Message"
             }

--- a/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
+++ b/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
@@ -432,24 +432,14 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum  by (time, violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg) rate(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}[5m]))",
+          "expr": "group(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}) by (violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg)",
           "format": "table",
-          "hide": true,
+          "hide": false,
+          "instant": true,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
-        },
-        {
-          "exemplar": false,
-          "expr": "group(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}) by (time, violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg)",
-          "format": "table",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "B"
         }
       ],
       "timeFrom": null,


### PR DESCRIPTION
## Description
Admission-policy-engine security dashboard definition in Grafana has been updated:
* Previously disabled and incorrect query has been removed;
* The query type has been changed to instant (from vector) and grouping by time has been removed.

OperationPolicy CRD has been updated:
* spec.policies.requiredLabels.watchKinds pattern regex expression has been fixed (wasn't working as it was intended)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Previously, OPA Violations table showed multiple entries for the same violations with different timestamps (range vector), rendering the whole table pretty cumbersome. After the aforementioned changes the table includes only unique records for the violating objects for the selected period of time.
Close #4415 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
OPA Violations table of Admission-policy-engine Dashboard in Grafana shows only unique entries.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: Admission-policy-engine security dashboard in Grafana has been updated so that OPA Violations table doesn't show multiple entries for the same violations.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
