### PR TITLE
[deckhouse] Fix DeckhouseRelease cleanup hook

### DIFF
--- a/modules/002-deckhouse/hooks/cleanup_deckhouse_releases.go
+++ b/modules/002-deckhouse/hooks/cleanup_deckhouse_releases.go
@@ -92,7 +92,8 @@ func cleanupReleases(input *go_hook.HookInput) error {
 		}
 		// everything except the last Deployed release
 		for i := 1; i < len(deployedReleasesIndexes); i++ {
-			release := releases[i]
+			index := deployedReleasesIndexes[i]
+			release := releases[index]
 			input.PatchCollector.MergePatch(sp, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name, object_patch.WithSubresource("/status"))
 		}
 	}
@@ -100,7 +101,8 @@ func cleanupReleases(input *go_hook.HookInput) error {
 	// save only last 10 outdated releases
 	if len(outdatedReleasesIndexes) > 10 {
 		for i := 10; i < len(outdatedReleasesIndexes); i++ {
-			release := releases[i]
+			index := outdatedReleasesIndexes[i]
+			release := releases[index]
 			input.PatchCollector.Delete("deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name, object_patch.InBackground())
 		}
 	}

--- a/modules/002-deckhouse/hooks/cleanup_deckhouse_releases_test.go
+++ b/modules/002-deckhouse/hooks/cleanup_deckhouse_releases_test.go
@@ -173,6 +173,160 @@ status:
 			Expect(rl19.Field("status.phase").String()).Should(Equal("Pending"))
 		})
 	})
+
+	Context("Has Deployed releases", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: "2023-02-22T11:22:01Z"
+  generation: 1
+  name: v1-43-8
+  resourceVersion: "2035414797"
+  uid: 31be4cdd-2f35-458c-afe6-a227ba9e4d32
+spec:
+  applyAfter: "2023-02-22T11:52:01.994220949Z"
+  changelog:
+    candi:
+      fixes:
+      - impact: Fix restarts containerd services on nodes.
+        pull_request: https://github.com/deckhouse/deckhouse/pull/3929
+        summary: Update of containerd to .
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.43.8
+  requirements:
+    ingressNginx: "1.1"
+    k8s: 1.21.0
+  version: v1.43.8
+status:
+  approved: false
+  message: ""
+  phase: Superseded
+  transitionTime: "2023-06-15T21:20:00.254776566Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: true
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: "2023-03-29T08:42:01Z"
+  generation: 2
+  name: v1-44-4
+  resourceVersion: "2035413896"
+  uid: f33a9ae9-140d-4e8e-bfcd-071e454ee5db
+spec:
+  changelog:
+    log-shipper:
+      fixes:
+      - pull_request: https://github.com/deckhouse/deckhouse/pull/4222
+        summary: Fix throttling alert labels.
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.44.4
+  requirements:
+    ingressNginx: "1.1"
+    k8s: 1.21.0
+    nodesMinimalOSVersionUbuntu: "18.04"
+  version: v1.44.4
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2023-06-15T21:19:30.267810792Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: true
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: "2023-05-25T13:18:01Z"
+  generation: 2
+  name: v1-45-11
+  resourceVersion: "2077388270"
+  uid: bd114b8b-41c6-4089-b73c-9a5a9c10048a
+spec:
+  applyAfter: "2023-05-25T15:48:01.682158774Z"
+  changelog:
+    helm:
+      fixes:
+      - pull_request: https://github.com/deckhouse/deckhouse/pull/4751
+        summary: Fix deprecated k8s resources metrics.
+    ingress-nginx:
+      fixes:
+      - pull_request: https://github.com/deckhouse/deckhouse/pull/4734
+        summary: Add protection for ingress-nginx-controller daemonset migration.
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.45.11
+  requirements:
+    ingressNginx: "1.1"
+    k8s: 1.22.0
+    nodesMinimalOSVersionUbuntu: "18.04"
+  version: v1.45.11
+status:
+  approved: true
+  message: ""
+  phase: Superseded
+  transitionTime: "2023-07-03T21:06:00.100969353Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: "2023-05-17T16:48:01Z"
+  generation: 1
+  name: v1-45-9
+  resourceVersion: "2035447662"
+  uid: 5ed4e921-c6ca-4085-ae1a-af0e47a1881c
+spec:
+  applyAfter: "2023-05-17T17:48:01.601411184Z"
+  changelog:
+    candi:
+      fixes:
+      - pull_request: https://github.com/deckhouse/deckhouse/pull/4669
+        summary: Fix the error in the script.
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.45.9
+  requirements:
+    ingressNginx: "1.1"
+    k8s: 1.22.0
+    nodesMinimalOSVersionUbuntu: "18.04"
+  version: v1.45.9
+status:
+  approved: false
+  message: Skipped by cleanup hook
+  phase: Skipped
+  transitionTime: "2023-06-15T21:35:37.013703518Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: true
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: "2023-06-23T07:24:01Z"
+  generation: 2
+  name: v1-46-10
+  resourceVersion: "2077388269"
+  uid: 4184d860-aa1b-457e-a11d-7d61199470eb
+spec:
+  applyAfter: "2023-06-23T08:24:01.700912496Z"
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.46.10
+  requirements:
+    ingressNginx: "1.1"
+    k8s: 1.22.0
+    nodesMinimalOSVersionUbuntu: "18.04"
+  version: v1.46.10
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2023-07-03T21:06:00.100966635Z"
+`)
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Should mark old deployed release as Superseded", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			rel := f.KubernetesGlobalResource("DeckhouseRelease", "v1-44-4")
+			Expect(rel.Field("status.phase").String()).Should(Equal("Superseded"))
+		})
+	})
 })
 
 func generateReleases(deployedReleasesCount, outdatedReleasesCount int) string {


### PR DESCRIPTION
## Description
Fix cleanup hook

## Why do we need it, and what problem does it solve?
If the releases were not followed one by one, then the wrong index selection resulted in cleaning up the wrong releases

## Why do we need it in the patch release (if we do)?
In some cases we can break the release order

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Fix DeckhouseRelease cleanup hook. Mark superseded releases in the right order.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
