### PR TITLE
[deckhouse-controller] Move `tools/change-registry.sh` to `deckhouse-controller`

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -51,7 +51,7 @@ const (
 )
 
 func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTag string, insecure bool) error {
-	ctx := context.TODO()
+	ctx := context.Background()
 	logEntry := log.WithField("operator.component", "ChangeRegistry")
 
 	nameOpts := newNameOptions(insecure)

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -28,13 +28,12 @@ import (
 	"path"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	authchallenge "github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -353,19 +353,15 @@ func checkBearerSupport(ctx context.Context, reg name.Registry) error {
 		if challenges := authchallenge.ResponseChallenges(resp); len(challenges) != 0 {
 			// If we hit more than one, I'm not even sure what to do.
 			wac := challenges[0]
-			if toChallenge(wac.Scheme) == bearer {
+			if strings.ToLower(wac.Scheme) == bearer {
 				return nil
 			}
 		}
-		if toChallenge(resp.Header.Get(wwwAuthHeader)) == bearer {
+		if strings.ToLower(resp.Header.Get(wwwAuthHeader)) == bearer {
 			return nil
 		}
 		return fmt.Errorf("can't use bearer token auth with registry %s", reg.Name())
 	}
 
 	return errors.New(strings.Join(errs, "; "))
-}
-
-func toChallenge(s string) string {
-	return strings.ToLower(s)
 }

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -256,7 +256,7 @@ func updateDeployment(ctx context.Context, kubeCl kclient.KubeClient, deploy *ap
 	return nil
 }
 
-func updateImageRepoForContainers(containers []v1.Container, newRepository string, nameOpts []name.Option, remoteOpts []remote.Option, newTagsForContainer map[string]string /* map[<container name>]>newTag> */) ([]v1.Container, error) {
+func updateImageRepoForContainers(containers []v1.Container, newRepository string, nameOpts []name.Option, remoteOpts []remote.Option, newTagsForContainer map[string]string /* map[<container name>]<newTag> */) ([]v1.Container, error) {
 	for i, container := range containers {
 		oldImage, err := name.ParseReference(container.Image)
 		if err != nil {

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -1,0 +1,372 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changeregistry
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	authchallenge "github.com/docker/distribution/registry/client/auth/challenge"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kclient "github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+)
+
+// TODO (alex123012): Use new methods in transport package for getting bearer token:
+// in the PR https://github.com/google/go-containerregistry/pull/1709
+// some methods became public and we can use them except of copying the source code.
+// (waiting for new "go-containerregistry" version)
+
+const (
+	d8SystemNS = "d8-system"
+)
+
+func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTag string, insecure bool) error {
+	ctx := context.TODO()
+	logEntry := log.WithField("operator.component", "ChangeRegistry")
+
+	nameOpts := newNameOptions(insecure)
+	newRepo, err := name.NewRepository(newRegistry, nameOpts...)
+	if err != nil {
+		return err
+	}
+
+	if err := checkBearerSupport(ctx, newRepo.Registry); err != nil {
+		return err
+	}
+
+	authConfig := newAuthConfig(username, password)
+
+	remoteOpts, err := newRemoteOptions(ctx, newRepo, authConfig)
+	if err != nil {
+		return err
+	}
+
+	kubeCl, err := newKubeClient()
+	if err != nil {
+		return err
+	}
+
+	logEntry.Println("Retrieving deckhouse deployment...")
+	deckhouseDeploy, err := deckhouseDeployment(ctx, kubeCl)
+	if err != nil {
+		return err
+	}
+
+	// Check that all images for deckhouse deploy exist in the new repo before
+	// updating image pull secret and prepare deployment with updated images.
+	if err := updateDeployContainersImagesToNewRepo(deckhouseDeploy, newRepo, nameOpts, remoteOpts, newDeckhouseImageTag); err != nil {
+		return err
+	}
+
+	imagePullSecretData, err := newImagePullSecretData(newRepo, authConfig, caFile)
+	if err != nil {
+		return err
+	}
+
+	logEntry.Println("Updating deckhouse image pull secret...")
+	if err := updateImagePullSecret(ctx, kubeCl, imagePullSecretData); err != nil {
+		return err
+	}
+
+	logEntry.Println("Updating deckhouse deployment...")
+	if err := updateDeployment(ctx, kubeCl, deckhouseDeploy); err != nil {
+		return err
+	}
+
+	logEntry.Println("Done")
+	return nil
+}
+
+func newAuthConfig(username, password string) authn.AuthConfig {
+	var cfg authn.AuthConfig
+	if username != "" && password != "" {
+		cfg = authn.AuthConfig{
+			Username: username,
+			Password: password,
+			Auth:     base64.StdEncoding.EncodeToString([]byte(username + ":" + password)),
+		}
+	}
+	return cfg
+}
+
+func newRemoteOptions(ctx context.Context, repo name.Repository, authConfig authn.AuthConfig) ([]remote.Option, error) {
+	var opts []remote.Option
+
+	transportOpt, err := newTransportOption(ctx, repo, authConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, transportOpt)
+	return opts, nil
+}
+
+func newNameOptions(insecure bool) []name.Option {
+	opts := []name.Option{name.StrictValidation}
+	if insecure {
+		opts = append(opts, name.Insecure)
+	}
+	return opts
+}
+
+func newTransportOption(ctx context.Context, repo name.Repository, authConfig authn.AuthConfig) (remote.Option, error) {
+	authorizer := authn.FromConfig(authConfig)
+
+	scopes := []string{repo.Scope(transport.PullScope)}
+	t, err := transport.NewWithContext(ctx, repo.Registry, authorizer, http.DefaultTransport, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return remote.WithTransport(t), nil
+}
+
+func newKubeClient() (kclient.KubeClient, error) {
+	kubeCl := kclient.NewKubernetesClient()
+	if err := kubeCl.Init(kclient.AppKubernetesInitParams()); err != nil {
+		return nil, err
+	}
+	return kubeCl.KubeClient, nil
+}
+
+func updateImagePullSecret(ctx context.Context, kubeCl kclient.KubeClient, newSecretData map[string]string) error {
+	secretClient := kubeCl.CoreV1().Secrets(d8SystemNS)
+	deckhouseRegSecret, err := secretClient.Get(ctx, "deckhouse-registry", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	deckhouseRegSecret.StringData = newSecretData
+
+	updateOpts := metav1.UpdateOptions{FieldValidation: metav1.FieldValidationStrict}
+	if _, err := secretClient.Update(ctx, deckhouseRegSecret, updateOpts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newImagePullSecretData(newRepo name.Repository, authConfig authn.AuthConfig, caFile string) (map[string]string, error) {
+	authConfBytes, err := json.Marshal(
+		map[string]map[string]authn.AuthConfig{
+			"auths": {
+				newRepo.RegistryStr(): authn.AuthConfig{Auth: authConfig.Auth},
+			},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	newSecretData := map[string]string{
+		".dockerconfigjson": string(authConfBytes),
+		"address":           newRepo.RegistryStr(),
+		"path":              path.Join("/", newRepo.RepositoryStr()),
+		"scheme":            newRepo.Scheme(),
+	}
+
+	if caFile != "" {
+		ca, err := getCAContent(caFile)
+		if err != nil {
+			return nil, err
+		}
+		newSecretData["ca"] = ca
+	}
+	return newSecretData, nil
+}
+
+func getCAContent(caFile string) (string, error) {
+	caBytes, err := os.ReadFile(caFile)
+	if err != nil {
+		return "", err
+	}
+
+	keyBlock, _ := pem.Decode(caBytes)
+	if keyBlock == nil {
+		return "", errors.New("can't read CA file content as pem file")
+	}
+
+	// Check that file content is a certificate
+	if _, err := x509.ParseCertificate(keyBlock.Bytes); err != nil {
+		return "", err
+	}
+	return strings.Trim(string(caBytes), "\n "), nil
+}
+
+func deckhouseDeployment(ctx context.Context, kubeCl kclient.KubeClient) (*appsv1.Deployment, error) {
+	deployClient := kubeCl.AppsV1().Deployments(d8SystemNS)
+	return deployClient.Get(ctx, "deckhouse", metav1.GetOptions{})
+}
+
+func updateDeployContainersImagesToNewRepo(deploy *appsv1.Deployment, newRepo name.Repository, nameOpts []name.Option, remoteOpts []remote.Option, newDeckhouseTag string) error {
+	newInitContainers, err := updateImageRepoForContainers(deploy.Spec.Template.Spec.InitContainers, newRepo.Name(), nameOpts, remoteOpts, nil)
+	if err != nil {
+		return err
+	}
+	deploy.Spec.Template.Spec.InitContainers = newInitContainers
+
+	newImageForDeckhouseContainer := make(map[string]string)
+	if newDeckhouseTag != "" {
+		newImageForDeckhouseContainer["deckhouse"] = newDeckhouseTag
+	}
+
+	newContainers, err := updateImageRepoForContainers(deploy.Spec.Template.Spec.Containers, newRepo.Name(), nameOpts, remoteOpts, newImageForDeckhouseContainer)
+	if err != nil {
+		return err
+	}
+	deploy.Spec.Template.Spec.Containers = newContainers
+
+	return nil
+}
+
+func updateDeployment(ctx context.Context, kubeCl kclient.KubeClient, deploy *appsv1.Deployment) error {
+	deployClient := kubeCl.AppsV1().Deployments(deploy.Namespace)
+	updateOpts := metav1.UpdateOptions{FieldValidation: metav1.FieldValidationStrict}
+	if _, err := deployClient.Update(ctx, deploy, updateOpts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateImageRepoForContainers(containers []v1.Container, newRepository string, nameOpts []name.Option, remoteOpts []remote.Option, newTagsForContainer map[string]string /* map[<container name>]>newTag> */) ([]v1.Container, error) {
+	for i, container := range containers {
+		oldImage, err := name.ParseReference(container.Image)
+		if err != nil {
+			return nil, err
+		}
+
+		tagOrDigestref := oldImage.Identifier()
+		if newTagsForContainer != nil {
+			if v, f := newTagsForContainer[container.Name]; f && v != "" {
+				tagOrDigestref = v
+			}
+		}
+
+		var delim string
+		switch oldImage.(type) {
+		case name.Digest:
+			delim = "@"
+		case name.Tag:
+			delim = ":"
+		}
+
+		newRef, err := name.ParseReference(newRepository+delim+tagOrDigestref, nameOpts...)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check that new reference exists in the new repo before applying changes.
+		if err := checkImageExists(newRef, remoteOpts); err != nil {
+			return nil, fmt.Errorf("\nimage '%s' doesn't exist: %w", newRef.Name(), err)
+		}
+
+		container.Image = newRef.Name()
+		containers[i] = container
+	}
+
+	return containers, nil
+}
+
+func checkImageExists(imageRef name.Reference, opts []remote.Option) error {
+	img, err := remote.Image(imageRef, opts...)
+	if err != nil {
+		return err
+	}
+
+	if _, err := img.Digest(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkBearerSupport func checks that registry accepts bearer token authentification.
+// This is modified "ping" func from
+// https://github.com/google/go-containerregistry/blob/v0.5.1/pkg/v1/remote/transport/ping.go
+func checkBearerSupport(ctx context.Context, reg name.Registry) error {
+	const (
+		bearer        = "bearer"
+		wwwAuthHeader = "WWW-Authenticate"
+	)
+
+	client := http.Client{Transport: http.DefaultTransport}
+
+	// This first attempts to use "https" for every request, falling back to http
+	// if the registry matches our localhost heuristic or if it is intentionally
+	// set to insecure via name.NewInsecureRegistry.
+	schemes := []string{"https"}
+	if reg.Scheme() == "http" {
+		schemes = append(schemes, "http")
+	}
+
+	var errs []string
+	for _, scheme := range schemes {
+		url := fmt.Sprintf("%s://%s/v2/", scheme, reg.Name())
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req.WithContext(ctx))
+		if err != nil {
+			errs = append(errs, err.Error())
+			// Potentially retry with http.
+			continue
+		}
+		defer func() {
+			// By draining the body, make sure to reuse the connection made by
+			// the ping for the following access to the registry
+			defer resp.Body.Close()
+			io.Copy(io.Discard, resp.Body)
+		}()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			return transport.CheckError(resp, http.StatusUnauthorized)
+		}
+
+		if challenges := authchallenge.ResponseChallenges(resp); len(challenges) != 0 {
+			// If we hit more than one, I'm not even sure what to do.
+			wac := challenges[0]
+			if toChallenge(wac.Scheme) == bearer {
+				return nil
+			}
+		}
+		if toChallenge(resp.Header.Get(wwwAuthHeader)) == bearer {
+			return nil
+		}
+		return fmt.Errorf("can't use bearer token auth with registry %s", reg.Name())
+	}
+
+	return errors.New(strings.Join(errs, "; "))
+}
+
+func toChallenge(s string) string {
+	return strings.ToLower(s)
+}

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -38,7 +38,7 @@ func DefineHelperCommands(kpApp *kingpin.Application) {
 
 	{
 		changeRegistryCommand := helpersCommand.Command("change-registry", "Change registry for deckhouse images.")
-		newRegistry := changeRegistryCommand.Arg("new-registry", "Registry that will be used for deckhouse images (example: registry.example.com/deckhouse).").Required().String()
+		newRegistry := changeRegistryCommand.Arg("new-registry", "Registry that will be used for deckhouse images (example: registry.deckhouse.io/deckhouse/ce). By default, https will be used, if you need http - provide '--insecure' flag").Required().String()
 
 		user := changeRegistryCommand.Flag("user", "User with pull access to registry.").String()
 		password := changeRegistryCommand.Flag("password", "Password/token for registry user.").String()

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -18,6 +18,7 @@ import (
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	"gopkg.in/alecthomas/kingpin.v2"
 
+	changeregistry "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers/change_registry"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers/jwt"
 	dhctlapp "github.com/deckhouse/deckhouse/dhctl/cmd/dhctl/commands"
 )
@@ -32,6 +33,22 @@ func DefineHelperCommands(kpApp *kingpin.Application) {
 		ttl := genJWTCommand.Flag("ttl", "TTL duration (ex. 10s).").Required().Duration()
 		genJWTCommand.Action(func(c *kingpin.ParseContext) error {
 			return jwt.GenJWT(*privateKeyPath, *claims, *ttl)
+		})
+	}
+
+	{
+		changeRegistryCommand := helpersCommand.Command("change-registry", "Change registry for deckhouse images.")
+		newRegistry := changeRegistryCommand.Arg("new-registry", "Registry that will be used for deckhouse images (example: registry.example.com/deckhouse).").Required().String()
+
+		user := changeRegistryCommand.Flag("user", "User with pull access to registry.").String()
+		password := changeRegistryCommand.Flag("password", "Password/token for registry user.").String()
+		caFile := changeRegistryCommand.Flag("ca-file", "Path to registry CA.").ExistingFile()
+
+		insecure := changeRegistryCommand.Flag("insecure", "Use HTTP while connecting to new registry.").Bool()
+
+		newImageTag := changeRegistryCommand.Flag("new-deckhouse-tag", "New tag that will be used for deckhouse deployment image (by default current tag from deckhouse deployment will be used).").String()
+		changeRegistryCommand.Action(func(c *kingpin.ParseContext) error {
+			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *insecure)
 		})
 	}
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -346,7 +346,21 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user my-user --password my-password registry.example.com/deckhouse
   ```
 
-  * If the registry uses a self-signed certificate, put the root CA certificate that validates the registry's HTTPS certificate to file `ca.crt` in the `deckhouse` Pod and add the `--ca-file ca.crt` option to the script.
+  * If the registry uses a self-signed certificate, put the root CA certificate that validates the registry's HTTPS certificate to file `ca.crt` in the `deckhouse` Pod and add the `--ca-file ca.crt` option to the script or put the content of CA into a variable.
+
+  ```shell
+  $ CA_CONTENT=$(cat <<EOF
+  -----BEGIN CERTIFICATE-----
+  CERTIFICATE
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  CERTIFICATE
+  -----END CERTIFICATE-----
+  EOF
+  )
+  $ kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password YUvio925tyxFNBnqhfcx89nABwcnTP1K registry.deckhouse.io/deckhou --ca-file <(cat <<<$CA_CONTENT)
+  ```
+
 * Wait for the Deckhouse Pod to become `Ready`. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
 * If you want to disable Deckhouse automatic updates, remove the `releaseChannel` parameter from the `deckhouse` module configuration.

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -339,14 +339,14 @@ proxy:
 
 To switch the Deckhouse cluster to using a third-party registry, follow these steps:
 
-* Run `deckhouse-controller helper change-registry` inside `Deckhouse` pod with the new registry settings.
+* Run `deckhouse-controller helper change-registry` inside the `deckhouse` Pod with the new registry settings.
   * Example:
 
   ```shell
   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user my-user --password my-password registry.example.com/deckhouse
   ```
 
-  * If the registry uses a self-signed certificate, put the root CA certificate that validates the registry's HTTPS certificate to file `ca.crt` in the deckhouse pod and add the `--ca-file ca.crt` option to the script.
+  * If the registry uses a self-signed certificate, put the root CA certificate that validates the registry's HTTPS certificate to file `ca.crt` in the `deckhouse` Pod and add the `--ca-file ca.crt` option to the script.
 * Wait for the Deckhouse Pod to become `Ready`. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
 * If you want to disable Deckhouse automatic updates, remove the `releaseChannel` parameter from the `deckhouse` module configuration.

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -358,7 +358,7 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
   -----END CERTIFICATE-----
   EOF
   )
-  $ kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password YUvio925tyxFNBnqhfcx89nABwcnTP1K registry.deckhouse.io/deckhou --ca-file <(cat <<<$CA_CONTENT)
+  $ kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password YUvio925tyxFNBnqhfcx89nABwcnTP1K registry.deckhouse.io/deckhouse --ca-file <(cat <<<$CA_CONTENT)
   ```
 
 * Wait for the Deckhouse Pod to become `Ready`. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -343,14 +343,14 @@ proxy:
 
 Для переключения кластера Deckhouse на использование стороннего registry выполните следующие действия:
 
-* Запустите `deckhouse-controller helper change-registry` из пода `Deckhouse` с параметрами нового registry.
+* Выполните команду `deckhouse-controller helper change-registry` из Пода `deckhouse` с параметрами нового registry.
   * Пример запуска:
 
   ```shell
   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user my-user --password my-password registry.example.com/deckhouse
   ```
 
-  * Если registry использует самоподписные сертификаты, то положите корневой сертификат соответствующего сертификата registry в файл `ca.crt` в поде deckhouse и добавьте к вызову опцию `--ca-file ca.crt`.
+  * Если registry использует самоподписные сертификаты, то положите корневой сертификат соответствующего сертификата registry в файл `ca.crt` в Поде `deckhouse` и добавьте к вызову опцию `--ca-file ca.crt`.
 * Дождитесь перехода Pod'а Deckhouse в статус `Ready`. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.
 * Дождитесь применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
 * Если необходимо отключить автоматическое обновление Deckhouse через сторонний registry, то удалите параметр `releaseChannel` из конфигурации модуля `deckhouse`.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -350,7 +350,21 @@ proxy:
   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user my-user --password my-password registry.example.com/deckhouse
   ```
 
-  * Если registry использует самоподписные сертификаты, то положите корневой сертификат соответствующего сертификата registry в файл `ca.crt` в Поде `deckhouse` и добавьте к вызову опцию `--ca-file ca.crt`.
+  * Если registry использует самоподписные сертификаты, то положите корневой сертификат соответствующего сертификата registry в файл `ca.crt` в Поде `deckhouse` и добавьте к вызову опцию `--ca-file ca.crt` или вставьте содержимое CA в переменную:
+
+  ```shell
+  $ CA_CONTENT=$(cat <<EOF
+  -----BEGIN CERTIFICATE-----
+  CERTIFICATE
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  CERTIFICATE
+  -----END CERTIFICATE-----
+  EOF
+  )
+  $ kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password YUvio925tyxFNBnqhfcx89nABwcnTP1K registry.deckhouse.io/deckhou --ca-file <(cat <<<$CA_CONTENT)
+  ```
+
 * Дождитесь перехода Pod'а Deckhouse в статус `Ready`. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.
 * Дождитесь применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
 * Если необходимо отключить автоматическое обновление Deckhouse через сторонний registry, то удалите параметр `releaseChannel` из конфигурации модуля `deckhouse`.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -362,7 +362,7 @@ proxy:
   -----END CERTIFICATE-----
   EOF
   )
-  $ kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password YUvio925tyxFNBnqhfcx89nABwcnTP1K registry.deckhouse.io/deckhou --ca-file <(cat <<<$CA_CONTENT)
+  $ kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password YUvio925tyxFNBnqhfcx89nABwcnTP1K registry.deckhouse.io/deckhouse --ca-file <(cat <<<$CA_CONTENT)
   ```
 
 * Дождитесь перехода Pod'а Deckhouse в статус `Ready`. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 
 require (
 	github.com/deckhouse/deckhouse/go_lib/cloud-data v0.0.0
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/slok/kubewebhook/v2 v2.5.0
 	k8s.io/cli-runtime v0.25.5
 	k8s.io/kubectl v0.25.5
@@ -89,7 +90,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Move `tools/change-registry.sh` to `deckhouse-controller`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix #4328
Fix #4326

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Move `tools/change-registry.sh` to `deckhouse-controller`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
