### PR TITLE
[user-authn] Allow users to deploy DexAuthenticator trusted by Kubernetes

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -68,9 +68,6 @@ func applyDexAuthenticatorFilter(obj *unstructured.Unstructured) (go_hook.Filter
 	encodedName := encoding.ToFnvLikeDex(fmt.Sprintf("%s-%s-dex-authenticator", name, namespace))
 
 	_, allowAccessToKubernetes := obj.GetAnnotations()["dexauthenticator.deckhouse.io/allow-access-to-kubernetes"]
-	if namespace != "d8-dashboard" {
-		allowAccessToKubernetes = false
-	}
 
 	return DexAuthenticator{
 		ID:                      id,

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -98,7 +98,7 @@ spec:
       }
     ]
   },
-  "allowAccessToKubernetes": false,
+  "allowAccessToKubernetes": true,
   "encodedName": "orsxg5bnorsxg5bnmrsxqllbov2gqzlooruwgylun5zmx4u44scceizf",
   "credentials": {
     "cookieSecret": "testNexttestNexttestNext",
@@ -218,7 +218,7 @@ data:
     "applicationIngressClassName": "nginx",
     "sendAuthorizationHeader": false
   },
-  "allowAccessToKubernetes": false,
+  "allowAccessToKubernetes": true,
   "encodedName": "orsxg5bnmq4c23lpnzuxi33snfxgollemv4c2ylvorugk3tunfrwc5dpolf7fhheqqrcgji",
   "credentials": {
     "cookieSecret": "testNexttestNexttestNext",

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -66,7 +66,20 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
     tolerations:
     - key: foo
       operator: Equal
-      value: bar`)
+      value: bar
+- name: test-2
+  encodedName: justForTest2
+  namespace: d8-test
+  credentials:
+    appDexSecret: dexSecret
+    cookieSecret: cookieSecret
+  allowAccessToKubernetes: true
+  spec:
+    applicationDomain: authenticator.com
+    applicationIngressCertificateSecretName: test
+    applicationIngressClassName: test
+    sendAuthorizationHeader: false
+`)
 			hec.ValuesSet("userAuthn.idTokenTTL", "20m")
 			hec.HelmRender()
 		})
@@ -76,47 +89,81 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Secret", "d8-test", "registry-dex-authenticator").Exists()).To(BeTrue())
 
