### PR TITLE
[nginx-ingress] set default ingress class to nginx

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -36,7 +36,7 @@ spec:
                     **Caution!** If you set it to "nginx", then Ingress resources lacking the `kubernetes.io/ingress.class` annotation or `spec.ingressClassName` field will also be handled.
                   example: 'nginx'
                   default: 'nginx'
-                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 inlet:
                   type: string
                   description: |
@@ -488,7 +488,7 @@ spec:
                           description: |
                             Name of Secret containing SSL—certificate.
                           type: string
-                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                         namespace:
                           description: |
                             Namespace, where the Secret is located.

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -24,7 +24,7 @@ spec:
           properties:
             spec:
               type: object
-              required: ['ingressClass', 'inlet']
+              required: ['inlet']
               properties:
                 ingressClass:
                   type: string
@@ -35,6 +35,7 @@ spec:
 
                     **Caution!** If you set it to "nginx", then Ingress resources lacking the `kubernetes.io/ingress.class` annotation or `spec.ingressClassName` field will also be handled.
                   example: 'nginx'
+                  default: 'nginx'
                   pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                 inlet:
                   type: string


### PR DESCRIPTION
## Description
Having required to specify the .spec.ingressClass when defining an ingress nginx controller might seem daunting for some users. We can provide default value "nginx" if the field is left blank.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It makes it a bit easier to define an ingress nginx controller.
Close #4799 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
In case the .ingressClass isn't provided on create/update, we set it to 'nginx' via crd default field.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: feature
summary: Set ingressClass to 'nginx' if not explicitly set.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
