### PR TITLE
[user-authn] disable env expansion to support dollar character in bindPW for ldap connector

### DIFF
--- a/modules/150-user-authn/docs/CONFIGURATION.md
+++ b/modules/150-user-authn/docs/CONFIGURATION.md
@@ -4,7 +4,7 @@ title: "The user-authn module: configuration"
 
 <!-- SCHEMA -->
 
-The creation of the [`DexAuthenticator`](cr.html#dexauthenticator) Custom Resource leads to the automatic deployment of [oauth2-proxy](https://github.com/pusher/oauth2_proxy) to your application's namespace and connecting it to Dex.
+The creation of the [`DexAuthenticator`](cr.html#dexauthenticator) Custom Resource leads to the automatic deployment of [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) to your application's namespace and connecting it to Dex.
 
 **Caution!** Since using OpenID Connect over HTTP poses a significant threat to security (the fact that Kubernetes API server doesn't support OICD over HTTP confirms that), this module can only be installed if HTTPS is enabled (to do this, set the `https.mode` parameter to the value other than `Disabled` either at the cluster level or in the module).
 

--- a/modules/150-user-authn/docs/CONFIGURATION_RU.md
+++ b/modules/150-user-authn/docs/CONFIGURATION_RU.md
@@ -4,7 +4,7 @@ title: "Модуль user-authn: настройки"
 
 <!-- SCHEMA -->
 
-Автоматический деплой [oauth2-proxy](https://github.com/pusher/oauth2_proxy) в namespace вашего приложения и подключение его к Dex происходит при создании Custom Resource [`DexAuthenticator`](cr.html#dexauthenticator).
+Автоматический деплой [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) в namespace вашего приложения и подключение его к Dex происходит при создании Custom Resource [`DexAuthenticator`](cr.html#dexauthenticator).
 
 **Важно!** Так как использование OpenID Connect по протоколу HTTP является слишком значительной угрозой безопасности (что подтверждается например тем, что Kubernetes API-сервер не поддерживает работу с OIDC по HTTP), данный модуль можно установить только при включенном HTTPS (`https.mode` выставить в отличное от `Disabled` значение или на уровне кластера, или в самом модуле).
 

--- a/modules/150-user-authn/docs/FAQ.md
+++ b/modules/150-user-authn/docs/FAQ.md
@@ -5,7 +5,7 @@ title: "The user-authn module: FAQ"
 ## How to secure my application?
 
 It is possible to hide your application behind Dex authentication by using the `DexAuthenticator` custom resource (CR).
-In fact, by creating the DexAuthenticator in a cluster, user creates an instance [oauth2-proxy](https://github.com/pusher/oauth2_proxy), which is already connected to Dex.
+In fact, by creating the DexAuthenticator in a cluster, user creates an instance [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), which is already connected to Dex.
 
 ### An example of the `DexAuthenticator` CR
 

--- a/modules/150-user-authn/docs/FAQ_RU.md
+++ b/modules/150-user-authn/docs/FAQ_RU.md
@@ -5,7 +5,7 @@ title: "Модуль user-authn: FAQ"
 ## Как защитить мое приложение?
 
 Существует возможность спрятать ваше приложение за аутентификацией через Dex при помощи пользовательского ресурса `DexAuthenticator` (CR).
-По факту, создавая DexAuthenticator в кластере, пользователь создает экземпляр [oauth2-proxy](https://github.com/pusher/oauth2_proxy), который уже подключен к Dex.
+По факту, создавая DexAuthenticator в кластере, пользователь создает экземпляр [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), который уже подключен к Dex.
 
 ### Пример CR `DexAuthenticator`
 

--- a/modules/150-user-authn/docs/README.md
+++ b/modules/150-user-authn/docs/README.md
@@ -11,7 +11,7 @@ The module sets up a unified authentication system integrated with Kubernetes an
 It consists of the following components:
 - [dex](https://github.com/dexidp/dex) — is a federated OpenID Connect provider that acts as an identity service for static users and can be linked to one or more ID providers (e.g., SAML providers, GitHub, and Gitlab);
 - kubeconfig-generator (in fact, [dex-k8s-authenticator](https://github.com/mintel/dex-k8s-authenticator)) — is a helper web application that (being authorized with dex) generates kubectl commands for creating and modifying a kubeconfig;
-- dex-authenticator (in fact, [oauth2-proxy](https://github.com/pusher/oauth2_proxy)) — is an application that gets nginx ingress (auth_request) requests and authenticates them with dex.
+- dex-authenticator (in fact, [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy)) — is an application that gets nginx ingress (auth_request) requests and authenticates them with dex.
 
 Static users are managed using the [`User`](cr.html#user) Custom Resource. It contains all the user-related data, including the password.
 

--- a/modules/150-user-authn/docs/README_RU.md
+++ b/modules/150-user-authn/docs/README_RU.md
@@ -11,7 +11,7 @@ webIfaces:
 Модуль состоит из следующих компонентов:
 - [dex](https://github.com/dexidp/dex) — федеративный OpenID Connect провайдер, который обеспечивает работу со статическими пользователями и может быть подключен к одному или нескольким внешним провайдерам аутентификации (например, он поддерживает SAML, Gitlab и Github);
 - kubeconfig-generator (на самом деле [dex-k8s-authenticator](https://github.com/mintel/dex-k8s-authenticator)) — веб-приложение, которое после авторизации в Dex генерирует команды для настройки локального kubectl;
-- dex-authenticator (на самом деле [oauth2-proxy](https://github.com/pusher/oauth2_proxy)) — приложение, которое принимает запросы от nginx ingress (auth_request) и производит их аутентификацию в dex.
+- dex-authenticator (на самом деле [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy)) — приложение, которое принимает запросы от nginx ingress (auth_request) и производит их аутентификацию в dex.
 
 Управление статическими пользователями осуществляется с помощью Custom Resource [`User`](cr.html#user), в котором содержится вся информация о пользователе, включая пароль.
 

--- a/modules/150-user-authn/templates/dex/deployment.yaml
+++ b/modules/150-user-authn/templates/dex/deployment.yaml
@@ -77,6 +77,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: DEX_EXPAND_ENV
+          value: "false"
         ports:
         - name: https
           containerPort: 5556


### PR DESCRIPTION
## Description
LDAP bindPW with dollar character causes Invalid credentials

## Why do we need it, and what problem does it solve?
https://github.com/dexidp/dex/issues/1876
https://github.com/dexidp/dex/issues/1051

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Disable env expansion to support dollar character in bindPW for ldap connector
impact_level: default
```

