### PR TITLE
[admission-policy-engine] Add required-annotations OPA policy

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/required-annotations.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/required-annotations.yaml
@@ -1,0 +1,63 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: d8requiredannotations
+  labels:
+    heritage: deckhouse
+    module: admission-policy-engine
+    security.deckhouse.io: operation-policy
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Annotations"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires resources to contain specified annotations, with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: D8RequiredAnnotations
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            annotations:
+              type: array
+              description: >-
+                A list of annotations and values the object must specify.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: >-
+                      The required annotation.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      If specified, a regular expression the annotation's value
+                      must match. The value must contain at least one match for
+                      the regular expression.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package d8.operation_policies
+
+        violation[{"msg": msg, "details": {"missing_annotations": missing}}] {
+            provided := {annotation | input.review.object.metadata.annotations[annotation]}
+            required := {annotation | annotation := input.parameters.annotations[_].key}
+            missing := required - provided
+            count(missing) > 0
+            msg := sprintf("you must provide annotation(s): %v", [missing])
+        }
+
+        violation[{"msg": msg}] {
+          value := input.review.object.metadata.annotations[key]
+          expected := input.parameters.annotations[_]
+          expected.key == key
+          expected.allowedRegex != ""
+          not re_match(expected.allowedRegex, value)
+          msg := sprintf("Annotation <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+        }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/required-annotations.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/required-annotations.yaml
@@ -21,8 +21,6 @@ spec:
         openAPIV3Schema:
           type: object
           properties:
-            message:
-              type: string
             annotations:
               type: array
               description: >-

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/allowed_dep.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/allowed_dep.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: allowed
+  namespace: default
+  annotations:
+    foo: bar
+    bar: xxx.example.com
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+  selector:
+    matchLabels:
+      foo: bar

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/allowed_pod.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/allowed_pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowed
+  namespace: default
+  annotations:
+    foo: bar
+    bar: zcx.example.com
+spec:
+  containers:
+    - name: nginx
+      image: nginx

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/constraint.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/constraint.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8RequiredAnnotations
+metadata:
+  name: test
+spec:
+  enforcementAction: "deny"
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    annotations:
+      - key: foo
+      - key: bar
+        allowedRegex: "^[a-zA-Z]+.example.com$"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/disallowed_dep.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/disallowed_dep.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: allowed
+  namespace: default
+  annotations:
+    bar: xxx.example.com
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+  selector:
+    matchLabels:
+      foo: bar

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/disallowed_pod.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/disallowed_pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowed
+  namespace: default
+  annotations:
+    foo: bar
+    bar: xxx
+spec:
+  containers:
+    - name: nginx
+      image: nginx

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation-policy/test_samples/required-annotations/suite.yaml
@@ -1,0 +1,26 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: d8requiredannotations
+tests:
+  - name: d8requiredannotations
+    template: ../../required-annotations.yaml
+    constraint: constraint.yaml
+    cases:
+      - name: pod-allowed
+        object: allowed_pod.yaml
+        assertions:
+          - violations: no
+      - name: dep-allowed
+        object: allowed_dep.yaml
+        assertions:
+          - violations: no
+      - name: pod-disallowed
+        object: disallowed_pod.yaml
+        assertions:
+          - violations: yes
+      - name: dep-disallowed
+        object: disallowed_dep.yaml
+        assertions:
+          - violations: yes
+            message: 'you must provide annotations: {"foo"}'

--- a/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
@@ -51,7 +51,7 @@ spec:
                       description: |
                         Список аннотаций, которые должен указать объект.
                       properties:
-                        labels:
+                        annotations:
                           items:
                             properties:
                               key:

--- a/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
@@ -47,6 +47,22 @@ spec:
                         watchKinds:
                           description: |
                             Список объектов Kubernetes в формате `$apiGroup/$kind` для просмотра меток.
+                    requiredAnnotations:
+                      description: |
+                        Список аннотаций, которые должен указать объект.
+                      properties:
+                        labels:
+                          items:
+                            properties:
+                              key:
+                                description: >-
+                                  Требуемая аннотация.
+                              allowedRegex:
+                                description: >-
+                                  Если указано, то содержит регулярное выражение, которому должно соответствовать значение аннотации. Значение должно содержать хотя бы одно совпадение с регулярным выражением.
+                        watchKinds:
+                          description: |
+                            Список объектов Kubernetes в формате `$apiGroup/$kind` для просмотра аннотаций.
                     requiredProbes:
                       description: "Список проб, которые необходимы (например, `readinessProbe`)."
                     maxRevisionHistoryLimit:

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -99,13 +99,43 @@ spec:
                               allowedRegex:
                                 type: string
                                 description: >-
-                                  If specified, a regular expression, the annotation's value
+                                  If specified, a regular expression, the label's value
                                   must match. The value must contain at least one match for
                                   the regular expression.
                         watchKinds:
                           type: array
                           description: |
                             The list of kubernetes objects in the format `$apiGroup/$kind` to watch the labels on.
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: '^[a-z]*/[a-zA-Z]+$'
+                            example: ["apps/Deployment", "/Pod", "networking.k8s.io/Ingress"]
+                    requiredAnnotations:
+                      type: object
+                      description: |
+                        A list of annotations and values the object must specify.
+                      properties:
+                        annotations:
+                          type: array
+                          minItems: 1
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                                description: >-
+                                  The required annotation.
+                              allowedRegex:
+                                type: string
+                                description: >-
+                                  If specified, a regular expression, the annotation's value
+                                  must match. The value must contain at least one match for
+                                  the regular expression.
+                        watchKinds:
+                          type: array
+                          description: |
+                            The list of kubernetes objects in the format `$apiGroup/$kind` to watch the annotations on.
                           minItems: 1
                           items:
                             type: string

--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
@@ -68,6 +68,12 @@ spec:
         key: product-id
       watchKinds:
       - /Namespace
+    requiredAnnotations:
+      annotations:
+      - allowedRegex: ^P\d{4}$
+        key: foobar
+      watchKinds:
+      - /Namespace
     requiredProbes:
       - livenessProbe
       - readinessProbe

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -51,6 +51,13 @@ type OperationPolicySpec struct {
 			} `json:"labels,omitempty"`
 			WatchKinds []string `json:"watchKinds,omitempty"`
 		} `json:"requiredLabels,omitempty"`
+		RequiredAnnotations struct {
+			Annotations []struct {
+				Key          string `json:"key,omitempty"`
+				AllowedRegex string `json:"allowedRegex,omitempty"`
+			} `json:"annotations,omitempty"`
+			WatchKinds []string `json:"watchKinds,omitempty"`
+		} `json:"requiredAnnotations,omitempty"`
 		MaxRevisionHistoryLimit   *int     `json:"maxRevisionHistoryLimit,omitempty"`
 		ImagePullPolicy           string   `json:"imagePullPolicy,omitempty"`
 		PriorityClassNames        []string `json:"priorityClassNames,omitempty"`

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -47,6 +47,13 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 				],
 				"watchKinds": ["/Pod", "networking.k8s.io/Ingress"]
 			},
