### PR TITLE
[linstor] fix kernel-headers cleanup script

### DIFF
--- a/modules/041-linstor/templates/nodegroupconfiguration-install-kernel-headers.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-install-kernel-headers.yaml
@@ -46,9 +46,9 @@ spec:
       bb-apt-install "linux-headers-${version_in_use}"
 
       # Remove unused kernel-headers
-      version_in_use_pattern="$(echo "$version_in_use" | sed -r 's/([0-9\.-]+)-([^0-9]+)$/^linux-[a-z0-9\.-]+(\1|\1-\2)$/')"
+      version_in_use_pattern="$(echo "$version_in_use" | sed -r 's/([0-9\.-]+)-([^0-9]+)$/^linux-headers-(\1|\1-\2)$/')"
       packages_to_remove="$(
-        dpkg --get-selections | grep -E '^linux-headers-.*\s(install|hold)$' | awk '{print $1}' | grep -Ev "$version_in_use_pattern" | grep -Ev 'linux-headers-[^0-9]+$' || true
+        dpkg-query -S '/lib/modules/*/build' | awk -F: '{print $1}' | grep -Ev "$version_in_use_pattern" || true
       )"
       if [ -n "$packages_to_remove" ]; then
         bb-apt-remove $packages_to_remove


### PR DESCRIPTION
## Description


This PR updates regex for finding orphan kenel-header packages on debian-like distros

Currently it might trigger removing of meta-packages, which will remove the currently installed kernel headers by the dependency:

```
linux-headers-generic-hwe-22.04
linux-headers-virtual-hwe-22.04
```

UPD debian 11 also includes common pachage which should not be deleted:
```
linux-headers-*-common
```

fixes #4801 

## Why do we need it, and what problem does it solve?

Do not remove kernel-headers installed by meta package

## Why do we need it in the patch release (if we do)?

We have community users with such issue

## What is the expected result?

If user installed kernel-headers manually they will not be removed

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: fix kernel-headers cleanup script
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
