### PR TITLE
[common] Add commonName field to Deckhouse X.509 certificates

### DIFF
--- a/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
@@ -48,6 +48,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
   issuerRef:

--- a/ee/modules/502-delivery/templates/argocd/server/d8-ingress.yaml
+++ b/ee/modules/502-delivery/templates/argocd/server/d8-ingress.yaml
@@ -47,6 +47,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-argocd") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "argocd") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "argocd") }}
   issuerRef:

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.2.0
-digest: sha256:3637727bda75acf77943c31c21c48124c3b0549d922300d678ea2368cffefcea
-generated: "2023-05-03T23:36:15.206375+08:00"
+  version: 1.5.0
+digest: sha256:fbe23ae96d5998e7b83852ebd4f28918b8f9e737909d40224aa3a060c0a2feab
+generated: "2023-06-23T22:26:45.380233+08:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.2.0"
+    version: "1.5.0"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.2.0
+version: 1.5.0

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -41,6 +41,7 @@
 | [helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs) |
 | [helm_lib_module_pod_security_context_run_as_user_root](#helm_lib_module_pod_security_context_run_as_user_root) |
 | [helm_lib_module_container_security_context_not_allow_privilege_escalation](#helm_lib_module_container_security_context_not_allow_privilege_escalation) |
+| [helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux](#helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux) |
 | [helm_lib_module_container_security_context_read_only_root_filesystem](#helm_lib_module_container_security_context_read_only_root_filesystem) |
 | [helm_lib_module_container_security_context_privileged](#helm_lib_module_container_security_context_privileged) |
 | [helm_lib_module_container_security_context_privileged_read_only_root_filesystem](#helm_lib_module_container_security_context_privileged_read_only_root_filesystem) |
@@ -465,6 +466,19 @@ list:
 
 `{{ include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . }} `
 
+
+
+### helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux
+
+ returns SecurityContext parameters for Container with allowPrivilegeEscalation false and options for SELinux compatibility
+
+#### Usage
+
+`{{ include "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
 
 
 ### helm_lib_module_container_security_context_read_only_root_filesystem

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_public_domain.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_public_domain.tpl
@@ -7,5 +7,13 @@
   {{- if not (contains "%s" $context.Values.global.modules.publicDomainTemplate) }}
     {{ fail "Error!!! global.modules.publicDomainTemplate must contain \"%s\" pattern to render service fqdn!" }}
   {{- end }}
-  {{- printf $context.Values.global.modules.publicDomainTemplate $name_portion }}
+
+  {{- $domain := printf $context.Values.global.modules.publicDomainTemplate $name_portion -}}
+
+  {{- $domain_length := len $domain -}}
+  {{- if gt $domain_length 64 -}}
+    {{ fail "domain name must be not longer than 64 characters" }}
+  {{- end -}}
+
+  {{ $domain }}
 {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -48,6 +48,17 @@ securityContext:
   allowPrivilegeEscalation: false
 {{- end }}
 
+{{- /* Usage: {{ include "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" . }} */ -}}
+{{- /* returns SecurityContext parameters for Container with allowPrivilegeEscalation false and options for SELinux compatibility*/ -}}
+{{- define "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  allowPrivilegeEscalation: false
+  seLinuxOptions:
+    level: 's0'
+    type: 'spc_t'
+{{- end }}
+
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_read_only_root_filesystem" . }} */ -}}
 {{- /* returns SecurityContext parameters for Container with read only root filesystem */ -}}
 {{- define "helm_lib_module_container_security_context_read_only_root_filesystem" -}}

--- a/modules/110-istio/templates/certificate.yaml
+++ b/modules/110-istio/templates/certificate.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "istio-ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "istio") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "istio") }}
   issuerRef:

--- a/modules/150-user-authn/templates/dex/certificate.yaml
+++ b/modules/150-user-authn/templates/dex/certificate.yaml
@@ -12,7 +12,6 @@ spec:
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "dex") }}
-  - {{ include "helm_lib_module_public_domain" (list . "kubeconfig") }}
   issuerRef:
     name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
     kind: ClusterIssuer

--- a/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and (.Values.global.modules.publicDomainTemplate) (.Values.userAuthn.kubeconfigGenerator) }}
+  {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kubeconfig
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kubernetes-configurator")) | nindent 2 }}
+spec:
+  certificateOwnerRef: false
+  secretName: {{ include "helm_lib_module_https_secret_name" (list . "kubeconfig-ingress-tls") }}
+  dnsNames:
+  - {{ include "helm_lib_module_public_domain" (list . "kubeconfig") }}
+  issuerRef:
+    name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+    kind: ClusterIssuer
+  {{- end }}
+{{- end }}

--- a/modules/150-user-authn/templates/kubeconfig-generator/ingress.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/ingress.yaml
@@ -15,7 +15,7 @@ spec:
   tls:
   - hosts:
     - {{ include "helm_lib_module_public_domain" (list . "kubeconfig") }}
-    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+    secretName: {{ include "helm_lib_module_https_secret_name" (list . "kubeconfig-ingress-tls") }}
   {{- end }}
   rules:
   - host: {{ include "helm_lib_module_public_domain" (list . "kubeconfig") }}

--- a/modules/150-user-authn/templates/kubernetes-api/certificate.yaml
+++ b/modules/150-user-authn/templates/kubernetes-api/certificate.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "publish_api_certificate_name" . }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "api") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "api") }}
   issuerRef:

--- a/modules/300-prometheus/templates/grafana/ingress.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress.yaml
@@ -79,6 +79,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "grafana") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "grafana") }}
   - {{ include "helm_lib_module_public_domain" (list . "prometheus") }}

--- a/modules/491-containerized-data-importer/templates/ingress.yaml
+++ b/modules/491-containerized-data-importer/templates/ingress.yaml
@@ -41,6 +41,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "cdi-uploadproxy") }}
   dnsNames:
     - {{ include "helm_lib_module_public_domain" (list . "cdi-uploadproxy") }}
   issuerRef:

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -57,6 +57,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "hubble") }}
   dnsNames:
     - {{ include "helm_lib_module_public_domain" (list . "hubble") }}
   issuerRef:

--- a/modules/500-dashboard/templates/dashboard/ingress.yaml
+++ b/modules/500-dashboard/templates/dashboard/ingress.yaml
@@ -64,6 +64,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "dashboard") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "dashboard") }}
   issuerRef:

--- a/modules/500-openvpn/templates/openvpn/ingress.yaml
+++ b/modules/500-openvpn/templates/openvpn/ingress.yaml
@@ -56,6 +56,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "openvpn-admin") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "openvpn-admin") }}
   issuerRef:

--- a/modules/500-upmeter/templates/status/ingress.yaml
+++ b/modules/500-upmeter/templates/status/ingress.yaml
@@ -101,6 +101,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: ingress-tls-status
+  commonName: {{ include "helm_lib_module_public_domain" (list . "status") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "status") }}
   issuerRef:

--- a/modules/500-upmeter/templates/webui/ingress.yaml
+++ b/modules/500-upmeter/templates/webui/ingress.yaml
@@ -95,6 +95,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: ingress-tls-webui
+  commonName: {{ include "helm_lib_module_public_domain" (list . .Chart.Name) }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . .Chart.Name) }}
   issuerRef:

--- a/modules/810-documentation/templates/ingress.yaml
+++ b/modules/810-documentation/templates/ingress.yaml
@@ -59,6 +59,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  commonName: {{ include "helm_lib_module_public_domain" (list . "documentation") }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "documentation") }}
   issuerRef:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add commonName field to Deckhouse X.509 certificates.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close #4926.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Add commonName field to Deckhouse X.509 certificates.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
