### PR TITLE
[dashboard] Show username and groups

### DIFF
--- a/modules/500-dashboard/images/dashboard/logout_button.js
+++ b/modules/500-dashboard/images/dashboard/logout_button.js
@@ -3,8 +3,33 @@ function setupLogoutButton() {
 
   document.querySelectorAll("div").forEach(function (node) {
     if (node.innerHTML.startsWith("Logged in with auth header") === true) {
-      node.innerHTML += '<div><br><a class="mat-menu-content" href="/logout">Click to logout</a></div>';
-      flag = true;
+      let r = new XMLHttpRequest();
+      r.open('GET', window.location.origin + "/dex-authenticator/userinfo", false);
+      r.onload  = function() {
+        let payload = JSON.parse(r.response);
+
+        node.innerHTML = '' +
+          '<div>' +
+          '<button class="mat-focus-indicator mat-raised-button mat-button-base mat-primary" color="primary">' +
+          '<span class="mat-button-wrapper">' +
+          '<a href="/logout" style="color:#ffffff;">Click to logout</a>' +
+          '</span>' +
+          '</button>' +
+          '</div>' +
+          '<p><hr/></p>';
+        node.innerHTML += '<div><h3>Logged in as </h3> Username: <b>' + payload.email + '</b></div>'
+
+        if (payload.groups.length > 0) {
+          node.innerHTML += '<br> Groups: <br><ul>'
+          for (const group of payload.groups) {
+            let fgroup = '<li>' + group  + '</li>';
+            node.innerHTML += fgroup
+          }
+        }
+
+        flag = true;
+      };
+      r.send(null);
     }
   })
 
@@ -13,4 +38,14 @@ function setupLogoutButton() {
   }
 }
 
+// Resize dialog window because groups and emails can be long.
+function setResizeParent() {
+  let parent = document.querySelectorAll('#mat-menu-panel-0').item(0);
+  if (parent) {
+    parent.style.minWidth = "400px";
+  }
+  setTimeout(setResizeParent, 500);
+}
+
 setupLogoutButton()
+setResizeParent()


### PR DESCRIPTION
## Description
Show username and groups on click to the user icon instead of just "Logged in with an auth header".

## Why do we need it, and what problem does it solve?
This feature was requested a couple of times with complaints that users do not know who they are.

![image](https://github.com/deckhouse/deckhouse/assets/32434187/51089db5-9dba-48d7-ab18-a19fb2036afc)


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dashboard
type: feature
summary: Show username and groups.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
