### PR TITLE
[deckhouse] Add `prometheus.deckhouse.io/rules-watcher-enabled` on d8-system namespace

### DIFF
--- a/modules/002-deckhouse/hooks/enable_extended_monitoring.go
+++ b/modules/002-deckhouse/hooks/enable_extended_monitoring.go
@@ -27,16 +27,24 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, enableExtendedMonitoring)
 
 func enableExtendedMonitoring(input *go_hook.HookInput) error {
-	labelsPatch := map[string]interface{}{
+	d8SystemPatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]string{
+				"extended-monitoring.deckhouse.io/enabled":      "",
+				"prometheus.deckhouse.io/rules-watcher-enabled": "true",
+			},
+		},
+	}
+	input.PatchCollector.MergePatch(d8SystemPatch, "v1", "Namespace", "", "d8-system")
+
+	kubeSystemPatch := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{
 				"extended-monitoring.deckhouse.io/enabled": "",
 			},
 		},
 	}
-
-	input.PatchCollector.MergePatch(labelsPatch, "v1", "Namespace", "", "d8-system")
-	input.PatchCollector.MergePatch(labelsPatch, "v1", "Namespace", "", "kube-system")
+	input.PatchCollector.MergePatch(kubeSystemPatch, "v1", "Namespace", "", "kube-system")
 
 	input.PatchCollector.Filter(removeDeprecatedAnnotation, "v1", "Namespace", "", "d8-system")
 	input.PatchCollector.Filter(removeDeprecatedAnnotation, "v1", "Namespace", "", "kube-system")

--- a/modules/002-deckhouse/hooks/enable_extended_monitoring_test.go
+++ b/modules/002-deckhouse/hooks/enable_extended_monitoring_test.go
@@ -32,7 +32,7 @@ kind: Namespace
 metadata:
   name: kube-system
   annotations:
-  extended-monitoring.deckhouse.io: ""
+    extended-monitoring.flant.com/enabled: ""
 `
 		d8SystemNS = `
 ---
@@ -40,8 +40,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-system
-  labels:
-    extended-monitoring.deckhouse.io/enabled: ""
+  annotations:
+    extended-monitoring.flant.com/enabled: ""
 `
 	)
 
@@ -69,6 +69,23 @@ metadata:
 			Expect(label.String()).To(Equal(""))
 			Expect(f.KubernetesGlobalResource("Namespace", "kube-system").
 				Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
+		})
+
+		It("Rules watcher label should be present on d8-system namespace", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ns := f.KubernetesGlobalResource("Namespace", "d8-system")
+			label := ns.Field(`metadata.labels.prometheus\.deckhouse\.io/rules-watcher-enabled`)
+			Expect(label.Exists()).To(BeTrue())
+			Expect(label.String()).To(Equal("true"))
+		})
+
+		It("Rules watcher label should not be present on kube-system namespace", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ns := f.KubernetesGlobalResource("Namespace", "kube-system")
+			label := ns.Field(`metadata.labels.prometheus\.deckhouse\.io/rules-watcher-enabled`)
+			Expect(label.Exists()).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
## Description
Add prometheus.deckhouse.io/rules-watcher-enabled on d8-system namespace.

We should set label to all namespaces with prometheus rules (see related [pr](https://github.com/deckhouse/deckhouse/pull/4407)). 

But we forget to add label to `d8-system` namespace because we do not have manifest for it. d8-system ns was created by dhctl.

## Why do we need it, and what problem does it solve?
Prometheus rules from d8-system can not be found.

## Why do we need it in the patch release (if we do)?
Prometheus rules from d8-system can not be found.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/deckhouse/deckhouse/assets/30695496/bd7f07a0-1ee6-4862-8f4d-70c19cb2ccfb)

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Add prometheus.deckhouse.io/rules-watcher-enabled on d8-system namespace
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
