### PR TITLE
[ingress-nginx] Update HPA apiVersion to support 1.26.

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -19,7 +19,12 @@ spec:
 {{- $name := index . 2 }}
 
 ---
+# Remove apiVersion selection after dropping support of 1.22
+  {{- if semverCompare ">= 1.23" $context.Values.global.discovery.kubernetesVersion }}
+apiVersion: autoscaling/v2
+  {{- else }}
 apiVersion: autoscaling/v2beta2
+  {{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: hpa-scaler-{{ $name }}


### PR DESCRIPTION
## Description

Update HPA version for module `ingress-nginx`. Related to #2759.

Without this change I get helm error.
```
 1. ModuleRun:main:ingress-nginx:doStartup:OperatorStartup:failures 111:unable to build kubernetes objects from release manifest: resource mapping not found for name: "hpa-scaler-main" namespace: "d8-ingress-nginx" from "": no matches for kind "HorizontalPodAutoscaler" in version "
autoscaling/v2beta2"
ensure CRDs are installed first
```

## Why do we need it, and what problem does it solve?

Running deckhouse on Managed K8S with version 1.26

## Why do we need it in the patch release (if we do)?

This is very minor update.

## What is the expected result?

Using managed 1.26 without errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: Update apiVersion of HPA
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
