### PR TITLE
[decumentation] remove deckhouse-web module config on migration

### DIFF
--- a/global-hooks/migrate/migrate_deckhouse-web_mc.go
+++ b/global-hooks/migrate/migrate_deckhouse-web_mc.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
-	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,11 +80,9 @@ func documentationMCMigration(input *go_hook.HookInput, dc dependency.Container)
 	}
 
 	_, err = kubeCl.Dynamic().Resource(mcGVR).Create(context.TODO(), mc, v1.CreateOptions{})
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 
-	input.MetricsCollector.Set("d8_mc_deprecated", 1, map[string]string{"module": "deckhouse-web"}, metrics.WithGroup("d8_mc"))
-
-	return nil
+	return kubeCl.Dynamic().Resource(mcGVR).Delete(context.TODO(), "deckhouse-web", v1.DeleteOptions{})
 }

--- a/global-hooks/migrate/migrate_deckhouse-web_mc_test.go
+++ b/global-hooks/migrate/migrate_deckhouse-web_mc_test.go
@@ -19,10 +19,9 @@ package hooks
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"

--- a/modules/810-documentation/hooks/deprecated_mc.go
+++ b/modules/810-documentation/hooks/deprecated_mc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hooks
 
 import (
@@ -20,6 +36,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			ExecuteHookOnEvents:          pointer.Bool(true),
 			ExecuteHookOnSynchronization: pointer.Bool(true),
+			WaitForSynchronization:       pointer.Bool(true),
 			FilterFunc:                   filterMC,
 		},
 	},
@@ -33,7 +50,7 @@ func setAlertMetrics(input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire("d8_mc")
 
 	if len(input.Snapshots["mc"]) > 0 {
-		input.MetricsCollector.Set("d8_mc_deprecated", 1, map[string]string{"module": "deckhouse-web"}, metrics.WithGroup("d8_mc"))
+		input.MetricsCollector.Set("d8_mc_deprecated", 1, map[string]string{"module": "documentation"}, metrics.WithGroup("d8_mc"))
 	}
 
 	return nil

--- a/modules/810-documentation/hooks/deprecated_mc.go
+++ b/modules/810-documentation/hooks/deprecated_mc.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// TODO: remove after release 1.50
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Kubernetes: []go_hook.KubernetesConfig{
 		{

--- a/modules/810-documentation/hooks/deprecated_mc.go
+++ b/modules/810-documentation/hooks/deprecated_mc.go
@@ -1,0 +1,40 @@
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "mc",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ModuleConfig",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"deckhouse-web"},
+			},
+			ExecuteHookOnEvents:          pointer.Bool(true),
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			FilterFunc:                   filterMC,
+		},
+	},
+}, setAlertMetrics)
+
+func filterMC(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func setAlertMetrics(input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire("d8_mc")
+
+	if len(input.Snapshots["mc"]) > 0 {
+		input.MetricsCollector.Set("d8_mc_deprecated", 1, map[string]string{"module": "deckhouse-web"}, metrics.WithGroup("d8_mc"))
+	}
+
+	return nil
+}

--- a/modules/810-documentation/hooks/deprecated_mc.go
+++ b/modules/810-documentation/hooks/deprecated_mc.go
@@ -38,7 +38,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			ExecuteHookOnEvents:          pointer.Bool(true),
 			ExecuteHookOnSynchronization: pointer.Bool(true),
-			WaitForSynchronization:       pointer.Bool(true),
 			FilterFunc:                   filterMC,
 		},
 	},

--- a/modules/810-documentation/monitoring/prometheus-rules/deprecated-mc.yaml
+++ b/modules/810-documentation/monitoring/prometheus-rules/deprecated-mc.yaml
@@ -2,7 +2,7 @@
   rules:
   - alert: ModuleConfigDeprecated
     expr: |
-      max(d8_mc_deprecated{module="deckhouse-web"}) > 0
+      max(d8_mc_deprecated{module="documentation"}) > 0
     labels:
       severity_level: "9"
       tier: cluster
@@ -14,6 +14,4 @@
       description: |-
         The module `deckhouse-web` was renamed to the `documentation`.
 
-        The new ModuleConfig was generated automatically. Please, remove deprecated ModuleConfig via the command: `kubectl delete mc deckhouse-web`
-        and remove it from the CI deploy process.
-        You can get the new module config with the command: `kubectl get mc documentation -o yaml`.
+        The new ModuleConfig `documentation` was generated automatically. Please, remove deprecated ModuleConfig `deckhouse-web` from the CI deploy process and delete it: `kubectl delete mc deckhouse-web`.


### PR DESCRIPTION
## Description
Automatilcally remove `ModuleConfig/deckhouse-web` on migration.

## Why do we need it, and what problem does it solve?
Remove garbage without user actions.

## Why do we need it in the patch release (if we do)?

ref: #4982

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: documentation
type: fix
summary: Remove deckhouse-web mc on migration.
impact_level: low
```
