### PR TITLE
[ingress-nginx] Added Custom annotations and labels

### DIFF
--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -1,11 +1,35 @@
 spec:
   versions:
     - name: v1alpha1
-      schema:
+      schema: &schema
         openAPIV3Schema:
           properties:
             spec:
-              properties: &properties
+              properties:
+                annotations:
+                  description: |
+                    Пользовательские аннотации для DaemonSet Ingress Controller.
+
+                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                labels:
+                  description: |
+                    Пользовательские лэйблы для DaemonSet Ingress Controller.
+
+                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                pods:
+                  description: |
+                    Раздел параметров pods, создаваемых DaemonSet Ingress Controller.
+                  properties:
+                    annotations:
+                      description: |
+                        Пользовательские аннотации для стручков DaemonSet Ingress Controlle.
+
+                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                    labels:
+                      description: |
+                        Пользовательские лэйблы для стручков DaemonSet Ingress Controlle.
+
+                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
                 ingressClass:
                   description: |
                     Имя Ingress-класса для обслуживания Ingress NGINX controller.
@@ -304,33 +328,4 @@ spec:
     - name: v1
       served: true
       storage: false
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              properties:
-                <<: *properties
-                annotations:
-                  description: |
-                    Пользовательские аннотации для DaemonSet Ingress Controller.
-
-                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
-                labels:
-                  description: |
-                    Пользовательские лэйблы для DaemonSet Ingress Controller.
-
-                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
-                pods:
-                  description: |
-                    Раздел параметров pods, создаваемых DaemonSet Ingress Controller.
-                  properties:
-                    annotations:
-                      description: |
-                        Пользовательские аннотации для стручков DaemonSet Ingress Controlle.
-
-                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
-                    labels:
-                      description: |
-                        Пользовательские лэйблы для стручков DaemonSet Ingress Controlle.
-
-                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
+      schema: *schema

--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -1,35 +1,11 @@
 spec:
   versions:
     - name: v1alpha1
-      schema: &schema
+      schema:
         openAPIV3Schema:
           properties:
             spec:
-              properties:
-                annotations:
-                  description: |
-                    Пользовательские аннотации для DaemonSet Ingress Controller.
-
-                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
-                labels:
-                  description: |
-                    Пользовательские лэйблы для DaemonSet Ingress Controller.
-
-                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
-                pods:
-                  description: |
-                    Раздел параметров pods, создаваемых DaemonSet Ingress Controller.
-                  properties:
-                    annotations:
-                      description: |
-                        Пользовательские аннотации для стручков DaemonSet Ingress Controlle.
-
-                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
-                    labels:
-                      description: |
-                        Пользовательские лэйблы для стручков DaemonSet Ingress Controlle.
-
-                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
+              properties: &properties
                 ingressClass:
                   description: |
                     Имя Ingress-класса для обслуживания Ingress NGINX controller.
@@ -328,4 +304,33 @@ spec:
     - name: v1
       served: true
       storage: false
-      schema: *schema
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                <<: *properties
+                annotations:
+                  description: |
+                    Пользовательские аннотации для DaemonSet Ingress Controller.
+
+                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                labels:
+                  description: |
+                    Пользовательские лэйблы для DaemonSet Ingress Controller.
+
+                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                pods:
+                  description: |
+                    Раздел параметров pods, создаваемых DaemonSet Ingress Controller.
+                  properties:
+                    annotations:
+                      description: |
+                        Пользовательские аннотации для стручков DaemonSet Ingress Controlle.
+
+                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                    labels:
+                      description: |
+                        Пользовательские лэйблы для стручков DaemonSet Ingress Controlle.
+
+                        **Внимание!** Вы несете полную ответственность за применение этих параметров.

--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -1,11 +1,11 @@
 spec:
   versions:
     - name: v1alpha1
-      schema: &schema
+      schema:
         openAPIV3Schema:
           properties:
             spec:
-              properties:
+              properties: &properties
                 ingressClass:
                   description: |
                     Имя Ingress-класса для обслуживания Ingress NGINX controller.
@@ -304,4 +304,33 @@ spec:
     - name: v1
       served: true
       storage: false
