### PR TITLE
[linstor] Added node selector and fix tolerations for satellites

### DIFF
--- a/modules/041-linstor/openapi/config-values.yaml
+++ b/modules/041-linstor/openapi/config-values.yaml
@@ -1,2 +1,14 @@
 type: object
-properties: {}
+properties:
+  dataNodes:
+    type: object
+    description: Settings for Linstor on nodes with data
+    properties:
+      nodeSelector:
+        type: object
+        additionalProperties:
+          type: string
+        description: |
+          The same as in the Pods `spec.nodeSelector` parameter in Kubernetes.
+
+          If parameter is omitted, Linstor nodes will be placed on all nodes.

--- a/modules/041-linstor/openapi/doc-ru-config-values.yaml
+++ b/modules/041-linstor/openapi/doc-ru-config-values.yaml
@@ -1,2 +1,14 @@
 type: object
-properties: {}
+properties:
+  dataNodes:
+    type: object
+    description: Настройки для узлов Linstor с данными
+    properties:
+      nodeSelector:
+        type: object
+        additionalProperties:
+          type: string
+        description: |
+          Настройка аналогична `spec.nodeSelector` в Kubernetes.
+
+          Если параметр не указан, pod'ы для Linstor будут запущены на всех узлах.

--- a/modules/041-linstor/openapi/doc-ru-config-values.yaml
+++ b/modules/041-linstor/openapi/doc-ru-config-values.yaml
@@ -1,13 +1,9 @@
 type: object
 properties:
   dataNodes:
-    type: object
     description: Настройки для узлов Linstor с данными
     properties:
       nodeSelector:
-        type: object
-        additionalProperties:
-          type: string
         description: |
           Настройка аналогична `spec.nodeSelector` в Kubernetes.
 

