### PR TITLE
[preflight-check] Checking the availability of creating the SSH tunnel (#5065)

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
@@ -217,6 +218,11 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		printBanner()
 
 		showWarningAboutUsageDontUsePublicImagesFlagIfNeed()
+
+		err = preflight.PreflightCheck()
+		if err != nil {
+			return err
+		}
 
 		bootstrapState := bootstrap.NewBootstrapState(stateCache)
 

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -1,0 +1,13 @@
+package preflight
+
+import "github.com/deckhouse/deckhouse/dhctl/pkg/log"
+
+func PreflightCheck() error {
+	err := log.Process("preflight-check", "Checking SSH tunnel", func() error {
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -1,0 +1,40 @@
+package preflight
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/frontend"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
+)
+
+const (
+	DefaultLocalPort  = 20000
+	DefaultRemotePort = 20000
+)
+
+func CheckSSHTunel(sess *session.Session, localPort, remotePort int) error {
+	log.DebugF("Checking ssh tunnel with remote port %s and local port %d\n", remotePort, localPort)
+	if localPort == 0 {
+		localPort = DefaultLocalPort
+	}
+	if remotePort == 0 {
+		remotePort = DefaultRemotePort
+	}
+
+	builder := strings.Builder{}
+	builder.WriteString(strconv.Itoa(localPort))
+	builder.WriteString(":localhost:")
+	builder.WriteString(strconv.Itoa(remotePort))
+
+	tun := frontend.NewTunnel(sess, "L", builder.String())
+	err := tun.Up()
+	if err != nil {
+		return err
+	}
+
+	log.DebugLn("Checking ssh tunnel success")
+	tun.Stop()
+	return nil
+}


### PR DESCRIPTION
## Description
Checking the availability of creating the SSH tunnel 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
issue #5065 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Preventing failures before bootstrap execution
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: preflight-check
type: feature
summary: Checking the availability of creating the SSH tunnel before bootstrap
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
