### PR TITLE
 [alertmanager] fix example in alertmanager doc (#4851)

### DIFF
--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -428,6 +428,7 @@ Refer to the description of the [CustomAlertmanager](cr.html#customalertmanager)
 The solution comes down to configuring alert routing in the Alertmanager.
 
 You will need to:
+
 1. Create a parameterless receiver.
 1. Route unwanted alerts to this receiver.
 
@@ -440,14 +441,19 @@ receivers:
 - name: some-other-receiver
   # ...
 route:
+  # default receiver
+  receiver: some-other-receiver
   routes:
-  - match:
-      alertname: DeadMansSwitch
-    receiver: blackhole
-  - match_re:
-      service: ^(foo1|foo2|baz)$
-    receiver: blackhole
-  - receiver: some-other-receiver
+    - matchers:
+        - matchType: =
+          name: alertname
+          value: DeadMansSwitch
+      receiver: blackhole
+    - matchers:
+        - matchType: =~
+          name: service
+          value: ^(foo|bar|baz)$
+      receiver: some-other-receiver
 ```
 
 A detailed description of all parameters can be found in the [official documentation](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file).

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -425,6 +425,7 @@ spec:
 Решение сводится к настройке маршрутизации алертов в вашем Alertmanager.
 
 Потребуется:
+
 1. Завести получателя без параметров.
 1. Смаршрутизировать лишние алерты в этого получателя.
 
@@ -437,14 +438,19 @@ receivers:
 - name: some-other-receiver
   # ...
 route:
+  # receiver по умолчанию
+  receiver: some-other-receiver
   routes:
-  - match:
-      alertname: DeadMansSwitch
-    receiver: blackhole
-  - match_re:
-      service: ^(foo1|foo2|baz)$
-    receiver: blackhole
-  - receiver: some-other-receiver
+    - matchers:
+        - matchType: =
+          name: alertname
+          value: DeadMansSwitch
+      receiver: blackhole
+    - matchers:
+        - matchType: =~
+          name: service
+          value: ^(foo|bar|baz)$
+      receiver: some-other-receiver
 ```
 
 С подробным описанием всех параметров можно ознакомиться в [официальной документации](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file).


### PR DESCRIPTION
## Description
fix example in alertmanager doc

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Incorrect example in the documentation. #4851  

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: alertmanager
type: fix
summary: fix example in alertmanager doc
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
