### PR TITLE
[docs] Add ability to add search keywords for parameters in OpenAPI spec

### DIFF
--- a/docs/documentation/_includes/search.liquid
+++ b/docs/documentation/_includes/search.liquid
@@ -59,6 +59,13 @@ var documents=[
     {%- assign keywords = page['legacy-enabled-commands'] %}
   {%- endif %}
 {%- endif %}
+{%- if page.search.size > 0 %}
+  {%- if keywords.size > 0 %}
+    {%- assign keywords = page.search | append: ", " | append: keywords %}
+  {%- else %}
+    {%- assign keywords = page.search %}
+  {%- endif %}
+{%- endif %}
 {
 "title": "{{ page.title | escape }}",
 "url": "{{ page_canonical_url }}",
@@ -73,6 +80,14 @@ var documents=[
 var parameters=[
 {%- for item in site.data.search.searchItems[page.lang] %}
 {%- assign page_canonical_url = item.url | relative_url %}
+{%- assign keywords = "" %}
+{%- if item.search.size > 0 %}
+  {%- if keywords.size > 0 %}
+    {%- assign keywords = item.search | append: ", " | append: keywords %}
+  {%- else %}
+    {%- assign keywords = item.search %}
+  {%- endif %}
+{%- endif %}
 {
 "name": "{{ item.name }}",
 "url": "{{ page_canonical_url }}",
@@ -82,6 +97,9 @@ var parameters=[
 {%- endif %}
 {%- if item.deprecated %}
 "deprecated": "true",
+{%- endif %}
+{%- if keywords.size > 0 %}
+"keywords": {{ keywords | jsonify }},
 {%- endif %}
 "path": "{{ item.pathString | escape }}",
 "content": {{ item.content | default: '' | normalizeSearchContent | jsonify }}

--- a/docs/documentation/js/search.js
+++ b/docs/documentation/js/search.js
@@ -235,6 +235,7 @@
       this.use(lunr.multiLanguage('en', 'ru'))
       this.ref('url')
       this.field('name', {boost: 10})
+      this.field('keywords', {boost: 20})
       this.field('content')
 
       parameters.forEach(function (doc) {


### PR DESCRIPTION
## Description
To add search keywords to a parameter in the OpenAPI specification, use the `x-doc-search` key.

## Why do we need it, and what problem does it solve?
E.g. the search does not give a result for the `ProviderClusterConfiguiration`. We need to add the ability to specify search keywords for OpenAPI spec parameters.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Use `x-doc-search` key for OpenAPI spec parameters to add search keywords. 
impact_level: low
```
