### PR TITLE
[node-manager] Separate the name of the node group from the command

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -22,7 +22,8 @@ To add a new static node (e.g., VM or bare metal server) to the cluster, follow 
    Example of getting a Base64-encoded script code to add a node to the NodeGroup `worker`:
 
    ```shell
-   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
+   node_group=worker
+   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-${node_group} -o json | jq '.data."bootstrap.sh"' -r
    ```
 
 3. Pre-configure the new node according to the specifics of your environment. For example:

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -22,8 +22,8 @@ To add a new static node (e.g., VM or bare metal server) to the cluster, follow 
    Example of getting a Base64-encoded script code to add a node to the NodeGroup `worker`:
 
    ```shell
-   node_group=worker
-   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-${node_group} -o json | jq '.data."bootstrap.sh"' -r
+   NODE_GROUP=worker
+   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} -o json | jq '.data."bootstrap.sh"' -r
    ```
 
 3. Pre-configure the new node according to the specifics of your environment. For example:

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -22,8 +22,8 @@ search: добавить ноду в кластер, добавить узел �
    Пример получения кода скрипта в кодировке Base64 для добавления узла в NodeGroup `worker`:
 
    ```shell
-   node_group=worker
-   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-${node_group} -o json | jq '.data."bootstrap.sh"' -r
+   NODE_GROUP=worker
+   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} -o json | jq '.data."bootstrap.sh"' -r
    ```
 
 3. Выполните предварительную настройку нового узла, в соответствии с особенностями вашего окружения. Например:

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -22,7 +22,8 @@ search: добавить ноду в кластер, добавить узел �
    Пример получения кода скрипта в кодировке Base64 для добавления узла в NodeGroup `worker`:
 
    ```shell
-   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
+   node_group=worker
+   kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-${node_group} -o json | jq '.data."bootstrap.sh"' -r
    ```
 
 3. Выполните предварительную настройку нового узла, в соответствии с особенностями вашего окружения. Например:


### PR DESCRIPTION
## Description
Separate the name of the node group from the command
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The divided command is more than comprehensible.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Separate the name of the node group from the command in the FAQ.
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
