### PR TITLE
[operator-trivy][ci] Build own trivy-db with OCI compatible artifact

### DIFF
--- a/.github/workflow_templates/trivy-db-schedule.yml
+++ b/.github/workflow_templates/trivy-db-schedule.yml
@@ -45,10 +45,6 @@ jobs:
     steps:
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
-      - name: Install oras
-        run: |
-          # install ORAS 1.0.0
-
       - name: Upload trivy-db to registries
         run: |
           git clone https://github.com/aquasecurity/trivy-db.git && cd trivy-db

--- a/.github/workflow_templates/trivy-db-schedule.yml
+++ b/.github/workflow_templates/trivy-db-schedule.yml
@@ -24,8 +24,9 @@ on:
 concurrency:
   group: trivy-db-download
 
+{!{ $registries := coll.Slice "${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-db" "${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db" "${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/deckhouse/security/trivy-db" -}!}
 jobs:
-  download-and-repush-images:
+  download-and-repush-images: # TODO (alex123012): remove after 1.47 in RockSolid
     name: Download and repush images
     runs-on: [self-hosted, regular]
     steps:
@@ -34,6 +35,25 @@ jobs:
       - name: Download crane and copy image
         run: |
           curl -sSfL https://github.com/google/go-containerregistry/releases/download/v0.13.0/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - && chmod +x crane
