### PR TITLE
[user-authz] Forbid empty .spec.subject field in ClusterAuthorizationRule

### DIFF
--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -76,7 +76,7 @@ function __main__() {
   done
   unset IFS
 
-  if context::jq -er '.review.request.object.spec.subjects // [] | length == 0'; then
+  if context::jq -er '.review.request.object.spec.subjects // [] | length == 0' >/dev/null 2>&1; then
     message="Field \".spec.subjects\" must not be empty"
   fi
 

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -77,7 +77,7 @@ function __main__() {
   unset IFS
 
   if context::jq -er '.review.request.object.spec.subjects // [] | length == 0' >/dev/null 2>&1; then
-    message="Field \".spec.subjects\" must not be empty"
+    message="$message Field \".spec.subjects\" must not be empty"
   fi
 
   if [[ "$message" == "error:" ]]; then

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -76,6 +76,10 @@ function __main__() {
   done
   unset IFS
 
+  if context::jq -er '.review.request.object.spec.subjects // [] | length == 0'; then
+    message="Field \".spec.subjects\" must not be empty"
+  fi
+
   if [[ "$message" == "error:" ]]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true}

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -79,9 +79,9 @@ function __main__() {
   set -x
 
   context::jq -r '.'
-  
+
   if context::jq -er '.review.request.object.spec.subjects // [] | length == 0' >/dev/null 2>&1; then
-    message="$message Field \".spec.subjects\" must not be empty"
+    message="$message Field <.spec.subjects> must not be empty"
   fi
 
   if [[ "$message" == "error:" ]]; then

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -76,6 +76,10 @@ function __main__() {
   done
   unset IFS
 
+  set -x
+
+  context::jq -r '.'
+  
   if context::jq -er '.review.request.object.spec.subjects // [] | length == 0' >/dev/null 2>&1; then
     message="$message Field \".spec.subjects\" must not be empty"
   fi
@@ -89,6 +93,7 @@ EOF
 {"allowed":false, "message":"$message"}
 EOF
   fi
+  set +x
 }
 
 hook::run "$@"

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -76,10 +76,6 @@ function __main__() {
   done
   unset IFS
 
-  set -x
-
-  context::jq -r '.'
-
   if context::jq -er '.review.request.object.spec.subjects // [] | length == 0' >/dev/null 2>&1; then
     message="$message Field <.spec.subjects> must not be empty"
   fi
@@ -93,7 +89,6 @@ EOF
 {"allowed":false, "message":"$message"}
 EOF
   fi
-  set +x
 }
 
 hook::run "$@"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added a check for the ".spec.subjects" field to the cluster_authorization_rule validation webhook to prevent it from being left empty.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The main Deckhouse queue stops when a ClusterAuthorizationRule exists with an empty "subjects" field.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: Forbid empty .spec.subject field in ClusterAuthorizationRule
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
