### PR TITLE
[node-manager] rework CRI requirements

### DIFF
--- a/modules/040-node-manager/hooks/check_nodes_cri.go
+++ b/modules/040-node-manager/hooks/check_nodes_cri.go
@@ -19,22 +19,39 @@
 package hooks
 
 import (
+	"errors"
 	"regexp"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 )
 
 const (
 	hasNodesOtherThanContainerd = "nodeManager:hasNodesOtherThanContainerd"
 	containerUnknownVersion     = "unknownVersion"
-	snapName                    = "check_nodes_cri"
+	nodeSnapName                = "check_nodes_cri"
+	notManagedCriMaxKubeVersion = "1.24.0"
+	nodeGroupSnapName           = "node_group"
+	criTypeNotManaged           = "NotManaged"
 )
+
+type nodeGroupCRIType struct {
+	Name    string
+	CriType string
+}
+
+type nodeCRIVersion struct {
+	CloudInstanceGroup      string
+	ContainerRuntimeVersion string
+}
 
 var isContainerdRegexp = regexp.MustCompile(`^containerd.*?`)
 
@@ -43,7 +60,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:                         snapName,
+			Name:                         nodeSnapName,
 			WaitForSynchronization:       pointer.Bool(false),
 			ExecuteHookOnSynchronization: pointer.Bool(true),
 			ExecuteHookOnEvents:          pointer.Bool(true),
@@ -59,25 +76,114 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			FilterFunc: applyNodesCRIVersionFilter,
 		},
+		{
+			Name:                   nodeGroupSnapName,
+			Kind:                   "NodeGroup",
+			ApiVersion:             "deckhouse.io/v1",
+			WaitForSynchronization: pointer.Bool(false),
+			FilterFunc:             applyNodeGroupCRITypeFilter,
+		},
 	},
 }, discoverNodesCRIVersion)
 
 func applyNodesCRIVersionFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	containerVersion, ok, err := unstructured.NestedString(obj.Object, "status", "nodeInfo", "containerRuntimeVersion")
-	if !ok {
-		return containerUnknownVersion, err
+	var node corev1.Node
+
+	err := sdk.FromUnstructured(obj, &node)
+	if err != nil {
+		return nil, err
 	}
-	return containerVersion, err
+
+	cloudInstanceGroup := node.Labels["node.deckhouse.io/group"]
+	containerRuntimeVersion := node.Status.NodeInfo.ContainerRuntimeVersion
+
+	if containerRuntimeVersion == "" {
+		containerRuntimeVersion = containerUnknownVersion
+	}
+
+	return nodeCRIVersion{
+		CloudInstanceGroup:      cloudInstanceGroup,
+		ContainerRuntimeVersion: containerRuntimeVersion,
+	}, nil
+}
+
+func applyNodeGroupCRITypeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var ng ngv1.NodeGroup
+
+	err := sdk.FromUnstructured(obj, &ng)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeGroupCRIType{
+		Name:    ng.GetName(),
+		CriType: ng.Spec.CRI.Type,
+	}, nil
+}
+
+func getMaxKubeVersion(input *go_hook.HookInput) (semver.Version, bool) {
+	maxKubeVersion := semver.Version{}
+	exist := false
+	for _, item := range input.Values.Get("global.discovery.kubernetesVersions").Array() {
+		version, err := semver.NewVersion(item.String())
+		if err != nil {
+			continue
+		}
+		if maxKubeVersion.LessThan(version) {
+			maxKubeVersion = *version
+			exist = true
+		}
+	}
+
+	return maxKubeVersion, exist
 }
 
 func discoverNodesCRIVersion(input *go_hook.HookInput) error {
-	snap := input.Snapshots[snapName]
-	if len(snap) == 0 {
+	ngSnap := input.Snapshots[nodeGroupSnapName]
+	ngCRITypeMap := make(map[string]string)
+
+	maxKubeVersion, ok := getMaxKubeVersion(input)
+	if !ok {
+		return errors.New("unknown kubernetes version")
+	}
+
+	notManagedCriKubeVersion, err := semver.NewVersion(notManagedCriMaxKubeVersion)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range ngSnap {
+		ng := item.(nodeGroupCRIType)
+		ngCRITypeMap[ng.Name] = ng.CriType
+	}
+
+	nSnap := input.Snapshots[nodeSnapName]
+	if len(nSnap) == 0 {
 		return nil
 	}
 
-	for _, s := range snap {
-		if !isContainerdRegexp.MatchString(s.(string)) {
+	for _, item := range nSnap {
+		n := item.(nodeCRIVersion)
+		criType, ok := ngCRITypeMap[n.CloudInstanceGroup]
+
+		if isContainerdRegexp.MatchString(n.ContainerRuntimeVersion) {
+			continue
+		}
+
+		// not found NodeGroup CRI Type
+		if !isContainerdRegexp.MatchString(n.ContainerRuntimeVersion) && !ok {
+			requirements.SaveValue(hasNodesOtherThanContainerd, true)
+			return nil
+		}
+
+		// skip if NodeGroup CRI Type == NotManaget and max Kube ver < notManagedCriKubeVersion
+		if !isContainerdRegexp.MatchString(n.ContainerRuntimeVersion) &&
+			criType == criTypeNotManaged &&
+			maxKubeVersion.LessThan(notManagedCriKubeVersion) {
+			continue
+		}
+
+		if !isContainerdRegexp.MatchString(n.ContainerRuntimeVersion) {
 			requirements.SaveValue(hasNodesOtherThanContainerd, true)
 			return nil
 		}


### PR DESCRIPTION
## Description
Rework CRI requirements. Add ignore NodeGroup with CRI Type == NotManaged and Kube ver < 1.24  
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Issues #4807
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Checking for the presence of containerd on all nodes exclude NodeGroup with CRI Type == NotManaged and Kube ver < 1.24  
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Rework CRI requirements. Add ignore NodeGroup with CRI Type == NotManaged and Kube ver < 1.24  
impact: It will be impossible to update Deckhouse until docker is replaced with containerd.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
