### PR TITLE
[deckhouse] added selinux security options

### DIFF
--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -9,10 +9,18 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# Copy patches
+COPY ./patches /patches
+
 # Using source code from GitHub repository
 RUN git clone ${DRBD_GITREPO} /drbd \
  && cd /drbd \
  && git reset --hard drbd-${DRBD_VERSION} \
+ && git apply /patches/*.patch \
+ && git config --global user.email "vasily.oleynikov@flant.com" \
+ && git config --global user.name "duckhawk" \
+ && git add docker/entry.sh \
+ && git commit -m "changes in entry.sh for SELimux support" \
  && make tarball \
  && mv ./drbd-*.tar.gz /drbd.tar.gz
 

--- a/modules/041-linstor/images/drbd-driver-loader/patches/README.md
+++ b/modules/041-linstor/images/drbd-driver-loader/patches/README.md
@@ -1,0 +1,7 @@
+## Patches
+
+### Add change context directive for built modules
+
+Without it SELinux not allow to load kernel modules. This will be added in next release.
+
+https://lists.linbit.com/pipermail/drbd-dev/2023-May/007050.html

--- a/modules/041-linstor/images/drbd-driver-loader/patches/chcon.patch
+++ b/modules/041-linstor/images/drbd-driver-loader/patches/chcon.patch
@@ -1,0 +1,15 @@
+diff --git a/docker/entry.sh b/docker/entry.sh
+index 2c91734e6..7913e1fc5 100644
+--- a/docker/entry.sh
++++ b/docker/entry.sh
+@@ -217,6 +217,10 @@ load_from_ram() {
+ 		find . -name "*.ko" -print0 | xargs -0 -n1 "/lib/modules/$(uname -r)/build/scripts/sign-file" "$CONFIG_MODULE_SIG_HASH" "${LB_SIGN}/signing_key.pem" "${LB_SIGN}/signing_key.x509" 
+ 	fi
+ 
++	chcon -t modules_object_t ./drbd.ko || true
++	chcon -t modules_object_t ./drbd_transport_tcp.ko || true
++	chcon -t modules_object_t ./drbd_transport_rdma.ko || true
++
+ 	insmod ./drbd.ko usermode_helper=disabled
+ 	insmod ./drbd_transport_tcp.ko
+ 	insmod ./drbd_transport_rdma.ko 2>/dev/null || true

--- a/modules/041-linstor/images/piraeus-operator/patches/README.md
+++ b/modules/041-linstor/images/piraeus-operator/patches/README.md
@@ -1,5 +1,11 @@
 ## Patches
 
+### Add SELinux params for enforced mode
+
+This is proposition from upstream, made for set satellite usable in enforced SELinux mode. 
+
+https://github.com/piraeusdatastore/piraeus-operator/pull/477
+
 ### Disable finalizers
 
 This is our internal patch to disable finalizers logic for piraeus-operator custom resources.

--- a/modules/041-linstor/images/piraeus-operator/patches/add-selinux-params.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/add-selinux-params.patch
@@ -1,0 +1,49 @@
+diff --git a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+index 2c93547..23c2b21 100644
+--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
++++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+@@ -960,7 +960,8 @@ func newSatelliteDaemonSet(satelliteSet *piraeusv1.LinstorSatelliteSet, satellit
+ 							}, // Run linstor-satellite.
+ 							Env:             satelliteSet.Spec.AdditionalEnv,
+ 							ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
+-							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
++							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
++								SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
+ 							Ports: []corev1.ContainerPort{
+ 								{
+ 									HostPort:      satelliteSet.Spec.SslConfig.Port(),
+@@ -1266,10 +1267,11 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
+ 			Name:            "kernel-module-injector",
+ 			Image:           satelliteSet.Spec.KernelModuleInjectionImage,
+ 			ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
+-			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
+-			Env:             env,
+-			VolumeMounts:    volumeMounts,
+-			Resources:       satelliteSet.Spec.KernelModuleInjectionResources,
++			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
++				SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
++			Env:          env,
++			VolumeMounts: volumeMounts,
++			Resources:    satelliteSet.Spec.KernelModuleInjectionResources,
+ 		},
+ 	}
+
+diff --git a/pkg/k8s/spec/const.go b/pkg/k8s/spec/const.go
+index fe89064..1fb8051 100644
+--- a/pkg/k8s/spec/const.go
++++ b/pkg/k8s/spec/const.go
+@@ -100,11 +100,13 @@ var (
+ 	HostPathDirectoryType         = corev1.HostPathDirectory
+ 	HostPathDirectoryOrCreateType = corev1.HostPathDirectoryOrCreate
+ 	MountPropagationBidirectional = corev1.MountPropagationBidirectional
+-	FileType = corev1.HostPathFile
++	FileType                      = corev1.HostPathFile
+ )
+
+ // Shared consts common to container security. These need to be vars, so they
+ // are addressible.
+ var (
+ 	Privileged = true
++	Level      = "s0"
++	Type       = "spc_t"
+ )


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added params for enabled SELinux support

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In case of enabled SELinux, in linstor module there is a problems with lack of permissions.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Working linstor module on nodes with enabled SELinux

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: feature
summary: Added params for enabled SELinux support
impact: linstor satellite pods will be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
