### PR TITLE
[dhctl] add cache identity for kubeconfig (#4948)

### DIFF
--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -16,8 +16,6 @@ package commands
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -30,31 +28,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
-
-func getCacheIdentityFromKubeconfig(
-	kubeconfigPath string,
-	kubeconfigContext string,
-) (string, error) {
-	builder := strings.Builder{}
-	builder.WriteString("kubeconfig")
-
-	kubeconfigName := filepath.Base(kubeconfigPath)
-	if kubeconfigName == "." || kubeconfigName == ".." || kubeconfigName == "/" {
-		return "", fmt.Errorf("incorrect kubeconfig path")
-	}
-
-	builder.WriteString("-")
-	builder.WriteString(kubeconfigName)
-
-	if kubeconfigContext == "" {
-		return builder.String(), nil
-	}
-
-	builder.WriteString("-")
-	builder.WriteString(kubeconfigContext)
-
-	return builder.String(), nil
-}
 
 func DefineConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	cmd := kpApp.Command("converge", "Converge kubernetes cluster.")
@@ -78,13 +51,10 @@ func DefineConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		}
 
 		if app.KubeConfig != "" {
-			cacheIdentity, err = getCacheIdentityFromKubeconfig(
+			cacheIdentity = cache.GetCacheIdentityFromKubeconfig(
 				app.KubeConfig,
 				app.KubeConfigContext,
 			)
-			if err != nil {
-				return err
-			}
 		}
 
 		if cacheIdentity == "" {

--- a/dhctl/pkg/state/cache/init_test.go
+++ b/dhctl/pkg/state/cache/init_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import "testing"
+
+func TestCacheIdentity(t *testing.T) {
+	tests := []struct {
+		name              string
+		kubeconfigPath    string
+		kubeconfigContext string
+		want              string
+	}{
+		{"Cache identity with kubeconfigPath and kubeconfigContext", "foo", "bar", "kubeconfig-c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"},
+		{"Cache identity with kubeconfigPath", "foo", "", "kubeconfig-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"},
+		{"Cache identity without kubeconfigPath", "", "", ""},
+	}
+	// The execution loop
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans := GetCacheIdentityFromKubeconfig(tt.kubeconfigPath, tt.kubeconfigContext)
+			if ans != tt.want {
+				t.Errorf("got %s, want %s", ans, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Add cache identity for a kubeconfig parameter in the converge command
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
issues #4948 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Converge should start with a kubeconfig parameter

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add cache identity for a kubeconfig parameter in the converge command
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
