### PR TITLE
[ingress-nginx] tune kruise leader election and verbosity

### DIFF
--- a/modules/402-ingress-nginx/templates/kruise/manager.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/manager.yaml
@@ -89,7 +89,7 @@ spec:
             - --logtostderr=true
             - --leader-election-namespace=d8-ingress-nginx
             - --namespace=d8-ingress-nginx
-            - --v=2
+            - --v=5
             - --feature-gates=ResourcesDeletionProtection=true,PodWebhook=false
             - --sync-period=0
             - --advancedcronjob-workers=0
@@ -107,6 +107,9 @@ spec:
             - --statefulset-workers=0
             - --uniteddeployment-workers=0
             - --workloadspread-workers=0
+            - --leader-election-retry-period=13s
+            - --leader-election-lease-duration=40s
+            - --leader-election-renew-deadline=20s
           command:
             - /manager
           image: {{ include "helm_lib_module_image" (list . "kruise") }}

--- a/modules/402-ingress-nginx/templates/kruise/manager.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/manager.yaml
@@ -107,9 +107,10 @@ spec:
             - --statefulset-workers=0
             - --uniteddeployment-workers=0
             - --workloadspread-workers=0
-            - --leader-election-retry-period=13s
-            - --leader-election-lease-duration=40s
-            - --leader-election-renew-deadline=20s
+            - --leader-election-resource-lock=leases
+            - --leader-election-retry-period=10s
+            - --leader-election-lease-duration=35s
+            - --leader-election-renew-deadline=30s
           command:
             - /manager
           image: {{ include "helm_lib_module_image" (list . "kruise") }}


### PR DESCRIPTION
## Description
By default, `kruise controller` uses `configmapLeasese` leader-election-resource-lock type. The leader election timers are also a bit aggressive (lease duration - 15s, retry period - 2s). 
We change resource-lock type to use only leases, decreasing the amount of API requests, and readjust leader election timers to:
* lease retry - 10s
* lease duration - 35s
* lease renew deadline - 30s.

Tests show that kruise controller is able to elect its leader and start converging after a full restart in 50-60 seconds.

Also, the verbosity level of `kruise controller` was raised from 2 to 5 so that system administrators and cluster operators could perform preliminary diagnosis and troubleshooting of what was going on.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We update timers and resource lock type to decrease "the noise" of `kruise controller` in a cluster, without compromising severely its perfomance.
Log verbosity is increased for the sake of making it easier to understand `kruise controller's` logic and behavior when an issue arises.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Kruise controller operates in a bit more inert but still robust way in terms of electing a leader, providing more logs about what it's up to.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: feature
summary: Tune kruise controller's leader election and verbosity.
impact: Kruise controller deployment will be updated and restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
