### PR TITLE
[runtime-audit-engine] Mount sockets and fix webhook output

### DIFF
--- a/ee/modules/650-runtime-audit-engine/hack/far-converter/main.go
+++ b/ee/modules/650-runtime-audit-engine/hack/far-converter/main.go
@@ -6,6 +6,7 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -23,7 +24,7 @@ type RawRule map[string]interface{}
 
 // FalcoAuditRule is a structure to encode FalcoAuditRules custom resources.
 type FalcoAuditRule struct {
-	ApiVersion string
+	ApiVersion string `yaml:"apiVersion"`
 	Kind       string
 	Metadata   Metadata
 	Spec       FalcoAuditRuleSpec
@@ -86,12 +87,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	res, err := yaml.Marshal(convert(input, rules))
-	if err != nil {
+	buf := bytes.Buffer{}
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(convert(input, rules)); err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(string(res))
+	fmt.Print(buf.String())
 }
 
 func convert(path string, rules []RawRule) FalcoAuditRule {

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/lib/test.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/lib/test.py
@@ -6,6 +6,8 @@
 import unittest
 
 from convert import convert_spec
+
+
 class TestConvertSpec(unittest.TestCase):
     def test_success_rule(self):
         res = convert_spec({

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/webhook/webhook.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/webhook/webhook.py
@@ -11,6 +11,7 @@ from yaml import dump
 
 from lib.convert import convert_spec
 
+
 def main(ctx: hook.Context):
     try:
         request = ctx.binding_context["review"]["request"]
@@ -18,7 +19,7 @@ def main(ctx: hook.Context):
         ctx.output.validations.allow()
     except subprocess.CalledProcessError as e:
         print(e.output)
-        ctx.output.validations.deny("Spec validation error")
+        ctx.output.validations.deny(f"spec validation error: {e.output}")
     except Exception as e:
         ctx.output.validations.error(str(e))
 

--- a/ee/modules/650-runtime-audit-engine/rules/k8s_audit_rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/rules/k8s_audit_rules.yaml
@@ -85,7 +85,7 @@
   condition: ka.target.resource=secrets
 
 - macro: falcoauditrules
-  condition: ka.target.resource=secrets
+  condition: ka.target.resource=falcoauditrules
 
 # Endpoints
 - macro: health_endpoint

--- a/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
@@ -387,4 +387,5 @@ data:
       chunk_wait_us: 1000
       # @ Watch frequency (in seconds) when fetching metadata from Kubernetes.
       watch_freq_sec: 1
+
 {{ (.Files.Glob "rules/*" ).AsConfig | indent 2 }}

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -146,6 +146,10 @@ spec:
           readOnly: true
         - name: rules-data
           mountPath: /etc/falco/rules.d
+        - name: dockersock
+          mountPath: /var/run/docker.sock
+        - name: containerdsock
+          mountPath: /run/containerd/containerd.sock
 
       - name: falcosidekick
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
@@ -201,6 +205,8 @@ spec:
           mountPath: /etc/falco/rules.d
         - name: tmp
           mountPath: /tmp
+        - mountPath: /etc/falco
+          name: config-volume
         # Check that rules were uploaded successfully
         readinessProbe:
           exec:
@@ -278,6 +284,12 @@ spec:
       - hostPath:
           path: /usr
         name: usr-fs
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
+      - hostPath:
+          path: /run/containerd/containerd.sock
+        name: containerdsock
       - hostPath:
           path: /etc
         name: etc-fs

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -146,8 +146,6 @@ spec:
           readOnly: true
         - name: rules-data
           mountPath: /etc/falco/rules.d
-        - name: dockersock
-          mountPath: /var/run/docker.sock
         - name: containerdsock
           mountPath: /run/containerd/containerd.sock
 
@@ -284,9 +282,6 @@ spec:
       - hostPath:
           path: /usr
         name: usr-fs
-      - hostPath:
-          path: /var/run/docker.sock
-        name: dockersock
       - hostPath:
           path: /run/containerd/containerd.sock
         name: containerdsock


### PR DESCRIPTION
## Description
* Mount docker and containerd sockets to fetch metadata.
* Mount falco config to rules-loader to enable plugins for validating webhook. Otherwise, webhook returns an error for valid rules.
* Output webhook validation error. Without this change, users have to search it in logs among all running falco pods.
* Fix converter `apiVersion` header, it was `apiversion`, which is not valid.
* Fix falcoauditrules resource name in rules. 

## Why do we need it, and what problem does it solve?
Various fixes of problems found while developing rules.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Falco pods will be restarted.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary:  Mount docker and containerd sockets to fetch metadata.
---
section: runtime-audit-engine
type: fix
summary: Mount falco config to rules-loader to enable plugins for validating webhook. Otherwise, webhook returns an error for valid rules.
---
section: runtime-audit-engine
type: fix
summary:  Output webhook validation error. Without this change, users have to search it in logs among all running falco pods.
---
section: runtime-audit-engine
type: fix
summary:  Fix falcoauditrules resource name in rules. 
---
section: runtime-audit-engine
type: fix
summary:  Fix converter `apiVersion` header, it was `apiversion`, which is not valid.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
