### PR TITLE
[candi] fix install containerd step

### DIFF
--- a/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
@@ -43,6 +43,7 @@ if bb-yum-package? docker-ce; then
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-yum-remove docker.io docker-ce containerd-io
+  systemctl unmask containerd.service
   rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -44,6 +44,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-apt-remove docker.io docker-ce containerd-io
+  systemctl unmask containerd.service
   rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /opt/deckhouse/bin/crictl

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
@@ -44,6 +44,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-apt-remove docker.io docker-ce containerd-io
+  systemctl unmask containerd.service
   rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /opt/deckhouse/bin/crictl

--- a/ee/candi/bashible/bundles/alteros/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/alteros/node-group/031_install_containerd.sh.tpl
@@ -32,6 +32,7 @@ if bb-yum-package? docker-ce; then
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-yum-remove docker.io docker-ce containerd-io
+  systemctl unmask containerd.service
   rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl

--- a/ee/candi/bashible/bundles/astra/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/node-group/031_install_containerd.sh.tpl
@@ -33,6 +33,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-apt-remove docker.io docker-ce containerd-io
+  systemctl unmask containerd.service
   rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /opt/deckhouse/bin/crictl

--- a/ee/candi/bashible/bundles/redos/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/node-group/031_install_containerd.sh.tpl
@@ -32,6 +32,7 @@ if bb-yum-package? docker-ce; then
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-yum-remove docker.io docker-ce containerd-io
+  systemctl unmask containerd.service
   rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added containerd.service unmask to bashible containerd install step.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Sometimes when we change nodeGroup cri from docker to containerd, we've got a problem with uninstall docker.
After uninstall contianerd (as part of docker uninstall) containerd.service freezes in masked state. When we try to install new version of containerd,  it fails.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: fix install containerd step for cases when nodegroup cri changes from docker to containerd.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
