### PR TITLE
cli hubble, incorrect socket address

### DIFF
--- a/modules/021-cni-cilium/images/cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/cilium/werf.inc.yaml
@@ -64,7 +64,7 @@ shell:
   - rm -rf /go
 docker:
   ENV:
-    HUBBLE_SERVER: "unix:///var/run/cilium/hubble:sock"
+    HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
     INITSYSTEM: SYSTEMD
     HUBBLE_COMPAT: legacy-json-output
   WORKDIR: "/home/cilium"


### PR DESCRIPTION
## Description

hubble, correct socket address

## Why do we need it, and what problem does it solve?

> hubble observe

```log
failed to connect to 'unix:///var/run/cilium/hubble:sock': connection error: desc = "transport: error while dialing: dial unix /var/run/cilium/hubble:sock: connect: no such file or directory"
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
run `hubble observe` in pod cilium-agent

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix 
summary: cli hubble, incorrect socket address
impact_level: low
```
