### PR TITLE
[cloud-provider-openstack] Add param etcdDiskSizeGb and migrate from openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/ee/fe/modules/340-monitoring-applications/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/fe/modules/500-basic-auth/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-openstack/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-openstack/hooks/migrate"
 	_ "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vsphere/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/ee"
 	_ "github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/ee/lib/crd"

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
@@ -106,6 +106,9 @@ An internal cluster network is created that does not have access to the public n
 
 > **Caution!**
 > This strategy does not support a LoadBalancer since a Floating IP is not available for the router-less network. Thus, you cannot provision a load balancer with the Floating IP. An internal load balancer with the virtual IP in the public network is only accessible to cluster nodes.
+>
+> **Caution!**
+> In this strategy, it is necessary to explicitly specify the name of the internal network in `additionalNetworks` when creating an `OpenStackInstanceClass` in the cluster.
 
 ![resources](https://docs.google.com/drawings/d/e/2PACX-1vR9Vlk22tZKpHgjOeQO2l-P0hyAZiwxU6NYGaLUsnv-OH0so8UXNnvrkNNiAROMHVI9iBsaZpfkY-kh/pub?w=960&h=720)
 <!--- Source: https://docs.google.com/drawings/d/1gkuJhyGza0bXB2lcjdsQewWLEUCjqvTkkba-c5LtS_E/edit --->

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
@@ -170,6 +170,9 @@ nodeGroups:
     additionalSecurityGroups:
     - sec_group_1
     - sec_group_2
+  # Required if rootDiskSize is specified. Volume type map for node's root volume
+  volumeTypeMap:
+    nova: ceph-ssd
 sshPublicKey: "<SSH_PUBLIC_KEY>"
 provider:
   ...

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
@@ -179,6 +179,9 @@ nodeGroups:
     additionalSecurityGroups:
     - sec_group_1
     - sec_group_2
+  # Требуется, если указан параметр rootDiskSize. Карта типов томов для главного корневого тома нод
+  volumeTypeMap:
+    nova: ceph-ssd
 sshPublicKey: "<SSH_PUBLIC_KEY>"
 provider:
   ...

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
@@ -113,6 +113,9 @@ provider:
 > В данной конфигурации не поддерживается LoadBalancer. Это связано с тем, что в OpenStack нельзя заказать Floating IP для
 сети без роутера, соответственно нельзя заказать балансировщик с Floating IP. Если заказывать internal loadbalancer, у которого
 virtual IP создаётся в публичной сети, то он всё равно доступен только с узлов кластера.
+>
+> **Внимание!**
+> В данной конфигурации необходимо явно указывать название внутренней сети в `additionalNetworks` при создании `OpenStackInstanceClass` в кластере.
 
 ![resources](https://docs.google.com/drawings/d/e/2PACX-1vR9Vlk22tZKpHgjOeQO2l-P0hyAZiwxU6NYGaLUsnv-OH0so8UXNnvrkNNiAROMHVI9iBsaZpfkY-kh/pub?w=960&h=720)
 <!--- Исходник: https://docs.google.com/drawings/d/1gkuJhyGza0bXB2lcjdsQewWLEUCjqvTkkba-c5LtS_E/edit --->

--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
@@ -11,6 +11,7 @@ locals {
   volume_type = local.volume_type_map[local.zone]
   flavor_name = var.providerClusterConfiguration.masterNodeGroup.instanceClass.flavorName
   root_disk_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "rootDiskSize", "")
+  etcd_volume_size = var.providerClusterConfiguration.masterNodeGroup.instanceClass.etcdDiskSizeGb
   additional_tags = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {})
 }
 
@@ -31,6 +32,7 @@ module "master" {
   image_name = local.image_name
   keypair_ssh_name = data.openstack_compute_keypair_v2.ssh.name
   network_port_ids = list(local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id)
+  internal_network_cidr = data.openstack_networking_subnet_v2.internal.cidr
   floating_ip_network = local.external_network_floating_ip ? local.external_network_name : ""
   tags = local.tags
   zone = local.zone
@@ -43,6 +45,7 @@ module "kubernetes_data" {
   prefix = local.prefix
   node_index = var.nodeIndex
   master_id = module.master.id
+  volume_size = local.etcd_volume_size
   volume_type = local.volume_type
   volume_zone = module.volume_zone.zone
   tags = local.tags

--- a/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
@@ -9,6 +9,7 @@ locals {
   volume_type = local.volume_type_map[local.zone]
   flavor_name = var.providerClusterConfiguration.masterNodeGroup.instanceClass.flavorName
   root_disk_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "rootDiskSize", "")
+  etcd_volume_size = var.providerClusterConfiguration.masterNodeGroup.instanceClass.etcdDiskSizeGb
   additional_tags = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {})
 }
 
