### PR TITLE
[linstor] fixed prometheus-rules renamed exported_node to node

### DIFF
--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -145,7 +145,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "((sum by (storage_pool)(linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"} != 0)-sum by (storage_pool)(linstor_storage_pool_capacity_free_bytes{exported_node=~\"$node\"}))*100/sum by (storage_pool)(linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"}))",
+          "expr": "((sum by (storage_pool)(linstor_storage_pool_capacity_total_bytes{node=~\"$node\"} != 0)-sum by (storage_pool)(linstor_storage_pool_capacity_free_bytes{node=~\"$node\"}))*100/sum by (storage_pool)(linstor_storage_pool_capacity_total_bytes{node=~\"$node\"}))",
           "hide": false,
           "legendFormat": "{{ storage_pool }}",
           "refId": "A"
@@ -201,7 +201,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (storage_pool) (linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"} != 0)",
+          "expr": "sum by (storage_pool) (linstor_storage_pool_capacity_total_bytes{node=~\"$node\"} != 0)",
           "hide": false,
           "legendFormat": "{{ storage_pool }}",
           "refId": "A"
@@ -258,7 +258,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (storage_pool) (linstor_storage_pool_capacity_free_bytes{exported_node=~\"$node\"} != 0)",
+          "expr": "sum by (storage_pool) (linstor_storage_pool_capacity_free_bytes{node=~\"$node\"} != 0)",
           "hide": false,
           "legendFormat": "{{ storage_pool }}",
           "refId": "A"
@@ -314,7 +314,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (storage_pool) ((linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"} != 0) - (linstor_storage_pool_capacity_free_bytes{exported_node=~\"$node\"} != 0))",
+          "expr": "sum by (storage_pool) ((linstor_storage_pool_capacity_total_bytes{node=~\"$node\"} != 0) - (linstor_storage_pool_capacity_free_bytes{node=~\"$node\"} != 0))",
           "hide": false,
           "legendFormat": "{{ storage_pool }}",
           "refId": "A"
@@ -370,7 +370,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\",exported_node=~\"$node\"} == 2) OR on() vector(0)",
+          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\",node=~\"$node\"} == 2) OR on() vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -425,7 +425,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(linstor_storage_pool_capacity_total_bytes{driver!=\"DISKLESS\",exported_node=~\"$node\"}) OR on() vector(0)",
+          "expr": "count(linstor_storage_pool_capacity_total_bytes{driver!=\"DISKLESS\",node=~\"$node\"}) OR on() vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -535,7 +535,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(linstor_resource_state{exported_node=~\"$node\"}) OR on() vector(0)",
+          "expr": "count(linstor_resource_state{node=~\"$node\"}) OR on() vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -741,7 +741,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\", exported_node=~\"$node\"} != 2) OR on() vector(0)",
+          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\", node=~\"$node\"} != 2) OR on() vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -800,7 +800,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(linstor_storage_pool_error_count{driver!=\"DISKLESS\", exported_node=~\"$node\"} != 0) OR on() vector(0)",
+          "expr": "count(linstor_storage_pool_error_count{driver!=\"DISKLESS\", node=~\"$node\"} != 0) OR on() vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -859,7 +859,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count((linstor_volume_state{exported_node=~\"$node\"} != 1) != 4) OR on() vector(0)",
+          "expr": "count((linstor_volume_state{node=~\"$node\"} != 1) != 4) OR on() vector(0)",
           "legendFormat": "",
           "refId": "A"
         }

--- a/modules/041-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
+++ b/modules/041-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.linstor.storage_pool_state
   rules:
     - alert: D8LinstorStoragePoolHasErrors
-      expr: max by (exported_node, storage_pool) (linstor_storage_pool_error_count != 0)
+      expr: max by (node, storage_pool) (linstor_storage_pool_error_count != 0)
       for: 5m
       labels:
         severity_level: "6"
@@ -13,14 +13,14 @@
         plk_grouped_by__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: LINSTOR storage pool has errors
         description: |
-          LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.exported_node }} has errors
+          LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.node }} has errors
 
           The recommended course of action:
-          1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
+          1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.node }} -s {{ $labels.storage_pool }}`
           2. Check backing storage devices
 
     - alert: D8LinstorStoragePoolCapacityPressure
-      expr: max by (exported_node, storage_pool) (linstor_storage_pool_capacity_free_bytes * 100 / linstor_storage_pool_capacity_total_bytes < 10)
+      expr: max by (node, storage_pool) (linstor_storage_pool_capacity_free_bytes * 100 / linstor_storage_pool_capacity_total_bytes < 10)
       for: 5m
       labels:
         severity_level: "6"
@@ -32,15 +32,15 @@
         plk_grouped_by__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Storage pool running out of free space
         description: |
-          LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.exported_node }} has less than 10% space left. Current free space: {{ $value }}%
+          LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.node }} has less than 10% space left. Current free space: {{ $value }}%
 
           The recommended course of action:
-          1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
-          2. Check the LINSTOR volumes: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor volume list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
+          1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.node }} -s {{ $labels.storage_pool }}`
+          2. Check the LINSTOR volumes: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor volume list -n {{ $labels.node }} -s {{ $labels.storage_pool }}`
           3. Consider adding more backing devices or relocating some resources to other nodes:
              ```
              alias linstor="kubectl exec -n d8-linstor deploy/linstor-controller -- linstor"
              linstor resource-definition auto-place <res> --place-count +1 -s {{ $labels.storage_pool }}
              linstor resource-definition wait-sync <res>
-             linstor resource delete {{ $labels.exported_node }} <res>
+             linstor resource delete {{ $labels.node }} <res>
              ```

--- a/modules/041-linstor/templates/linstor-controller/servicemonitor.yaml
+++ b/modules/041-linstor/templates/linstor-controller/servicemonitor.yaml
@@ -21,8 +21,6 @@ spec:
       action: labeldrop
     - targetLabel: job
       replacement: linstor-controller
-    - sourceLabels: [__meta_kubernetes_pod_node_name]
-      targetLabel: node
     - targetLabel: tier
       replacement: cluster
     - sourceLabels: [__meta_kubernetes_endpoint_ready]

--- a/modules/041-linstor/templates/linstor-node/podmonitor.yaml
+++ b/modules/041-linstor/templates/linstor-node/podmonitor.yaml
@@ -21,8 +21,6 @@ spec:
       action: labeldrop
     - targetLabel: job
       replacement: linstor-node
-    - sourceLabels: [__meta_kubernetes_pod_node_name]
-      targetLabel: node
     - targetLabel: tier
       replacement: cluster
     - sourceLabels: [__meta_kubernetes_pod_ready]


### PR DESCRIPTION
## Description
Rename `exported_node` to `node` in PrometheusRule.

## Why do we need it, and what problem does it solve?
Alert is not rendered correctly commands do not work in it without correction


## Why do we need it in the patch release (if we do)?
Alert is not rendered correctly commands do not work in it without correction

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: linstor
type: fix
summary: Rename `exported_node` to `node` in PrometheusRule.
impact_level: default
```
