### PR TITLE
[istio] added a way to globally override resources for istio-proxy

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -266,13 +266,11 @@ properties:
           **Caution!** The setting only applies to new pods with istio-proxy.
         default: {}
         x-examples:
-          - mode: Static
-            static:
+          - static:
               requests:
                 cpu: "100m"
                 memory: "128Mi"
               limits:
-                cpu: 2
                 memory: "1Gi"
         properties:
           mode:

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -259,6 +259,74 @@ properties:
         example: ["8080", "8443"]
         x-examples:
         - ["8080", "8443"]
+      resourcesManagement:
+        description: |
+          istio sidecar resources management options.
+
+          **Caution!** The setting only applies to new pods with istio-proxy.
+        default: {}
+        x-examples:
+          - mode: Static
+            static:
+              requests:
+                cpu: "100m"
+                memory: "128Mi"
+              limits:
+                cpu: 2
+                memory: "1Gi"
+        properties:
+          mode:
+            type: string
+            description: |
+              The mode for managing resource requests. Classical `Static` requests/limit.
+            enum: [ 'Static']
+            default: 'Static'
+          static:
+            type: object
+            description: |
+              Static resource management settings.
+            properties:
+              requests:
+                type: object
+                description: |
+                  Requests configuration.
+                properties:
+                  cpu:
+                    oneOf:
+                      - type: string
+                        pattern: "^[0-9]+m?$"
+                      - type: number
+                    default: '100m'
+                    description: |
+                      CPU requests.
+                  memory:
+                    oneOf:
+                      - type: string
+                        pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                      - type: number
+                    default: '128Mi'
+                    description: |
+                      Memory requests.
+              limits:
+                type: object
+                description: |
+                  Limits configuration.
+                properties:
+                  cpu:
+                    oneOf:
+                      - type: string
+                        pattern: "^[0-9]+m?$"
+                      - type: number
+                    description: |
+                      CPU limits.
+                  memory:
+                    oneOf:
+                      - type: string
+                        pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                      - type: number
+                    default: '1Gi'
+                    description: |
+                      Memory limits.
   ca:
     type: object
     description: Explicitly specified root certificate. It signs individual service certificates to use in mutual TLS connections.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -261,9 +261,9 @@ properties:
         - ["8080", "8443"]
       resourcesManagement:
         description: |
-          istio sidecar resources management options.
+          Manages Istio sidecar container resources.
 
-          **Caution!** The setting only applies to new pods with istio-proxy.
+          **Caution!** The setting only applies to new Pods with `istio-proxy`.
         default: {}
         x-examples:
           - static:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -125,6 +125,33 @@ properties:
         items:
           type: string
           pattern: '^[0-9]{1,5}$'
+      resourceManagement:
+        description: |
+          Настройки управления ресурсами istio-sidecar.
+
+          **Внимание!** Настройка применяется только для новых pods с istio-proxy.
+        properties:
+          mode:
+          static:
+            description: |
+              Настройки управления ресурсами в статическом режиме.
+            properties:
+              requests:
+                properties:
+                  cpu:
+                    description: |
+                      Реквесты CPU.
+                  memory:
+                    description: |
+                      Реквесты памяти.
+              limits:
+                properties:
+                  cpu:
+                    description: |
+                      Лимиты CPU.
+                  memory:
+                    description: |
+                      Лимиты памяти.
   ca:
     description: Явно заданный корневой сертификат, который будет использован для подписывания индивидуальных сертификатов сервисов в случае включения MTLS.
     properties:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -127,7 +127,7 @@ properties:
           pattern: '^[0-9]{1,5}$'
       resourcesManagement:
         description: |
-          Настройки управления ресурсами sidecar-контейнера Istio.
+          Управляет ресурсами sidecar-контейнера Istio.
 
           **Внимание!** Настройка применяется только для новых Pod'ов с `istio-proxy`.
         properties:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -125,7 +125,7 @@ properties:
         items:
           type: string
           pattern: '^[0-9]{1,5}$'
-      resourceManagement:
+      resourcesManagement:
         description: |
           Настройки управления ресурсами istio-sidecar.
 
@@ -185,7 +185,7 @@ properties:
           Опциональные tolerations для компонента istiod. Структура, аналогичная  `spec.tolerations` в Kubernetes Pod.
 
           Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
