### PR TITLE
[node-manager] NodeUser fixed the ability to use parameters in sshPublicKeys

### DIFF
--- a/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
@@ -47,7 +47,7 @@ function put_user_ssh_key() {
   local ssh_dir="$base_path/$user_name/.ssh"
 
   tmp_file="$(mktemp -u)"
-  sed "s/\,/\n/g" <<< "$ssh_keys" | sort -u > "$tmp_file"
+  sed "s/\;/\n/g" <<< "$ssh_keys" | sort -u > "$tmp_file"
 
   if ! diff -q "$ssh_dir/authorized_keys" "$tmp_file" >/dev/null 2>/dev/null ; then
     mkdir -p "$ssh_dir"
@@ -77,7 +77,7 @@ mkdir -p $home_base_path
 for uid in $(jq -rc '.[].spec.uid' <<< "$node_users_json"); do
   user_name="$(jq --arg uid $uid -rc '.[] | select(.spec.uid==($uid | tonumber)) | .name' <<< "$node_users_json")"
   password_hash="$(jq --arg uid $uid -rc '.[] | select(.spec.uid==($uid | tonumber)) | .spec.passwordHash' <<< "$node_users_json")"
-  ssh_public_keys="$(jq --arg uid $uid -rc '.[] | select(.spec.uid==($uid | tonumber)) | [.spec.sshPublicKeys[]?] + (if .spec.sshPublicKey then [.spec.sshPublicKey] else [] end) | join(",")' <<< "$node_users_json")"
+  ssh_public_keys="$(jq --arg uid $uid -rc '.[] | select(.spec.uid==($uid | tonumber)) | [.spec.sshPublicKeys[]?] + (if .spec.sshPublicKey then [.spec.sshPublicKey] else [] end) | join(";")' <<< "$node_users_json")"
   extra_groups="$(jq --arg uid "$uid" --arg sudo_group "$sudo_group" -rc '.[] | select(.spec.uid==($uid | tonumber)) | [.spec.extraGroups[]?] + (if .spec.isSudoer then [$sudo_group] else [] end) | join(",")' <<< "$node_users_json")"
 
   # check for uid > 1000

--- a/modules/040-node-manager/crds/nodeuser.yaml
+++ b/modules/040-node-manager/crds/nodeuser.yaml
@@ -63,7 +63,7 @@ spec:
                     Node user SSH public keys.
 
                     Either `sshPublicKey` or `sshPublicKeys` **must** be specified.
-                  example: [ 'ssh-rsa AAABBB', 'ssh-rsa BBBCCC' ]
+                  example: [ 'ssh-rsa AAABBB', 'cert-authority,principals="name" ssh-rsa BBBCCC' ]
                 passwordHash:
                   type: string
                   description: |


### PR DESCRIPTION
## Description
NodeUser fixed the ability to use parameters in sshPublicKeys
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Comma delimiter is bad because it is a valid character which would split key string into two lines.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: NodeUser fixed the ability to use parameters in sshPublicKeys
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
