### PR TITLE
[linstor] fix check drbd version step

### DIFF
--- a/modules/041-linstor/templates/nodegroupconfiguration-check-drbd-version.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-check-drbd-version.yaml
@@ -32,6 +32,15 @@ spec:
     current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
     desired_version="{{ $.Values.linstor.internal.drbdVersion }}"
 
+    # We expect the loaded DRBD module to be version 9.
+    # If version 8 is loaded, it means that for some reason, the in-tree kernel module has been automatically loaded.
+    # (For example, this can happen due to drbd-utils installed on the host, which should not occur in standard scenarios).
+    # We are only interested in the version 9 loaded by our helper script, so unload module and wait until it done.
+    if [[ ! $current_version =~ ^9.* ]]; then
+      rmmod drbd_transport_rdma drbd_transport_tcp drbd
+      exit 0
+    fi
+
     if [ "${current_version}" != "${desired_version}" ]; then
         bb-log-info "Non-actual version of drbd (now "$current_version", desired "$desired_version"), setting reboot flag"
         bb-flag-set reboot


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix in bashible step in case of installed drbd-utils

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We can have looped reboot if drbd-utils installed on host.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Problem can affect nodes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Fixed problem

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Fix in bashible step in case of installed drbd-utils
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
