### PR TITLE
[cni-cilium] Added severity_levels for alerts

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -6,7 +6,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
-      severity_level: "5"
+      severity_level: "4"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -23,7 +23,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
-      severity_level: "5"
+      severity_level: "4"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -41,6 +41,7 @@
       d8_module: cni-cilium
       d8_component: agent
       severity_level: "4"
+      experimental: "true"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -56,7 +57,8 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
-      severity_level: "7"
+      severity_level: "9"
+      experimental: "true"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -74,7 +76,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
-      severity_level: "3"
+      severity_level: "4"
       tier: cluster
     annotations:
       plk_protocol_version: "1"

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -6,6 +6,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
+      severity_level: "5"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -22,6 +23,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
+      severity_level: "5"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -38,6 +40,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
+      severity_level: "4"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -53,6 +56,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
+      severity_level: "7"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
@@ -70,6 +74,7 @@
     labels:
       d8_module: cni-cilium
       d8_component: agent
+      severity_level: "3"
       tier: cluster
     annotations:
       plk_protocol_version: "1"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added missing severity levels for Cilium alerts.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

All alerts should have a severity_level.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

severity_level is present on all alerts.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Added severity_levels to all alerts
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
