### PR TITLE
[ingress-nginx] Fix kube-rbac-proxy resources indentation

### DIFF
--- a/modules/402-ingress-nginx/templates/kruise/manager.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/manager.yaml
@@ -190,7 +190,7 @@ spec:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 14 }}
           {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-              {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+              {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 14 }}
           {{- end }}
         - args:
           - --namespaces=d8-ingress-nginx


### PR DESCRIPTION
## Description
Fixed incorrect indentation of `resources` block in `kube-rbac-proxy` container of `kruise-controller-manager` deployment. The issue occurs if module `vertical-pod-autoscaler-crd` is not enabled.

## Why do we need it, and what problem does it solve?
The issue blocks `ingress-nginx` module deployment. Here are logs from deckhouse pod:
```
{"binding":"ConvergeModules","event.type":"OperatorStartup","level":"error","module":"ingress-nginx","msg":"ModuleRun failed in phase 'CanRunHelm'. Requeue task to retry after delay. Failed count is 2. Error: helm upgrade failed: error validating \"\": error validating data: [ValidationError(Deployment.spec.template.spec.containers[1].resources): unknown field \"cpu\" in io.k8s.api.core.v1.ResourceRequirements, ValidationError(Deployment.spec.template.spec.containers[1].resources): unknown field \"memory\" in io.k8s.api.core.v1.ResourceRequirements]\n","queue":"main","task.id":"69597a4b-3288-4147-86bc-1dfb41bcc3a4","time":"2023-05-24T10:43:59Z"}
```

## Why do we need it in the patch release (if we do)?

The issue is present in release 1.45.10.

## What is the expected result?
Module `ingress-nginx` successfully deployed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fixed incorrect indentation of resources block in kube-rbac-proxy container of kruise-controller-manager deployment.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
