### PR TITLE
[monitoring-kubernetes] Fix kubelet-eviction-thresholds-exporter

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-disk-usage.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-disk-usage.yaml
@@ -3,9 +3,9 @@
     - alert: KubeletNodeFSInodesUsage
       expr: |
         (
-          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) >
+          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) * 100 <
           max by (node, mountpoint) (kubelet_eviction_nodefs_inodes{type="soft"})
-        ) * 100
+        )
       for: 10m
       labels:
         severity_level: "9"
@@ -26,9 +26,9 @@
     - alert: KubeletNodeFSInodesUsage
       expr: |
         (
-          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) >
-          max by (node, mountpoint) (kubelet_eviction_nodefs_inodes{type="hard"} - 5)
-        ) * 100
+          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) * 100 <
+          max by (node, mountpoint) (kubelet_eviction_nodefs_inodes{type="hard"} + 5)
+        )
       for: 5m
       labels:
         severity_level: "7"
@@ -50,9 +50,9 @@
     - alert: KubeletNodeFSInodesUsage
       expr: |
         (
-          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) >
+          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) * 100 <
           max by (node, mountpoint) (kubelet_eviction_nodefs_inodes{type="hard"})
-        ) * 100
+        )
       labels:
         severity_level: "6"
         tier: cluster
@@ -90,9 +90,9 @@
     - alert: KubeletImageFSInodesUsage
       expr: |
         (
-          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) >
+          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) * 100 <
           max by (node, mountpoint) (kubelet_eviction_imagefs_inodes{type="soft"})
-        ) * 100
+        )
       for: 10m
       labels:
         severity_level: "9"
@@ -113,9 +113,9 @@
     - alert: KubeletImageFSInodesUsage
       expr: |
         (
-          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) >
-          max by (node, mountpoint) (kubelet_eviction_imagefs_inodes{type="hard"} - 5)
-        ) * 100
+          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) * 100 <
+          max by (node, mountpoint) (kubelet_eviction_imagefs_inodes{type="hard"} + 5)
+        )
       for: 5m
       labels:
         severity_level: "7"
@@ -136,9 +136,9 @@
     - alert: KubeletImageFSInodesUsage
       expr: |
         (
-          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) >
+          max by (node, mountpoint) (node_filesystem_files_free / node_filesystem_files) * 100 <
           max by (node, mountpoint) (kubelet_eviction_imagefs_inodes{type="hard"})
-        ) * 100
+        )
       labels:
         severity_level: "6"
         tier: cluster
@@ -178,7 +178,7 @@
     - alert: KubeletNodeFSBytesUsage
       expr: |
         (
-          max by (node, mountpoint) ((node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes) * 100 >
+          max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 <
           max by (node, mountpoint) (kubelet_eviction_nodefs_bytes{type="soft"})
         )
       for: 10m
@@ -201,8 +201,8 @@
     - alert: KubeletNodeFSBytesUsage
       expr: |
         (
-          max by (node, mountpoint) ((node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes) * 100 >
-          max by (node, mountpoint) (kubelet_eviction_nodefs_bytes{type="hard"} - 5)
+          max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 <
+          max by (node, mountpoint) (kubelet_eviction_nodefs_bytes{type="hard"} + 5)
         )
       for: 5m
       labels:
@@ -224,7 +224,7 @@
     - alert: KubeletNodeFSBytesUsage
       expr: |
         (
-          max by (node, mountpoint) ((node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes) * 100 >
+          max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 <
           max by (node, mountpoint) (kubelet_eviction_nodefs_bytes{type="hard"})
         )
       labels:
@@ -264,7 +264,7 @@
     - alert: KubeletImageFSBytesUsage
       expr: |
         (
-          max by (node, mountpoint) ((node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes) * 100 >
+          max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 <
           max by (node, mountpoint) (kubelet_eviction_imagefs_bytes{type="soft"})
         )
       for: 10m
@@ -287,8 +287,8 @@
     - alert: KubeletImageFSBytesUsage
       expr: |
         (
-          max by (node, mountpoint) ((node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes) * 100 >
-          max by (node, mountpoint) (kubelet_eviction_imagefs_bytes{type="hard"} - 5)
+          max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 <
+          max by (node, mountpoint) (kubelet_eviction_imagefs_bytes{type="hard"} + 5)
         )
       for: 5m
       labels:
@@ -310,7 +310,7 @@
     - alert: KubeletImageFSBytesUsage
       expr: |
         (
-          max by (node, mountpoint) ((node_filesystem_size_bytes - node_filesystem_avail_bytes) / node_filesystem_size_bytes) * 100 >
+          max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes) * 100 <
           max by (node, mountpoint) (kubelet_eviction_imagefs_bytes{type="hard"})
         )
       labels:


### PR DESCRIPTION
## Description
 - Fix eviction threshold percent extraction for the case when they are specified in the kubelet configuration as bytes.
 - Fix conditions in `node-disk-usage` prometheus rules

## Why do we need it, and what problem does it solve?
After refactoring of `kubelet-eviction-thresholds-exporter` metric `kubelet_eviction_nodefs_bytes` started returning eviction threshold percent `as-is` (before refactoring it was 100%-eviction threshold).

Conditions in prometheus rules must satisfy the changes that have been made with the metric values.

Some conditions were initially incorrect (the multiplication operation by 100 to calculate percentages was performed in the wrong place).

Another problem is that the metric uses `root-dir` kubelet as the `mountpoint`, and not the mountpoint of this folder.

If the cluster node has only one mountpoint, then in all conditions where operations with vectors are performed, the metrics node_filesystem_* and kubelet_eviction_* there will be no matching mountpoint label.

## What is the expected result?
  - Prometheus metrics `kubelet_eviction_*` must contains correct `mountpoint` labels.
  - Prometheus rules `node-disk-usage` must contains correct conditions

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes
type: fix
summary: Fix kubelet-eviction-thresholds-exporter prometheus metric and node-disk-usage prometheus rules
```