### PR TITLE
[log-shipper] fix vector new config propagation

### DIFF
--- a/modules/460-log-shipper/images/vector/main.go
+++ b/modules/460-log-shipper/images/vector/main.go
@@ -67,10 +67,12 @@ func main() {
 				}
 				log.Println("event: ", event)
 				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+					log.Println("Reloading config...")
 					err := reloadVectorConfig()
 					if err != nil {
 						log.Fatal(err)
 					}
+					log.Println("Config reloaded")
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
@@ -102,6 +104,16 @@ func reloadVectorConfig() error {
 		return err
 	} else if !ok {
 		return nil
+	}
+
+	sampleConfigContentsBytes, err := os.ReadFile(filepath.Join(tempConfigDir, "vector.json"))
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(filepath.Join(dynamicConfigDir, "vector.json"), []byte(os.ExpandEnv(string(sampleConfigContentsBytes))), 0666)
+	if err != nil {
+		return err
 	}
 
 	processes, err := process.Processes()


### PR DESCRIPTION
## Description
Fix config propagation from tmp dir to /etc/vector/dynamic dir after successful validation
TODO: fix inotify issue
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Config reloader doesn't create '/etc/vector/dynamic/vector.json' on a legitimate config change.
Inotify watcher goes down on a config change (a symlink issue).
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Vector config is successfully reloaded on changes
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Fix log-shipper config reload functionality
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
