### PR TITLE
[cert-manager] Added max concurrent challenges parameter

### DIFF
--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -116,7 +116,9 @@ properties:
     x-examples: [true, false]
 
   maxConcurrentChallenges:
-    type: int
+    type: integer
+    format: int32
+    minimum: 0
     description: |
       The maximum number of challenges that can be scheduled as 'processing' at once. (default 60)
     x-examples: [25]

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -115,3 +115,8 @@ properties:
       Disable `letsencrypt` and `letsencrypt-staging` ClusterIssuer objects (if set to `true`).
     x-examples: [true, false]
 
+  maxConcurrentChallenges:
+    type: int
+    description: |
+      The maximum number of challenges that can be scheduled as 'processing' at once. (default 60)
+    x-examples: [25]

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -55,3 +55,6 @@ properties:
   disableLetsencrypt:
     description: |
       Не создавать ClusterIssuer `letsencrypt` и `letsencrypt-staging` в кластере (если `true`).
+  maxConcurrentChallenges:
+    description: |
+      Максимальное количество одновременных Challenges в статусе `processing`

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -65,6 +65,9 @@ spec:
           - --acme-http01-solver-resource-limits-cpu=0
           - --acme-http01-solver-resource-request-cpu=0
           - "--acme-http01-solver-image={{ include "helm_lib_module_image" (list . "certManagerAcmeSolver") }}"
+          {{- if $.Values.certManager.maxConcurrentChallenges }}
+          - --max-concurrent-challenges={{ $.Values.certManager.maxConcurrentChallenges }}
+          {{- end }}
 {{- if (hasKey $.Values.global.modules "https") }}
 {{- if eq $.Values.global.modules.https.mode "CertManager" }}
           - --default-issuer-kind=ClusterIssuer


### PR DESCRIPTION
## Description

Add max concurrent challenges parameter for cert-manager-controller

## Why do we need it, and what problem does it solve?
The simultaneous update of a large number of certificates with HTTP challenges can generate a high load on ingress controllers

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: feature
summary: Added max concurrent challenges parameter for cert-manager-controller.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
