### PR TITLE
[user-authn] Do not send groups header from DexAuthenticator

### DIFF
--- a/modules/150-user-authn/images/dex-authenticator/Dockerfile
+++ b/modules/150-user-authn/images/dex-authenticator/Dockerfile
@@ -8,8 +8,9 @@ RUN apk --update add make git build-base curl bash ca-certificates wget \
  && update-ca-certificates
 RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . \
  && git checkout v7.2.0
-ADD patches/cookie-refresh.patch /
+ADD patches/cookie-refresh.patch patches/remove-groups.patch /
 RUN patch -p1 < /cookie-refresh.patch \
+  && patch -p1 < /remove-groups.patch \
   && make build
 
 FROM $BASE_ALPINE

--- a/modules/150-user-authn/images/dex-authenticator/patches/README.md
+++ b/modules/150-user-authn/images/dex-authenticator/patches/README.md
@@ -6,3 +6,11 @@ There is a problem when we are using nonpersistent Redis for session storage. If
 Storing refresh token in cookie adds the possibility to restore access- and id- token even if there is no data in Redis.
 
 Upstream PR - https://github.com/oauth2-proxy/oauth2-proxy/pull/313
+
+### Remove groups
+
+Prevents sending groups auth request header (may cause uncontrollable headers grows).
+Two options to fix this without patch:
+
+Add a new flag: https://github.com/oauth2-proxy/oauth2-proxy/issues/2144
+Migrate to a structured config (alpha config): https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/alpha-config

--- a/modules/150-user-authn/images/dex-authenticator/patches/remove-groups.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/remove-groups.patch
@@ -1,0 +1,21 @@
+diff --git a/pkg/apis/options/legacy_options.go b/pkg/apis/options/legacy_options.go
+index 3441fd4..709e008 100644
+--- a/pkg/apis/options/legacy_options.go
++++ b/pkg/apis/options/legacy_options.go
+@@ -411,16 +411,6 @@ func getXAuthRequestHeaders() []Header {
+ 				},
+ 			},
+ 		},
+-		{
+-			Name: "X-Auth-Request-Groups",
+-			Values: []HeaderValue{
+-				{
+-					ClaimSource: &ClaimSource{
+-						Claim: "groups",
+-					},
+-				},
+-			},
+-		},
+ 	}
+
+ 	return headers


### PR DESCRIPTION
## Description
The Group header size can grow without control, which can cause requests to fail because of the body size

## Why do we need it, and what problem does it solve?
This is a regression after upgrading oauth2-proxy 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Do not send groups header from DexAuthenticator
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
