### PR TITLE
[operator-trivy] Add configuration for `tolerations` and `nodeSelector` for scanJobs

### DIFF
--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -1,2 +1,30 @@
 type: object
-properties: {}
+properties:
+  scanJobs:
+    type: object
+    description: Options for operator trivy scan jobs
+    default: {}
+    properties:
+      tolerations:
+        type: array
+        description: |
+          Scan jobs tolerations.
+
+          The same as `spec.tolerations` for the Kubernetes pod.
+        items:
+          type: object
+          properties:
+            effect:
+              type: string
+            key:
+              type: string
+            operator:
+              type: string
+            tolerationSeconds:
+              type: integer
+              format: int64
+            value:
+              type: string
+        x-examples:
+        - [{"operator": "Exists"}]
+        - [{"effect":"NoSchedule","key":"key1","operator":"Equal","value":"value1"}]

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -1,2 +1,10 @@
 type: object
-properties: {}
+properties:
+  scanJobs:
+    description: Общие настройки для scan Jobs
+    properties:
+      tolerations:
+        description: |
+          tolerations для Scan Jobs.
+
+          Структура, аналогичная `spec.tolerations` Kubernetes pod.

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
   configAuditReports.scanner: "Trivy"
   report.recordFailedChecksOnly: "true"
   node.collector.imageRef: {{ include "helm_lib_module_image" (list . "nodeCollector") }}
+  {{- with ( .Values.operatorTrivy | dig "scanJobs" "tolerations" (list) ) }}
+  scanJob.tolerations: {{ . | toJson | quote }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add configuration to module values for scan jobs `tolerations` and `nodeSelector`
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #4713 
Sometimes users want to configure where (nodes) to run trivy operator scan jobs
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Users can configure `tolerations` and `nodeSelector` for trivy operator scan jobs via `ModuleConfig`

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature
summary: Add configuration for `tolerations` and `nodeSelector` for scanJobs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
