### PR TITLE
[helm] Fix deprecated k8s resources metrics

### DIFF
--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -80,8 +80,12 @@ const unsupportedVersionsYAML = `
 "1.26":
   "flowcontrol.apiserver.k8s.io/v1beta1": ["FlowSchema", "PriorityLevelConfiguration"]
   "autoscaling/v2beta2": ["HorizontalPodAutoscaler"]
+
 "1.27":
   "storage.k8s.io/v1beta1": ["CSIStorageCapacity"]
+
+"1.29":
+  "flowcontrol.apiserver.k8s.io/v1beta2": ["FlowSchema", "PriorityLevelConfiguration"]
 `
 
 const (

--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -70,7 +70,7 @@ const unsupportedVersionsYAML = `
   "snapshot.storage.k8s.io/v1beta1": ["VolumeSnapshot"]
 
 "1.25":
-  "batch/v1": ["CronJob"]
+  "batch/v1beta1": ["CronJob"]
   "discovery.k8s.io/v1beta1": ["EndpointSlice"]
   "events.k8s.io/v1beta1": ["Event"]
   "autoscaling/v2beta1": ["HorizontalPodAutoscaler"]
@@ -79,7 +79,7 @@ const unsupportedVersionsYAML = `
 
 "1.26":
   "flowcontrol.apiserver.k8s.io/v1beta1": ["FlowSchema", "PriorityLevelConfiguration"]
-
+  "autoscaling/v2beta2": ["HorizontalPodAutoscaler"]
 "1.27":
   "storage.k8s.io/v1beta1": ["CSIStorageCapacity"]
 `


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix deprecated k8s resources metrics

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There are some mistakes in deprecated resources config
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
There are some mistakes in deprecated resources config, that are in k8s version 1.25, which we start to support in deckhouse v1.42

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: helm
type: fix
summary: Fix deprecated k8s resources metrics.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
