### PR TITLE
[ingress-nginx] Add annotation for keeping helm objects

### DIFF
--- a/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods.go
+++ b/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods.go
@@ -125,6 +125,14 @@ func migrateDaemonSet(input *go_hook.HookInput) (err error) {
 
 	for _, ds := range dss {
 		dsName := ds.(string)
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]string{
+					"helm.sh/resource-policy": "keep",
+				},
+			},
+		}
+		input.PatchCollector.MergePatch(patch, "apps/v1", "DaemonSet", internal.Namespace, dsName, object_patch.IgnoreMissingObject())
 		input.PatchCollector.Delete("apps/v1", "DaemonSet", internal.Namespace, dsName, object_patch.NonCascading())
 	}
 

--- a/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
+++ b/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Global hooks :: discovery :: migrate_daemonset ", func() {
+var _ = Describe("Global hooks :: discovery :: migrate_daemonset ", func() {
 	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`
 	globalValuesString := `{}`
 	f := HookExecutionConfigInit(initValuesString, globalValuesString)

--- a/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
+++ b/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Global hooks :: discovery :: migrate_daemonset ", func() {
+var _ = FDescribe("Global hooks :: discovery :: migrate_daemonset ", func() {
 	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`
 	globalValuesString := `{}`
 	f := HookExecutionConfigInit(initValuesString, globalValuesString)


### PR DESCRIPTION
## Description
Add helm `keep resource` annotation

## Why do we need it, and what problem does it solve?
We can have a race when DaemonSet is not deleted by hook and helm tries to delete it with all siblings (pods).
We can set the annotation and prevent helm from deleting this pod

## Why do we need it in the patch release (if we do)?
In some cases (I guess it's some kind of race) helm can delete DaemonSet with pods, according to this messages:
```
34m         Normal    SuccessfulDelete                  daemonset/controller-main-host-port               Deleted pod: controller-main-host-port-4pn66
```
Let's add one more protection for this case

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Add protection for ingress-nginx-controller daemonset migration.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
