### PR TITLE
[ingress-nginx] Fix drain for AdvancedDaemonSet

### DIFF
--- a/go_lib/dependency/k8s/drain/README.md
+++ b/go_lib/dependency/k8s/drain/README.md
@@ -1,2 +1,7 @@
 The code in this directory has been copied from: https://github.com/kubernetes/kubernetes/blob/v1.25.4/staging/src/k8s.io/kubectl/pkg/drain
 Tag 0.25.4
+
+
+!!!Attention!!!
+This version is patched to ignore kruise AdvancedDaemonSetPods.
+Move this patch between updates: filters.go#L183-185

--- a/go_lib/dependency/k8s/drain/filters.go
+++ b/go_lib/dependency/k8s/drain/filters.go
@@ -179,6 +179,11 @@ func (d *Helper) daemonSetFilter(pod corev1.Pod) PodDeleteStatus {
 	// management resource - including DaemonSet - is not found).
 	// Such pods will be deleted if --force is used.
 	controllerRef := metav1.GetControllerOf(&pod)
+
+	if d.IgnoreAllDaemonSets && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
+		return MakePodDeleteStatusWithWarning(false, "ignoring Kruise AdvancedDaemonSet-managed Pods")
+	}
+
 	if controllerRef == nil || controllerRef.Kind != appsv1.SchemeGroupVersion.WithKind("DaemonSet").Kind {
 		return MakePodDeleteStatusOkay()
 	}

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -21,20 +21,6 @@
 {{- $defaultSSLCertificate := $crd.spec.defaultSSLCertificate | default dict }}
 {{- $defaultSSLCertificateSecretRef := $defaultSSLCertificate.secretRef | default dict }}
 
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: controller-{{ $name }}
-  namespace: d8-ingress-nginx
-  {{ include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name )) | nindent 2 }}
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: controller
-      name: {{ $name }}
-
 {{- if ( $context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1

--- a/modules/402-ingress-nginx/templates/failover/daemonset.yaml
+++ b/modules/402-ingress-nginx/templates/failover/daemonset.yaml
@@ -19,19 +19,6 @@ spec:
     updateMode: "Off"
     {{- end }}
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: proxy-{{ $crd.name }}-failover
-  namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name )) | nindent 2 }}
-spec:
-  {{- include "helm_lib_pdb_daemonset" $context | nindent 2}}
-  selector:
-    matchLabels:
-      app: proxy-failover
-      name: {{ $crd.name }}
----
 apiVersion: apps.kruise.io/v1alpha1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
## Description
Fix drain helper to ignore kruise controller AdvancedDaemonSets also.
PDB for ingress daemonset is also removed, because they don' work and only invoke some problems.

## Why do we need it, and what problem does it solve?
Ingress controller pods could not be evicted and block a node drain. We have to ignore that pods such as normal DaemonSets

## Why do we need it in the patch release (if we do)?

Node updates can stuck.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix kruise DaemonSet handling on node drain.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