-			oauth2client := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest")
-			Expect(oauth2client.Exists()).To(BeTrue())
-			Expect(oauth2client.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.example.com/dex-authenticator/callback"]`))
-			Expect(oauth2client.Field("secret").String()).To(Equal("dexSecret"))
-			Expect(oauth2client.Field("allowedGroups").String()).To(MatchJSON(`["everyone","admins"]`))
-
-			ingress := hec.KubernetesResource("Ingress", "d8-test", "test-dex-authenticator")
-			Expect(ingress.Exists()).To(BeTrue())
-			Expect(ingress.Field("spec.ingressClassName").String()).To(Equal("test"))
-			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-buffer-size").String()).To(Equal("32k"))
-			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range").String()).To(Equal("1.1.1.1,192.168.0.0/24"))
-
-			Expect(ingress.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator.example.com"]`))
-			Expect(ingress.Field("spec.tls.0.secretName").String()).To(Equal("test"))
-
 			secret := hec.KubernetesResource("Secret", "d8-test", "dex-authenticator-test")
 			Expect(secret.Exists()).To(BeTrue())
 			Expect(secret.Field("data.client-secret").String()).To(Equal("ZGV4U2VjcmV0"))
 			Expect(secret.Field("data.cookie-secret").String()).To(Equal("Y29va2llU2VjcmV0"))
 
-			deployment := hec.KubernetesResource("Deployment", "d8-test", "test-dex-authenticator")
-			Expect(deployment.Exists()).To(BeTrue())
-			Expect(deployment.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"testnode": ""}`))
-			Expect(deployment.Field("spec.template.spec.tolerations").String()).To(MatchYAML(`
+			oauth2clientTest := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest")
+			Expect(oauth2clientTest.Exists()).To(BeTrue())
+			Expect(oauth2clientTest.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.example.com/dex-authenticator/callback"]`))
+			Expect(oauth2clientTest.Field("secret").String()).To(Equal("dexSecret"))
+			Expect(oauth2clientTest.Field("allowedGroups").String()).To(MatchJSON(`["everyone","admins"]`))
+
+			ingressTest := hec.KubernetesResource("Ingress", "d8-test", "test-dex-authenticator")
+			Expect(ingressTest.Exists()).To(BeTrue())
+			Expect(ingressTest.Field("spec.ingressClassName").String()).To(Equal("test"))
+			Expect(ingressTest.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-buffer-size").String()).To(Equal("32k"))
+			Expect(ingressTest.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range").String()).To(Equal("1.1.1.1,192.168.0.0/24"))
+
+			Expect(ingressTest.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator.example.com"]`))
+			Expect(ingressTest.Field("spec.tls.0.secretName").String()).To(Equal("test"))
+
+			deploymentTest := hec.KubernetesResource("Deployment", "d8-test", "test-dex-authenticator")
+			Expect(deploymentTest.Exists()).To(BeTrue())
+			Expect(deploymentTest.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"testnode": ""}`))
+			Expect(deploymentTest.Field("spec.template.spec.tolerations").String()).To(MatchYAML(`
 - key: foo
   operator: Equal
   value: "bar"
 `))
 
-			var oauth2proxyArgs []string
-			for _, result := range deployment.Field("spec.template.spec.containers.0.args").Array() {
-				oauth2proxyArgs = append(oauth2proxyArgs, result.String())
+			var oauth2proxyArgTest []string
+			for _, result := range deploymentTest.Field("spec.template.spec.containers.0.args").Array() {
+				oauth2proxyArgTest = append(oauth2proxyArgTest, result.String())
 			}
 
-			Expect(oauth2proxyArgs).Should(ContainElement("--client-id=test-d8-test-dex-authenticator"))
-			Expect(oauth2proxyArgs).Should(ContainElement("--oidc-issuer-url=https://dex.example.com/"))
-			Expect(oauth2proxyArgs).Should(ContainElement("--redirect-url=https://authenticator.example.com"))
-			Expect(oauth2proxyArgs).Should(ContainElement("--set-authorization-header=true"))
-			Expect(oauth2proxyArgs).Should(ContainElement("--cookie-expire=1020h"))
-			Expect(oauth2proxyArgs).Should(ContainElement("--cookie-refresh=20m"))
-			Expect(oauth2proxyArgs).Should(ContainElement("--whitelist-domain=authenticator.example.com"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--client-id=test-d8-test-dex-authenticator"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--oidc-issuer-url=https://dex.example.com/"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--redirect-url=https://authenticator.example.com"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--set-authorization-header=true"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--cookie-expire=1020h"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--cookie-refresh=20m"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--whitelist-domain=authenticator.example.com"))
+			Expect(oauth2proxyArgTest).Should(ContainElement("--scope=groups email openid offline_access"))
+
+			oauth2client2 := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest2")
+			Expect(oauth2client2.Exists()).To(BeTrue())
+			Expect(oauth2client2.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.com/dex-authenticator/callback"]`))
+			Expect(oauth2client2.Field("secret").String()).To(Equal("dexSecret"))
+
+			ingressTest2 := hec.KubernetesResource("Ingress", "d8-test", "test-2-dex-authenticator")
+			Expect(ingressTest2.Exists()).To(BeTrue())
+			Expect(ingressTest2.Field("spec.ingressClassName").String()).To(Equal("test"))
+
+			Expect(ingressTest2.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator.com"]`))
+			Expect(ingressTest2.Field("spec.tls.0.secretName").String()).To(Equal("test"))
+			Expect(ingressTest2.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-buffer-size").Exists()).To(BeFalse())
+			Expect(ingressTest2.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range").Exists()).To(BeFalse())
+
+			deploymentTest2 := hec.KubernetesResource("Deployment", "d8-test", "test-2-dex-authenticator")
+			Expect(deploymentTest2.Exists()).To(BeTrue())
+			Expect(deploymentTest2.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"node-role.deckhouse.io/system": ""}`))
+			Expect(deploymentTest2.Field("spec.template.spec.tolerations").Exists()).To(BeTrue()) // default taints
+
+			var oauth2proxyArgTest2 []string
+			for _, result := range deploymentTest2.Field("spec.template.spec.containers.0.args").Array() {
+				oauth2proxyArgTest2 = append(oauth2proxyArgTest2, result.String())
+			}
+
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--client-id=test-2-d8-test-dex-authenticator"))
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--oidc-issuer-url=https://dex.example.com/"))
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--redirect-url=https://authenticator.com"))
+			Expect(oauth2proxyArgTest2).ShouldNot(ContainElement("--set-authorization-header=true"))
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--cookie-expire=168h"))
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--cookie-refresh=20m"))
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--whitelist-domain=authenticator.com"))
+			Expect(oauth2proxyArgTest2).Should(ContainElement("--scope=groups email openid offline_access audience:server:client_id:kubernetes"))
 		})
 	})
 })


### PR DESCRIPTION
## Description
* Ease restriction of using tokens received by DexAuthenticators to access the Kubernetes API

## Why do we need it, and what problem does it solve?
This is not possible to deploy web interfaces, that can reuse token to access the Kubernetes API.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Allow users to deploy DexAuthenticator trusted by Kubernetes.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
