### PR TITLE
[loki] Added kube-rbac-proxy sidecar in loki statefullset

### DIFF
--- a/modules/462-loki/openapi/config-values.yaml
+++ b/modules/462-loki/openapi/config-values.yaml
@@ -92,6 +92,15 @@ properties:
     description: |
       Loki resources management options.
     default: {}
+    oneOf:
+      - properties:
+          mode:
+            enum: [ "VPA" ]
+          vpa: {}
+      - properties:
+          mode:
+            enum: [ "Static" ]
+          static: {}
     x-examples:
       - mode: VPA
         vpa:

--- a/modules/462-loki/template_tests/template_test.go
+++ b/modules/462-loki/template_tests/template_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const (
+	globalValues = `
+enabledModules: ["vertical-pod-autoscaler-crd", "loki"]
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+`
+	lokiValues = `
+internal:
+  activated: true
+  effectiveStorageClass: testStorageClass
+resourcesManagement:
+  mode: VPA
+  vpa:
+    mode: Auto
+    cpu:
+      min: "50m"
+      max: "2"
+    memory:
+      min: "256Mi"
+      max: "2Gi"
+`
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("Module :: loki :: helm template ::", func() {
+	f := SetupHelmConfig(``)
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", globalValues)
+		f.ValuesSetFromYaml("loki", lokiValues)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+	})
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for empty cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("Check ClusterLoggingConfig for system logs", func() {
+
+		It("Render chart with ClusterLoggingConfig", func() {
+			f.ValuesSet("loki.storeSystemLogs", true)
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			obj := f.KubernetesGlobalResource("ClusterLoggingConfig", "d8-namespaces-to-loki")
+			Expect(obj.Exists()).To(BeTrue())
+		})
+
+		It("Render chart without ClusterLoggingConfig", func() {
+			f.ValuesSet("loki.storeSystemLogs", false)
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			obj := f.KubernetesGlobalResource("ClusterLoggingConfig", "d8-namespaces-to-loki")
+			Expect(obj.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Check GrafanaAdditionalDatasource render", func() {
+
+		It("Render chart with grafana datasource if prometheus-crd enabled", func() {
+			f.ValuesSet("global.enabledModules", []string{"loki", "prometheus-crd"})
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			obj := f.KubernetesGlobalResource("GrafanaAdditionalDatasource", "d8-loki")
+			Expect(obj.Exists()).To(BeTrue())
+		})
+
+		It("Render chart without grafana datasource if prometheus-crd disabled", func() {
+			f.ValuesSet("global.enabledModules", []string{"loki"})
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			obj := f.KubernetesGlobalResource("GrafanaAdditionalDatasource", "d8-loki")
+			Expect(obj.Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/462-loki/templates/configmap.yaml
+++ b/modules/462-loki/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     auth_enabled: false
 
     server:
-      http_listen_port: 3100
+      http_listen_port: 3099
 
     limits_config:
       retention_period: {{ .Values.loki.retentionPeriodHours | default 168 }}h

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
           - name: KUBE_RBAC_PROXY_CONFIG
             value: |
               upstreams:
-              - upstream: http://127.0.0.1:3100/
+              - upstream: http://127.0.0.1:3099/
                 path: /
                 authorization:
                   resourceAttributes:
@@ -90,7 +90,7 @@ spec:
             mountPath: /loki
         ports:
           - name: http-metrics
-            containerPort: 3100
+            containerPort: 3099
             protocol: TCP
         livenessProbe:
           httpGet:

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -7,7 +7,10 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
 spec:
-  {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "StatefulSet" .Chart.Name "loki" .Values.loki.resourcesManagement ) | nindent 2}}
+  {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "StatefulSet" .Chart.Name "loki" .Values.loki.resourcesManagement ) | nindent 2 }}
+  {{- if .Values.loki.resourcesManagement.vpa }}
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+  {{- end }}
 {{- end }}
 ---
 apiVersion: apps/v1
@@ -37,6 +40,44 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs" . | nindent 6 }}
       containers:
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+        args:
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):3100"
+          - "--v=2"
+          - "--logtostderr=true"
+          - "--stale-cache-interval=1h30m"
+        ports:
+          - containerPort: 3100
+            name: loki
+        env:
+          - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: KUBE_RBAC_PROXY_CONFIG
+            value: |
+              upstreams:
+              - upstream: http://127.0.0.1:3100/
+                path: /
+                authorization:
+                  resourceAttributes:
+                    namespace: d8-monitoring
+                    apiGroup: apps
+                    apiVersion: v1
+                    resource: statefulsets
+                    subresource: logs
+                    name: loki
+        resources:
+          requests:
+        {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+        {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+        {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+        volumeMounts:
+          - name: kube-rbac-proxy-ca
+            mountPath: /etc/kube-rbac-proxy
+{{- end }}
       - name: loki
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "loki") }}
@@ -68,6 +109,10 @@ spec:
         configMap:
           name: {{ .Chart.Name }}
           defaultMode: 0644
+      - name: kube-rbac-proxy-ca
+        configMap:
+          defaultMode: 420
+          name: kube-rbac-proxy-ca.crt
 {{- $storageClass := .Values.loki.internal.effectiveStorageClass }}
 {{- if $storageClass }}
   volumeClaimTemplates:


### PR DESCRIPTION
## Description

Added kube-rbac-proxy sidecar container in loki statefulset, to protect it from unauthorized access.


## Why do we need it, and what problem does it solve?

Fix #4315

## Why do we need it in the patch release (if we do)?

I guess it need to be back-ported into the patch release, because it is security related staff  ¯\_(ツ)_/¯

## What is the expected result?

Loki 3100 port protected with kube-rbac-proxy.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: loki
type: fix
summary: "kube-rbac-proxy sidecar has beed added to the loki statefulset"
impact_level: default
```
