### PR TITLE
[testing] Increase resources creation timeout in e2e tests

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -444,7 +444,7 @@ check_e2e_labels:
 
     - name: "Run e2e test: {!{ $ctx.providerName }!}/{!{ $ctx.criName }!}/{!{ $ctx.kubernetesVersion }!}"
       id: e2e_test_run
-      timeout-minutes: 60
+      timeout-minutes: 80
       env:
         PROVIDER: {!{ $ctx.providerName }!}
         CRI: {!{ $ctx.criName }!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -863,7 +863,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1312,7 +1312,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1761,7 +1761,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -2210,7 +2210,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -2659,7 +2659,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -3108,7 +3108,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -3557,7 +3557,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -4006,7 +4006,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -4455,7 +4455,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -4904,7 +4904,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -5353,7 +5353,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -871,7 +871,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1328,7 +1328,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1785,7 +1785,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -2242,7 +2242,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -2699,7 +2699,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -3156,7 +3156,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -3613,7 +3613,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -4070,7 +4070,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -4527,7 +4527,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -4984,7 +4984,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -5441,7 +5441,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -331,7 +331,7 @@ jobs:
 
       - name: "Run e2e test: AWS/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -755,7 +755,7 @@ jobs:
 
       - name: "Run e2e test: Azure/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -1187,7 +1187,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -1607,7 +1607,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2035,7 +2035,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2455,7 +2455,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2879,7 +2879,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -420,7 +420,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Docker
@@ -904,7 +904,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Docker
@@ -1388,7 +1388,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Docker
@@ -1872,7 +1872,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Docker
@@ -2356,7 +2356,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Docker
@@ -2840,7 +2840,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Docker
@@ -3324,7 +3324,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Containerd
@@ -3808,7 +3808,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Containerd
@@ -4292,7 +4292,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Containerd
@@ -4776,7 +4776,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Containerd
@@ -5260,7 +5260,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Containerd
@@ -5744,7 +5744,7 @@ jobs:
 
       - name: "Run e2e test: EKS/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: EKS
           CRI: Containerd

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -859,7 +859,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1304,7 +1304,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1749,7 +1749,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -2194,7 +2194,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -2639,7 +2639,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -3084,7 +3084,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -3529,7 +3529,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -3974,7 +3974,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -4419,7 +4419,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -4864,7 +4864,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -5309,7 +5309,7 @@ jobs:
 
       - name: "Run e2e test: GCP/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: GCP
           CRI: Containerd

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -859,7 +859,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1304,7 +1304,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1749,7 +1749,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -2194,7 +2194,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -2639,7 +2639,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -3084,7 +3084,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -3529,7 +3529,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -3974,7 +3974,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -4419,7 +4419,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -4864,7 +4864,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -5309,7 +5309,7 @@ jobs:
 
       - name: "Run e2e test: OpenStack/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: OpenStack
           CRI: Containerd

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: Static/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Docker
@@ -859,7 +859,7 @@ jobs:
 
       - name: "Run e2e test: Static/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1304,7 +1304,7 @@ jobs:
 
       - name: "Run e2e test: Static/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1749,7 +1749,7 @@ jobs:
 
       - name: "Run e2e test: Static/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Docker
@@ -2194,7 +2194,7 @@ jobs:
 
       - name: "Run e2e test: Static/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Docker
@@ -2639,7 +2639,7 @@ jobs:
 
       - name: "Run e2e test: Static/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Docker
@@ -3084,7 +3084,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -3529,7 +3529,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -3974,7 +3974,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -4419,7 +4419,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -4864,7 +4864,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -5309,7 +5309,7 @@ jobs:
 
       - name: "Run e2e test: Static/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Static
           CRI: Containerd

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -863,7 +863,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1312,7 +1312,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1761,7 +1761,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -2210,7 +2210,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -2659,7 +2659,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -3108,7 +3108,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -3557,7 +3557,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -4006,7 +4006,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -4455,7 +4455,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -4904,7 +4904,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -5353,7 +5353,7 @@ jobs:
 
       - name: "Run e2e test: vSphere/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: vSphere
           CRI: Containerd

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -867,7 +867,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1320,7 +1320,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1773,7 +1773,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -2226,7 +2226,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -2679,7 +2679,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -3132,7 +3132,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -3585,7 +3585,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.23"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -4038,7 +4038,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.24"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -4491,7 +4491,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.25"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -4944,7 +4944,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.26"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -5397,7 +5397,7 @@ jobs:
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.27"
         id: e2e_test_run
-        timeout-minutes: 60
+        timeout-minutes: 80
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -575,7 +575,7 @@ ENDSSH
 
   # Bootstrap
   >&2 echo "Run dhctl bootstrap ..."
-  dhctl bootstrap --yes-i-want-to-drop-cache --ssh-bastion-host "$bastion_ip" --ssh-bastion-user="$ssh_user" --ssh-host "$master_ip" --ssh-agent-private-keys "$ssh_private_key_path" --ssh-user "$ssh_user" \
+  dhctl bootstrap --resources-timeout="30m" --yes-i-want-to-drop-cache --ssh-bastion-host "$bastion_ip" --ssh-bastion-user="$ssh_user" --ssh-host "$master_ip" --ssh-agent-private-keys "$ssh_private_key_path" --ssh-user "$ssh_user" \
   --config "$cwd/configuration.yaml" --resources "$cwd/resources.yaml" | tee -a "$bootstrap_log" || return $?
 
   >&2 echo "==============================================================
@@ -666,7 +666,7 @@ ENDSSH
 
 function bootstrap() {
   >&2 echo "Run dhctl bootstrap ..."
-  dhctl bootstrap --yes-i-want-to-drop-cache --ssh-agent-private-keys "$ssh_private_key_path" --ssh-user "$ssh_user" \
+  dhctl bootstrap --resources-timeout="30m" --yes-i-want-to-drop-cache --ssh-agent-private-keys "$ssh_private_key_path" --ssh-user "$ssh_user" \
   --resources "$cwd/resources.yaml" --config "$cwd/configuration.yaml" | tee -a "$bootstrap_log"
 
   dhctl_exit_code=$?


### PR DESCRIPTION
## Description
Add `--resources-timeout=30m` argument for `dhctl bootstrap` command in e2e test.
Increase job timeout in e2e workflows, because we added `resources-timeout` argument.

## Why do we need it, and what problem does it solve?
Close #5075

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Testing
Tested [here](https://github.com/deckhouse/deckhouse-test-2/pull/328)

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Increase resources creation timeout in e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