-          ./crane copy ghcr.io/aquasecurity/trivy-db:2 ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-db:2
-          ./crane copy ghcr.io/aquasecurity/trivy-db:2 ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2
-          ./crane copy ghcr.io/aquasecurity/trivy-db:2 ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/deckhouse/security/trivy-db:2
+{!{- range $registry := $registries }!}
+          ./crane copy ghcr.io/aquasecurity/trivy-db:2 {!{ $registry }!}:2
+{!{- end }!}
+
+  create-oci-compatible-trivy-db:
+    name: Create OCI compatible trivy-db
+    runs-on: [self-hosted, regular]
+    steps:
+{!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
+      - name: Install oras
+        run: |
+          # install ORAS 1.0.0
+
+      - name: Upload trivy-db to registries
+        run: |
+          git clone https://github.com/aquasecurity/trivy-db.git && cd trivy-db
+          curl -sSfL https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz | tar -xzf - oras && chmod +x oras
+          make db-all
+{!{- range $registry := $registries }!}
+          ./oras push --artifact-type application/vnd.oci.image.config.v1+json {!{ $registry }!}-oci:2 assets/db.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+{!{- end }!}

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -140,10 +140,6 @@ jobs:
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_dev_registry_step>
-      - name: Install oras
-        run: |
-          # install ORAS 1.0.0
-
       - name: Upload trivy-db to registries
         run: |
           git clone https://github.com/aquasecurity/trivy-db.git && cd trivy-db

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -29,7 +29,7 @@ concurrency:
   group: trivy-db-download
 
 jobs:
-  download-and-repush-images:
+  download-and-repush-images: # TODO (alex123012): remove after 1.47 in RockSolid
     name: Download and repush images
     runs-on: [self-hosted, regular]
     steps:
@@ -87,3 +87,68 @@ jobs:
           ./crane copy ghcr.io/aquasecurity/trivy-db:2 ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-db:2
           ./crane copy ghcr.io/aquasecurity/trivy-db:2 ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2
           ./crane copy ghcr.io/aquasecurity/trivy-db:2 ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/deckhouse/security/trivy-db:2
+
+  create-oci-compatible-trivy-db:
+    name: Create OCI compatible trivy-db
+    runs-on: [self-hosted, regular]
+    steps:
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{secrets.DECKHOUSE_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to rw registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+      - name: Install oras
+        run: |
+          # install ORAS 1.0.0
+
+      - name: Upload trivy-db to registries
+        run: |
+          git clone https://github.com/aquasecurity/trivy-db.git && cd trivy-db
+          curl -sSfL https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz | tar -xzf - oras && chmod +x oras
+          make db-all
+          ./oras push --artifact-type application/vnd.oci.image.config.v1+json ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-db-oci:2 assets/db.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+          ./oras push --artifact-type application/vnd.oci.image.config.v1+json ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db-oci:2 assets/db.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+          ./oras push --artifact-type application/vnd.oci.image.config.v1+json ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/deckhouse/security/trivy-db-oci:2 assets/db.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip

--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_GOLANG_19_ALPINE
 FROM $BASE_GOLANG_19_ALPINE AS build
 WORKDIR /src
 RUN apk add --update --no-cache patch
-RUN wget https://github.com/aquasecurity/trivy-operator/archive/refs/tags/v0.14.0.tar.gz -O - | tar -xz --strip-components=1
+RUN wget https://github.com/aquasecurity/trivy-operator/archive/refs/tags/v0.14.1.tar.gz -O - | tar -xz --strip-components=1
 
 COPY patches/001-add-registry-secret-as-dockerconfigjson.patch /src
 COPY patches/002-skip-some-checks.patch /src

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -3,7 +3,15 @@ ARG BASE_GOLANG_19_ALPINE
 
 FROM $BASE_GOLANG_19_ALPINE AS build
 WORKDIR /src
-RUN wget https://github.com/aquasecurity/trivy/archive/refs/tags/v0.42.0.tar.gz -O - | tar -xz --strip-components=1
+RUN apk add --update --no-cache patch
+RUN wget https://github.com/aquasecurity/trivy/archive/refs/tags/v0.42.1.tar.gz -O - | tar -xz --strip-components=1
+
+COPY patches/001-trivy-db-mediatype-hack.patch /src
+COPY patches/002-insecure-registry-artifact.patch /src
+
+RUN patch -p1 < 001-trivy-db-mediatype-hack.patch && \
+    patch -p1 < 002-insecure-registry-artifact.patch
+
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 FROM $BASE_ALPINE

--- a/ee/modules/500-operator-trivy/images/trivy/patches/001-trivy-db-mediatype-hack.patch
+++ b/ee/modules/500-operator-trivy/images/trivy/patches/001-trivy-db-mediatype-hack.patch
@@ -1,0 +1,26 @@
+diff --git a/pkg/db/db.go b/pkg/db/db.go
+index 6b69ccbe7..7baa9f561 100644
+--- a/pkg/db/db.go
++++ b/pkg/db/db.go
+@@ -18,7 +18,7 @@ import (
+ )
+ 
+ const (
+-	dbMediaType         = "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
++	dbMediaType         = "application/vnd.oci.image.layer.v1.tar+gzip"
+ 	defaultDBRepository = "ghcr.io/aquasecurity/trivy-db"
+ )
+ 
+diff --git a/pkg/db/db_test.go b/pkg/db/db_test.go
+index ef1537087..56b59b38e 100644
+--- a/pkg/db/db_test.go
++++ b/pkg/db/db_test.go
+@@ -22,7 +22,7 @@ import (
+ 	"github.com/aquasecurity/trivy/pkg/oci"
+ )
+ 
+-const mediaType = "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
++const mediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
+ 
+ type fakeLayer struct {
+ 	v1.Layer

--- a/ee/modules/500-operator-trivy/images/trivy/patches/002-insecure-registry-artifact.patch
+++ b/ee/modules/500-operator-trivy/images/trivy/patches/002-insecure-registry-artifact.patch
@@ -1,0 +1,18 @@
+diff --git a/pkg/oci/artifact.go b/pkg/oci/artifact.go
+index d82f74244..7fb3ef436 100644
+--- a/pkg/oci/artifact.go
++++ b/pkg/oci/artifact.go
+@@ -78,7 +78,12 @@ func (a *Artifact) populate(ctx context.Context, opt types.RemoteOptions) error
+ 	a.m.Lock()
+ 	defer a.m.Unlock()
+ 
+-	ref, err := name.ParseReference(a.repository)
++	var nameOpts []name.Option
++	if opt.Insecure {
++		nameOpts = append(nameOpts, name.Insecure)
++	}
++
++	ref, err := name.ParseReference(a.repository, nameOpts...)
+ 	if err != nil {
+ 		return xerrors.Errorf("repository name error (%s): %w", a.repository, err)
+ 	}

--- a/ee/modules/500-operator-trivy/images/trivy/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/trivy/patches/README.md
@@ -1,0 +1,39 @@
+# Patches
+
+## 001-trivy-db-mediatype-hack.patch
+
+[issue](https://github.com/aquasecurity/trivy/issues/294)
+
+[discussion](https://github.com/aquasecurity/trivy/discussions/4702)
+
+This is a hack for downloading trivy-db from quay registry. Because quay only accepts several media types of image configs and layers:
+```text
+Failed validating \'enum\' in schema[\'properties\'][\'config\'][\'properties\'][\'mediaType\']:
+    {\'description\': \'The MIME type of the referenced manifest\',
+     \'enum\': [\'application/vnd.oci.image.config.v1+json\',
+              \'application/vnd.cncf.helm.config.v1+json\',
+              \'application/vnd.oci.source.image.config.v1+json\'],
+     \'type\': \'string\'}
+
+On instance[\'config\'][\'mediaType\']:
+    \'application/vnd.aquasec.trivy.config.v1+json\'}]} {errors:[message:manifest invalid]}
+```
+
+## 002-insecure-registry-artifact.patch
+
+[PR](https://github.com/aquasecurity/trivy/pull/4701)
+
+Fix pulling artifacts from http registry:
+
+```text
+2023-06-23T13:52:56.086+0300    INFO    Need to update DB
+2023-06-23T13:52:56.086+0300    INFO    DB Repository: registry.quay:8080/admin/deckhouse/security/trivy-db-docker
+2023-06-23T13:52:56.086+0300    INFO    Downloading DB...
+true
+true
+2023-06-23T13:52:56.426+0300    FATAL   init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
+        * Get "https://registry.quay:8080/v2/": http: server gave HTTP response to HTTPS client
+
+```
+
+

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
   trivy.additionalVulnerabilityReportFields: ""
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.slow: "true"
-  trivy.dbRepository: "{{ .Values.global.modulesImages.registry.base }}/security/trivy-db"
+  trivy.dbRepository: "{{ .Values.global.modulesImages.registry.base }}/security/trivy-db-oci"
   trivy.command: "image"
   trivy.dbRepositoryInsecure: "false"
   trivy.useBuiltinRegoPolicies: "true"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
 Build own trivy-db with OCI compatible artifact for quay registry support

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Currently we can't upload trivy-db to quay registry because of error:
```
Failed validating 'enum' in schema['properties']['config']['properties']['mediaType']:
    {'description': 'The MIME type of the referenced manifest',
     'enum': ['application/vnd.oci.image.config.v1+json',
              'application/vnd.sylabs.sif.config.v1+json',
              'application/vnd.cncf.helm.config.v1+json'],
     'type': 'string'}

On instance['config']['mediaType']:
    'application/vnd.aquasec.trivy.config.v1+json']
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Upload trivy-db to quay with no error

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
---
section: operator-trivy
type: fix
summary: Add patch to support insecure registry pull.
impact_level: default
---
section: operator-trivy
type: fix
summary: Add patch to change trivy-db artifact mediaType.
impact_level: default
---
section: ci
type: chore
summary: Add building of the own trivy-db.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
