### PR TITLE
[prometheus] Handle grafana dashboard's json unmarshaller error

### DIFF
--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/hooks/dashboard_provisioner.py
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/hooks/dashboard_provisioner.py
@@ -30,8 +30,13 @@ def main(ctx: hook.Context):
 
     for i in ctx.snapshots.get("dashboard_resources", []):
         dashboard = i["filterResult"]
-        definition = json.loads(dashboard["definition"])
         dashboard_name = dashboard.get('name', '')
+        try:
+            definition = json.loads(dashboard["definition"])
+        except Exception as e:
+            print(f"ERROR: Dashboard '{dashboard_name}' contains errors: {e}.")
+            malformed_dashboards.append(dashboard_name)
+            continue
 
         title = definition.get("title")
         if not title:


### PR DESCRIPTION
## Description
Add error handler for dasboard definition json unmarshalling

## Why do we need it, and what problem does it solve?
If we have a malformed dashboard hook will fail and stuck. No other dashboards would be rendered.

## Why do we need it in the patch release (if we do)?
Hook blocks dashboard provisioning and we can have a situation when all dashboards in the Grafana are absent.

## What is the expected result?
New hook handles error, reports about malformed dashboard and skip it:
```
{"binding":"dashboard_resources","event":"kubernetes","hook":"dashboard_provisioner.py","level":"info","msg":"Execute hook","queue":"main","task":"HookRun","time":"2023-05-19T08:48:42Z"}
{"binding":"dashboard_resources","event":"kubernetes","hook":"dashboard_provisioner.py","level":"info","msg":"ERROR: Dashboard 'foobar' contains errors: Expecting property name enclosed in double quotes: line 2 column 3 (char 4).","output":"stdout","queue":"main","task":"HookRun","time":"2023-05-19T08:48:42Z"}
{"binding":"dashboard_resources","event":"kubernetes","hook":"dashboard_provisioner.py","level":"info","msg":"WARN: Skipping malformed dashboards: foobar","output":"stdout","queue":"main","task":"HookRun","time":"2023-05-19T08:48:42Z"}
{"binding":"dashboard_resources","event":"kubernetes","hook":"dashboard_provisioner.py","level":"info","msg":"Hook executed successfully","queue":"main","task":"HookRun","time":"2023-05-19T08:48:42Z"}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Handle error on malformed grafana dashboard and skip it instead of failing
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
