### PR TITLE
[global-hooks] Delete `d8-deckhouse-validating-webhook-handler` validating webhook configurations

### DIFF
--- a/global-hooks/migrate/migrate_reomove_old_d8_validating_webhook_configuration.go
+++ b/global-hooks/migrate/migrate_reomove_old_d8_validating_webhook_configuration.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+// TODO: remove this hook after Deckhouse 1.50
+
+// shell-operator >= 1.2 adds suffix `-hooks` for validating webhook configuration
+// https://github.com/flant/shell-operator/pull/439/files#diff-c93f73840012ea2edf0f924aab72794a77de0132bf1351776df8dd9b494002f9R14
+// after updating shell-operator we have two webhook configuration old `d8-deckhouse-validating-webhook-handler` and new `d8-deckhouse-validating-webhook-handler-hooks`
+// this hook removes old `d8-deckhouse-validating-webhook-handler`
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(removeOldD8ValidationWebhookConfiguration))
+
+func removeOldD8ValidationWebhookConfiguration(_ *go_hook.HookInput, dc dependency.Container) error {
+	kubeCl, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("cannot init Kubernetes client: %v", err)
+	}
+
+	err = kubeCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), "d8-deckhouse-validating-webhook-handler", metav1.DeleteOptions{})
+	if !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}

--- a/global-hooks/migrate/migrate_reomove_old_d8_validating_webhook_configuration_test.go
+++ b/global-hooks/migrate/migrate_reomove_old_d8_validating_webhook_configuration_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	oldValidationWebhookConfigMocks = `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: d8-deckhouse-validating-webhook-handler
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: QUFBCg==
+    service:
+      name: validating-webhook-handler
+      namespace: d8-system
+      path: /hooks/cluster-authorization-rules-deckhouse-io
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: cluster-authorization-rules.deckhouse.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - deckhouse.io
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterauthorizationrules
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 10
+`
+
+	newValidationWebhookConfigMocks = `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: d8-deckhouse-validating-webhook-handler-hooks
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: QUFBCg==
+    service:
+      name: validating-webhook-handler
+      namespace: d8-system
+      path: /hooks/d8-cluster-configuration-secret-deckhouse-io
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: d8-cluster-configuration-secret.deckhouse.io
+  namespaceSelector: {}
+  objectSelector:
+    matchLabels:
+      name: d8-cluster-configuration
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - '*'
+    resources:
+    - secrets
+    scope: Namespaced
+  sideEffects: None
+  timeoutSeconds: 10
+`
+)
+
+func createValidationWebhookConfigMocks(doc string) {
+	var c admissionv1.ValidatingWebhookConfiguration
+	err := yaml.Unmarshal([]byte(doc), &c)
+	if err != nil {
+		panic(err)
+	}
+	_, err = dependency.TestDC.MustGetK8sClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), &c, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+var _ = Describe("Global :: migrate_reomove_old_d8_validating_webhook_configuration ::", func() {
+	getValidationWebhookConfigMocks := func(name string) (*admissionv1.ValidatingWebhookConfiguration, error) {
+		return dependency.TestDC.MustGetK8sClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
+	}
+
+	assertOldConfigurationWasDeleted := func() {
+		_, err := getValidationWebhookConfigMocks("d8-deckhouse-validating-webhook-handler")
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	}
+
+	assertNewConfigurationKeep := func() {
+		c, err := getValidationWebhookConfigMocks("d8-deckhouse-validating-webhook-handler-hooks")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(c).ToNot(BeNil())
+		Expect(c.GetName()).To(Equal("d8-deckhouse-validating-webhook-handler-hooks"))
+	}
+
+	Context("Empty cluster", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Old and new configuration exists", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			createValidationWebhookConfigMocks(oldValidationWebhookConfigMocks)
+			createValidationWebhookConfigMocks(newValidationWebhookConfigMocks)
+			f.RunHook()
+		})
+
+		It("Should delete old configuration and keep new", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			assertOldConfigurationWasDeleted()
+
+			assertNewConfigurationKeep()
+		})
+	})
+
+	Context("Only new configuration exists", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			createValidationWebhookConfigMocks(newValidationWebhookConfigMocks)
+			f.RunHook()
+		})
+
+		It("should not fail and keep new configuration", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			assertOldConfigurationWasDeleted()
+
+			assertNewConfigurationKeep()
+		})
+	})
+})


### PR DESCRIPTION
## Description
This PR removes old `d8-deckhouse-validating-webhook-handler` validating webhook configuration.

`shell-operator` >= 1.2 adds suffix `-hooks` for validating webhook configuration.
https://github.com/flant/shell-operator/pull/439/files#diff-c93f73840012ea2edf0f924aab72794a77de0132bf1351776df8dd9b494002f9R14


## Why do we need it, and what problem does it solve?
After updating shell-operator we have two webhook configuration: old `d8-deckhouse-validating-webhook-handler` and new `d8-deckhouse-validating-webhook-handler-hooks`. We shold remove old configuration.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manual Testing Proofs
Before switching to branch: have 2 validating webhook configurations:
![image](https://github.com/deckhouse/deckhouse/assets/30695496/e2cfedeb-d059-4a88-b7eb-3333c3587481)

After switching, Deckhouse is ready and old validation webhook configuration has deleted:
![image](https://github.com/deckhouse/deckhouse/assets/30695496/44fa9521-9c55-49e9-9f60-22675e3dda8a)

After it, restart Deckhouse and waiting for readiness Dechouse pod. Here we check that deckhouse correctly handle absence old validating webhook configuration
![image](https://github.com/deckhouse/deckhouse/assets/30695496/111f73db-3f3b-4afb-814a-dfcd69e930fb)

New validation webhook works:
![image](https://github.com/deckhouse/deckhouse/assets/30695496/91ea93be-756d-404b-810c-e060f29abb6e)

Restarting webhook handler does not recreate webhook configuration
![image](https://github.com/deckhouse/deckhouse/assets/30695496/8d0df36b-e250-4ff8-a948-d8866b5e2b1b)


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix
summary: Delete d8-deckhouse-validating-webhook-handler validating webhook configurations
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
