### PR TITLE
[monitoring] Fix links in alerts

### DIFF
--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
@@ -19,5 +19,7 @@
         - or reserved `spec.taints` *dedicated.deckhouse.io* with values not in `(system|frontend|monitoring|_deckhouse_module_name_)`
 
 {{- if .Values.global.modules.publicDomainTemplate }}
-        [Get instructions on how to fix it here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/040-node-manager/faq.html#%D0%BA%D0%B0%D0%BA-%D0%B2%D1%8B%D0%B4%D0%B5%D0%BB%D0%B8%D1%82%D1%8C-%D1%83%D0%B7%D0%BB%D1%8B-%D0%BF%D0%BE%D0%B4-%D1%81%D0%BF%D0%B5%D1%86%D0%B8%D1%84%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D0%B5-%D0%BD%D0%B0%D0%B3%D1%80%D1%83%D0%B7%D0%BA%D0%B8).
+        [Get instructions on how to fix it here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
+{{- else }}
+        [Get instructions on how to fix it here](https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
 {{- end }}

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
@@ -17,8 +17,7 @@
         Node {{`{{ $labels.name }}`}} uses:
         - reserved `metadata.labels` *node-role.deckhouse.io/* with ending not in `(system|frontend|monitoring|_deckhouse_module_name_)`
         - or reserved `spec.taints` *dedicated.deckhouse.io* with values not in `(system|frontend|monitoring|_deckhouse_module_name_)`
-
-{{- if .Values.global.modules.publicDomainTemplate }}
+{{ if .Values.global.modules.publicDomainTemplate }}
         [Get instructions on how to fix it here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
 {{- else }}
         [Get instructions on how to fix it here](https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/storage-class.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/storage-class.tpl
@@ -1,17 +1,17 @@
 {{- define "cloud-provider-storage-documentation-url" }}
 {{- if .Values.global.modules.publicDomainTemplate }}
   {{- if ( .Values.global.enabledModules | has "cloud-provider-aws") }}
-        [AWS storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/030-cloud-provider-aws/configuration.html#storage).
+        [AWS storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/030-cloud-provider-aws/configuration.html#storage).
   {{- else if ( .Values.global.enabledModules | has "cloud-provider-gcp") }}
-        [GCP storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/030-cloud-provider-gcp/configuration.html#storage).
+        [GCP storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/030-cloud-provider-gcp/configuration.html#storage).
   {{- else if ( .Values.global.enabledModules | has "cloud-provider-openstack") }}
-        [Openstack storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/030-cloud-provider-openstack/configuration.html#storage).
+        [Openstack storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/030-cloud-provider-openstack/configuration.html#storage).
   {{- else if ( .Values.global.enabledModules | has "cloud-provider-vsphere") }}
-        [vSphere storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/030-cloud-provider-vsphere/configuration.html#storage).
+        [vSphere storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/030-cloud-provider-vsphere/configuration.html#storage).
   {{- else if ( .Values.global.enabledModules | has "cloud-provider-yandex") }}
-        [Yandex storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/030-cloud-provider-yandex/configuration.html#storage).
+        [Yandex storage documentation is here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/030-cloud-provider-yandex/configuration.html#storage).
   {{- else }}
-        [Find storage configuration documentation for your cloud-provider here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/kubernetes.html).
+        [Find storage configuration documentation for your cloud-provider here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/kubernetes.html).
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Fix incorrect links to documentation in alerts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix incorrect links to documentation in alerts.
impact_level: low
```
