### PR TITLE
[docs] Add the experimental badge to the delivery module

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -488,8 +488,9 @@ entries:
     - title:
         en: Delivery
         ru: Доставка
-      modulename: delivery
+      moduleName: delivery
       d8Revision: ee
+      featureStatus: experimental
       folders:
         - title:
             en: Description

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -107,6 +107,7 @@ defaults:
       type: "pages"
     values:
       d8Revision: ee
+      featureStatus: experimental
   - scope:
       path: "*/500-operator-trivy"
       type: "pages"


### PR DESCRIPTION
## Description
Add the experimental badge to the delivery module documentation.

## Changelog entries
```changes
section: docs
type: chore
summary: Add the experimental badge to the delivery module documentation.
impact_level: low
```
