### PR TITLE
[dhctl] Add to debug log information about error got during getting deckhouse pod

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -33,6 +33,7 @@ func GetPod(kubeCl *client.KubernetesClient) (*v1.Pod, error) {
 	}
 
 	if len(pods.Items) == 0 {
+		log.DebugF("Cannot get deckhouse pod. Count of returned pods is zero")
 		return nil, ErrListPods
 	}
 

--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -22,12 +22,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
 func GetPod(kubeCl *client.KubernetesClient) (*v1.Pod, error) {
 	pods, err := kubeCl.CoreV1().Pods("d8-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app=deckhouse"})
 	if err != nil {
-		return nil, fmt.Errorf("%v: %v", ErrListPods, err)
+		log.DebugF("Cannot get deckhouse pod. Got error: %v", err)
+		return nil, ErrListPods
 	}
 
 	if len(pods.Items) == 0 {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -27,7 +27,7 @@ import (
 func GetPod(kubeCl *client.KubernetesClient) (*v1.Pod, error) {
 	pods, err := kubeCl.CoreV1().Pods("d8-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app=deckhouse"})
 	if err != nil {
-		return nil, ErrListPods
+		return nil, fmt.Errorf("%v: %v", ErrListPods, err)
 	}
 
 	if len(pods.Items) == 0 {


### PR DESCRIPTION
## Description
 Add to debug log information about error got during getting deckhouse pod.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When we got error during getting deckhouse pod we get `No Deckhouse pod found.` error only, without root cased error.
We should output it to debug log

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add to debug log information about error got during getting deckhouse pod
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
