### PR TITLE
[dhctl] Fix parsing node index (CWE-190, CWE-681)

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -649,4 +650,12 @@ func (i *imagesDigests) ConvertToMap() map[string]interface{} {
 		res[k] = v
 	}
 	return res
+}
+
+func GetIndexFromNodeName(name string) (int, error) {
+	index, err := strconv.Atoi(name[strings.LastIndex(name, "-")+1:])
+	if err != nil {
+		return 0, err
+	}
+	return index, nil
 }

--- a/dhctl/pkg/kubernetes/actions/converge/node.go
+++ b/dhctl/pkg/kubernetes/actions/converge/node.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -364,13 +363,4 @@ func IsNodeExistsInCluster(kubeCl *client.KubernetesClient, nodeName string) (bo
 	})
 
 	return exists, err
-}
-
-func getIndexFromNodeName(name string) (int64, bool) {
-	index, err := strconv.ParseInt(name[strings.LastIndex(name, "-")+1:], 10, 64)
-	if err != nil {
-		log.ErrorLn(err)
-		return 0, false
-	}
-	return index, true
 }


### PR DESCRIPTION
## Description
* Use a single function to parse node index
* Convert directly to `int`

## Why do we need it, and what problem does it solve?
From the description of the problems
> If a string is parsed into an int using strconv.Atoi, and subsequently that int is converted into another integer type of a smaller size, the result can produce unexpected values.

> This also applies to the results of strconv.ParseInt and strconv.ParseUint when the specified size is larger than the size of the type that number is converted to.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
summary: Fix parsing node index (CWE-190, CWE-681).
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
