### PR TITLE
[global] add ingressClass validation to global hooks and dex

### DIFF
--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -30,6 +30,7 @@ properties:
         description: |
           The class of the Ingress controller ([Ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)) used for Deckhouse modules.
         x-examples: [ "nginx" ]
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:
         type: string
         pattern: '^(%s([-a-z0-9]*[a-z0-9])?|[a-z0-9]([-a-z0-9]*)?%s([-a-z0-9]*)?[a-z0-9]|[a-z0-9]([-a-z0-9]*)?%s)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'

--- a/modules/010-user-authn-crd/crds/dex-authenticator.yaml
+++ b/modules/010-user-authn-crd/crds/dex-authenticator.yaml
@@ -51,10 +51,12 @@ spec:
                   type: string
                   description: 'Name of TLS-certificate secret specified in your application Ingress object to add to dex authenticator Ingress object for HTTPS access. Secret must be located in the same namespace with DexAuthenticator object.'
                   example: 'ingress-tls'
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 applicationIngressClassName:
                   type: string
                   description: 'Ingress class that serves your application ingress resource.'
                   example: 'nginx'
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 signOutURL:
                   type: string
                   description: 'Provide the URL from which requests will be proxied to the Dex authenticator sign out URL.'

--- a/modules/150-user-authn/openapi/config-values.yaml
+++ b/modules/150-user-authn/openapi/config-values.yaml
@@ -11,6 +11,7 @@ properties:
         description: 'Setting it to `true` will create an Ingress resource in the `d8-user-authn` namespace in the cluster (it exposes the Kubernetes API).'
       ingressClass:
         type: string
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
         description: 'The Ingress class that will be used to expose the Kubernetes API via Ingress.'
       whitelistSourceRanges:
         type: array
@@ -132,6 +133,7 @@ properties:
       If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/documentation/v1/#advanced-scheduling).
   ingressClass:
     type: string
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
     description: |
       The class of the Ingress controller of the documentation web UI.
 

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -106,6 +106,7 @@ properties:
           ```
   ingressClass:
     type: string
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
     x-examples: ["public"]
     description: |
       The class of the Ingress controller used for Grafana/Prometheus.

--- a/modules/402-ingress-nginx/openapi/values.yaml
+++ b/modules/402-ingress-nginx/openapi/values.yaml
@@ -37,6 +37,7 @@ properties:
             ingressClass:
               type: string
               x-examples: ["nginx"]
+              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
             data:
               type: object
               default: {}
@@ -69,6 +70,7 @@ properties:
                 ingressClass:
                   type: string
                   x-examples: ["nginx"]
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 inlet:
                   type: string
                   x-examples: ["HostWithFailover"]

--- a/modules/500-dashboard/openapi/config-values.yaml
+++ b/modules/500-dashboard/openapi/config-values.yaml
@@ -2,6 +2,7 @@ type: object
 properties:
   ingressClass:
     type: string
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
     description: |
       The class of the Ingress controller used for the dashboard.
 

--- a/modules/500-openvpn/openapi/config-values.yaml
+++ b/modules/500-openvpn/openapi/config-values.yaml
@@ -137,6 +137,7 @@ properties:
       By default, data from an `openvpn-external` service are used.
   ingressClass:
     type: string
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
     description: |
       The class of the Ingress controller used for the OpenVPN admin panel.
 

--- a/modules/500-upmeter/openapi/config-values.yaml
+++ b/modules/500-upmeter/openapi/config-values.yaml
@@ -169,6 +169,7 @@ properties:
           Setting it to `false` forces the use of an emptyDir volume.
       ingressClass:
         type: string
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
         description: |
           The class of the Ingress controller used for the smoke-mini.
 

--- a/modules/810-documentation/openapi/config-values.yaml
+++ b/modules/810-documentation/openapi/config-values.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   ingressClass:
     type: string
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
     description: |
       The class of the Ingress controller of the documentation web UI.
 


### PR DESCRIPTION
## Description
Add validation pattern for the ingressClass and IngressCertificateSecretName fields.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We need it to sanitize what values can be passed as names, so that deckhouse reconcile loop wouldn't break in attempts to install objects with invalid names.
Close #4697 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
If one attempts to set something similar:
```
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: documentation
spec:
  enabled: true
  version: 1
  settings:
    ingressClas: nginX
```    
then there is an error 
```
error: moduleconfigs.deckhouse.io "documentation" could not be patched: admission webhook "validate.deckhouse-config-webhook.deckhouse.io" denied the request: spec.settings are not valid (version 1 converted to 2):  1 error occurred: * documentation.ingressClass should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
```
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: chore
summary: Add necessary validations for the ingressClass and secretName fields
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
