### PR TITLE
[dhctl] checking the length of the secret name

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/state.go
+++ b/dhctl/pkg/kubernetes/actions/converge/state.go
@@ -101,14 +101,14 @@ func GetClusterStateFromCluster(kubeCl *client.KubernetesClient) ([]byte, error)
 
 // Create secret for node with group settings only.
 func CreateNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup string, settings []byte) error {
-	secret, err := manifests.SecretWithNodeTerraformState(nodeName, nodeGroup, nil, settings)
-	if err != nil {
-		return err
-	}
-
 	task := actions.ManifestTask{
-		Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
-		Manifest: func() interface{} { return secret },
+		Name: fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
+		Manifest: func() interface{} {
+			return manifests.NewManifestWrapper(
+				manifests.SecretWithNodeTerraformState(nodeName, nodeGroup, nil, settings),
+				manifests.SecretNameLenghtValidator,
+			)
+		},
 		CreateFunc: func(manifest interface{}) error {
 			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
@@ -126,14 +126,14 @@ func SaveNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup
 		return ErrNoTerraformState
 	}
 
-	secret, err := manifests.SecretWithNodeTerraformState(nodeName, nodeGroup, tfState, settings)
-	if err != nil {
-		return err
-	}
-
 	task := actions.ManifestTask{
-		Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
-		Manifest: func() interface{} { return secret },
+		Name: fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
+		Manifest: func() interface{} {
+			return manifests.NewManifestWrapper(
+				manifests.SecretWithNodeTerraformState(nodeName, nodeGroup, tfState, settings),
+				manifests.SecretNameLenghtValidator,
+			)
+		},
 		CreateFunc: func(manifest interface{}) error {
 			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
@@ -151,13 +151,11 @@ func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName stri
 		return ErrNoTerraformState
 	}
 
-	secretWithNodeTerraformState, err := manifests.SecretWithNodeTerraformState(nodeName, MasterNodeGroupName, tfState, nil)
-	if err != nil {
-		return err
-	}
-
 	getTerraformStateManifest := func() interface{} {
-		return secretWithNodeTerraformState
+		return manifests.NewManifestWrapper(
+			manifests.SecretWithNodeTerraformState(nodeName, MasterNodeGroupName, tfState, nil),
+			manifests.SecretNameLenghtValidator,
+		)
 	}
 	getDevicePathManifest := func() interface{} {
 		return manifests.SecretMasterDevicePath(nodeName, devicePath)
@@ -367,14 +365,15 @@ func (s *NodeStateSaver) SaveState(outputs *terraform.PipelineOutputs) error {
 	if outputs == nil || len(outputs.TerraformState) == 0 {
 		return nil
 	}
-	secret, err := manifests.SecretWithNodeTerraformState(s.nodeName, s.nodeGroup, outputs.TerraformState, s.nodeGroupSettings)
-	if err != nil {
-		return err
-	}
 
 	task := actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, s.nodeName),
-		Manifest: func() interface{} { return secret },
+		Manifest: func() interface{} {
+			return manifests.NewManifestWrapper(
+				manifests.SecretWithNodeTerraformState(s.nodeName, s.nodeGroup, outputs.TerraformState, s.nodeGroupSettings),
+				manifests.SecretNameLenghtValidator,
+			)
+		},
 		CreateFunc: func(manifest interface{}) error {
 			_, err := s.kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
@@ -383,18 +382,16 @@ func (s *NodeStateSaver) SaveState(outputs *terraform.PipelineOutputs) error {
 			return manifests.PatchWithNodeTerraformState(outputs.TerraformState)
 		},
 		PatchFunc: func(patchData []byte) error {
-			secretName, err := manifests.SecretNameForNodeTerraformState(s.nodeName)
-			if err != nil {
-				return err
-			}
+			secretName := manifests.SecretNameForNodeTerraformState(s.nodeName)
+
 			// MergePatch is used because we need to replace one field in "data".
-			_, err = s.kubeCl.CoreV1().Secrets("d8-system").Patch(context.TODO(), secretName, types.MergePatchType, patchData, metav1.PatchOptions{})
+			_, err := s.kubeCl.CoreV1().Secrets("d8-system").Patch(context.TODO(), secretName, types.MergePatchType, patchData, metav1.PatchOptions{})
 			return err
 		},
 	}
 	taskName := fmt.Sprintf("Save intermediate Terraform state for Node %q", s.nodeName)
 	log.DebugF("Intermediate save state for node %s in cluster...\n", s.nodeName)
-	err = retry.NewSilentLoop(taskName, 45, 10*time.Second).Run(task.PatchOrCreate)
+	err := retry.NewSilentLoop(taskName, 45, 10*time.Second).Run(task.PatchOrCreate)
 	msg := fmt.Sprintf("Intermediate state for node %s was saved in cluster\n", s.nodeName)
 	if err != nil {
 		msg = fmt.Sprintf("Intermediate state for node %s was not saved in cluster: %v\n", s.nodeName, err)

--- a/dhctl/pkg/kubernetes/actions/manifests/interface.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/interface.go
@@ -1,0 +1,20 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifests
+
+type Manifest interface {
+	IsValid() error
+	GetManifest() interface{}
+}

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -611,20 +611,12 @@ func SecretWithStaticClusterConfig(configData []byte) *apiv1.Secret {
 	return generateSecret("d8-static-cluster-configuration", "kube-system", data, nil)
 }
 
-const maxLenSecretName = 63
-
-func SecretNameForNodeTerraformState(nodeName string) (string, error) {
+func SecretNameForNodeTerraformState(nodeName string) string {
 	builder := strings.Builder{}
 	builder.WriteString("d8-node-terraform-state-")
 	builder.WriteString(nodeName)
 
-	if builder.Len() > maxLenSecretName {
-		return "", fmt.Errorf("the length of the secret name %s must be less than %d",
-			builder.String(),
-			maxLenSecretName,
-		)
-	}
-	return builder.String(), nil
+	return builder.String()
 }
 
 func SecretWithNodeTerraformState(
@@ -632,19 +624,14 @@ func SecretWithNodeTerraformState(
 	nodeGroup string,
 	data,
 	settings []byte,
-) (*apiv1.Secret, error) {
+) *apiv1.Secret {
 	body := map[string][]byte{"node-tf-state.json": data}
 	if settings != nil {
 		body["node-group-settings.json"] = settings
 	}
 
-	secretName, err := SecretNameForNodeTerraformState(nodeName)
-	if err != nil {
-		return nil, err
-	}
-
 	return generateSecret(
-		secretName,
+		SecretNameForNodeTerraformState(nodeName),
 		"d8-system",
 		body,
 		map[string]string{
@@ -652,7 +639,7 @@ func SecretWithNodeTerraformState(
 			"node.deckhouse.io/node-name":       nodeName,
 			"node.deckhouse.io/terraform-state": "",
 		},
-	), nil
+	)
 }
 
 func PatchWithNodeTerraformState(stateData []byte) interface{} {

--- a/dhctl/pkg/kubernetes/actions/manifests/validator.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/validator.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifests
+
+import (
+	"errors"
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+const maxLenghtSecretName = 63
+
+func SecretNameLenghtValidator(manifest interface{}) error {
+	data, ok := manifest.(*apiv1.Secret)
+	if !ok {
+		return errors.New("manifest is not *apiv1.Secret")
+	}
+
+	if len(data.ObjectMeta.Name) > maxLenghtSecretName {
+		return fmt.Errorf("the length of the secret name %s must be less than %d",
+			data.ObjectMeta.Name,
+			maxLenghtSecretName,
+		)
+	}
+
+	return nil
+}

--- a/dhctl/pkg/kubernetes/actions/manifests/wrapper.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/wrapper.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifests
+
+type ValidatorFunc func(manifest interface{}) error
+
+type ManifestWrapper struct {
+	validators []ValidatorFunc
+	data       interface{}
+}
+
+func NewManifestWrapper(data interface{}, validator ...ValidatorFunc) Manifest {
+	mw := &ManifestWrapper{}
+	mw.SetManifest(data)
+	mw.AddValidator(validator...)
+	return mw
+}
+
+func (mw *ManifestWrapper) AddValidator(validator ...ValidatorFunc) {
+	mw.validators = append(mw.validators, validator...)
+}
+
+func (mw *ManifestWrapper) IsValid() error {
+	var err error
+	for _, v := range mw.validators {
+		err = v(mw.data)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mw *ManifestWrapper) GetManifest() interface{} {
+	return mw.data
+}
+
+func (mw *ManifestWrapper) SetManifest(data interface{}) {
+	mw.data = data
+}

--- a/dhctl/pkg/kubernetes/actions/manifests/wrapper.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/wrapper.go
@@ -21,7 +21,7 @@ type ManifestWrapper struct {
 	data       interface{}
 }
 
-func NewManifestWrapper(data interface{}, validator ...ValidatorFunc) Manifest {
+func NewManifestWrapper(data interface{}, validator ...ValidatorFunc) *ManifestWrapper {
 	mw := &ManifestWrapper{}
 	mw.SetManifest(data)
 	mw.AddValidator(validator...)

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -107,12 +107,16 @@ func (task *ManifestTask) PatchOrCreate() error {
 }
 
 func (task *ManifestTask) GetValidManifest() (interface{}, error) {
-	if mw, ok := task.Manifest().(manifests.Manifest); ok {
+	manifest := task.Manifest()
+	log.DebugF("Manifest: %v\n", manifest)
+	if mw, ok := manifest.(manifests.Manifest); ok {
+		log.DebugLn("Found Manifest interface")
 		err := mw.IsValid()
 		if err != nil {
 			return nil, fmt.Errorf("validate manifest: %w", err)
 		}
+		log.DebugLn("Manifest is valid")
 		return mw.GetManifest(), nil
 	}
-	return task.Manifest(), nil
+	return manifest, nil
 }

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -39,7 +39,7 @@ func (task *ManifestTask) CreateOrUpdate() error {
 	log.InfoF("Manifest for %s\n", task.Name)
 	manifest, err := task.GetValidManifest()
 	if err != nil {
-		return err
+		return fmt.Errorf("manifest validation: %v", err)
 	}
 
 	err = task.CreateFunc(manifest)
@@ -96,7 +96,7 @@ func (task *ManifestTask) PatchOrCreate() error {
 	log.DebugF("%s is not found. Trying to create ... \n", task.Name)
 	manifest, err := task.GetValidManifest()
 	if err != nil {
-		return err
+		return fmt.Errorf("manifest validation '%s': %v", task.Name, err)
 	}
 
 	err = task.CreateFunc(manifest)
@@ -108,12 +108,11 @@ func (task *ManifestTask) PatchOrCreate() error {
 
 func (task *ManifestTask) GetValidManifest() (interface{}, error) {
 	manifest := task.Manifest()
-	log.DebugF("Manifest: %v\n", manifest)
 	if mw, ok := manifest.(manifests.Manifest); ok {
 		log.DebugLn("Found Manifest interface")
 		err := mw.IsValid()
 		if err != nil {
-			return nil, fmt.Errorf("validate manifest: %w", err)
+			return nil, err
 		}
 		log.DebugLn("Manifest is valid")
 		return mw.GetManifest(), nil

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -39,7 +39,7 @@ func (task *ManifestTask) CreateOrUpdate() error {
 	log.InfoF("Manifest for %s\n", task.Name)
 	manifest, err := task.GetValidManifest()
 	if err != nil {
-		return fmt.Errorf("manifest validation: %v", err)
+		return fmt.Errorf("manifest validation: %w", err)
 	}
 
 	err = task.CreateFunc(manifest)
@@ -96,7 +96,7 @@ func (task *ManifestTask) PatchOrCreate() error {
 	log.DebugF("%s is not found. Trying to create ... \n", task.Name)
 	manifest, err := task.GetValidManifest()
 	if err != nil {
-		return fmt.Errorf("manifest validation '%s': %v", task.Name, err)
+		return fmt.Errorf("manifest validation '%s': %w", task.Name, err)
 	}
 
 	err = task.CreateFunc(manifest)
@@ -111,7 +111,6 @@ func (task *ManifestTask) GetValidManifest() (interface{}, error) {
 	if mw, ok := manifest.(manifests.Manifest); ok {
 		log.DebugLn("Found Manifest interface")
 		err := mw.IsValid()
-		log.DebugF("Validation result: ", err)
 		if err != nil {
 			return nil, err
 		}

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -111,6 +111,7 @@ func (task *ManifestTask) GetValidManifest() (interface{}, error) {
 	if mw, ok := manifest.(manifests.Manifest); ok {
 		log.DebugLn("Found Manifest interface")
 		err := mw.IsValid()
+		log.DebugF("Validation result: ", err)
 		if err != nil {
 			return nil, err
 		}

--- a/dhctl/pkg/kubernetes/actions/task_test.go
+++ b/dhctl/pkg/kubernetes/actions/task_test.go
@@ -1,0 +1,64 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestManifestValidation(t *testing.T) {
+	mt := ManifestTask{
+		Name: "Test",
+		Manifest: func() interface{} {
+			return manifests.NewManifestWrapper(
+				&apiv1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong-name",
+					},
+				},
+				manifests.SecretNameLenghtValidator,
+			)
+		},
+	}
+
+	_, err := mt.GetValidManifest()
+	if err == nil {
+		t.Error(fmt.Errorf("manifest should be invalid"))
+	}
+
+	mt = ManifestTask{
+		Name: "Test",
+		Manifest: func() interface{} {
+			return manifests.NewManifestWrapper(
+				&apiv1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "short-name",
+					},
+				},
+				manifests.SecretNameLenghtValidator,
+			)
+		},
+	}
+
+	_, err = mt.GetValidManifest()
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Description
Checking the length of the secret name
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
issue #4908 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
If the length of the secret name is greater than 63 an error will be displayed
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: checking the length of the secret name
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
