### PR TITLE
[node-manager] Bump cluster autoscaler from 1.24.0 to 1.26.2

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/Dockerfile
+++ b/modules/040-node-manager/images/cluster-autoscaler/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_ALPINE
-ARG  BASE_GOLANG_18_ALPINE
-FROM $BASE_GOLANG_18_ALPINE as artifact
+ARG  BASE_GOLANG_19_ALPINE
+FROM $BASE_GOLANG_19_ALPINE as artifact
 WORKDIR /go/src/github.com/gardener/autoscaler
 COPY "patches/daemonset-eviction.patch" /
 COPY "patches/scale-from-zero.patch" /

--- a/modules/040-node-manager/images/cluster-autoscaler/Dockerfile
+++ b/modules/040-node-manager/images/cluster-autoscaler/Dockerfile
@@ -6,7 +6,7 @@ COPY "patches/daemonset-eviction.patch" /
 COPY "patches/scale-from-zero.patch" /
 
 RUN apk add --no-cache linux-headers build-base git mercurial patch && \
-    wget https://github.com/gardener/autoscaler/archive/v1.24.0.tar.gz -O - | tar -xz --strip-components=1 -C /go/src/github.com/gardener/autoscaler/ && \
+    wget https://github.com/gardener/autoscaler/archive/v1.26.2.tar.gz -O - | tar -xz --strip-components=1 -C /go/src/github.com/gardener/autoscaler/ && \
     patch -p1 < "/daemonset-eviction.patch" && \
     patch -p1 < "/scale-from-zero.patch" && \
     cd cluster-autoscaler && \

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/scale-from-zero.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/scale-from-zero.patch
@@ -1,8 +1,8 @@
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
-index c3deb5e64..2db8bd502 100644
+index 52fd0b9b8..06e1ed259 100644
 --- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
 +++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
-@@ -733,7 +733,27 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
+@@ -759,7 +759,27 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
  			return nil, cloudprovider.ErrNotImplemented
  		}
  	default:
@@ -29,5 +29,5 @@ index c3deb5e64..2db8bd502 100644
 +			return nil, cloudprovider.ErrNotImplemented
 +		}
  	}
-
+ 
  	labels := make(map[string]string)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump cluster autoscaler from 1.24.0 to 1.26.2

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
policy/v1beta1/PodDisruptionBudget was remove in the kubernetes 1.25

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Bump cluster autoscaler from 1.24.0 to 1.26.2
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
