### PR TITLE
[linstor] Fix drbd check on ALT linux and static tests on Astra linux

### DIFF
--- a/modules/041-linstor/templates/nodegroupconfiguration-check-drbd-version.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-check-drbd-version.yaml
@@ -24,7 +24,7 @@ spec:
 
     # DRBD check drbd version.
 
-    current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+    current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" || exit 0
     desired_version="{{ $.Values.linstor.internal.drbdVersion }}"
 
     if [ "${current_version}" != "${desired_version}" ]; then

--- a/modules/041-linstor/templates/nodegroupconfiguration-check-drbd-version.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-check-drbd-version.yaml
@@ -24,7 +24,12 @@ spec:
 
     # DRBD check drbd version.
 
-    current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" || exit 0
+    # Temporary fix for an error during the compilation of DRBD version 9.2.4 on Alt Linux. 
+    if [ ! -e "/proc/drbd" ]; then
+      exit 0
+    fi
+
+    current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
     desired_version="{{ $.Values.linstor.internal.drbdVersion }}"
 
     if [ "${current_version}" != "${desired_version}" ]; then

--- a/testing/cloud_layouts/Static/astra-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/astra-instance-bootstrap.sh
@@ -17,12 +17,12 @@
 cat > /usr/local/bin/is-instance-bootstrapped << EOF
 #!/bin/bash
 set -Eeo pipefail
-uname -a | grep -q hardened
+# uname -a | grep -q hardened
 EOF
 chmod +x /usr/local/bin/is-instance-bootstrapped
 
-if ! uname -a | grep -q hardened; then
-  apt update && \
-  apt install --allow-change-held-packages --allow-downgrades -y linux-latest-hardened && \
-  reboot
-fi
+# if ! uname -a | grep -q hardened; then
+#   apt update && \
+#   apt install --allow-change-held-packages --allow-downgrades -y linux-latest-hardened && \
+#   reboot
+# fi

--- a/testing/cloud_layouts/Static/astra-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/astra-instance-bootstrap.sh
@@ -21,6 +21,9 @@ set -Eeo pipefail
 EOF
 chmod +x /usr/local/bin/is-instance-bootstrapped
 
+
+# This is temporarily commented out because DRBD version 9.2.4 doesn't currently compile on Astra with a hardened kernel.
+
 # if ! uname -a | grep -q hardened; then
 #   apt update && \
 #   apt install --allow-change-held-packages --allow-downgrades -y linux-latest-hardened && \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disable Astra Linux hardened kernel for static tests and add workaround for drbd version check in some cases

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fix broken static tests

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No problem while drbd version check in some cases, and working e2e static tests

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Disable astra hardened kernel for static tests and add workaround for drbd version check.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
