### PR TITLE
[cilium-hubble] Fix error with install if global https OnlyInURI

### DIFF
--- a/modules/500-cilium-hubble/templates/ui/authenticator.yaml
+++ b/modules/500-cilium-hubble/templates/ui/authenticator.yaml
@@ -8,7 +8,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" "cilium-hubble" )) | nindent 2 }}
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "hubble") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- with .Values.ciliumHubble.auth.allowedUserGroups }}
   allowedGroups:


### PR DESCRIPTION
## Description
Add Ingress TLS enabled condition for secret name rendering.


## Why do we need it, and what problem does it solve?
Fix the bug when clients could not install the `cilium-hubble` module  if the [modules.https.mode](https://deckhouse.io/documentation/v1/deckhouse-configure-global.html#parameters-modules-https-mode) global parameter set to `OnlyInURI`.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cilium-hubble
type: fix
summary: Fix the error with the install if the [modules.https.mode](https://deckhouse.io/documentation/v1/deckhouse-configure-global.html#parameters-modules-https-mode) global parameter is `OnlyInURI`.
impact_level: default 
```
