### PR TITLE
[deckhouse] Add cluster-autoscaler logs into debug logs collector

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -129,6 +129,11 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", "kubectl -n $(kubectl get ns -o custom-columns=NAME:metadata.name | grep d8-cloud-provider) logs -l app=cloud-controller-manager --tail=3000"},
 		},
 		{
+			File: "cluster-autoscaler-logs.txt",
+			Cmd:  "kubectl",
+			Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=cluster-autoscaler", "--tail", "3000", "-c", "cluster-autoscaler"},
+		},
+		{
 			File: "vpa-admission-controller-logs.txt",
 			Cmd:  "kubectl",
 			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-admission-controller", "--tail", "3000", "-c", "admission-controller"},

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -129,6 +129,21 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", "kubectl -n $(kubectl get ns -o custom-columns=NAME:metadata.name | grep d8-cloud-provider) logs -l app=cloud-controller-manager --tail=3000"},
 		},
 		{
+			File: "vpa-admission-controller-logs.txt",
+			Cmd:  "kubectl",
+			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-admission-controller", "--tail", "3000", "-c", "admission-controller"},
+		},
+		{
+			File: "vpa-recommender-logs.txt",
+			Cmd:  "kubectl",
+			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-recommender", "--tail", "3000", "-c", "recommender"},
+		},
+		{
+			File: "vpa-updater-logs.txt",
+			Cmd:  "kubectl",
+			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-updater", "--tail", "3000", "-c", "updater"},
+		},
+		{
 			File: "terraform-check.json",
 			Cmd:  "kubectl",
 			Args: []string{"exec", "deploy/terraform-state-exporter", "--", "dhctl", "terraform", "check", "--logger-type", "json", "-o", "json"},

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -57,6 +57,9 @@ Data that will be collected:
 * Deckhouse logs
 * machine controller manager logs
 * cloud controller manager logs
+* vertical-pod-autoscaler admission controller logs
+* vertical-pod-autoscaler recommender logs
+* vertical-pod-autoscaler updater logs
 * all firing alerts from Prometheus
 * terraform-state-exporter metrics
 

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -57,9 +57,10 @@ Data that will be collected:
 * Deckhouse logs
 * machine controller manager logs
 * cloud controller manager logs
-* vertical-pod-autoscaler admission controller logs
-* vertical-pod-autoscaler recommender logs
-* vertical-pod-autoscaler updater logs
+* cluster autoscaler logs
+* Vertical Pod Autoscaler admission controller logs
+* Vertical Pod Autoscaler recommender logs
+* Vertical Pod Autoscaler updater logs
 * all firing alerts from Prometheus
 * terraform-state-exporter metrics
 

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -57,9 +57,10 @@ kubectl logs job.batch/kube-bench
 * логи Deckhouse
 * логи machine controller manager
 * логи cloud controller manager
-* логи vertical-pod-autoscaler admission controller
-* логи vertical-pod-autoscaler recommender
-* логи vertical-pod-autoscaler updater
+* логи cluster autoscaler
+* логи Vertical Pod Autoscaler admission controller
+* логи Vertical Pod Autoscaler recommender
+* логи Vertical Pod Autoscaler updater
 * все горящие уведомления в Prometheus
 * метрики terraform-state-exporter
 

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -57,6 +57,9 @@ kubectl logs job.batch/kube-bench
 * логи Deckhouse
 * логи machine controller manager
 * логи cloud controller manager
+* логи vertical-pod-autoscaler admission controller
+* логи vertical-pod-autoscaler recommender
+* логи vertical-pod-autoscaler updater
 * все горящие уведомления в Prometheus
 * метрики terraform-state-exporter
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add cluster-autoscaler logs into debug logs collector.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Client applications can experience problems if cluster-autoscaler doesn't work properly. It's better to collect its logs in cloud clusters.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Add cluster-autoscaler logs into debug logs collector.
impact_level:  default
```