--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -170,8 +170,7 @@ spec:
       maxUnavailable: 1
     {{- end }}
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
-  {{- if .Values.linstor.dataNodes }}
-  {{- if .Values.linstor.dataNodes.nodeSelector }}
+  {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
   nodeAffinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -183,9 +182,6 @@ spec:
               values:
               - {{ $v | quote }}
             {{- end }}
-  {{- else }}
-  nodeAffinity: {}
-  {{- end }}
   {{- else }}
   nodeAffinity: {}
   {{- end }}

--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -170,7 +170,8 @@ spec:
       maxUnavailable: 1
     {{- end }}
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
-  {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+  {{- if .Values.linstor.dataNodes }}
+  {{- if .Values.linstor.dataNodes.nodeSelector }}
   nodeAffinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -182,6 +183,9 @@ spec:
               values:
               - {{ $v | quote }}
             {{- end }}
+  {{- else }}
+  nodeAffinity: {}
+  {{- end }}
   {{- else }}
   nodeAffinity: {}
   {{- end }}

--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -170,9 +170,23 @@ spec:
       maxUnavailable: 1
     {{- end }}
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
+  {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+  nodeAffinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            {{- range $k, $v := .Values.linstor.dataNodes.nodeSelector }}
+            - key: {{ $k }}
+              operator: In
+              values:
+              - {{ $v | quote }}
+            {{- end }}
+  {{- else }}
   nodeAffinity: {}
+  {{- end }}
   nodeTolerations:
-    {{- index (include "helm_lib_tolerations" (tuple . "wildcard") | fromYaml) "tolerations" | toYaml | nindent 4 }}
+    {{- index (include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | fromYaml) "tolerations" | toYaml | nindent 4 }}
   controllerAffinity:
     {{- with (include "helm_lib_node_selector" (tuple . "system")) }}
     nodeAffinity:

--- a/modules/041-linstor/templates/linstor-ha-controller/daemonset.yaml
+++ b/modules/041-linstor/templates/linstor-ha-controller/daemonset.yaml
@@ -47,7 +47,8 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
-      {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+      {{- if .Values.linstor.dataNodes }}
+      {{- if .Values.linstor.dataNodes.nodeSelector }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -59,6 +60,7 @@ spec:
                   values:
                   - {{ $v | quote }}
                 {{- end }}
+      {{- end }}
       {{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/modules/041-linstor/templates/linstor-ha-controller/daemonset.yaml
+++ b/modules/041-linstor/templates/linstor-ha-controller/daemonset.yaml
@@ -47,8 +47,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
-      {{- if .Values.linstor.dataNodes }}
-      {{- if .Values.linstor.dataNodes.nodeSelector }}
+      {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -60,7 +59,8 @@ spec:
                   values:
                   - {{ $v | quote }}
                 {{- end }}
-      {{- end }}
+      {{- else }}
+      affinity: {}
       {{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/modules/041-linstor/templates/linstor-ha-controller/daemonset.yaml
+++ b/modules/041-linstor/templates/linstor-ha-controller/daemonset.yaml
@@ -45,8 +45,21 @@ spec:
         app: linstor-ha-controller
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                {{- range $k, $v := .Values.linstor.dataNodes.nodeSelector }}
+                - key: {{ $k }}
+                  operator: In
+                  values:
+                  - {{ $v | quote }}
+                {{- end }}
+      {{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -60,8 +60,7 @@ spec:
   linstorHttpsClientSecret: linstor-client-https-cert
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
   automaticStorageType: None
-  {{- if .Values.linstor.dataNodes }}
-  {{- if .Values.linstor.dataNodes.nodeSelector }}
+  {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -73,9 +72,6 @@ spec:
               values:
               - {{ $v | quote }}
             {{- end }}
-  {{- else }}
-  affinity: {}
-  {{- end }}
   {{- else }}
   affinity: {}
   {{- end }}

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -60,7 +60,8 @@ spec:
   linstorHttpsClientSecret: linstor-client-https-cert
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
   automaticStorageType: None
-  {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+  {{- if .Values.linstor.dataNodes }}
+  {{- if .Values.linstor.dataNodes.nodeSelector }}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -72,6 +73,9 @@ spec:
               values:
               - {{ $v | quote }}
             {{- end }}
+  {{- else }}
+  affinity: {}
+  {{- end }}
   {{- else }}
   affinity: {}
   {{- end }}

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -51,7 +51,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-node")) | nindent 2 }}
 spec:
   {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 2 }}
-  {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 2 }}
+  {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 2 }}
   sslSecret: linstor-node-ssl-cert
   drbdRepoCred: deckhouse-registry
   imagePullPolicy: IfNotPresent
@@ -60,7 +60,21 @@ spec:
   linstorHttpsClientSecret: linstor-client-https-cert
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
   automaticStorageType: None
+  {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            {{- range $k, $v := .Values.linstor.dataNodes.nodeSelector }}
+            - operator: In
+              key: {{ $k }}
+              values:
+              - {{ $v | quote }}
+            {{- end }}
+  {{- else }}
   affinity: {}
+  {{- end }}
   resources:
     requests:
       {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 6 }}

--- a/modules/041-linstor/templates/linstor-pools-importer/daemonset.yaml
+++ b/modules/041-linstor/templates/linstor-pools-importer/daemonset.yaml
@@ -44,8 +44,21 @@ spec:
         app: linstor-pools-importer
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                {{- range $k, $v := .Values.linstor.dataNodes.nodeSelector }}
+                - key: {{ $k }}
+                  operator: In
+                  values:
+                  - {{ $v | quote }}
+                {{- end }}
+      {{- end }}
       imagePullSecrets:
         - name: deckhouse-registry
       serviceAccountName: linstor-pools-importer

--- a/modules/041-linstor/templates/linstor-pools-importer/daemonset.yaml
+++ b/modules/041-linstor/templates/linstor-pools-importer/daemonset.yaml
@@ -46,7 +46,8 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
-      {{- if and (.Values.linstor.dataNodes) (.Values.linstor.dataNodes.nodeSelector) }}
+      {{- if .Values.linstor.dataNodes }}
+      {{- if .Values.linstor.dataNodes.nodeSelector }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -58,6 +59,7 @@ spec:
                   values:
                   - {{ $v | quote }}
                 {{- end }}
+      {{- end }}
       {{- end }}
       imagePullSecrets:
         - name: deckhouse-registry

--- a/modules/041-linstor/templates/linstor-pools-importer/daemonset.yaml
+++ b/modules/041-linstor/templates/linstor-pools-importer/daemonset.yaml
@@ -46,8 +46,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
-      {{- if .Values.linstor.dataNodes }}
-      {{- if .Values.linstor.dataNodes.nodeSelector }}
+      {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -59,7 +58,8 @@ spec:
                   values:
                   - {{ $v | quote }}
                 {{- end }}
-      {{- end }}
+      {{- else }}
+      affinity: {}
       {{- end }}
       imagePullSecrets:
         - name: deckhouse-registry


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Now we have redundant tolerations for linstor satellites. Also, we have no opportunity to set affinity for them.  This PR fix both of this situations.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now satellites places over all nodes in cluster, if linstor mode enabeld.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We have clients that want it ASAP.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct tolerations and ability to add node selector for linstor satellites.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: feature
summary: Added node selector and fix tolerations for satellites.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
