### PR TITLE
[docs] Fix the module comparison table in the documentation

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -488,6 +488,7 @@ entries:
     - title:
         en: Delivery
         ru: Доставка
+      modulename: delivery
       d8Revision: ee
       folders:
         - title:
@@ -937,6 +938,7 @@ entries:
         - title:
             en: Audit
             ru: Аудит
+          moduleName: runtime-audit-engine
           d8Revision: ee
           featureStatus: experimental
           folders:

--- a/docs/documentation/_plugins/custom_hooks.rb
+++ b/docs/documentation/_plugins/custom_hooks.rb
@@ -3,7 +3,13 @@ require 'json'
 def parse_module_data(input, site)
     if input.has_key?("featureStatus")
        featureStatus = input["featureStatus"]
-       moduleName = input["title"]
+       if input.has_key?("moduleName")
+         moduleName = input["moduleName"]
+       elsif input["title"].is_a?(Hash) && input["title"].has_key?('en')
+         moduleName = input["title"]['en']
+       else
+         moduleName = input["title"]
+       end
        if ! site.data["modulesFeatureStatus"]
           site.data["modulesFeatureStatus"] = {}
        end


### PR DESCRIPTION
## Description
Fix the module comparison table in the documentation: the experimental badge did show if a module had a special title.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix the module comparison table in the documentation.
impact_level: low
```
