### PR TITLE
[linstor] enable WaitForFirstConsumer

### DIFF
--- a/modules/041-linstor/images/linstor-pools-importer/main.go
+++ b/modules/041-linstor/images/linstor-pools-importer/main.go
@@ -542,7 +542,7 @@ func newKubernetesEvent(nodeName string, involvedObject v1.ObjectReference, even
 }
 
 func newKubernetesStorageClass(sp *lclient.StoragePool, r int) storagev1.StorageClass {
-	volBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 	return storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -567,6 +567,9 @@ func newKubernetesStorageClass(sp *lclient.StoragePool, r int) storagev1.Storage
 }
 
 func allParametersAreSet(sc, oldSC *storagev1.StorageClass) bool {
+	if oldSC.VolumeBindingMode != sc.VolumeBindingMode {
+		return false
+	}
 	for k := range sc.Parameters {
 		if oldSC.Parameters[k] != sc.Parameters[k] {
 			return false

--- a/modules/041-linstor/images/linstor-pools-importer/main_test.go
+++ b/modules/041-linstor/images/linstor-pools-importer/main_test.go
@@ -196,7 +196,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 	}
 	got := newKubernetesStorageClass(&tp, 2)
 
-	volBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	expected := storagev1.StorageClass{
@@ -226,7 +226,7 @@ func TestNewKubernetesStorageClasses(t *testing.T) {
 }
 
 func TestAllParametersAreSet(t *testing.T) {
-	volBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	oldSC := &storagev1.StorageClass{
@@ -275,7 +275,8 @@ func TestAllParametersAreSet(t *testing.T) {
 }
 
 func TestAppendOldParameters(t *testing.T) {
-	volBindMode := storagev1.VolumeBindingImmediate
+	oldVolBindMode := storagev1.VolumeBindingImmediate
+	volBindMode := storagev1.VolumeBindingWaitForFirstConsumer
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 
 	oldSC := &storagev1.StorageClass{
@@ -289,7 +290,7 @@ func TestAppendOldParameters(t *testing.T) {
 			},
 		},
 		Provisioner:          "linstor.csi.linbit.com",
-		VolumeBindingMode:    &volBindMode,
+		VolumeBindingMode:    &oldVolBindMode,
 		AllowVolumeExpansion: pointer.BoolPtr(true),
 		ReclaimPolicy:        &reclaimPolicy,
 		Parameters: map[string]string{

--- a/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             - --leader-election-id=$(NAME)
             - --lease-lock-namespace=$(NAMESPACE)
             - --lease-lock-name=linstor-affinity-controller
-            - --v=5
+            - --v=2
           env:
             - name: LEASE_LOCK_NAME
               value: linstor-affinity-controller


### PR DESCRIPTION
## Description

This PR enables WaitForFirstConsumer for all auto-generated storageclasses for linstor

## Why do we need it, and what problem does it solve?

This is approved part from https://github.com/deckhouse/deckhouse/pull/4500 to enhance data-locality but not totally enforce it.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Enable `WaitForFirstConsumer`.
impact: |
  - all auto-generated linstor storageclasses will be recreated with WaitForFirstConsumer option.
  - all existing Persistent Volumes do not require any update or modifications.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
