### PR TITLE
[ingress-nginx] patch kruise controller update logic

### DIFF
--- a/modules/402-ingress-nginx/images/kruise/Dockerfile
+++ b/modules/402-ingress-nginx/images/kruise/Dockerfile
@@ -6,11 +6,13 @@ ARG KRUISE_CONTROLLER_VERSION=1.4.0
 
 COPY patches/disable-controllers.patch /
 COPY patches/disable-jobs.patch /
+COPY patches/stick-to-maxunavailable.patch /
 
 RUN git clone --depth 1 --branch v${KRUISE_CONTROLLER_VERSION} https://github.com/openkruise/kruise.git && \
     cd kruise && \
     git apply /disable-controllers.patch && \
     git apply /disable-jobs.patch && \
+    git apply /stick-to-maxunavailable.patch && \
     CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -a -o /tmp/manager main.go
 
 

--- a/modules/402-ingress-nginx/images/kruise/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise/patches/README.md
@@ -9,3 +9,11 @@ We can check the number of workers (concurrent reconciles) and if we have 0 work
 
 ### Disable jobs
 Remove CRD check of `BroadcastJob` and `ImagePullJob`. We don't need them for DaemonSet workflow. We don't install that CRDs.
+
+### Stick to MaxUnavailable
+In case DaemonSet has surge == 0, Kruise Controller still able to designated more pods as allowed for replacement than
+maxUnavailable settings allows, resulting in parallel update instead of gradual.
+We impose additional condition to check if the list of the pods, marked by the controller as Unavailable, is bigger than maxUnavailable
+and drop excessive pods from the list so as to obbey maxUnavailable setting.
+The thing is that having a pod marked as Unavailable from the Controller point of view doesn't mean that the pod doesn't work and
+should be updated ASAP.

--- a/modules/402-ingress-nginx/images/kruise/patches/stick-to-maxunavailable.patch
+++ b/modules/402-ingress-nginx/images/kruise/patches/stick-to-maxunavailable.patch
@@ -1,0 +1,17 @@
+diff --git a/pkg/controller/daemonset/daemonset_update.go b/pkg/controller/daemonset/daemonset_update.go
+index 17946a6e..9836c1be 100644
+--- a/pkg/controller/daemonset/daemonset_update.go
++++ b/pkg/controller/daemonset/daemonset_update.go
+@@ -134,6 +134,12 @@ func (dsc *ReconcileDaemonSet) rollingUpdate(ds *appsv1alpha1.DaemonSet, nodeLis
+ 		}
+ 		oldPodsToDelete := append(allowedReplacementPods, candidatePodsToDelete[:remainingUnavailable]...)
+ 
++		// If there is no free Unavailable slots left - need not delete any pods.
++		if len(oldPodsToDelete) > remainingUnavailable {
++			oldPodsToDelete = oldPodsToDelete[:remainingUnavailable]
++			klog.V(5).Infof("DaemonSet %s/%s wanted to delete more then MaxUnvailable: %d replacements, up to %d unavailable, %d new are unavailable, %d candidates", ds.Namespace, ds.Name, len(allowedReplacementPods), maxUnavailable, numUnavailable, len(candidatePodsToDelete))
++		}
++
+ 		// Advanced: update pods in-place first and still delete the others
+ 		if ds.Spec.UpdateStrategy.RollingUpdate.Type == appsv1alpha1.InplaceRollingUpdateType {
+ 			oldPodsToDelete, err = dsc.inPlaceUpdatePods(ds, oldPodsToDelete, curRevision, oldRevisions)


### PR DESCRIPTION
## Description
Periodically it happens that Kruise Controller marks more than one pod of a DaemonSet as unavailable and its logic allows it to delete all Unavailable pods simultaneously, without considering maxUnavailable setting, which leads to DoS. We patch it to force it to obey maxUnavailable during updates.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We had multiple occurrences when all pods of an ingress-nginx controller got deleted simultaneously during a major deckhouse update, causing DoS for our clients. It transpired that Kruise controller relies on [this function](https://github.com/kubernetes/kubectl/blob/156d5a9a9702e101fc010f37933f8e9a4013309b/pkg/util/podutils/podutils.go#L32) to decide if a pod is available or not. In its turn, the function takes into consideration the pod's lastTransitionTime and minReadySeconds parameters. 
The important thing is that during updates, sometimes we have to restart nodes' kubelet services and it results in having pods' lastTransitionTime fields updated (even though the containers/pods themselves aren't getting restarted), which, according to the function's logic, means that the pods get Unavailable (lastTransitionTime + minReadySeconds > now, ignoring their Ready statuses) and Kruise Controller designates the pods for an upcoming deletion.
Taking the aforementioned problem into consideration, it's highly desirable to have kruise controller follow the maxUnavailable setting.
Close #5005 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
The described problem affects our possibility of providing ingress-nginx upgrades without downtimes.
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Kruise controller should delete no more that `maxUnavailable` pods of a daemonset controller at a time.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix | feature | chore
summary: Pathch kruse controller manager logic so that it doesn't delete more than maxUnavailable pods at a time during updates.
impact: Kruise controller manager will be restarted.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
