### PR TITLE
[flant-integration] refactor madison registration hook and provide tests for getPrometheusURLSchema

### DIFF
--- a/ee/modules/600-flant-integration/hooks/madison/registration.go
+++ b/ee/modules/600-flant-integration/hooks/madison/registration.go
@@ -75,8 +75,8 @@ const (
 	internalLicenseKeyPath = "flantIntegration.internal.licenseKey"
 
 	prometheusSecretNS      = "d8-monitoring"
-	prometheusSecretName    = "prometheus-https-mode"
-	prometheusSecretField   = "https_mode"
+	prometheusSecretName    = "prometheus-url-schema"
+	prometheusSecretField   = "url_schema"
 	prometheusSecretBinding = prometheusSecretName
 
 	madisonSecretNS      = "d8-monitoring"
@@ -135,11 +135,11 @@ func registrationHandler(input *go_hook.HookInput, dc dependency.Container) erro
 
 	// No auth key set in configuration, no auth key stored in the Secret — register in madison.
 	domainTemplate := input.Values.Get("global.modules.publicDomainTemplate").String()
-	prometheusHTTPSMode := getPrometheusHTTPSMode(input)
+	prometheusURLSchema := getPrometheusURLSchema(input)
 
 	// Create payload for Madison with Prometheus and Grafana URLs.
 	// Use https mode calculated in 300-prometheus module.
-	payload := createMadisonPayload(domainTemplate, prometheusHTTPSMode)
+	payload := createMadisonPayload(domainTemplate, prometheusURLSchema)
 
 	// Create http request to d8-connect proxy.
 	req, err := newRegistrationRequest(registrationURL, payload, licenseKey.String())
@@ -192,8 +192,8 @@ func createMadisonPayload(domainTemplate string, schema string) madisonRequestDa
 	return data
 }
 
-// getPrometheusHTTPSMode returns https mode from Secret.
-func getPrometheusHTTPSMode(input *go_hook.HookInput) string {
+// getPrometheusURLSchema returns the Prometheus module url schema from Secret.
+func getPrometheusURLSchema(input *go_hook.HookInput) string {
 	snap := input.Snapshots[prometheusSecretBinding]
 	if len(snap) == 0 {
 		return "http"

--- a/ee/modules/600-flant-integration/hooks/madison/registration_test.go
+++ b/ee/modules/600-flant-integration/hooks/madison/registration_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	_ "github.com/flant/addon-operator/sdk"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -184,6 +185,31 @@ data:
 					GrafanaURL:    "https://grafana.one.two",
 					PrometheusURL: "https://grafana.one.two/prometheus",
 				},
+			),
+		)
+	})
+
+	Context("getPrometheusURLSchema", func() {
+
+		table.DescribeTable("getPrometheusURLSchema",
+			func(input *go_hook.HookInput, want string) {
+				p := getPrometheusURLSchema(input)
+				Expect(p).To(Equal(want))
+			},
+			table.Entry(
+				"an empty snapshot",
+				&go_hook.HookInput{Snapshots: go_hook.Snapshots{prometheusSecretBinding: []go_hook.FilterResult{}}},
+				"http",
+			),
+			table.Entry(
+				"a snapshot with http",
+				&go_hook.HookInput{Snapshots: go_hook.Snapshots{prometheusSecretBinding: []go_hook.FilterResult{"http"}}},
+				"http",
+			),
+			table.Entry(
+				"a snapshot with https",
+				&go_hook.HookInput{Snapshots: go_hook.Snapshots{prometheusSecretBinding: []go_hook.FilterResult{"https"}}},
+				"https",
 			),
 		)
 	})

--- a/modules/300-prometheus/templates/prometheus-https-mode-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus-https-mode-secret.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: prometheus-https-mode
+  name: prometheus-url-schema
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: Opaque
 data:
-  https_mode: {{ include "helm_lib_module_uri_scheme" . | b64enc }}
+  url_schema: {{ include "helm_lib_module_uri_scheme" . | b64enc }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
* Updated the Prometheus module's secret `prometheus-https-mode` to `prometheus-url-schema` so that its name corresponds to its function.
* Made some renaming in the Flant-integration Madison Registration hook in accordance with the new Prometheus secret and field names.
* Added tests for getPrometheusURLSchema function to make sure it returns expected values.

## Why do we need it, and what problem does it solve?
The aforementioned changes improve the readability and provide necessary testing.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: flant-integration
type: chore
summary: Rename prometheus secret from prometheus-https-mode to prometheus-url-schema, update madison registration hook to use new secret and field, add some tests.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