-      resourceManagement:
+      resourcesManagement:
         description: |
           Настройки управления ресурсами istiod.
         properties:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -127,9 +127,9 @@ properties:
           pattern: '^[0-9]{1,5}$'
       resourcesManagement:
         description: |
-          Настройки управления ресурсами istio-sidecar.
+          Настройки управления ресурсами sidecar-контейнера Istio.
 
-          **Внимание!** Настройка применяется только для новых pods с istio-proxy.
+          **Внимание!** Настройка применяется только для новых Pod'ов с `istio-proxy`.
         properties:
           mode:
           static:

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -140,12 +140,12 @@ spec:
       proxy:
         image: {{ include "helm_lib_module_image" (list $ (printf "proxyv2%s" $imageSuffix )) }}
         clusterDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
-        {{- if $.Values.istio.sidecar.resourcesManagement }}
+  {{- if $.Values.istio.sidecar.resourcesManagement }}
         resources:
-          {{ include "helm_lib_resources_management_original_pod_resources" $.Values.istio.sidecar.resourcesManagement | nindent 10 }}
-        {{- else }}
+          {{- include "helm_lib_resources_management_original_pod_resources" $.Values.istio.sidecar.resourcesManagement | nindent 10 }}
+  {{- else }}
         resources: {}
-        {{- end }}
+  {{- end }}
         logLevel: warning
         componentLogLevel: "misc:error"
         includeIPRanges:      {{ $.Values.istio.sidecar.includeOutboundIPRanges | default list "0.0.0.0/0" | join "," | quote }}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -140,12 +140,12 @@ spec:
       proxy:
         image: {{ include "helm_lib_module_image" (list $ (printf "proxyv2%s" $imageSuffix )) }}
         clusterDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
-{{-     if $.Values.istio.sidecar.resourcesManagement }}
+        {{- if $.Values.istio.sidecar.resourcesManagement }}
         resources:
-{{ include "helm_lib_resources_management_original_pod_resources" $.Values.istio.sidecar.resourcesManagement | nindent 10 }}
-{{-     else }}
+          {{ include "helm_lib_resources_management_original_pod_resources" $.Values.istio.sidecar.resourcesManagement | nindent 10 }}
+        {{- else }}
         resources: {}
-{{-     end }}
+        {{- end }}
         logLevel: warning
         componentLogLevel: "misc:error"
         includeIPRanges:      {{ $.Values.istio.sidecar.includeOutboundIPRanges | default list "0.0.0.0/0" | join "," | quote }}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -140,7 +140,8 @@ spec:
       proxy:
         image: {{ include "helm_lib_module_image" (list $ (printf "proxyv2%s" $imageSuffix )) }}
         clusterDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
-        resources: {}
+        resources:
+{{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.sidecar.resourcesManagement "1Mi") | nindent 10 }}
         logLevel: warning
         componentLogLevel: "misc:error"
         includeIPRanges:      {{ $.Values.istio.sidecar.includeOutboundIPRanges | default list "0.0.0.0/0" | join "," | quote }}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -140,8 +140,12 @@ spec:
       proxy:
         image: {{ include "helm_lib_module_image" (list $ (printf "proxyv2%s" $imageSuffix )) }}
         clusterDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
+{{-     if $.Values.istio.sidecar.resourcesManagement }}
         resources:
-{{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.sidecar.resourcesManagement "1Mi") | nindent 10 }}
+{{ include "helm_lib_resources_management_original_pod_resources" $.Values.istio.sidecar.resourcesManagement | nindent 10 }}
+{{-     else }}
+        resources: {}
+{{-     end }}
         logLevel: warning
         componentLogLevel: "misc:error"
         includeIPRanges:      {{ $.Values.istio.sidecar.includeOutboundIPRanges | default list "0.0.0.0/0" | join "," | quote }}


### PR DESCRIPTION
## Description
Added a way to globally override resources for `istio-proxy`.

Ref: #4710

## Why do we need it, and what problem does it solve?
In large clusters, 1Gi of memory is not enough. it is too time consuming and impractical to set each Pods.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: feature
summary: Added a way to globally override resources for `istio-proxy`.
impact_level: default
```
