### PR TITLE
[cloud-provider-azure] is not correctly handled by acceleratedNetworking

### DIFF
--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -189,7 +189,7 @@ internal:
     cloudInstances:
       classReference:
         kind: AzureInstanceClass
-        name: test
+        name: aaa
       maxPerZone: 1
       minPerZone: 1
       zones:
@@ -203,7 +203,7 @@ internal:
     cloudInstances:
       classReference:
         kind: AzureInstanceClass
-        name: worker
+        name: bbb
       maxPerZone: 1
       minPerZone: 1
       zones:
@@ -1399,7 +1399,7 @@ ccc: ddd
 				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "aaa-02320933")
 				Expect(t.Exists()).To(BeTrue())
 				//checksum := mc.Field("spec.properties.networkProfile.acceleratedNetworking").String()
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("true"))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("false"))
 			})
 
 			It("spec.properties.networkProfile.acceleratedNetworking false", func() {
@@ -1408,7 +1408,7 @@ ccc: ddd
 				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "bbb-02320933")
 				Expect(t.Exists()).To(BeTrue())
 				//checksum := mc.Field("spec.properties.networkProfile.acceleratedNetworking").String()
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("false"))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("true"))
 			})
 
 			// Important! If checksum changes, the MachineDeployments will re-deploy!

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -173,13 +173,41 @@ internal:
       type: "Docker"
     cloudInstances:
       classReference:
-        kind: GCPInstanceClass
+        kind: AzureInstanceClass
         name: worker
       maxPerZone: 5
       minPerZone: 2
       zones:
       - zonea
       - zoneb
+  - name: aaa
+    instanceClass:
+      acceleratedNetworking: false
+      machineSize: test
+      urn: test
+    nodeType: CloudEphemeral
+    cloudInstances:
+      classReference:
+        kind: AzureInstanceClass
+        name: test
+      maxPerZone: 1
+      minPerZone: 1
+      zones:
+      - zonea
+  - name: bbb
+    instanceClass:
+      acceleratedNetworking: true
+      machineSize: bbb
+      urn: zzz
+    nodeType: CloudEphemeral
+    cloudInstances:
+      classReference:
+        kind: AzureInstanceClass
+        name: worker
+      maxPerZone: 1
+      minPerZone: 1
+      zones:
+      - zonea
   machineControllerManagerEnabled: true
 `
 
@@ -1354,6 +1382,33 @@ ccc: ddd
 
 				Expect(mcls.Exists()).To(BeTrue())
 				assertValues(mcls, "spec.tags")
+			})
+
+			It("spec.properties.networkProfile.acceleratedNetworking default true", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "worker-02320933")
+				Expect(t.Exists()).To(BeTrue())
+				//checksum := mcdt.Field("spec.properties.networkProfile.acceleratedNetworking").String()
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("true"))
+			})
+
+			It("spec.properties.networkProfile.acceleratedNetworking true", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "aaa-02320933")
+				Expect(t.Exists()).To(BeTrue())
+				//checksum := mc.Field("spec.properties.networkProfile.acceleratedNetworking").String()
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("true"))
+			})
+
+			It("spec.properties.networkProfile.acceleratedNetworking false", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "bbb-02320933")
+				Expect(t.Exists()).To(BeTrue())
+				//checksum := mc.Field("spec.properties.networkProfile.acceleratedNetworking").String()
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("false"))
 			})
 
 			// Important! If checksum changes, the MachineDeployments will re-deploy!

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1396,17 +1396,17 @@ ccc: ddd
 			It("spec.properties.networkProfile.acceleratedNetworking true", func() {
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "aaa-02320933")
+				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "bbb-02320933")
 				Expect(t.Exists()).To(BeTrue())
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(false))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(true))
 			})
 
 			It("spec.properties.networkProfile.acceleratedNetworking false", func() {
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "bbb-02320933")
+				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "aaa-02320933")
 				Expect(t.Exists()).To(BeTrue())
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(true))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(false))
 			})
 
 			// Important! If checksum changes, the MachineDeployments will re-deploy!

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1390,7 +1390,7 @@ ccc: ddd
 				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "worker-02320933")
 				Expect(t.Exists()).To(BeTrue())
 				//checksum := mcdt.Field("spec.properties.networkProfile.acceleratedNetworking").String()
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("true"))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(true))
 			})
 
 			It("spec.properties.networkProfile.acceleratedNetworking true", func() {
@@ -1398,8 +1398,7 @@ ccc: ddd
 
 				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "aaa-02320933")
 				Expect(t.Exists()).To(BeTrue())
-				//checksum := mc.Field("spec.properties.networkProfile.acceleratedNetworking").String()
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("false"))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(false))
 			})
 
 			It("spec.properties.networkProfile.acceleratedNetworking false", func() {
@@ -1407,8 +1406,7 @@ ccc: ddd
 
 				t := f.KubernetesResource("AzureMachineClass", "d8-cloud-instance-manager", "bbb-02320933")
 				Expect(t.Exists()).To(BeTrue())
-				//checksum := mc.Field("spec.properties.networkProfile.acceleratedNetworking").String()
-				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").String()).To(Equal("true"))
+				Expect(t.Field("spec.properties.networkProfile.acceleratedNetworking").Bool()).To(Equal(true))
 			})
 
 			// Important! If checksum changes, the MachineDeployments will re-deploy!


### PR DESCRIPTION

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: fix
summary:  fixed the behavior of the acceleratedNetworking variable 
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
