### PR TITLE
[docs] Update search index to search by the <Module>[Enabled|Disabled] parameter

### DIFF
--- a/docs/documentation/_includes/search.liquid
+++ b/docs/documentation/_includes/search.liquid
@@ -29,7 +29,26 @@ var documents=[
 "title": "{{ page.title | escape }}",
 "url": "{{ page_canonical_url }}",
 {%- if page['module-name'] %}
-"keywords": {{ page['module-name'] | jsonify }},
+  {%- assign keywords = page['module-name'] %}
+{%- else %}
+  {%- assign keywords = "" %}
+{%- endif %}
+{%- if page['legacy-enabled-commands'] %}
+  {%- if keywords.size > 0 %}
+    {%- assign keywords = page['legacy-enabled-commands'] | append: ", " | append: keywords %}
+  {%- else %}
+    {%- assign keywords = page['legacy-enabled-commands'] %}
+  {%- endif %}
+{%- endif %}
+{%- if page.search.size > 0 %}
+  {%- if keywords.size > 0 %}
+    {%- assign keywords = page.search | append: ", " | append: keywords %}
+  {%- else %}
+    {%- assign keywords = page.search %}
+  {%- endif %}
+{%- endif %}
+{%- if keywords.size > 0 %}
+"keywords": {{ keywords | jsonify }},
 {%- endif %}
 "content": {{ page.content | normalizeSearchContent | jsonify }}
 }

--- a/docs/documentation/_plugins/custom_hooks.rb
+++ b/docs/documentation/_plugins/custom_hooks.rb
@@ -57,7 +57,10 @@ Jekyll::Hooks.register :site, :post_read do |site|
   # Exclude custom resource and module setting files from the search index by setting the 'searchable' parameter to false.
   site.pages.each do |page|
     if ( page.url.match?(%r{/modules/[0-9]+-[^/]+/$}) ) then
-      page.data['module-name'] = page.url.sub(%r{(.*)?/modules/[0-9]+-([^/]+)/$},'\2')
+      moduleKebabCase = page.url.sub(%r{(.*)?/modules/[0-9]+-([^/]+)/$},'\2')
+      moduleSnakeCase = moduleKebabCase.gsub(/-[a-z]/,&:upcase).gsub(/-/,'')
+      page.data['module-name'] = moduleKebabCase
+      page.data['legacy-enabled-commands'] = %Q(#{moduleSnakeCase}Enabled, #{moduleSnakeCase}Disabled)
     end
     next if ! ( page.name.end_with?('CR.md') or page.name.end_with?('CR_RU.md') or page.name.end_with?('CONFIGURATION.md') or page.name.end_with?('CONFIGURATION_RU.md') )
     next if page['force_searchable'] == true


### PR DESCRIPTION
## Description
Updated search index to make available search module by the `<module>Enabled` or `<module>Disabled` word.

## Why do we need it, and what problem does it solve?
Users could not find anything by the `<module>Enabled` or `<module>Disabled`, which is used in the InitConfigration resource.

## What is the expected result?
When you search in the documentation by cniCiliumDisabled or cniCiliumEnabled you should get at least a page to the cni-cilium module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add ability to search module documentation by the `<module>Enabled` or `<module>Disabled` word.
impact_level: low
```