@@ -42,6 +43,7 @@ module "kubernetes_data" {
   prefix = local.prefix
   node_index = var.nodeIndex
   master_id = openstack_compute_instance_v2.master.id
+  volume_size = local.etcd_volume_size
   volume_type = local.volume_type
   volume_zone = module.volume_zone.zone
   tags = local.tags
@@ -51,7 +53,7 @@ locals {
   metadata_tags = merge(local.tags, local.additional_tags)
 }
 
-resource "openstack_blockstorage_volume_v2" "master" {
+resource "openstack_blockstorage_volume_v3" "master" {
   count = local.root_disk_size == "" ? 0 : 1
   name = join("-", [local.prefix, "master-root-volume", var.nodeIndex])
   size = local.root_disk_size
@@ -59,6 +61,7 @@ resource "openstack_blockstorage_volume_v2" "master" {
   metadata = local.metadata_tags
   volume_type = local.volume_type
   availability_zone = module.volume_zone.zone
+  enable_online_resize = true
   lifecycle {
     ignore_changes = [
       metadata,
@@ -82,7 +85,7 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   dynamic "block_device" {
-    for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v2.master[0])
+    for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v3.master[0])
     content {
       uuid = block_device.value["id"]
       boot_index = 0

--- a/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/master-node/main.tf
@@ -9,6 +9,7 @@ locals {
   volume_type = local.volume_type_map[local.zone]
   flavor_name = var.providerClusterConfiguration.masterNodeGroup.instanceClass.flavorName
   root_disk_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "rootDiskSize", "")
+  etcd_volume_size = var.providerClusterConfiguration.masterNodeGroup.instanceClass.etcdDiskSizeGb
   additional_tags = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {})
 }
 
@@ -35,6 +36,7 @@ module "master" {
   image_name = local.image_name
   keypair_ssh_name = data.openstack_compute_keypair_v2.ssh.name
   network_port_ids = local.network_security ? list(openstack_networking_port_v2.master_external_with_security[0].id, openstack_networking_port_v2.master_internal_with_security[0].id) : list(openstack_networking_port_v2.master_external_without_security[0].id, openstack_networking_port_v2.master_internal_without_security[0].id)
+  internal_network_cidr = local.internal_network_cidr
   config_drive = !local.external_network_dhcp
   tags = local.tags
   zone = local.zone
@@ -47,6 +49,7 @@ module "kubernetes_data" {
   prefix = local.prefix
   node_index = var.nodeIndex
   master_id = module.master.id
+  volume_size = local.etcd_volume_size
   volume_type = local.volume_type
   volume_zone = module.volume_zone.zone
   tags = local.tags

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -87,7 +87,7 @@ module "volume_zone" {
   region = var.providerClusterConfiguration.provider.region
 }
 
-resource "openstack_blockstorage_volume_v2" "root" {
+resource "openstack_blockstorage_volume_v3" "root" {
   count       = local.bastion_instance != {} ? 1 : 0
   name        = join("-", [local.name, "root-volume"])
   size        = local.root_disk_size
@@ -95,6 +95,7 @@ resource "openstack_blockstorage_volume_v2" "root" {
   metadata    = local.metadata_tags
   volume_type = local.volume_type
   availability_zone = module.volume_zone.zone
+  enable_online_resize = true
   lifecycle {
     ignore_changes = [
       metadata,
@@ -117,7 +118,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   }
 
   block_device {
-    uuid                  = openstack_blockstorage_volume_v2.root[0].id
+    uuid                  = openstack_blockstorage_volume_v3.root[0].id
     boot_index            = 0
     source_type           = "volume"
     destination_type      = "volume"

--- a/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
@@ -9,6 +9,7 @@ locals {
   volume_type          = local.volume_type_map[local.zone]
   flavor_name          = var.providerClusterConfiguration.masterNodeGroup.instanceClass.flavorName
   root_disk_size       = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "rootDiskSize", "")
+  etcd_volume_size     = var.providerClusterConfiguration.masterNodeGroup.instanceClass.etcdDiskSizeGb
   additional_tags      = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {})
 }
 
@@ -25,21 +26,22 @@ module "volume_zone" {
 }
 
 module "master" {
-  source              = "../../../terraform-modules/master"
-  prefix              = local.prefix
-  node_index          = var.nodeIndex
-  cloud_config        = var.cloudConfig
-  flavor_name         = local.flavor_name
-  root_disk_size      = local.root_disk_size
-  additional_tags     = local.additional_tags
-  image_name          = local.image_name
-  keypair_ssh_name    = data.openstack_compute_keypair_v2.ssh.name
-  network_port_ids    = list(local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id)
-  floating_ip_network = lookup(local.standard, "bastion", {}) == {} ? data.openstack_networking_network_v2.external.name : ""
-  tags                = local.tags
-  zone                = local.zone
-  volume_type         = local.volume_type
-  volume_zone = module.volume_zone.zone
+  source                = "../../../terraform-modules/master"
+  prefix                = local.prefix
+  node_index            = var.nodeIndex
+  cloud_config          = var.cloudConfig
+  flavor_name           = local.flavor_name
+  root_disk_size        = local.root_disk_size
+  additional_tags       = local.additional_tags
+  image_name            = local.image_name
+  keypair_ssh_name      = data.openstack_compute_keypair_v2.ssh.name
+  network_port_ids      = list(local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id)
+  internal_network_cidr = local.internal_network_cidr
+  floating_ip_network   = lookup(local.standard, "bastion", {}) == {} ? data.openstack_networking_network_v2.external.name : ""
+  tags                  = local.tags
+  zone                  = local.zone
+  volume_type           = local.volume_type
+  volume_zone           = module.volume_zone.zone
 }
 
 module "kubernetes_data" {
@@ -47,6 +49,7 @@ module "kubernetes_data" {
   prefix      = local.prefix
   node_index  = var.nodeIndex
   master_id   = module.master.id
+  volume_size = local.etcd_volume_size
   volume_type = local.volume_type
   volume_zone = module.volume_zone.zone
   tags        = local.tags

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -119,8 +119,8 @@ apiVersions:
             type: object
             required: [flavorName, imageName]
             additionalProperties: false
-            properties: &instanceClassProperties
-              flavorName:
+            properties:
+              flavorName: &instanceClassFlavorName
                 type: string
                 description: |
                   Flavor of OpenStack servers.
@@ -131,7 +131,7 @@ apiVersions:
 
                   Flavor create example: `openstack flavor create c4m8d50 --ram 8192 --disk 50 --vcpus 4`
                 x-doc-required: true
-              imageName:
+              imageName: &instanceClassImageName
                 description: |
                   Image to use while provisioning OpenStack servers.
 
@@ -140,13 +140,19 @@ apiVersions:
                   > **Caution!** Currently, only `Ubuntu 18.04`, `Ubuntu 20.04`, `Ubuntu 22.04`, `Centos 7`, `Centos 8`, `Centos 9`, `Debian 9`, `Debian 10`, `Debian 11` are supported and tested to work.
                 type: string
                 x-doc-required: true
-              rootDiskSize:
+              rootDiskSize: &instanceClassRootDiskSize
                 description: |
                   The size of a root disk (in gigabytes).
 
                   This parameter also has influence on type of volume that will be used for root disk; the ["How to use rootDiskSize and when it is preferred"](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/faq.html#how-to-use-rootdisksize-and-when-it-is-preferred) section describes how to use it.
                 type: integer
-              additionalSecurityGroups:
+              etcdDiskSizeGb:
+                description: |
+                  Etcd disk size in gigabytes.
+                example: 10
+                default: 10
+                type: integer
+              additionalSecurityGroups: &instanceClassAdditionalSecurityGroups
                 type: array
                 description: |
                   Security groups that will be applied to VM's network ports in addition to security groups set in a cloud provider configuration.
@@ -157,7 +163,7 @@ apiVersions:
                 items:
                   type: string
                 uniqueItems: true
-              additionalTags:
+              additionalTags: &instanceClassAdditionalTags
                 description: |
                   The additional tags to attach to the instances created (in addition to those specified in the cloud provider configuration).
                 x-examples:
@@ -190,7 +196,6 @@ apiVersions:
         items:
           additionalProperties: false
           type: object
-          required: [name, replicas, instanceClass]
           properties:
             name:
               type: string
@@ -262,7 +267,11 @@ apiVersions:
               additionalProperties: false
               type: object
               properties:
-                <<: *instanceClassProperties
+                flavorName: *instanceClassFlavorName
+                imageName: *instanceClassImageName
+                rootDiskSize: *instanceClassRootDiskSize
+                additionalSecurityGroups: *instanceClassAdditionalSecurityGroups
+                additionalTags: *instanceClassAdditionalTags
                 configDrive:
                   type: boolean
                   default: false
@@ -320,6 +329,20 @@ apiVersions:
               additionalProperties:
                 type: string
                 minLength: 1
+          oneOf:
+          - required: [name, replicas, instanceClass, volumeTypeMap]
+            properties:
+              instanceClass:
+                properties:
+                  rootDiskSize:
+                    type: integer
+          - required: [name, replicas, instanceClass]
+            properties:
+              instanceClass:
+                properties:
+                  rootDiskSize:
+                    not:
+                      type: integer
       layout:
         description: |
           The way resources are located in the cloud.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -65,6 +65,9 @@ apiVersions:
                   Размер root-диска. Значение указывается в гигабайтах.
 
                   Параметр также влияет на тип диска. [Подробнее...](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/faq.html#как-использовать-rootdisksize-и-когда-он-предпочтителен)
+              etcdDiskSizeGb:
+                description: |
+                  Размер диска для etcd. Значение указывается в гигабайтах.
               additionalSecurityGroups:
                 description: |
                   Дополнительный список security groups, которые будут добавлены на заказанные инстансы соответствующего `OpenStackInstanceClass` в дополнение к указанным в конфигурации cloud-провайдера.

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
@@ -1,12 +1,13 @@
 # Copyright 2021 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
-resource "openstack_blockstorage_volume_v2" "kubernetes_data" {
+resource "openstack_blockstorage_volume_v3" "kubernetes_data" {
   name = join("-", [var.prefix, "kubernetes-data", var.node_index])
   description = "volume for etcd and kubernetes certs"
-  size = 10
+  size = var.volume_size
   volume_type = var.volume_type
   availability_zone = var.volume_zone
+  enable_online_resize = true
   metadata = var.tags
   lifecycle {
     ignore_changes = [
@@ -18,5 +19,5 @@ resource "openstack_blockstorage_volume_v2" "kubernetes_data" {
 
 resource "openstack_compute_volume_attach_v2" "kubernetes_data" {
   instance_id = var.master_id
-  volume_id = openstack_blockstorage_volume_v2.kubernetes_data.id
+  volume_id = openstack_blockstorage_volume_v3.kubernetes_data.id
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
@@ -13,6 +13,10 @@ variable "master_id" {
   type = string
 }
 
+variable "volume_size" {
+  type = number
+}
+
 variable "volume_type" {
   type = string
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -9,14 +9,15 @@ data "openstack_images_image_v2" "master" {
   name = var.image_name
 }
 
-resource "openstack_blockstorage_volume_v2" "master" {
-  count             = var.root_disk_size == "" ? 0 : 1
-  name              = join("-", [var.prefix, "master-root-volume", var.node_index])
-  size              = var.root_disk_size
-  image_id          = data.openstack_images_image_v2.master.id
-  metadata          = local.metadata_tags
-  volume_type       = var.volume_type
-  availability_zone = var.volume_zone
+resource "openstack_blockstorage_volume_v3" "master" {
+  count                = var.root_disk_size == "" ? 0 : 1
+  name                 = join("-", [var.prefix, "master-root-volume", var.node_index])
+  size                 = var.root_disk_size
+  image_id             = data.openstack_images_image_v2.master.id
+  metadata             = local.metadata_tags
+  volume_type          = var.volume_type
+  availability_zone    = var.volume_zone
+  enable_online_resize = true
   lifecycle {
     ignore_changes = [
       metadata,
@@ -43,7 +44,7 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   dynamic "block_device" {
-    for_each = var.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v2.master[0])
+    for_each = var.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v3.master[0])
     content {
       uuid                  = block_device.value["id"]
       boot_index            = 0

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/outputs.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/outputs.tf
@@ -6,7 +6,7 @@ output "id" {
 }
 
 output "node_internal_ip_address" {
-  value = lookup(openstack_compute_instance_v2.master.network[0], "fixed_ip_v4")
+  value = [for ip in openstack_compute_instance_v2.master.network: ip.fixed_ip_v4 if cidrhost("${ip.fixed_ip_v4}/${split("/", var.internal_network_cidr)[1]}", 0) == cidrhost(var.internal_network_cidr, 0)][0]
 }
 
 output "master_ip_address_for_ssh" {

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
@@ -30,7 +30,7 @@ variable "keypair_ssh_name" {
 }
 
 variable "floating_ip_network" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -38,8 +38,12 @@ variable "network_port_ids" {
   type = list(string)
 }
 
+variable "internal_network_cidr" {
+  type    = string
+}
+
 variable "config_drive" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -5,8 +5,8 @@ locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.openstack_compute_availability_zones_v2.zones.names, var.providerClusterConfiguration.zones)) : data.openstack_compute_availability_zones_v2.zones.names
   zones        = lookup(local.ng, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.ng["zones"])) : local.actual_zones
   volume_type_map      = lookup(local.ng, "volumeTypeMap", {})
-  zone                 = element(tolist(setintersection(keys(local.volume_type_map), local.actual_zones)), var.nodeIndex)
-  volume_type          = local.volume_type_map[local.zone]
+  zone                 = local.volume_type_map != {} ? element(tolist(setintersection(keys(local.volume_type_map), local.zones)), var.nodeIndex) : element(tolist(local.zones), var.nodeIndex)
+  volume_type          = local.volume_type_map != {} ? local.volume_type_map[local.zone] : null
 }
 
 module "security_groups" {
@@ -47,7 +47,7 @@ resource "openstack_networking_port_v2" "port" {
   }
 }
 
-resource "openstack_blockstorage_volume_v2" "volume" {
+resource "openstack_blockstorage_volume_v3" "volume" {
   count             = local.root_disk_size == "" ? 0 : 1
   name              = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
   size              = local.root_disk_size
@@ -55,6 +55,7 @@ resource "openstack_blockstorage_volume_v2" "volume" {
   metadata          = local.metadata_tags
   volume_type       = local.volume_type
   availability_zone = module.volume_zone.zone
+  enable_online_resize = true
   lifecycle {
     ignore_changes = [
       metadata,
@@ -81,7 +82,7 @@ resource "openstack_compute_instance_v2" "node" {
   }
 
   dynamic "block_device" {
-    for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v2.volume[0])
+    for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v3.volume[0])
     content {
       uuid                  = block_device.value["id"]
       boot_index            = 0

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/variables.tf
@@ -27,6 +27,7 @@ variable "clusterUUID" {
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
+  internal_network_name = local.prefix
   pod_subnet_cidr = var.clusterConfiguration.podSubnetCIDR
   ng = [for i in var.providerClusterConfiguration.nodeGroups: i if i.name == var.nodeGroupName][0]
   instance_class = local.ng["instanceClass"]
@@ -34,7 +35,7 @@ locals {
   image_name = local.instance_class["imageName"]
   root_disk_size = lookup(local.instance_class, "rootDiskSize", "")
   config_drive = lookup(local.instance_class, "configDrive", false)
-  networks = concat([local.instance_class["mainNetwork"]], lookup(local.instance_class, "additionalNetworks", []))
+  networks = local.layout == "standardWithNoRouter" ? concat([local.instance_class["mainNetwork"]], [local.internal_network_name], lookup(local.instance_class, "additionalNetworks", [])) : concat([local.instance_class["mainNetwork"]], lookup(local.instance_class, "additionalNetworks", []))
   networks_with_security_disabled = lookup(local.instance_class, "networksWithSecurityDisabled", [])
   floating_ip_pools = lookup(local.instance_class, "floatingIPPools", [])
   layout = join("", [lower(substr(var.providerClusterConfiguration.layout, 0, 1)), substr(var.providerClusterConfiguration.layout, 1, -1)])

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/common_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/common_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+// TODO remove after 1.48 release
+
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
+)
+
+const TerraformStateDataKey = "node-tf-state.json"
+const TerraformStateNamespace = "d8-system"
+const OpenstackV2ResourceType = "openstack_blockstorage_volume_v2"
+const OpenstackV3ResourceType = "openstack_blockstorage_volume_v3"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(openstackTerraformStateMigration))
+
+func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Container) error {
+	kubeCl, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("could not initialize Kubernetes client: %v", err)
+	}
+
+	terraformStateLabels := map[string]string{
+		"node.deckhouse.io/terraform-state": "",
+	}
+
+	terraformStateSecrets, err := kubeCl.CoreV1().
+		Secrets(TerraformStateNamespace).
+		List(context.TODO(), metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(terraformStateLabels))})
+	if err != nil {
+		return fmt.Errorf("failed to get Terraform state secrets in namespace %s with labels %s. The migration process has been aborted", TerraformStateNamespace, terraformStateLabels)
+	}
+
+	if terraformStateSecrets.Items == nil {
+		input.LogEntry.Infof("Terraform state not found. Migration is not needed.")
+		return nil
+	}
+
+	for _, secret := range terraformStateSecrets.Items {
+		input.LogEntry.Infof("Proceeding with Secret/%s/%s", TerraformStateNamespace, secret.ObjectMeta.Name)
+		backupSecretName := secret.ObjectMeta.Name + "-backup"
+
+		secretBackupExists, err := isSecretBackupExists(backupSecretName, TerraformStateNamespace, kubeCl, input)
+		if secretBackupExists && err == nil {
+			input.LogEntry.Infof("Secret backup with name %s/%s already exists! Migration is not needed for Secret/%s/%s", TerraformStateNamespace, backupSecretName, TerraformStateNamespace, secret.ObjectMeta.Name)
+			continue
+		}
+		terraformStateRaw, ok := secret.Data[TerraformStateDataKey]
+		if !ok {
+			return fmt.Errorf("key %s not found in Secret/%s/%s. ", TerraformStateDataKey, TerraformStateNamespace, secret.ObjectMeta.Name)
+		}
+
+		if !gjson.ValidBytes(terraformStateRaw) {
+			return fmt.Errorf("invalid JSON: %s", terraformStateRaw)
+		}
+
+		terraformState := gjson.ParseBytes(terraformStateRaw)
+		openstackV2Resources := terraformState.Get("resources.#(type==\"openstack_blockstorage_volume_v2\")#")
+
+		if len(openstackV2Resources.Array()) == 0 {
+			input.LogEntry.Infof("No old resources found. Migration is not needed for Secret/%s/%s.", TerraformStateNamespace, secret.ObjectMeta.Name)
+			continue
+		}
+
+		if !BackupSecret(backupSecretName, secret, TerraformStateNamespace, kubeCl, input) {
+			return fmt.Errorf("can't create backup for Secret/%s/%s. The migration process has been aborted", TerraformStateNamespace, secret.ObjectMeta.Name)
+		}
+
+		terraformResources := terraformState.Get("resources")
+		for i, terraformResource := range terraformResources.Array() {
+			if terraformResource.Get("type").String() == OpenstackV2ResourceType {
+				input.LogEntry.Infof("Found resourceType = %s with name %s. Index = %d. Modifying resource.", terraformResource.Get("type").String(), terraformResource.Get("name").String(), i)
+				terraformStateRaw, err = sjson.SetBytes(terraformStateRaw, fmt.Sprintf("resources.%d.instances.0.attributes.multiattach", i), nil)
+				if err != nil {
+					return err
+				}
+				terraformStateRaw, err = sjson.SetBytes(terraformStateRaw, fmt.Sprintf("resources.%d.instances.0.attributes.enable_online_resize", i), true)
+				if err != nil {
+					return err
+				}
+				terraformStateRaw, err = sjson.SetBytes(terraformStateRaw, fmt.Sprintf("resources.%d.type", i), OpenstackV3ResourceType)
+				if err != nil {
+					return err
+				}
+			}
+			for j, terraformDependency := range terraformResource.Get("instances.0.dependencies").Array() {
+				if strings.Contains(terraformDependency.String(), "openstack_blockstorage_volume_v2") {
+					input.LogEntry.Infof("Found dependency %s with old resource in resource = %s and type = %s. Modifying dependency.", terraformDependency.String(), terraformResource.Get("name").String(), terraformResource.Get("type").String())
+					terraformStateRaw, err = sjson.SetBytes(terraformStateRaw, fmt.Sprintf("resources.%d.instances.0.dependencies.%d", i, j), strings.ReplaceAll(terraformDependency.String(), OpenstackV2ResourceType, OpenstackV3ResourceType))
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+		var newTerraformState bytes.Buffer
+		err = json.Indent(&newTerraformState, terraformStateRaw, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		secret.Data[TerraformStateDataKey] = newTerraformState.Bytes()
+		_, err = kubeCl.CoreV1().
+			Secrets(TerraformStateNamespace).
+			Update(context.TODO(), &secret, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		input.LogEntry.Infof("Migration process completed for Secret/%s/%s.", TerraformStateNamespace, secret.ObjectMeta.Name)
+	}
+
+	input.LogEntry.Infof("Terraform migrate hook has been finished.")
+	return nil
+}
+
+func isSecretBackupExists(backupSecretName string, namespace string, kubeCl k8s.Client, input *go_hook.HookInput) (bool, error) {
+	input.LogEntry.Debugf("Function isSecretBackupExists: Starting function with parameters: backupSecretName=%s; namespace=%s", backupSecretName, namespace)
+	backupSecret, err := kubeCl.CoreV1().
+		Secrets(namespace).
+		Get(context.TODO(), backupSecretName, metav1.GetOptions{})
+	input.LogEntry.Debugf("Function isSecretBackupExists: Get secret. Secret=%s; err=%s", backupSecret, err)
+
+	if errors.IsNotFound(err) {
+		input.LogEntry.Debugf("Function isSecretBackupExists: errors.IsNotFound(err) = %t. secret \"%s\" not found'. Return false and nil", errors.IsNotFound(err), backupSecretName)
+		return false, nil
+	}
+
+	if err == nil {
+		input.LogEntry.Debugf("Function isSecretBackupExists: err == nil. Return true and nil")
+		return true, nil
+	}
+
+	input.LogEntry.Debugf("Function isSecretBackupExists: err !=nil and errors.IsNotFound(err) no true. Return false and err")
+	return false, err
+}
+
+func BackupSecret(backupSecretName string, secret v1.Secret, namespace string, kubeCl k8s.Client, input *go_hook.HookInput) bool {
+	nodeName := secret.ObjectMeta.Labels["node.deckhouse.io/node-name"]
+	nodeGroup := secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]
+	// nodeName := strings.TrimPrefix(secret.ObjectMeta.Name, "d8-node-terraform-state-")
+
+	input.LogEntry.Infof("Starting backup for Secret/%s/%s", namespace, secret.ObjectMeta.Name)
+	secretBackup := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backupSecretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"heritage":                     "deckhouse",
+				"name":                         backupSecretName,
+				"node.deckhouse.io/node-group": nodeGroup,
+				"node.deckhouse.io/node-name":  nodeName,
+				"node.deckhouse.io/terraform-state-backup": "",
+			},
+		},
+		Data: secret.Data,
+	}
+
+	_, err := kubeCl.CoreV1().
+		Secrets(namespace).
+		Create(context.TODO(), secretBackup, metav1.CreateOptions{})
+
+	if err != nil {
+		input.LogEntry.Warnf("An error occurred when creating secret backup. Backup aborted. Error: %s.", err)
+		return false
+	}
+	input.LogEntry.Infof("Secret backup completed successfully.")
+	return true
+}

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
@@ -128,10 +128,8 @@ func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Co
 		if err != nil {
 			return err
 		}
-		input.LogEntry.Infof("Migration process completed for Secret/%s/%s.", TerraformStateNamespace, secret.ObjectMeta.Name)
 	}
 
-	input.LogEntry.Infof("Terraform migrate hook has been finished.")
 	return nil
 }
 
@@ -161,7 +159,6 @@ func BackupSecret(backupSecretName string, secret v1.Secret, namespace string, k
 	nodeGroup := secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]
 	// nodeName := strings.TrimPrefix(secret.ObjectMeta.Name, "d8-node-terraform-state-")
 
-	input.LogEntry.Infof("Starting backup for Secret/%s/%s", namespace, secret.ObjectMeta.Name)
 	secretBackup := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupSecretName,
@@ -185,6 +182,5 @@ func BackupSecret(backupSecretName string, secret v1.Secret, namespace string, k
 		input.LogEntry.Warnf("An error occurred when creating secret backup. Backup aborted. Error: %s.", err)
 		return false
 	}
-	input.LogEntry.Infof("Secret backup completed successfully.")
 	return true
 }

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
@@ -3,7 +3,7 @@ Copyright 2023 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
-// TODO remove after 1.48 release
+// TODO remove after 1.49 release
 
 package hooks
 
@@ -137,10 +137,10 @@ func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Co
 
 func isSecretBackupExists(backupSecretName string, namespace string, kubeCl k8s.Client, input *go_hook.HookInput) (bool, error) {
 	input.LogEntry.Debugf("Function isSecretBackupExists: Starting function with parameters: backupSecretName=%s; namespace=%s", backupSecretName, namespace)
-	backupSecret, err := kubeCl.CoreV1().
+	_, err := kubeCl.CoreV1().
 		Secrets(namespace).
 		Get(context.TODO(), backupSecretName, metav1.GetOptions{})
-	input.LogEntry.Debugf("Function isSecretBackupExists: Get secret. Secret=%s; err=%s", backupSecret, err)
+	input.LogEntry.Debugf("Function isSecretBackupExists: Get secret. err=%s", err)
 
 	if errors.IsNotFound(err) {
 		input.LogEntry.Debugf("Function isSecretBackupExists: errors.IsNotFound(err) = %t. secret \"%s\" not found'. Return false and nil", errors.IsNotFound(err), backupSecretName)

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state_test.go
@@ -1,0 +1,516 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+// TODO remove after 1.48 release
+
+package hooks
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+func createTerraformStateSecret(secretName string, terraformState string, nodeGroup string, secretType string) error {
+	var secretTemplate = `
+---
+apiVersion: v1
+data:
+  %s: %s
+  %s: %s
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+    name: %s
+    node.deckhouse.io/node-group: %s
+    %s: ""
+  name: %s
+type: Opaque
+`
+	// terraformState := fmt.Sprintf(terraformState, nodeName)
+
+	secretYaml := fmt.Sprintf(secretTemplate,
+		TerraformStateDataKey, base64.StdEncoding.EncodeToString([]byte(terraformState)),
+		TestKey, base64.StdEncoding.EncodeToString([]byte(TestData)),
+		secretName, nodeGroup, secretType, secretName)
+
+	var secret v1.Secret
+	err := yaml.Unmarshal([]byte(secretYaml), &secret)
+	if err != nil {
+		return err
+	}
+	_, err = dependency.TestDC.MustGetK8sClient().
+		CoreV1().
+		Secrets(TerraformStateNamespace).
+		Create(context.TODO(), &secret, metav1.CreateOptions{})
+	return err
+}
+
+var _ = Describe("Global :: migrate_terraform_state ::", func() {
+	const (
+		initValuesString       = `{}`
+		initConfigValuesString = `{}`
+	)
+
+	Context("Secrets with terraform state does not exist in "+TerraformStateNamespace, func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook should generate proper log messages", func() {
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Terraform state not found. Migration is not needed."))
+		})
+
+	})
+
+	Context("Single master with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformStateDataKey+" contains old data", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+		nodeName := "master-0"
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, oldTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
+			Expect(err).To(BeNil())
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook should make backup", func() {
+			secret, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-node-terraform-state-"+nodeName+"-backup", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(secret.Data).NotTo(BeNil())
+			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Starting backup for Secret/%s/%s", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Secret backup completed successfully."))
+		})
+
+		It("Hook should migrate Terraform state", func() {
+			secret, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(secret.Data).NotTo(BeNil())
+			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name master.", OpenstackV2ResourceType))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found dependency"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Migration process completed for Secret/%s/%s.", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
+		})
+	})
+	Context("Single master with root size: Migration has been done already", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+		nodeName := "master-0"
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, newTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
+			Expect(err).To(BeNil())
+			err = createTerraformStateSecret("d8-node-terraform-state-"+nodeName+"-backup", oldTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state-backup")
+			Expect(err).To(BeNil())
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook should not change existing state", func() {
+			secret, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(secret.Data).NotTo(BeNil())
+			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+		})
+
+		It("Hook should generate proper log messages", func() {
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Secret backup with name %s/%s already exists! Migration is not needed for Secret/%s/%s", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName+"-backup", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
+		})
+	})
+
+	Context("Single master with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformStateDataKey+" contains new data, no migration was done", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+		nodeName := "master-0"
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, newTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
+			Expect(err).To(BeNil())
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook should not change existing state", func() {
+			secret, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(secret.Data).NotTo(BeNil())
+			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+		})
+
+		It("Hook should not create backup", func() {
+			_, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-node-terraform-state-"+nodeName+"-backup", metav1.GetOptions{})
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("Hook should generate proper log messages", func() {
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("No old resources found. Migration is not needed for Secret/%s/%s", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
+		})
+	})
+
+	Context("Multi master and other CloudPermanent nodes with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformStateDataKey+" contains old data", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+		nodeNames := []string{"master-0", "master-1", "master-2", "test-0", "front-0", "front-1"}
+		terraformStateBackupLabels := map[string]string{
+			"node.deckhouse.io/terraform-state-backup": "",
+		}
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			for _, nodeName := range nodeNames {
+				err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, oldTerraformStateWithRootDiskSize, strings.Split(nodeName, "-")[0], "node.deckhouse.io/terraform-state")
+				Expect(err).To(BeNil())
+			}
+
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook should make backup", func() {
+			for _, nodeName := range nodeNames {
+				secret, err := dependency.TestDC.K8sClient.CoreV1().
+					Secrets(TerraformStateNamespace).
+					Get(context.TODO(), "d8-node-terraform-state-"+nodeName+"-backup", metav1.GetOptions{})
+				Expect(err).To(BeNil())
+				Expect(secret.Data).NotTo(BeNil())
+				Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
+				Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+				Expect(secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]).To(BeEquivalentTo(strings.Split(nodeName, "-")[0]))
+				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Starting backup for Secret/%s/%s", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
+				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Secret backup completed successfully."))
+			}
+			terraformStateBackupSecrets, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				List(context.TODO(), metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(terraformStateBackupLabels))})
+			Expect(err).To(BeNil())
+			Expect(len(terraformStateBackupSecrets.Items)).To(BeEquivalentTo(6))
+		})
+
+		It("Hook should migrate Terraform state", func() {
+			for _, nodeName := range nodeNames {
+				secret, err := dependency.TestDC.K8sClient.CoreV1().
+					Secrets(TerraformStateNamespace).
+					Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
+				Expect(err).To(BeNil())
+				Expect(secret.Data).NotTo(BeNil())
+				Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+				Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+				Expect(secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]).To(BeEquivalentTo(strings.Split(nodeName, "-")[0]))
+				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
+				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name master.", OpenstackV2ResourceType))
+				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Migration process completed for Secret/%s/%s.", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
+			}
+		})
+
+	})
+
+})
+
+const (
+	TestKey                           = "test-key"
+	TestData                          = "my test data"
+	oldTerraformStateWithRootDiskSize = `
+{
+  "version": 4,
+  "terraform_version": "0.13.4",
+  "resources": [
+    {
+      "module": "module.kubernetes_data",
+      "type": "openstack_blockstorage_volume_v2",
+      "name": "kubernetes_data",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "volume_type": "ceph-ssd"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "data.openstack_compute_availability_zones_v2.zones",
+            "module.volume_zone.data.openstack_blockstorage_availability_zones_v3.zones"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.kubernetes_data",
+      "type": "openstack_compute_volume_attach_v2",
+      "name": "kubernetes_data",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "device": "/dev/vdb",
+            "id": "b66cc0e3-0839-4b21-8e93-a45540ac36d0/58d980ff-3126-48c8-b193-0493c92055db"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "module.kubernetes_data.openstack_blockstorage_volume_v2.kubernetes_data",
+            "module.master.openstack_blockstorage_volume_v2.master",
+            "module.master.openstack_compute_instance_v2.master"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.master",
+      "type": "openstack_blockstorage_volume_v2",
+      "name": "master",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "volume_type": "ceph-ssd"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "data.openstack_compute_availability_zones_v2.zones",
+            "module.master.data.openstack_images_image_v2.master",
+            "module.volume_zone.data.openstack_blockstorage_availability_zones_v3.zones"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.master",
+      "type": "openstack_compute_floatingip_associate_v2",
+      "name": "master",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "fixed_ip": "",
+            "floating_ip": "95.217.68.251",
+            "id": "95.217.68.251/b66cc0e3-0839-4b21-8e93-a45540ac36d0/",
+            "instance_id": "b66cc0e3-0839-4b21-8e93-a45540ac36d0",
+            "region": "HetznerFinland",
+            "timeouts": null,
+            "wait_until_associated": true
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDB9fQ==",
+          "dependencies": [
+            "module.master.data.openstack_images_image_v2.master",
+            "module.master.openstack_blockstorage_volume_v2.master",
+            "module.master.openstack_compute_floatingip_v2.master"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.master",
+      "type": "openstack_compute_instance_v2",
+      "name": "master",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "admin_pass": null,
+            "block_device": [
+              {
+                "boot_index": 0,
+                "delete_on_termination": true,
+                "destination_type": "volume"
+              }
+            ],
+            "config_drive": false
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjE4MDAwMDAwMDAwMDAsInVwZGF0ZSI6MTgwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.master.openstack_blockstorage_volume_v2.master",
+            "openstack_networking_port_v2.master_internal_without_security"
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+`
+	newTerraformStateWithRootDiskSize = `
+{
+  "version": 4,
+  "terraform_version": "0.13.4",
+  "resources": [
+    {
+      "module": "module.kubernetes_data",
+      "type": "openstack_blockstorage_volume_v3",
+      "name": "kubernetes_data",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_online_resize": true,
+            "multiattach": null,
+            "volume_type": "ceph-ssd"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "data.openstack_compute_availability_zones_v2.zones",
+            "module.volume_zone.data.openstack_blockstorage_availability_zones_v3.zones"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.kubernetes_data",
+      "type": "openstack_compute_volume_attach_v2",
+      "name": "kubernetes_data",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "device": "/dev/vdb",
+            "id": "b66cc0e3-0839-4b21-8e93-a45540ac36d0/58d980ff-3126-48c8-b193-0493c92055db"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "module.kubernetes_data.openstack_blockstorage_volume_v3.kubernetes_data",
+            "module.master.openstack_blockstorage_volume_v3.master",
+            "module.master.openstack_compute_instance_v2.master"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.master",
+      "type": "openstack_blockstorage_volume_v3",
+      "name": "master",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "enable_online_resize": true,
+            "multiattach": null,
+            "volume_type": "ceph-ssd"
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "data.openstack_compute_availability_zones_v2.zones",
+            "module.master.data.openstack_images_image_v2.master",
+            "module.volume_zone.data.openstack_blockstorage_availability_zones_v3.zones"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.master",
+      "type": "openstack_compute_floatingip_associate_v2",
+      "name": "master",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "fixed_ip": "",
+            "floating_ip": "95.217.68.251",
+            "id": "95.217.68.251/b66cc0e3-0839-4b21-8e93-a45540ac36d0/",
+            "instance_id": "b66cc0e3-0839-4b21-8e93-a45540ac36d0",
+            "region": "HetznerFinland",
+            "timeouts": null,
+            "wait_until_associated": true
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDB9fQ==",
+          "dependencies": [
+            "module.master.data.openstack_images_image_v2.master",
+            "module.master.openstack_blockstorage_volume_v3.master",
+            "module.master.openstack_compute_floatingip_v2.master"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.master",
+      "type": "openstack_compute_instance_v2",
+      "name": "master",
+      "provider": "provider[\"registry.terraform.io/terraform-provider-openstack/openstack\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "admin_pass": null,
+            "block_device": [
+              {
+                "boot_index": 0,
+                "delete_on_termination": true,
+                "destination_type": "volume"
+              }
+            ],
+            "config_drive": false
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjE4MDAwMDAwMDAwMDAsInVwZGF0ZSI6MTgwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.master.openstack_blockstorage_volume_v3.master",
+            "openstack_networking_port_v2.master_internal_without_security"
+          ]
+        }
+      ]
+    }
+  ]
+}
+`
+)

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state_test.go
@@ -108,8 +108,6 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 			Expect(secret.Data).NotTo(BeNil())
 			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
 			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Starting backup for Secret/%s/%s", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Secret backup completed successfully."))
 		})
 
 		It("Hook should migrate Terraform state", func() {
@@ -124,7 +122,6 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name master.", OpenstackV2ResourceType))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found dependency"))
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Migration process completed for Secret/%s/%s.", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
 		})
 	})
 	Context("Single master with root size: Migration has been done already", func() {
@@ -231,8 +228,6 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 				Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
 				Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 				Expect(secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]).To(BeEquivalentTo(strings.Split(nodeName, "-")[0]))
-				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Starting backup for Secret/%s/%s", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
-				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Secret backup completed successfully."))
 			}
 			terraformStateBackupSecrets, err := dependency.TestDC.K8sClient.CoreV1().
 				Secrets(TerraformStateNamespace).
