### PR TITLE
[nginx-ingress] provide some recommendations in D8NginxIngressKruiseControllerPodIsRestartingTooOften alert

### DIFF
--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -82,15 +82,23 @@
     labels:
       severity_level: "8"
     annotations:
-      description: |-
-        The number of restarts in the last hour: {{ $value }}.
-        Excessive kruise controller restarts indicate that something is wrong. Normally, it should be up and running all the time.
       plk_create_group_if_not_exists__d8_kruise_controller_malfunctioning: D8NginxIngressKruiseControllerMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_kruise_controller_malfunctioning: D8NginxIngressKruiseControllerMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes
       plk_labels_as_annotations: "pod"
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       summary: Too many kruise controller restarts have been detected in d8-ingress-nginx namespace.
+      description: |-
+        The number of restarts in the last hour: {{ $value }}.
+        Excessive kruise controller restarts indicate that something is wrong. Normally, it should be up and running all the time.
+
+        The recommended course of action:
+        1. Check any events regarding kruise-controller-manager in d8-ingress-nginx namespace
+        in case there were some issues there related to the nodes the manager runs on or memory shortage (OOM):  `kubectl -n d8-ingress-nginx get events | grep kruise-controller-manager`
+        2. Analyze the controller's pods' descriptions to check which containers were restarted
+        and what were the possible reasons (exit codes, etc.): `kubectl -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager`
+        3. In case `kruise` container was restarted, list relevant logs of the container to check
+        if there were some meaningful errors there: `kubectl -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise`
 
   - alert: NginxIngressDaemonSetReplicasUnavailable
     expr: kruise_daemonset_status_number_unavailable{namespace="d8-ingress-nginx"} > 0


### PR DESCRIPTION
## Description
Addition recommendation has been provided to follow in case thee is an issue with kruise controller manager.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Relates to https://github.com/deckhouse/deckhouse/issues/4976?utm=ford_dropdown-menu#issuecomment-1602135896,
helps users understand how to deal with kruise controller's restarts.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
The alert contains some recommendations to follow.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: nginx-ingress
type: chore
summary: provide some recommendations in D8NginxIngressKruiseControllerPodIsRestartingTooOften alert.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
