### PR TITLE
[extended-monitoring] Removed deprecated annotations from Deckhouse-managed objects

### DIFF
--- a/modules/002-deckhouse/hooks/enable_extended_monitoring_test.go
+++ b/modules/002-deckhouse/hooks/enable_extended_monitoring_test.go
@@ -32,7 +32,7 @@ kind: Namespace
 metadata:
   name: kube-system
   annotations:
-    extended-monitoring.flant.com/enabled: ""
+  extended-monitoring.deckhouse.io: ""
 `
 		d8SystemNS = `
 ---
@@ -40,8 +40,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-system
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
+  labels:
+    extended-monitoring.deckhouse.io/enabled: ""
 `
 	)
 

--- a/modules/400-descheduler/templates/namespace.yaml
+++ b/modules/400-descheduler/templates/namespace.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-descheduler
-  annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-descheduler") }}

--- a/modules/402-ingress-nginx/templates/namespace.yaml
+++ b/modules/402-ingress-nginx/templates/namespace.yaml
@@ -4,7 +4,6 @@ kind: Namespace
 metadata:
   name: d8-ingress-nginx
   annotations:
-    extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.flant.com/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Deckhouse objects are erroneously alerted on. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

A user of a cluster has no way of acting upon such alert.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Deckhouse-managed objects are not included in the alert.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix 
summary: Remove D8 objects from the `DeprecatatedAnnotation` alert.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
