### PR TITLE
[node-manager] do not render template by helm

### DIFF
--- a/modules/040-node-manager/templates/nodegroupconfiguration-prune-containerd-content.yaml
+++ b/modules/040-node-manager/templates/nodegroupconfiguration-prune-containerd-content.yaml
@@ -31,6 +31,7 @@ spec:
     # it will be removed automatically once they have been pulled and unpacked.
     #
     # Prune content to save disk space
+    {{- `
     {{- if eq .cri "Containerd" }}
     if [ -f /var/lib/bashible/containerd_content_store_is_cleared ] ; then
       exit 0
@@ -42,3 +43,4 @@ spec:
         bb-log-warning "Failed to clean up containerd's content store. Skip this for now"
     fi
     {{- end }}
+    `}}


### PR DESCRIPTION
## Description

Do not render template by Helm at deploy stage. We need this Go template at runtime stage.
Fixes deckhouse/deckhouse#4843 cleanup feature

## Why do we need it, and what problem does it solve?

The following template is rendered by Helm at deploy stage, which causes the script to come up empty in kubernetes cluster
```go
{{- if eq .cri "Containerd" }}
...
{{- end }}
```

## Why do we need it in the patch release (if we do)?

This is not an urgent fix because the feature it fixes is not critical. But I would like to bring it to the next release, as this fix will clean up unnecessary artifacts on the disk and free up space.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed ngc step rendering
impact_level: low
```