### PR TITLE
Revert "[prometheus] Bump 2.44.0"

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -12,7 +12,7 @@ ansible:
       unarchive:
         extra_opts:
           # The promtool version should match prometheus version from the 300-prometheus module.
-         {{- $promVersion := "2.44.0" }}
+         {{- $promVersion := "2.43.0+stringlabels" }}
           - prometheus-{{ $promVersion }}.linux-amd64/promtool
           - --strip-components=1
         src: https://github.com/prometheus/prometheus/releases/download/v{{ $promVersion }}/prometheus-{{ $promVersion }}.linux-amd64.tar.gz

--- a/modules/300-prometheus/images/prometheus/Dockerfile
+++ b/modules/300-prometheus/images/prometheus/Dockerfile
@@ -1,8 +1,9 @@
-ARG BASE_GOLANG_19_BULLSEYE
+ARG BASE_GOLANG_18_BULLSEYE
+ARG BASE_NODE_16_ALPINE
 ARG BASE_ALPINE
 
-FROM $BASE_GOLANG_19_BULLSEYE as artifact
-ENV PROMETHEUS_VERSION=v2.44.0
+FROM $BASE_GOLANG_18_BULLSEYE as artifact
+ENV PROMETHEUS_VERSION=v2.43.0+stringlabels
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - &&  \
   apt install -y nodejs && \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Reverts deckhouse/deckhouse#4684

Upstream [issue](https://github.com/prometheus/prometheus/issues/12394).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We are getting wrong metrics for a query. Even using a simple metric name as a parameter.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

It duplicates metrics and generates tons of failed recording rule evaluations.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No wrong metrics by a name query.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Revert https://github.com/deckhouse/deckhouse/pull/4684 due to a suspected bug https://github.com/prometheus/prometheus/issues/12394
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
