### PR TITLE
[candi] Old binary deletion fixes

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -142,7 +142,7 @@ function get_bundle() {
 }
 
 function main() {
-  export PATH="/opt/deckhouse/bin:$PATH"
+  export PATH="/opt/deckhouse/bin:/usr/local/bin:$PATH"
   export BOOTSTRAP_DIR="/var/lib/bashible"
   export BUNDLE_STEPS_DIR="$BOOTSTRAP_DIR/bundle_steps"
   export BUNDLE="{{ .bundle }}"

--- a/candi/bashible/common-steps/all/098_remove_old_binaries.sh.tpl
+++ b/candi/bashible/common-steps/all/098_remove_old_binaries.sh.tpl
@@ -14,4 +14,4 @@
 
 # TODO remove after 1.46 release !!!
 cd /usr/local/bin
-rm -rf crictl d8-curl d8-kubelet-forker jq sysctl-tuner toml-merge
+rm -rf crictl d8-curl d8-kubelet-forker sysctl-tuner toml-merge

--- a/candi/bashible/common-steps/node-group/000_migrate_containerd_to_cgroupfs.sh.tpl
+++ b/candi/bashible/common-steps/node-group/000_migrate_containerd_to_cgroupfs.sh.tpl
@@ -40,6 +40,8 @@ ExecStart=/opt/deckhouse/bin/d8-containerd-cgroup-migration.sh
 WantedBy=multi-user.target
 EOF
 
+mkdir -p /opt/deckhouse/bin
+
 bb-sync-file /opt/deckhouse/bin/d8-containerd-cgroup-migration.sh - << "EOF"
 #!/bin/bash
 # Copyright 2021 Flant JSC


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed a migration that did not include /opt/deckhouse/bin creation. Also save PATH to a previous jq location to avoid breaking the bashible.sh update process.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

bashible step failed mid-process due to a previous issue that was addressed in v1.46.1. Here we protect from losing path to a jq binary even more.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

More proofing against bashible exploding due to missing jq binary.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

jq is always available to bashible.sh main script.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed a migration that did not include /opt/deckhouse/bin creation. Also save PATH to a previous jq location to avoid breaking the bashible.sh update process.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