+            "requiredAnnotations": {
+				"labels": [
+					{ "key": "foo" },
+					{ "key": "bar", "allowedRegex": "^[a-zA-Z]+.myapp.demo$" }
+				],
+				"watchKinds": ["/Namespace"]
+			},
 			"requiredProbes":["livenessProbe","readinessProbe"],
 			"maxRevisionHistoryLimit":3,
 			"imagePullPolicy":"Always",
@@ -77,6 +84,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			Expect(f.KubernetesGlobalResource("D8PriorityClass", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8DNSPolicy", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8RequiredLabels", testPolicyName).Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("D8RequiredAnnotations", testPolicyName).Exists()).To(BeTrue())
 		})
 	})
 

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 				"watchKinds": ["/Pod", "networking.k8s.io/Ingress"]
 			},
             "requiredAnnotations": {
-				"labels": [
+				"annotations": [
 					{ "key": "foo" },
 					{ "key": "bar", "allowedRegex": "^[a-zA-Z]+.myapp.demo$" }
 				],

--- a/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
@@ -15,6 +15,9 @@
   {{- if hasKey $cr.spec.policies "requiredLabels"}}
     {{- include "required_labels_policy" (list $context $cr) }}
   {{- end }}
+  {{- if hasKey $cr.spec.policies "requiredAnnotations"}}
+    {{- include "required_annotations_policy" (list $context $cr) }}
+  {{- end }}
   {{- if hasKey $cr.spec.policies "requiredProbes"}}
     {{- include "required_probes_policy" (list $context $cr) }}
   {{- end }}
@@ -131,6 +134,30 @@ spec:
   parameters:
     labels:
       {{- $cr.spec.policies.requiredLabels.labels | toYaml | nindent 6 }}
+{{- end }}
+
+{{- define "required_annotations_policy" }}
+  {{- $context := index . 0 }}
+  {{- $cr := index . 1 }}
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8RequiredAnnotations
+metadata:
+  name: {{$cr.metadata.name}}
+  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
+spec:
+  enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
+  match:
+    kinds:
+      {{- range $cr.spec.policies.requiredAnnotations.watchKinds }}
+      {{ $arrk := regexSplit "/" . -1 }}
+      - apiGroups: [{{ index $arrk 0 | default "\"\"" }}]
+        kinds: [{{ index $arrk 1 }}]
+      {{- end }}
+    {{- include "constraint_selector" (list $cr) }}
+  parameters:
+    labels:
+      {{- $cr.spec.policies.requiredAnnotations.annotations | toYaml | nindent 6 }}
 {{- end }}
 
 {{- define "required_probes_policy" }}

--- a/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/operation-policy/constraint.yaml
@@ -156,7 +156,7 @@ spec:
       {{- end }}
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    labels:
+    annotations:
       {{- $cr.spec.policies.requiredAnnotations.annotations | toYaml | nindent 6 }}
 {{- end }}
 


### PR DESCRIPTION
## Description
Add `RequiredAnnotations` policy to the `OperationPolicy` Deckhouse CRD

## Why do we need it, and what problem does it solve?
We have `RequiredLabels` policy but sometimes we want to check annotations also.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Create `OperationPolicy`
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: OperationPolicy
metadata:
  name: defaultns
spec:
  enforcementAction: Deny
  match:
    namespaceSelector:
      labelSelector:
        matchLabels:
          operation-policy.deckhouse.io/enabled: "true"
  policies:
    requiredAnnotations:
      annotations:
      - allowedRegex: ^P\d{4}$
        key: foo
      watchKinds:
      - /Pod
```

try to create pod:
```bash
kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: busybox-sleep
spec:
  containers:
  - name: busybox
    image: busybox:1.28
    args:
    - sleep
    - "1000000"
EOF
```

result:
```bash
Error from server (Forbidden): error when creating "STDIN": admission webhook "admission-policy-engine.deckhouse.io" denied the request: [defaultns] you must provide annotation(s): {"foo"}
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: feature 
summary: Add RequiredAnnotation policy to the Deckhouse `OperationPolicy` resource.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