-      schema: *schema
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                <<: *properties
+                annotations:
+                  description: |
+                    Пользовательские аннотации для DaemonSet Ingress Controller.
+
+                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                labels:
+                  description: |
+                    Пользовательские лэйблы для DaemonSet Ingress Controller.
+
+                    **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                pods:
+                  description: |
+                    Раздел параметров pods, создаваемых DaemonSet Ingress Controller.
+                  properties:
+                    annotations:
+                      description: |
+                        Пользовательские аннотации для стручков DaemonSet Ingress Controlle.
+
+                        **Внимание!** Вы несете полную ответственность за применение этих параметров.
+                    labels:
+                      description: |
+                        Пользовательские лэйблы для стручков DaemonSet Ingress Controlle.
+
+                        **Внимание!** Вы несете полную ответственность за применение этих параметров.

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -17,7 +17,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      schema: &schema
+      schema:
         openAPIV3Schema:
           type: object
           required: ['spec']
@@ -25,7 +25,7 @@ spec:
             spec:
               type: object
               required: ['ingressClass', 'inlet']
-              properties:
+              properties: &properties
                 ingressClass:
                   type: string
                   description: |
@@ -533,5 +533,56 @@ spec:
     - name: v1
       served: true
       storage: true
-      schema: *schema
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ['spec']
+          properties:
+            spec:
+              type: object
+              required: ['ingressClass', 'inlet']
+              properties:
+                <<: *properties
+                annotations:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    Custom annotations for DaemonSet Ingress Controller.
+
+                    **Caution!** You are solely responsible for applying these parameters.
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    Custom labels for DaemonSet Ingress Controller.
+
+                    **Caution!** You are solely responsible for applying these parameters.
+                  additionalProperties:
+                    type: string
+                pods:
+                  type: object
+                  x-doc-required: false
+                  description: |
+                    A section of parameters of the pods that are created by DaemonSet Ingress Controller.
+                  properties:
+                    annotations:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Custom annotations for pods of DaemonSet Controller configuration.
+
+                        **Caution!** You are solely responsible for applying these parameters.
+                      additionalProperties:
+                        type: string
+                    labels:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Custom labels for pods of DaemonSet Controller configuration.
+
+                        **Caution!** You are solely responsible for applying these parameters.
+                      additionalProperties:
+                        type: string
       additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -17,7 +17,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      schema: &schema
+      schema:
         openAPIV3Schema:
           type: object
           required: ['spec']
@@ -25,49 +25,7 @@ spec:
             spec:
               type: object
               required: ['ingressClass', 'inlet']
-              properties:
-                annotations:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                  description: |
-                    Custom annotations for DaemonSet Ingress Controller.
-
-                    **Caution!** You are solely responsible for applying these parameters.
-                  additionalProperties:
-                    type: string
-                labels:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                  description: |
-                    Custom labels for DaemonSet Ingress Controller.
-
-                    **Caution!** You are solely responsible for applying these parameters.
-                  additionalProperties:
-                    type: string
-                pods:
-                  type: object
-                  x-doc-required: false
-                  description: |
-                    A section of parameters of the pods that are created by DaemonSet Ingress Controller.
-                  properties:
-                    annotations:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                      description: |
-                        Custom annotations for pods of DaemonSet Controller configuration.
-
-                        **Caution!** You are solely responsible for applying these parameters.
-                      additionalProperties:
-                        type: string
-                    labels:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                      description: |
-                        Custom labels for pods of DaemonSet Controller configuration.
-
-                        **Caution!** You are solely responsible for applying these parameters.
-                      additionalProperties:
-                        type: string
+              properties: &properties
                 ingressClass:
                   type: string
                   description: |
@@ -575,5 +533,56 @@ spec:
     - name: v1
       served: true
       storage: true
