### PR TITLE
[extended-monitoring] Send one ExtendedMonitoringDeprecatatedAnnotation alert per cluster

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/deprecated-annotation.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/deprecated-annotation.yaml
@@ -2,7 +2,7 @@
   rules:
   - alert: ExtendedMonitoringDeprecatatedAnnotation
     expr: >-
-      group by (kind,namespace,name) (d8_deprecated_legacy_annotation == 1)
+      group (d8_deprecated_legacy_annotation == 1)
     labels:
       severity_level: "4"
     annotations:
@@ -11,5 +11,6 @@
       plk_create_group_if_not_exists__d8_extended_monitoring_deprecated_annotation: "D8ExtendedMonitoringDeprecatedAnnotation,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_extended_monitoring_deprecated_annotation: "D8ExtendedMonitoringDeprecatedAnnotation,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: >
-        There is a deprecated `extended-monitoring.flant.com/enabled` annotation on {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }}.
+        Deprecated `extended-monitoring.flant.com/enabled` annotations are used in cluster.
         Migrate to `extended-monitoring.deckhouse.io/enabled` label ASAP.
+        Check d8_deprecated_legacy_annotation metric in Prometheus to get list of all usages.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change group in expression for ExtendedMonitoringDeprecatatedAnnotation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Reduce number of alerts from cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Clients get a lot of disturbing alerts that not critical.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix
summary: Send one `ExtendedMonitoringDeprecatatedAnnotation` alert per cluster.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