@@ -253,7 +248,6 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 				Expect(secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]).To(BeEquivalentTo(strings.Split(nodeName, "-")[0]))
 				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
 				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name master.", OpenstackV2ResourceType))
-				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Migration process completed for Secret/%s/%s.", TerraformStateNamespace, "d8-node-terraform-state-"+nodeName))
 			}
 		})
 


### PR DESCRIPTION
## Description
Added the `etcdDiskSizeGb` parameter for OpenStack and migration from `openstack_blockstorage_volume_v2` to `openstack_blockstorage_volume_v3`.

Yandex Cloud, GCP, and Azure `ClusterConfiguration` added in https://github.com/deckhouse/deckhouse/pull/4720
The `etcdDiskSizeGb` was not added to vSphere because there is no ability to resize `vsphere_virtual_disk` in `terraform-provider-vsphere`. See https://github.com/hashicorp/terraform-provider-vsphere/issues/851

## Why do we need it, and what problem does it solve?

The etcd disk size is now hardcoded. We've added a parameter to allow the user to choose the disk size, which solves the problem of the inflexible disk size in the previous version.
Partially closes issue https://github.com/deckhouse/deckhouse/issues/3348

We also migrated from `openstack_blockstorage_volume_v2` resource to `openstack_blockstorage_volume_v3`, as the former resource did not support disk resizing.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Added the `etcdDiskSizeGb` parameter for OpenStack and migration from `openstack_blockstorage_volume_v2` to `openstack_blockstorage_volume_v3`.
```

