### PR TITLE
[docs]  Add the experimental badge onto the runtime-audit-engine and  `operator-trivi` modules.

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -938,6 +938,7 @@ entries:
             en: Audit
             ru: Аудит
           d8Revision: ee
+          featureStatus: experimental
           folders:
             - title:
                 en: Description
@@ -1001,6 +1002,7 @@ entries:
                 url: /modules/101-cert-manager/faq.html
           - title: operator-trivy
             d8Revision: ee
+            featureStatus: experimental
             folders:
               - title:
                   en: Description

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -112,6 +112,7 @@ defaults:
       type: "pages"
     values:
       d8Revision: ee
+      featureStatus: experimental
   - scope:
       path: "*/041-linstor"
       type: "pages"
@@ -152,6 +153,7 @@ defaults:
       type: "pages"
     values:
       d8Revision: ee
+      featureStatus: experimental
   - scope:
       path: "*/500-okmeter"
       type: "pages"


### PR DESCRIPTION
## Description
Add the experimental badge to the `runtime-audit-engine` and `operator-trivi` modules documentation.

## What is the expected result?
The experimental badge in the `runtime-audit-engine` and `operator-trivi` modules documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add the experimental badge to the `runtime-audit-engine` and `operator-trivi` modules documentation.
impact_level: low
```
