### PR TITLE
[deckhouse] Keep manual release transition time

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -40,7 +40,8 @@ import (
 )
 
 const (
-	metricReleasesGroup = "d8_releases"
+	metricReleasesGroup      = "d8_releases"
+	waitingManualApprovalMsg = "Waiting for manual approval"
 )
 
 type DeckhouseUpdater struct {
@@ -215,7 +216,7 @@ func (du *DeckhouseUpdater) checkMinorReleaseConditions(predictedRelease *Deckho
 		if !predictedRelease.Status.Approved {
 			du.input.LogEntry.Infof("Release %s is waiting for manual approval", predictedRelease.Name)
 			du.input.MetricsCollector.Set("d8_release_waiting_manual", float64(du.totalPendingManualReleases), map[string]string{"name": predictedRelease.Name}, metrics.WithGroup(metricReleasesGroup))
-			du.updateStatus(predictedRelease, "Waiting for manual approval", v1alpha1.PhasePending)
+			du.updateStatus(predictedRelease, waitingManualApprovalMsg, v1alpha1.PhasePending)
 			return false
 		}
 	} else {
@@ -545,7 +546,7 @@ func (du *DeckhouseUpdater) patchManualRelease(release DeckhouseRelease) Deckhou
 
 	if !release.ManuallyApproved {
 		release.Status.Approved = false
-		release.Status.Message = "Release is waiting for manual approval"
+		release.Status.Message = waitingManualApprovalMsg
 		du.totalPendingManualReleases++
 	} else {
 		release.Status.Approved = true


### PR DESCRIPTION
## Description
Keep transition time for pending manual release

## Why do we need it, and what problem does it solve?
Release was changing transition time during the pending state because if different status messages

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Don't change time for pending manual DeckhouseRelease.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
