### PR TITLE
[candi] Fix AWSClusterConfiguration OpenAPI spec

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -78,7 +78,7 @@ apiVersions:
             required: [instanceType, ami]
             description: |
               Partial contents of the fields of the [AWSInstanceClass](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cr.html#awsinstanceclass).
-            properties: &instanceClassProperties
+            properties:
               instanceType:
                 type: string
                 description: |
@@ -219,7 +219,40 @@ apiVersions:
               description: |
                 Partial contents of the fields of the [AWSInstanceClass](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cr.html#awsinstanceclass).
               properties:
-                <<: *instanceClassProperties
+                instanceType:
+                  type: string
+                  description: |
+                    Instance type of AWS instance.
+
+                    **Caution!** Ensure that this type is present in all zones specified in the `zones` parameter.
+                  example: t3.large
+                ami:
+                  type: string
+                  description: |
+                    The Amazon Machine Image (AMI ID) to use in provisioned instances.
+
+                    Here is how you can find the required AMI (each region has its own set of AMIs):
+                    ```shell
+                    aws ec2 --region <REGION> describe-images \
+                    --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-2020*' | \
+                    jq '.Images[].ImageId'
+                    ```
+                  example: ami-040a1551f9c9d11ad
+                additionalSecurityGroups:
+                  type: array
+                  description: |
+                    The additional security groups to add to provisioned instances of the specific InstanceClass.
+                  items:
+                    type: string
+                diskType:
+                  description: Instance EBS disk type.
+                  example: "gp2"
+                  type: string
+                  enum: [ gp3, gp2, io2, io1, st1, sc1 ]
+                diskSizeGb:
+                  description: Instance disk size in gigabytes.
+                  example: 20
+                  type: integer
             zones:
               type: array
               items:
@@ -281,7 +314,7 @@ apiVersions:
                 required: [instanceType, ami]
                 description: |
                   Partial contents of the fields of the [AWSInstanceClass](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cr.html#awsinstanceclass).
-                properties: &instanceClassProperties
+                properties:
                   instanceType:
                     type: string
                     description: |

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -28,7 +28,7 @@ apiVersions:
           instanceClass:
             description: |
               Частичное содержимое полей [AWSInstanceClass](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-aws/cr.html#awsinstanceclass).
-            properties: &instanceClassProperties_ru
+            properties:
               instanceType:
                 type: string
                 description: |
@@ -103,7 +103,33 @@ apiVersions:
               description: |
                 Частичное содержимое полей [AWSInstanceClass](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-aws/cr.html#awsinstanceclass).
               properties:
-                <<: *instanceClassProperties_ru
+                instanceType:
+                  type: string
+                  description: |
+                    Тип заказываемых инстансов.
+
+                    > **Внимание!** Следует убедиться, что указанный тип есть во всех зонах, перечисленных в параметре `zones`.
+                ami:
+                  type: string
+                  description: |
+                    Образ (AMI ID), который будет использоваться в заказанных инстансах.
+
+                    Как найти нужный AMI (в каждом регионе AMI разные):
+                    ```shell
+                    aws ec2 --region <REGION> describe-images \
+                    --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-2020*' | \
+                    jq '.Images[].ImageId'
+                    ```
+                additionalSecurityGroups:
+                  type: array
+                  description: |
+                    Дополнительные secutiry groups, которые будут присвоены созданным инстансам.
+                  items:
+                    type: string
+                diskType:
+                  description: Тип созданного диска.
+                diskSizeGb:
+                  description: Размер root-диска. Значение указывается в гигабайтах.
             zones:
               description: |
                 Список зон, в которых допустимо создавать узлы.
@@ -131,7 +157,7 @@ apiVersions:
               instanceClass:
                 description: |
                   Частичное содержимое полей [AWSInstanceClass](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-aws/cr.html#awsinstanceclass).
-                properties: &instanceClassProperties_ru
+                properties:
                   instanceType:
                     type: string
                     description: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove anchor inheritance in the `AWSClusterConfiguration` OpenAPI specification. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to remove the property `etcdDisk` in `nodeGroups`. This property is inherited from `masterNodeGroup` by mistake.  We can fix this if we avoid anchor inheritance.

Close #4956

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Remove the property `etcdDisk` in `nodeGroups` and remove anchor inheritance in the 'AWSClusterConfiguration' OpenAPI specification.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
