### PR TITLE
[candi] CSI old mount cleaner

### DIFF
--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Flant JSC
+# Copyright 2023 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -35,14 +35,14 @@ return 0
 {{- if semverCompare "<1.24" .kubernetesVersion }}
 
 disable_systemd_units
-return 0
+exit 0
 
 {{- else }}
 
 if ! mount | grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/'; then
   echo 'No mounts of form "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/" present. No-op...'
   disable_systemd_units
-  return 0
+  exit 0
 fi
 
 bb-event-on 'old-csi-mount-cleaner' '_on_old_csi_mount_cleaner_changed'

--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -28,6 +28,8 @@ function disable_systemd_units() {
     rm -f /etc/systemd/system/old-csi-mount-cleaner.timer
   fi
 {{- end }}
+
+return 0
 }
 
 {{- if semverCompare "<1.24" .kubernetesVersion }}

--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -1,0 +1,99 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if semverCompare ">=1.24" .kubernetesVersion }}
+
+bb-event-on 'old_csi_mount_cleaner' '_on_old_csi_mount_cleaner_changed'
+_on_old_csi_mount_cleaner_changed() {
+{{ if ne .runType "ImageBuilding" }}
+  systemctl daemon-reload
+  systemctl restart old-csi-mount-cleaner.timer
+  systemctl restart old-csi-mount-cleaner
+{{ end }}
+  systemctl enable old-csi-mount-cleaner.timer
+  systemctl enable old-csi-mount-cleaner
+}
+
+bb-sync-file /var/lib/bashible/old-csi-mount-cleaner.sh - << "EOF"
+#!/bin/bash
+
+# $@ - messages
+function echo_err() {
+  echo "$@" 1>&2;
+}
+
+log_period_minutes=2
+
+declare -a old_mounts
+
+grep_pattern='(?<=is still mounted by other references \[)\/var\/lib\/kubelet\/plugins\/kubernetes\.io\/csi\/pv\/.+?(?=])'
+mapfile -t old_mounts < <(journalctl --since "$log_period_minutes min ago" -u kubelet.service | \
+  grep -Po "$grep_pattern" | \
+  sort -u)
+
+
+for mount in "${old_mounts[@]}"; do
+    if out=$(umount "$mount" 2>&1); then
+        echo_err "Mountpoint $mount successfully unmounted"
+    else
+        echo_err "Mountpoint $mount failed to unmount: $out"
+    fi
+done
+EOF
+
+chmod +x /var/lib/bashible/old-csi-mount-cleaner.sh
+
+bb-sync-file /etc/systemd/system/old-csi-mount-cleaner.timer - old-csi-mount-cleaner-changed << "EOF"
+[Unit]
+Description=Old CSI mount cleaner timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+bb-sync-file /etc/systemd/system/old-csi-mount-cleaner.service - old-csi-mount-cleaner-changed << "EOF"
+[Unit]
+Description=Old CSI mount cleaner service
+
+[Service]
+EnvironmentFile=/etc/environment
+ExecStart=/var/lib/bashible/old-csi-mount-cleaner.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+{{- else }}
+
+  {{- if ne .runType "ImageBuilding" }}
+
+if [[ -f "/etc/systemd/system/old-csi-mount-cleaner.service" ]]; then
+  systemctl stop old-csi-mount-cleaner.service
+  systemctl disable old-csi-mount-cleaner.service
+  rm -f /etc/systemd/system/old-csi-mount-cleaner.service
+  systemctl daemon-reload
+  systemctl reset-failed
+fi
+
+if [[ -f "/etc/systemd/system/old-csi-mount-cleaner.timer" ]]; then
+  systemctl stop old-csi-mount-cleaner.timer
+  systemctl disable old-csi-mount-cleaner.timer
+  rm -f /etc/systemd/system/old-csi-mount-cleaner.timer
+fi
+
+  {{- end }}
+{{- end }}

--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -14,7 +14,12 @@
 
 {{- if semverCompare ">=1.24" .kubernetesVersion }}
 
-bb-event-on 'old_csi_mount_cleaner' '_on_old_csi_mount_cleaner_changed'
+if mount | grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv' || true; then
+  echo "No mounts of form /var/lib/kubelet/plugins/kubernetes.io/csi/pv present. No-op..."
+  return 0
+fi
+
+bb-event-on 'old-csi-mount-cleaner' '_on_old_csi_mount_cleaner_changed'
 _on_old_csi_mount_cleaner_changed() {
 {{ if ne .runType "ImageBuilding" }}
   systemctl daemon-reload


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Cleanup of old CSI mounts that follow pre Kubernetes 1.24 naming convention. Get deployed only on Kubernetes >=1.24 and only if there are any 

Closes https://github.com/deckhouse/deckhouse/issues/5132

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It enabled successful Pod volume unmounts when upgrading Kubernetes on the go (without draining a Node).

Closes upstream issue: https://github.com/kubernetes/kubernetes/pull/107065

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

When a kubelet reports that it cannot delete a Pod because there is a mount (with path adhering to an old format), parse a log statement an `umount` manually. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Create a system unit that manually unmounts pre-1.24 CSI mounts. That should stop stuck Pods while upgrading kubelet without draining the Node.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