-      schema: *schema
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ['spec']
+          properties:
+            spec:
+              type: object
+              required: ['ingressClass', 'inlet']
+              properties:
+                <<: *properties
+                annotations:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    Custom annotations for DaemonSet Ingress Controller.
+
+                    **Caution!** You are solely responsible for applying these parameters.
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    Custom labels for DaemonSet Ingress Controller.
+
+                    **Caution!** You are solely responsible for applying these parameters.
+                  additionalProperties:
+                    type: string
+                pods:
+                  type: object
+                  x-doc-required: false
+                  description: |
+                    A section of parameters of the pods that are created by DaemonSet Ingress Controller.
+                  properties:
+                    annotations:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Custom annotations for pods of DaemonSet Controller configuration.
+
+                        **Caution!** You are solely responsible for applying these parameters.
+                      additionalProperties:
+                        type: string
+                    labels:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Custom labels for pods of DaemonSet Controller configuration.
+
+                        **Caution!** You are solely responsible for applying these parameters.
+                      additionalProperties:
+                        type: string
       additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -17,7 +17,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      schema:
+      schema: &schema
         openAPIV3Schema:
           type: object
           required: ['spec']
@@ -25,7 +25,49 @@ spec:
             spec:
               type: object
               required: ['ingressClass', 'inlet']
-              properties: &properties
+              properties:
+                annotations:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    Custom annotations for DaemonSet Ingress Controller.
+
+                    **Caution!** You are solely responsible for applying these parameters.
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    Custom labels for DaemonSet Ingress Controller.
+
+                    **Caution!** You are solely responsible for applying these parameters.
+                  additionalProperties:
+                    type: string
+                pods:
+                  type: object
+                  x-doc-required: false
+                  description: |
+                    A section of parameters of the pods that are created by DaemonSet Ingress Controller.
+                  properties:
+                    annotations:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Custom annotations for pods of DaemonSet Controller configuration.
+
+                        **Caution!** You are solely responsible for applying these parameters.
+                      additionalProperties:
+                        type: string
+                    labels:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Custom labels for pods of DaemonSet Controller configuration.
+
+                        **Caution!** You are solely responsible for applying these parameters.
+                      additionalProperties:
+                        type: string
                 ingressClass:
                   type: string
                   description: |
@@ -533,56 +575,5 @@ spec:
     - name: v1
       served: true
       storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          required: ['spec']
-          properties:
-            spec:
-              type: object
-              required: ['ingressClass', 'inlet']
-              properties:
-                <<: *properties
-                annotations:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                  description: |
-                    Custom annotations for DaemonSet Ingress Controller.
-
-                    **Caution!** You are solely responsible for applying these parameters.
-                  additionalProperties:
-                    type: string
-                labels:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                  description: |
-                    Custom labels for DaemonSet Ingress Controller.
-
-                    **Caution!** You are solely responsible for applying these parameters.
-                  additionalProperties:
-                    type: string
-                pods:
-                  type: object
-                  x-doc-required: false
-                  description: |
-                    A section of parameters of the pods that are created by DaemonSet Ingress Controller.
-                  properties:
-                    annotations:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                      description: |
-                        Custom annotations for pods of DaemonSet Controller configuration.
-
-                        **Caution!** You are solely responsible for applying these parameters.
-                      additionalProperties:
-                        type: string
-                    labels:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                      description: |
-                        Custom labels for pods of DaemonSet Controller configuration.
-
-                        **Caution!** You are solely responsible for applying these parameters.
-                      additionalProperties:
-                        type: string
+      schema: *schema
       additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/402-ingress-nginx/openapi/values.yaml
+++ b/modules/402-ingress-nginx/openapi/values.yaml
@@ -66,6 +66,21 @@ properties:
                 - ingressClass
                 - inlet
               properties:
+                annotations:
+                  type: object
+                  additionalProperties: true
+                labels:
+                  type: object
+                  additionalProperties: true
+                pods:
+                  type: object
+                  properties:
+                    annotations:
+                      type: object
+                      additionalProperties: true
+                    labels:
+                      type: object
+                      additionalProperties: true
                 ingressClass:
                   type: string
                   x-examples: ["nginx"]

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -167,6 +167,13 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
         test: "pA"
       labels:
         test: "pL"
+- name: al-istio
+  spec:
+    enableIstioSidecar: true
+    controllerVersion: "1.1"
+    inlet: LoadBalancer
+    labels:
+      test: "L"
 `)
 			hec.HelmRender()
 		})
@@ -320,6 +327,12 @@ memory: 500Mi`))
 				"spec.template.metadata.annotations")).To(MatchJSON(`{ "test":"pA"}`))
 			Expect(hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-al").Field(
 				"spec.template.metadata.labels")).To(MatchJSON(`{"app": "controller","name": "al", "test": "pL" }`))
