### PR TITLE
[docs][openstack] Expand volumeTypeMap description

### DIFF
--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -323,7 +323,7 @@ apiVersions:
               description: |
                 A dictionary of disk types for root drive.
 
-                Specifies as <availability zone name>: <volume type name>
+                Specifies as `<availability zone name>: <volume type name>`
 
                 Get list of availability zones: `openstack availability zone list`
 

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -323,7 +323,7 @@ apiVersions:
               description: |
                 A dictionary of disk types for root drive.
 
-                Specifies as `<availability zone name>: <volume type name>`
+                Specifies as `availability-zone-name: volume-type-name`
 
                 Get list of availability zones: `openstack availability zone list`
 

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -323,6 +323,12 @@ apiVersions:
               description: |
                 A dictionary of disk types for root drive.
 
+                Specifies as <availability zone name>: <volume type name>
+
+                Get list of availability zones: `openstack availability zone list`
+
+                Get list of volume types: `openstack volume type list`
+
                 If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `eu-1a` disk type, while worker-1, worker-3 will have the `eu-1b` disk type.
 
                 Useful commands:

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -176,15 +176,17 @@ apiVersions:
             description: |
               A dictionary of disk types for storing etcd data and Kubernetes configuration files.
 
+              Format of dictionary elements: `<AVAILABILITY ZONE>: <VOLUME TYPE>` (see the example).
+
               If the `rootDiskSize` parameter is specified, the same disk type will be used for the VM's boot drive.
 
               We recommend using the fastest disks provided by the provider in all cases.
 
-              If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `eu-1a` disk type, while master-1, master-3 will have the `eu-1b` disk type.
+              If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `fast-eu-1a` disk type, while master-1, master-3 will have the `fast-eu-1b` disk type.
 
               Useful commands:
-              - `openstack availability zone list`
-              - `openstack volume type list`
+              - `openstack availability zone list` — get list of availability zones.
+              - `openstack volume type list` — get list of volume types.
             x-examples:
             - eu-1a: fast-eu-1a
               eu-1b: fast-eu-1b
@@ -323,17 +325,13 @@ apiVersions:
               description: |
                 A dictionary of disk types for root drive.
 
-                Specifies as `availability-zone-name: volume-type-name`
+                Format of dictionary elements: `<AVAILABILITY ZONE>: <VOLUME TYPE>` (see the example).
 
-                Get list of availability zones: `openstack availability zone list`
-
-                Get list of volume types: `openstack volume type list`
-
-                If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `eu-1a` disk type, while worker-1, worker-3 will have the `eu-1b` disk type.
+                If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `fast-eu-1a` disk type, while worker-1, worker-3 will have the `fast-eu-1b` disk type.
 
                 Useful commands:
-                - `openstack availability zone list`
-                - `openstack volume type list`
+                - `openstack availability zone list` — get list of availability zones.
+                - `openstack volume type list` — get list of volume types.
               x-examples:
                 - eu-1a: fast-eu-1a
                   eu-1b: fast-eu-1b

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -82,7 +82,7 @@ apiVersions:
             description: |
               Словарь типов дисков для хранения данных etcd и конфигурационных файлов Kubernetes.
 
-              Указывается в формате `<availability zone name>: <volume type name>`
+              Указывается в формате `availability-zone-name: volume-type-name`
 
               Получить список зон доступности: `openstack availability zone list`
 

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -82,6 +82,12 @@ apiVersions:
             description: |
               Словарь типов дисков для хранения данных etcd и конфигурационных файлов Kubernetes.
 
+              Указывается в формате <availability zone name>: <volume type name>
+
+              Получить список зон доступности: `openstack availability zone list`
+
+              Получить список список volume type: `openstack volume type list`
+
               Если указан параметр `rootDiskSize`, то этот же тип диска будет использован в качестве загрузочного диска виртуальной машины.
 
               Всегда рекомендуется использовать самые быстрые диски, предоставляемые провайдером.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -86,7 +86,7 @@ apiVersions:
 
               Получить список зон доступности: `openstack availability zone list`
 
-              Получить список список типов дисков: `openstack volume type list`
+              Получить список типов дисков: `openstack volume type list`
 
               Если указан параметр `rootDiskSize`, то этот же тип диска будет использован в качестве загрузочного диска виртуальной машины.
 

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -82,11 +82,7 @@ apiVersions:
             description: |
               Словарь типов дисков для хранения данных etcd и конфигурационных файлов Kubernetes.
 
-              Указывается в формате `availability-zone-name: volume-type-name`
-
-              Получить список зон доступности: `openstack availability zone list`
-
-              Получить список типов дисков: `openstack volume type list`
+              Формат элементов словаря: `<ЗОНА ДОСТУПНОСТИ>: <ТИП ДИСКА>` (см. пример).
 
               Если указан параметр `rootDiskSize`, то этот же тип диска будет использован в качестве загрузочного диска виртуальной машины.
 
@@ -94,11 +90,11 @@ apiVersions:
 
               Если значение, указанное в `replicas`, превышает количество элементов в словаре, то master-узлы, чьи номера превышают
               длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
-              диска `eu-1a` будут master-0, master-2 и master-4, а с типом диска `eu-1b` будут master-1 и master-3.
+              диска `fast-eu-1a` будут master-0, master-2 и master-4, а с типом диска `fast-eu-1b` будут master-1 и master-3.
 
               Полезные команды:
-              - `openstack availability zone list`
-              - `openstack volume type list`
+              - `openstack availability zone list` — получить список зон доступности.
+              - `openstack volume type list` — получить список типов дисков.
       nodeGroups:
         description: |
           Массив дополнительных NodeGroup для создания статичных узлов (например, для выделенных frontend-узлов или шлюзов).
@@ -176,13 +172,15 @@ apiVersions:
               description: |
                 Словарь типов дисков для загрузочного диска.
 
+                Формат элементов словаря: `<ЗОНА ДОСТУПНОСТИ>: <ТИП ДИСКА>` (см. пример).
+
                 Если значение, указанное в `replicas`, превышает количество элементов в словаре, то узлы, чьи номера превышают
                 длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
-                диска `eu-1a` будут worker-0, worker-2 и worker-4, а с типом диска `eu-1b` будут worker-1 и worker-3.
+                диска `fast-eu-1a` будут worker-0, worker-2 и worker-4, а с типом диска `fast-eu-1b` будут worker-1 и worker-3.
 
                 Полезные команды:
-                - `openstack availability zone list`
-                - `openstack volume type list`
+                - `openstack availability zone list` — получить список зон доступности.
+                - `openstack volume type list` — получить список типов дисков.
       layout:
         description: |
           Название схемы размещения.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -82,11 +82,11 @@ apiVersions:
             description: |
               Словарь типов дисков для хранения данных etcd и конфигурационных файлов Kubernetes.
 
-              Указывается в формате <availability zone name>: <volume type name>
+              Указывается в формате `<availability zone name>: <volume type name>`
 
               Получить список зон доступности: `openstack availability zone list`
 
-              Получить список список volume type: `openstack volume type list`
+              Получить список список типов дисков: `openstack volume type list`
 
               Если указан параметр `rootDiskSize`, то этот же тип диска будет использован в качестве загрузочного диска виртуальной машины.
 


### PR DESCRIPTION
## Description

Added reference on how to look up volume types and availability zones in Openstack CLI

## Why do we need it, and what problem does it solve?

To add a place to start when configuring volume types.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-providers-openstack
type: chore 
summary: Update description of the `volumeTypeMap` parameter.
impact_level: low 
```
