### PR TITLE
[ingress-nginx] update stick-to-maxunavailable.patch

### DIFF
--- a/modules/402-ingress-nginx/images/kruise/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise/patches/README.md
@@ -11,7 +11,7 @@ We can check the number of workers (concurrent reconciles) and if we have 0 work
 Remove CRD check of `BroadcastJob` and `ImagePullJob`. We don't need them for DaemonSet workflow. We don't install that CRDs.
 
 ### Stick to MaxUnavailable
-In case DaemonSet has surge == 0, Kruise Controller still able to designated more pods as allowed for replacement than
+In case DaemonSet has surge == 0, Kruise Controller still able to designate more pods as allowed for replacement than
 maxUnavailable settings allows, resulting in parallel update instead of gradual.
 We impose additional condition to check if the list of the pods, marked by the controller as Unavailable, is bigger than maxUnavailable
 and drop excessive pods from the list so as to obbey maxUnavailable setting.

--- a/modules/402-ingress-nginx/images/kruise/patches/stick-to-maxunavailable.patch
+++ b/modules/402-ingress-nginx/images/kruise/patches/stick-to-maxunavailable.patch
@@ -1,17 +1,21 @@
 diff --git a/pkg/controller/daemonset/daemonset_update.go b/pkg/controller/daemonset/daemonset_update.go
-index 17946a6e..9836c1be 100644
+index 17946a6e..1c9385f6 100644
 --- a/pkg/controller/daemonset/daemonset_update.go
 +++ b/pkg/controller/daemonset/daemonset_update.go
-@@ -134,6 +134,12 @@ func (dsc *ReconcileDaemonSet) rollingUpdate(ds *appsv1alpha1.DaemonSet, nodeLis
+@@ -129,10 +129,13 @@ func (dsc *ReconcileDaemonSet) rollingUpdate(ds *appsv1alpha1.DaemonSet, nodeLis
+ 		if remainingUnavailable < 0 {
+ 			remainingUnavailable = 0
  		}
- 		oldPodsToDelete := append(allowedReplacementPods, candidatePodsToDelete[:remainingUnavailable]...)
- 
+-		if max := len(candidatePodsToDelete); remainingUnavailable > max {
+-			remainingUnavailable = max
++		oldPodsToDelete := append(allowedReplacementPods, candidatePodsToDelete...)
++
 +		// If there is no free Unavailable slots left - need not delete any pods.
 +		if len(oldPodsToDelete) > remainingUnavailable {
 +			oldPodsToDelete = oldPodsToDelete[:remainingUnavailable]
 +			klog.V(5).Infof("DaemonSet %s/%s wanted to delete more then MaxUnvailable: %d replacements, up to %d unavailable, %d new are unavailable, %d candidates", ds.Namespace, ds.Name, len(allowedReplacementPods), maxUnavailable, numUnavailable, len(candidatePodsToDelete))
-+		}
-+
+ 		}
+-		oldPodsToDelete := append(allowedReplacementPods, candidatePodsToDelete[:remainingUnavailable]...)
+ 
  		// Advanced: update pods in-place first and still delete the others
  		if ds.Spec.UpdateStrategy.RollingUpdate.Type == appsv1alpha1.InplaceRollingUpdateType {
- 			oldPodsToDelete, err = dsc.inPlaceUpdatePods(ds, oldPodsToDelete, curRevision, oldRevisions)


### PR DESCRIPTION
## Description
It transpired that conditional
`		if max := len(candidatePodsToDelete); remainingUnavailable > max {
			remainingUnavailable = max
` may result in an inability to revert a `daemonset` to the previous version (similar to `kubectl rollout undo` comman).
The `candiatePodsToDelete` variable contains pods of the former version and in case we update a `daemonset` and a new pod doesn't get ready and running (for any reason, e.g. wrong container's image), breaking the update process, if we revert changes (to deal with the new broken pod), there is the situation when there is no new revision (we're reverting), thus, `candidatePodsToDelete` has length of 0, preventing the update from progressing.

It's rather a rare situation and it's possible to recover
* through deleting a failed new pod after reverting manually;
* through applying new changes to `daemonset`;
but it makes sense to fix it.

We remove the conditional  and `remainingUnavailable = max` logic because we don't separate `candidatePodsToDelete` and `Unavailable` pods in terms of calculating how many pods are allowed to be deleted on update. Instead, we apply `remainingUnavailable` limit to the whole `oldPodsToDelete` array if the array's length is bigger than `MaxUnavailable` spec setting.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It solves the case when we need to recover a broken `daemonset` after an update.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Advanved DaemonSet are able to be reverted (they don't support `rollout undo` but the idea is the same) from a failed update.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: Ingress-Nginx
type: fix
summary: Fix kruise controller update logic when reverting a failed update.
impact: Kruise controller manager will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