+			Expect(hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-al-istio").Field("metadata.annotations")).To(MatchJSON(
+				`{ "ingress-nginx-controller.deckhouse.io/checksum": "ffd682214c936faae5ea7769021320b9116efce201d5118f8d211f1df479718a",
+                        "ingress-nginx-controller.deckhouse.io/controller-version": "1.1",
+						"ingress-nginx-controller.deckhouse.io/inlet": "LoadBalancer" }`))
+			Expect(hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-al-istio").Field("metadata.labels")).To(MatchJSON(
+				`{ "app": "controller", "heritage": "deckhouse", "module": "ingress-nginx", "name": "al-istio", "test":"L"}`))
 		})
 
 		Context("Vertical pod autoscaler CRD is disabled", func() {

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -146,7 +146,7 @@ spec:
 {{-     range $key, $value := $crd.spec.pods.annotations }}
         {{ $key }}: {{ $value | quote }}
 {{-     end }}
-{{-     end }}
+{{-   end }}
     spec:
   {{- if $crd.spec.nodeSelector }}
       nodeSelector:

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -137,7 +137,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
 {{-       end }}
 {{-     end }}
-{{-   if $crd.spec.enableIstioSidecar or $crd.spec.pods }}
+{{-   if or $crd.spec.enableIstioSidecar $crd.spec.pods }}
       annotations:
 {{-     if $crd.spec.enableIstioSidecar }}
         traffic.sidecar.istio.io/includeInboundPorts: ""

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -80,10 +80,16 @@ metadata:
     ingress-nginx-failover: ""
     {{- end }}
   {{- end }}
+  {{- range $key, $value := $crd.spec.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   annotations:
     ingress-nginx-controller.deckhouse.io/controller-version: {{ $controllerVersion | quote }}
     ingress-nginx-controller.deckhouse.io/inlet: {{ $crd.spec.inlet | quote }}
     ingress-nginx-controller.deckhouse.io/checksum: {{ $crdChecksum }}
+{{- range $key, $value := $crd.spec.annotations }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
 spec:
   revisionHistoryLimit: 3
   {{- if $loadBalancer }}
@@ -126,11 +132,21 @@ spec:
       {{- end }}
         app: controller
         name: {{ $name }}
-      {{- if $crd.spec.enableIstioSidecar }}
+{{-     if $crd.spec.pods }}
+{{-       range $key, $value := $crd.spec.pods.labels }}
+        {{ $key }}: {{ $value | quote }}
+{{-       end }}
+{{-     end }}
+{{-   if $crd.spec.enableIstioSidecar or $crd.spec.pods }}
       annotations:
+{{-     if $crd.spec.enableIstioSidecar }}
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $context.Values.global.discovery.serviceSubnet | quote }}
-      {{- end }}
+{{-     end }}
+{{-     range $key, $value := $crd.spec.pods.annotations }}
+        {{ $key }}: {{ $value | quote }}
+{{-     end }}
+{{-     end }}
     spec:
   {{- if $crd.spec.nodeSelector }}
       nodeSelector:

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -143,7 +143,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $context.Values.global.discovery.serviceSubnet | quote }}
 {{-     end }}
-{{-     if $crd.spec.pods.annotations }}
+{{-     if $crd.spec.pods }}
 {{-       range $key, $value := $crd.spec.pods.annotations }}
         {{ $key }}: {{ $value | quote }}
 {{-       end }}

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -143,8 +143,10 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $context.Values.global.discovery.serviceSubnet | quote }}
 {{-     end }}
-{{-     range $key, $value := $crd.spec.pods.annotations }}
+{{-     if $crd.spec.pods.annotations }}
+{{-       range $key, $value := $crd.spec.pods.annotations }}
         {{ $key }}: {{ $value | quote }}
+{{-       end }}
 {{-     end }}
 {{-   end }}
     spec:


### PR DESCRIPTION
## Description
Adds fields to the crd to control annotations and labels
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
https://github.com/deckhouse/deckhouse/issues/4712
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: feature
summary: Adds fields to the crd to control annotations and labels.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
