### PR TITLE
[docs] Better search for <Provider>ClusterConfiguration resources

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -13,6 +13,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: AWSClusterConfiguration

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -11,6 +11,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     properties:
       peeredVPCs:
         description: |

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -13,6 +13,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: AzureClusterConfiguration

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -11,6 +11,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     properties:
       layout:
         description: |

--- a/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
@@ -13,6 +13,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: GCPClusterConfiguration

--- a/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
@@ -11,6 +11,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     properties:
       subnetworkCIDR:
         description: Подсеть, в которой будут работать узлы кластера.

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -13,6 +13,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: YandexClusterConfiguration

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -11,6 +11,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     properties:
       sshPublicKey:
         description: |

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -13,6 +13,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: OpenStackClusterConfiguration

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -12,6 +12,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     properties:
       sshPublicKey:
         description: |

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -14,6 +14,8 @@ apiVersions:
       ```shell
       kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
       ```
+    x-doc-search: |
+      ProviderClusterConfiguration
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: VsphereClusterConfiguration

--- a/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
@@ -12,6 +12,8 @@ apiVersions:
         ```shell
         kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
         ```
+      x-doc-search: |
+        ProviderClusterConfiguration
       properties:
         masterNodeGroup:
           description: |


### PR DESCRIPTION
## Description
Add search keywords for searching `*ClusterConfiguration` resources by the `ProviderClusterConfiguration` keyword.

Based on the #5155 

## Why do we need it, and what problem does it solve?
Allows to find `*ClusterConfiguration` resources by the `ProviderClusterConfiguration` search keyword (as specified in the documentation)

## What is the expected result?
If you search by the `ProviderClusterConfiguration` keywords, you get `[AWS|GCP|...]ProviderConfigurationResources`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Add search keywords for searching *ClusterConfiguration resources by the ProviderClusterConfiguration keyword.
impact_level: low
```
