### PR TITLE
[prometheus] add external labels knob

### DIFF
--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -121,7 +121,10 @@ properties:
     description: |
       The set of external labels to add to the metrics.
       
-      It is possible to expand environment variables (for example: `HOSTNAME`, `POD_NAME`, `SHARD`) in external labels.
+      It's possible to expand the environment variables of the `config-reloader` container in external labels
+      such as:
+      * `HOSTNAME`/`POD_NAME` - contains the name of the pod (for example `prometheus-main-0`, `prometheus-main-1`, etc.).
+      * `SHARD` - contains the [shard](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/shards-and-replicas.md) number.
     additionalProperties:
       type: string
   https:

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -115,16 +115,15 @@ properties:
   externalLabels:
     type: object
     x-examples:
-      - prometheus: dev
-        prometheus_replica: ${HOSTNAME}
-        env: $MY_ENV
+      - prometheus_replica: $(POD_NAME)
+        shard: $(SHARD)
+        hostname: $(HOSTNAME)
     description: |
       The set of external labels to add to the metrics.
       
-      It is possible to expand [environment variables](https://prometheus.io/docs/prometheus/latest/feature_flags/#expand-environment-variables-in-external-labels) in external labels.
+      It is possible to expand environment variables (for example: `HOSTNAME`, `POD_NAME`, `SHARD`) in external labels.
     additionalProperties:
       type: string
-      maxLength: 63
   https:
     type: object
     x-examples:

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -112,6 +112,19 @@ properties:
       The class of the Ingress controller used for Grafana/Prometheus.
 
       An optional parameter. By default, the `modules.ingressClass` global value is used.
+  externalLabels:
+    type: object
+    x-examples:
+      - prometheus: dev
+        prometheus_replica: ${HOSTNAME}
+        env: $MY_ENV
+    description: |
+      The set of external labels to add to the metrics.
+      
+      It is possible to expand [environment variables](https://prometheus.io/docs/prometheus/latest/feature_flags/#expand-environment-variables-in-external-labels) in external labels.
+    additionalProperties:
+      type: string
+      maxLength: 63
   https:
     type: object
     x-examples:

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -76,7 +76,10 @@ properties:
     description: |
       Набор внешних меток для маркировки метрик.
 
-      Допускается использование значений переменных окружения (например: `HOSTNAME`, `POD_NAME`, `SHARD`) в качестве значений меток.
+      Допускается использование значений переменных окружения контейнера `config-reloader` в качестве значений меток,
+      например:
+      * `HOSTNAME`/`POD_NAME` - содержит наименование пода (пример `prometheus-main-0`, `prometheus-main-1`, etc.).
+      * `SHARD` - содержит номер [шарда](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/shards-and-replicas.md).
   https:
     description: |
       Тип сертификата используемого для Grafana/Prometheus.

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -72,6 +72,11 @@ properties:
       Класс Ingress-контроллера, который используется для Grafana/Prometheus.
 
       Опциональный параметр, по умолчанию используется глобальное значение `modules.ingressClass`.
+  externalLabels:
+    description: |
+      Набор дополнительных меток для маркировки метрик.
+
+      Допускается использование [переменных окружения](https://prometheus.io/docs/prometheus/latest/feature_flags/#expand-environment-variables-in-external-labels) в качестве значений.
   https:
     description: |
       Тип сертификата используемого для Grafana/Prometheus.

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -74,9 +74,9 @@ properties:
       Опциональный параметр, по умолчанию используется глобальное значение `modules.ingressClass`.
   externalLabels:
     description: |
-      Набор дополнительных меток для маркировки метрик.
+      Набор внешних меток для маркировки метрик.
 
-      Допускается использование [переменных окружения](https://prometheus.io/docs/prometheus/latest/feature_flags/#expand-environment-variables-in-external-labels) в качестве значений.
+      Допускается использование значений переменных окружения (например: `HOSTNAME`, `POD_NAME`, `SHARD`) в качестве значений меток.
   https:
     description: |
       Тип сертификата используемого для Grafana/Prometheus.

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -55,9 +55,6 @@ spec:
   enableRemoteWriteReceiver: true
   enableFeatures:
   - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/
-{{- if .Values.prometheus.externalLabels }}
-  - expand-external-labels # https://prometheus.io/docs/prometheus/latest/feature_flags/#expand-environment-variables-in-external-labels
-{{- end }}
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true
@@ -137,10 +134,9 @@ spec:
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
   externalLabels:
+    prometheus: deckhouse
 {{- with .Values.prometheus.externalLabels }}
     {{- . | toYaml | nindent 4 }}
-{{- else }}
-    prometheus: deckhouse
 {{- end }}
   prometheusExternalLabelName: ""
   replicaExternalLabelName: ""

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -134,10 +134,10 @@ spec:
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
   externalLabels:
-    prometheus: deckhouse
 {{- with .Values.prometheus.externalLabels }}
     {{- . | toYaml | nindent 4 }}
 {{- end }}
+    prometheus: deckhouse
   prometheusExternalLabelName: ""
   replicaExternalLabelName: ""
   serviceAccountName: prometheus

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -55,6 +55,9 @@ spec:
   enableRemoteWriteReceiver: true
   enableFeatures:
   - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/
+{{- if .Values.prometheus.externalLabels }}
+  - expand-external-labels # https://prometheus.io/docs/prometheus/latest/feature_flags/#expand-environment-variables-in-external-labels
+{{- end }}
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true
@@ -134,7 +137,11 @@ spec:
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
   externalLabels:
+{{- if .Values.prometheus.externalLabels }}
+    {{- .Values.prometheus.externalLabels | toYaml | nindent 4 }}
+{{- else }}
     prometheus: deckhouse
+{{- end }}
   prometheusExternalLabelName: ""
   replicaExternalLabelName: ""
   serviceAccountName: prometheus

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -137,8 +137,8 @@ spec:
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
   externalLabels:
-{{- if .Values.prometheus.externalLabels }}
-    {{- .Values.prometheus.externalLabels | toYaml | nindent 4 }}
+{{- with .Values.prometheus.externalLabels }}
+    {{- . | toYaml | nindent 4 }}
 {{- else }}
     prometheus: deckhouse
 {{- end }}


### PR DESCRIPTION
## Description
Adds the way to set custom external labels for the main Prometheus. According to the description: "The labels to add to any time series or alerts when communicating with external systems (federation, remote storage, Alertmanager)". The value of `prometheus` label is set to `deckhouse` by default and can't be changed. It's possible to set label values through resolving the environment variables of the `config-relloader` container( some meaningful examples: `SHARD`, `POD_NAME`, `HOSTNAME`). This env substitution functionality is provided by the `prometheus-config-reloader` binary, so no restart is required.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It allows a user to set custom external labels depending on their needs. 
Close #4673
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
It is possible to set external labels through the Prometheus module configuration.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: feature
summary: Add module external labels setting.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
