### PR TITLE
[getting-started] Update install on bare metal

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -10,7 +10,7 @@ For real-world conditions (production and test environments), you need to add ad
 <p>If you install Deckhouse for <strong>evaluation purposes</strong> and one node in  the cluster is enough for you, allow Deckhouse components to work on the master node. To do this, remove the taint from the master node by running the following command:</p>
 {% snippetcut %}
 ```bash
-sudo kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
+kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
 ```
 {% endsnippetcut %}
 </blockquote>
@@ -24,7 +24,7 @@ After that, there will be three more actions.
   <p>Apply it using the following command on the <strong>master node</strong>>:</p>
 {% snippetcut %}
 ```shell
-sudo kubectl create -f ingress-nginx-controller.yml
+kubectl create -f ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -36,7 +36,7 @@ sudo kubectl create -f ingress-nginx-controller.yml
 <p>Apply it using the following command on the <strong>master node</strong>:</p>
 {% snippetcut %}
 ```shell
-sudo kubectl create -f user.yml
+kubectl create -f user.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -54,7 +54,7 @@ sudo kubectl create -f user.yml
 argocd.example.com
 cdi-uploadproxy.example.com
 dashboard.example.com
-deckhouse.example.com
+documentation.example.com
 dex.example.com
 grafana.example.com
 hubble.example.com
@@ -79,7 +79,7 @@ $PUBLIC_IP api.example.com
 $PUBLIC_IP argocd.example.com
 $PUBLIC_IP cdi-uploadproxy.example.com
 $PUBLIC_IP dashboard.example.com
-$PUBLIC_IP deckhouse.example.com
+$PUBLIC_IP documentation.example.com
 $PUBLIC_IP dex.example.com
 $PUBLIC_IP grafana.example.com
 $PUBLIC_IP hubble.example.com

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -10,10 +10,29 @@ For real-world conditions (production and test environments), you need to add ad
 <p>If you install Deckhouse for <strong>evaluation purposes</strong> and one node in  the cluster is enough for you, allow Deckhouse components to work on the master node. To do this, remove the taint from the master node by running the following command:</p>
 {% snippetcut %}
 ```bash
-kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
+sudo /opt/deckhouse/bin/kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
 ```
 {% endsnippetcut %}
 </blockquote>
+
+It may take some time to start the Ingress controller after installing Deckhouse. Make sure that the Ingress controller has started before continuing:
+
+{% snippetcut %}
+```shell
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
+```
+{% endsnippetcut %}
+
+Wait for the Pods to switch to `Ready` state.
+
+{% offtopic title="Example of the output..." %}
+```
+$ sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
+NAME                                       READY   STATUS    RESTARTS   AGE
+controller-nginx-r6hxc                     3/3     Running   0          16h
+kruise-controller-manager-78786f57-82wph   3/3     Running   0          16h
+```
+{%- endofftopic %}
 
 After that, there will be three more actions.
 <ul><li><p><strong>Setup Ingress controller</strong></p>
@@ -24,7 +43,7 @@ After that, there will be three more actions.
   <p>Apply it using the following command on the <strong>master node</strong>>:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f ingress-nginx-controller.yml
+sudo /opt/deckhouse/bin/kubectl create -f ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -36,7 +55,7 @@ kubectl create -f ingress-nginx-controller.yml
 <p>Apply it using the following command on the <strong>master node</strong>:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f user.yml
+sudo /opt/deckhouse/bin/kubectl create -f user.yml
 ```
 {% endsnippetcut %}
 </li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -10,7 +10,7 @@
 <p>Если вы развернули кластер <strong>для ознакомительных целей</strong> и одного узла вам достаточно, разрешите компонентам Deckhouse работать на master-узле. Для этого, снимите с master-узла taint, выполнив на master-узле следующую команду:</p>
 {% snippetcut %}
 ```bash
-sudo kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
+kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
 ```
 {% endsnippetcut %}
 </blockquote>
@@ -24,7 +24,7 @@ sudo kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-sudo kubectl create -f ingress-nginx-controller.yml
+kubectl create -f ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -36,7 +36,7 @@ sudo kubectl create -f ingress-nginx-controller.yml
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-sudo kubectl create -f user.yml
+kubectl create -f user.yml
 ```
 {% endsnippetcut %}
 </li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -10,10 +10,29 @@
 <p>Если вы развернули кластер <strong>для ознакомительных целей</strong> и одного узла вам достаточно, разрешите компонентам Deckhouse работать на master-узле. Для этого, снимите с master-узла taint, выполнив на master-узле следующую команду:</p>
 {% snippetcut %}
 ```bash
-kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
+sudo /opt/deckhouse/bin/kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/nodeTemplate/taints"}]'
 ```
 {% endsnippetcut %}
 </blockquote>
+
+Запуск Ingress-контроллера после завершения установки Deckhouse может занять какое-то время. Прежде чем продолжить убедитесь что Ingress-контроллер запустился:
+
+{% snippetcut %}
+```shell
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
+```
+{% endsnippetcut %}
+
+Дождитесь перехода Pod'ов в статус `Ready`.
+
+{% offtopic title="Пример вывода..." %}
+```
+$ sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
+NAME                                       READY   STATUS    RESTARTS   AGE
+controller-nginx-r6hxc                     3/3     Running   0          16h
+kruise-controller-manager-78786f57-82wph   3/3     Running   0          16h
+```
+{%- endofftopic %}
 
 Далее, остается выполнить следующие три действия.
 <ul><li><p><strong>Установка Ingress-контроллера</strong></p>
@@ -24,7 +43,7 @@ kubectl patch nodegroup master --type json -p '[{"op": "remove", "path": "/spec/
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f ingress-nginx-controller.yml
+sudo /opt/deckhouse/bin/kubectl create -f ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 </li>
@@ -36,7 +55,7 @@ kubectl create -f ingress-nginx-controller.yml
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-kubectl create -f user.yml
+sudo /opt/deckhouse/bin/kubectl create -f user.yml
 ```
 {% endsnippetcut %}
 </li>

--- a/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS.md
+++ b/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS.md
@@ -16,13 +16,13 @@ ssh {% if page.platform_code == "azure" %}azureuser{% elsif page.platform_code =
 Check the kubectl is working by displaying a list of cluster nodes:
 {% snippetcut %}
 ```shell
-sudo kubectl get nodes
+sudo /opt/deckhouse/bin/kubectl get nodes
 ```
 {% endsnippetcut %}
 
 {% offtopic title="Example of the output..." %}
 ```
-$ sudo kubectl get nodes
+$ sudo /opt/deckhouse/bin/kubectl get nodes
 NAME                                     STATUS   ROLES                  AGE   VERSION
 cloud-demo-master-0                      Ready    control-plane,master   12h   v1.23.9
 cloud-demo-worker-01a5df48-84549-jwxwm   Ready    worker                 12h   v1.23.9
@@ -33,17 +33,18 @@ It may take some time to start the Ingress controller after installing Deckhouse
 
 {% snippetcut %}
 ```shell
-sudo kubectl -n d8-ingress-nginx get po
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
 ```
 {% endsnippetcut %}
 
-Wait for the Ingress controller Pod to switch to `Ready` state.
+Wait for the Pods to switch to `Ready` state.
 
 {% offtopic title="Example of the output..." %}
 ```
-$ sudo kubectl -n d8-ingress-nginx get po
-NAME                     READY   STATUS    RESTARTS   AGE
-controller-nginx-l2gk6   3/3     Running   0          12m
+$ sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
+NAME                                       READY   STATUS    RESTARTS   AGE
+controller-nginx-r6hxc                     3/3     Running   0          16h
+kruise-controller-manager-78786f57-82wph   3/3     Running   0          16h
 ```
 {%- endofftopic %}
 
@@ -51,7 +52,7 @@ controller-nginx-l2gk6   3/3     Running   0          12m
 Also wait for the load balancer to be ready:
 {% snippetcut %}
 ```shell
-sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer
 ```
 {% endsnippetcut %}
 
@@ -59,7 +60,7 @@ The `EXTERNAL-IP` value must be filled with a public IP address or DNS name.
 
 {% offtopic title="Example of the output..." %}
 ```
-$ sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer
+$ sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer
 NAME                  TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
 nginx-load-balancer   LoadBalancer   10.222.91.204   1.2.3.4         80:30493/TCP,443:30618/TCP   1m
 ```
@@ -82,10 +83,10 @@ Run the following command on **the master node** to get the load balancer IP and
 {% snippetcut %}
 {% raw %}
 ```shell
-BALANCER_IP=$(dig $(sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname') +short | head -1) && \
-echo "Balancer IP is '${BALANCER_IP}'." && sudo kubectl patch mc global --type merge \
+BALANCER_IP=$(dig $(sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname') +short | head -1) && \
+echo "Balancer IP is '${BALANCER_IP}'." && sudo /opt/deckhouse/bin/kubectl patch mc global --type merge \
   -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"%s.${BALANCER_IP}.sslip.io\"}}}}" && echo && \
-echo "Domain template is '$(sudo kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
+echo "Domain template is '$(sudo /opt/deckhouse/bin/kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
 ```
 {% endraw %}
 {% endsnippetcut %}
@@ -93,10 +94,10 @@ echo "Domain template is '$(sudo kubectl get mc global -o=jsonpath='{.spec.setti
 {% snippetcut %}
 {% raw %}
 ```shell
-BALANCER_IP=$(sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip') && \
-echo "Balancer IP is '${BALANCER_IP}'." && sudo kubectl patch mc global --type merge \
+BALANCER_IP=$(sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip') && \
+echo "Balancer IP is '${BALANCER_IP}'." && sudo /opt/deckhouse/bin/kubectl patch mc global --type merge \
   -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"%s.${BALANCER_IP}.sslip.io\"}}}}" && echo && \
-echo "Domain template is '$(sudo kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
+echo "Domain template is '$(sudo /opt/deckhouse/bin/kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
 ```
 {% endraw %}
 {% endsnippetcut %}
@@ -121,7 +122,7 @@ Then, run the following command on the **master node** (specify the template for
 {% snippetcut %}
 ```shell
 DOMAIN_TEMPLATE='<DOMAIN_TEMPLATE>'
-sudo kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
+sudo /opt/deckhouse/bin/kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
 ```
 {% endsnippetcut %}
 </div>
@@ -138,7 +139,7 @@ Then, run the following command on the **master node** (specify the template for
 {% raw %}
 ```shell
 DOMAIN_TEMPLATE='<DOMAIN_TEMPLATE>'
-sudo kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
+sudo /opt/deckhouse/bin/kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
 ```
 {% endraw %}
 {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS_RU.md
+++ b/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS_RU.md
@@ -16,13 +16,13 @@ ssh {% if page.platform_code == "azure" %}azureuser{% elsif page.platform_code =
 Проверьте работу kubectl, выведя список узлов кластера:
 {% snippetcut %}
 ```shell
-sudo kubectl get nodes
+sudo /opt/deckhouse/bin/kubectl get nodes
 ```
 {% endsnippetcut %}
 
 {% offtopic title="Пример вывода..." %}
 ```
-$ sudo kubectl get nodes
+$ sudo /opt/deckhouse/bin/kubectl get nodes
 NAME                                     STATUS   ROLES                  AGE   VERSION
 cloud-demo-master-0                      Ready    control-plane,master   12h   v1.23.9
 cloud-demo-worker-01a5df48-84549-jwxwm   Ready    worker                 12h   v1.23.9
@@ -33,17 +33,18 @@ cloud-demo-worker-01a5df48-84549-jwxwm   Ready    worker                 12h   v
 
 {% snippetcut %}
 ```shell
-sudo kubectl -n d8-ingress-nginx get po
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
 ```
 {% endsnippetcut %}
 
-Дождитесь перехода Pod'а Ingress-контроллера в статус `Ready`.
+Дождитесь перехода Pod'ов в статус `Ready`.
 
 {% offtopic title="Пример вывода..." %}
 ```
-$ sudo kubectl -n d8-ingress-nginx get po
-NAME                     READY   STATUS    RESTARTS   AGE
-controller-nginx-l2gk6   3/3     Running   0          12m
+$ sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get po
+NAME                                       READY   STATUS    RESTARTS   AGE
+controller-nginx-r6hxc                     3/3     Running   0          16h
+kruise-controller-manager-78786f57-82wph   3/3     Running   0          16h
 ```
 {%- endofftopic %}
 
@@ -51,7 +52,7 @@ controller-nginx-l2gk6   3/3     Running   0          12m
 Также дождитесь готовности балансировщика:
 {% snippetcut %}
 ```shell
-sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer
 ```
 {% endsnippetcut %}
 
@@ -59,7 +60,7 @@ sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer
 
 {% offtopic title="Пример вывода..." %}
 ```
-$ sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer
+$ sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer
 NAME                  TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE
 nginx-load-balancer   LoadBalancer   10.222.91.204   1.2.3.4         80:30493/TCP,443:30618/TCP   1m
 ```
@@ -82,10 +83,10 @@ nginx-load-balancer   LoadBalancer   10.222.91.204   1.2.3.4         80:30493/TC
 {% snippetcut %}
 {% raw %}
 ```shell
-BALANCER_IP=$(dig $(sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname') +short | head -1) && \
-echo "Balancer IP is '${BALANCER_IP}'." && sudo kubectl patch mc global --type merge \
+BALANCER_IP=$(dig $(sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname') +short | head -1) && \
+echo "Balancer IP is '${BALANCER_IP}'." && sudo /opt/deckhouse/bin/kubectl patch mc global --type merge \
   -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"%s.${BALANCER_IP}.sslip.io\"}}}}" && echo && \
-echo "Domain template is '$(sudo kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
+echo "Domain template is '$(sudo /opt/deckhouse/bin/kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
 ```
 {% endraw %}
 {% endsnippetcut %}
@@ -93,10 +94,10 @@ echo "Domain template is '$(sudo kubectl get mc global -o=jsonpath='{.spec.setti
 {% snippetcut %}
 {% raw %}
 ```shell
-BALANCER_IP=$(sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip') && \
-echo "Balancer IP is '${BALANCER_IP}'." && sudo kubectl patch mc global --type merge \
+BALANCER_IP=$(sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip') && \
+echo "Balancer IP is '${BALANCER_IP}'." && sudo /opt/deckhouse/bin/kubectl patch mc global --type merge \
   -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"%s.${BALANCER_IP}.sslip.io\"}}}}" && echo && \
-echo "Domain template is '$(sudo kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
+echo "Domain template is '$(sudo /opt/deckhouse/bin/kubectl get mc global -o=jsonpath='{.spec.settings.modules.publicDomainTemplate}')'."
 ```
 {% endraw %}
 {% endsnippetcut %}
@@ -121,7 +122,7 @@ Domain template is '%s.1.2.3.4.sslip.io'.
 {% snippetcut %}
 ```shell
 DOMAIN_TEMPLATE='<DOMAIN_TEMPLATE>'
-sudo kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
+sudo /opt/deckhouse/bin/kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
 ```
 {% endsnippetcut %}
 </div>
@@ -138,7 +139,7 @@ sudo kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"module
 {% raw %}
 ```shell
 DOMAIN_TEMPLATE='<DOMAIN_TEMPLATE>'
-sudo kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
+sudo /opt/deckhouse/bin/kubectl patch mc global --type merge -p "{\"spec\": {\"settings\":{\"modules\":{\"publicDomainTemplate\":\"${DOMAIN_TEMPLATE}\"}}}}"
 ```
 {% endraw %}
 {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
@@ -12,7 +12,7 @@ Essentials
 </h3>
 <div class="cards-item__text">
 <p>The documentation for the installed in your cluster version of Deckhouse.</p>
-<p>Web service name: {% include getting_started/global/partials/dns-template-title.html.liquid name="deckhouse" %}</p>
+<p>Web service name: {% include getting_started/global/partials/dns-template-title.html.liquid name="documentation" %}</p>
 </div>
 </div>
 {% endif %}

--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
@@ -12,7 +12,7 @@
 </h3>
 <div class="cards-item__text">
 <p>Документация по установленной в кластере версии Deckhouse.</p>
-<p>Имя веб-сервиса: {% include getting_started/global/partials/dns-template-title.html.liquid name="deckhouse" %}</p>
+<p>Имя веб-сервиса: {% include getting_started/global/partials/dns-template-title.html.liquid name="documentation" %}</p>
 </div>
 </div>
 {% endif %}

--- a/docs/site/_includes/getting_started/global/partials/GET_BALANCER_ADDR.liquid
+++ b/docs/site/_includes/getting_started/global/partials/GET_BALANCER_ADDR.liquid
@@ -2,14 +2,14 @@
 {% if include.mode == 'hosts' %}
 {% snippetcut %}
 ```shell
-BALANCER_HOSTNAME=$(sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname') && \
+BALANCER_HOSTNAME=$(sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname') && \
 BALANCER_IP=$(dig "$BALANCER_HOSTNAME" +short | head -1) && echo "Balancer IP is ${BALANCER_IP}"
 ```
 {% endsnippetcut %}
 {% else %}
 {% snippetcut %}
 ```shell
-sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname'
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].hostname'
 ```
 {% endsnippetcut %}
 {%- endif -%}
@@ -17,13 +17,13 @@ sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.s
 {% if include.mode == 'hosts' %}
 {% snippetcut %}
 ```shell
-BALANCER_IP=$(sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip') && \
+BALANCER_IP=$(sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip') && \
 ```
 {% endsnippetcut %}
 {% else %}
 {% snippetcut %}
 ```shell
-sudo kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip'
+sudo /opt/deckhouse/bin/kubectl -n d8-ingress-nginx get svc nginx-load-balancer -o json | jq -r '.status.loadBalancer.ingress[0].ip'
 ```
 {% endsnippetcut %}
 {%- endif -%}

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -138,9 +138,9 @@ The `--ssh-user` parameter here refers to the default user for the relevant VM i
 
 The installation process may take about 15-30 minutes with a good connection.
 
-{%- if page.platform_type == "baremetal" %}
+{% if page.platform_type == "baremetal" %}
 Example of output upon successful completion of the installation:
-...
+```
 ...
 │ │ No more converge tasks found in Deckhouse queue.
 │ │ Deckhouse pod is Ready!
@@ -152,7 +152,7 @@ Example of output upon successful completion of the installation:
 │ ❗ ~ Next run of "dhctl bootstrap" will create a new Kubernetes cluster.
 └ ⛵ ~ Bootstrap: Clear cache (0.00 seconds)
 ```
-{%- else  %}
+{% else  %}
 After the installation is complete, the installer will output the IP of the **master node** (you will need it further). Example output:
 ```
 ...
@@ -160,7 +160,7 @@ After the installation is complete, the installer will output the IP of the **ma
 │ cloud-demo-master-0 | ssh {% if page.platform_code == "azure" %}azureuser{% elsif page.platform_code == "gcp" %}user{% else %}ubuntu{% endif %}@1.2.3.4
 └ 🎈 ~ Common: Kubernetes Master Node addresses for SSH (0.00 seconds)
 ```
-{%- endif %}
+{% endif %}
 
 {%- if page.platform_code == "kind" %}
 

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -138,6 +138,21 @@ The `--ssh-user` parameter here refers to the default user for the relevant VM i
 
 The installation process may take about 15-30 minutes with a good connection.
 
+{%- if page.platform_type == "baremetal" %}
+Example of output upon successful completion of the installation:
+...
+...
+│ │ No more converge tasks found in Deckhouse queue.
+│ │ Deckhouse pod is Ready!
+│ └ Waiting for Deckhouse to become Ready (157.34 seconds)
+└ ⛵ ~ Bootstrap: Install Deckhouse (158.47 seconds)
+
+❗ ~ Some resources require at least one non-master node to be added to the cluster.
+┌ ⛵ ~ Bootstrap: Clear cache
+│ ❗ ~ Next run of "dhctl bootstrap" will create a new Kubernetes cluster.
+└ ⛵ ~ Bootstrap: Clear cache (0.00 seconds)
+```
+{%- else  %}
 After the installation is complete, the installer will output the IP of the **master node** (you will need it further). Example output:
 ```
 ...
@@ -145,6 +160,7 @@ After the installation is complete, the installer will output the IP of the **ma
 │ cloud-demo-master-0 | ssh {% if page.platform_code == "azure" %}azureuser{% elsif page.platform_code == "gcp" %}user{% else %}ubuntu{% endif %}@1.2.3.4
 └ 🎈 ~ Common: Kubernetes Master Node addresses for SSH (0.00 seconds)
 ```
+{%- endif %}
 
 {%- if page.platform_code == "kind" %}
 

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -137,6 +137,21 @@ dhctl bootstrap --ssh-user={% if page.platform_code == "azure" %}azureuser{%- el
 
 Процесс установки может занять 15-30 минут при хорошем соединении.
 
+{%- if page.platform_type == "baremetal" %}
+Пример вывода при успешном окончании установки:
+...
+...
+│ │ No more converge tasks found in Deckhouse queue.
+│ │ Deckhouse pod is Ready!
+│ └ Waiting for Deckhouse to become Ready (157.34 seconds)
+└ ⛵ ~ Bootstrap: Install Deckhouse (158.47 seconds)
+
+❗ ~ Some resources require at least one non-master node to be added to the cluster.
+┌ ⛵ ~ Bootstrap: Clear cache
+│ ❗ ~ Next run of "dhctl bootstrap" will create a new Kubernetes cluster.
+└ ⛵ ~ Bootstrap: Clear cache (0.00 seconds)
+```
+{%- else  %}
 По окончании установки инсталлятор выведет IP-адрес **master-узла** (он вам потребуется далее). Пример вывода:
 ```
 ...
@@ -144,6 +159,7 @@ dhctl bootstrap --ssh-user={% if page.platform_code == "azure" %}azureuser{%- el
 │ cloud-demo-master-0 | ssh {% if page.platform_code == "azure" %}azureuser{% elsif page.platform_code == "gcp" %}user{% else %}ubuntu{% endif %}@1.2.3.4
 └ 🎈 ~ Common: Kubernetes Master Node addresses for SSH (0.00 seconds)
 ```
+{%- endif %}
 
 {%- if page.platform_code == "kind" %}
 

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -136,10 +136,9 @@ dhctl bootstrap --ssh-user={% if page.platform_code == "azure" %}azureuser{%- el
 {%- endif %}
 
 Процесс установки может занять 15-30 минут при хорошем соединении.
-
-{%- if page.platform_type == "baremetal" %}
+{% if page.platform_type == "baremetal" %}
 Пример вывода при успешном окончании установки:
-...
+```
 ...
 │ │ No more converge tasks found in Deckhouse queue.
 │ │ Deckhouse pod is Ready!
@@ -151,7 +150,7 @@ dhctl bootstrap --ssh-user={% if page.platform_code == "azure" %}azureuser{%- el
 │ ❗ ~ Next run of "dhctl bootstrap" will create a new Kubernetes cluster.
 └ ⛵ ~ Bootstrap: Clear cache (0.00 seconds)
 ```
-{%- else  %}
+{% else  %}
 По окончании установки инсталлятор выведет IP-адрес **master-узла** (он вам потребуется далее). Пример вывода:
 ```
 ...
@@ -159,7 +158,7 @@ dhctl bootstrap --ssh-user={% if page.platform_code == "azure" %}azureuser{%- el
 │ cloud-demo-master-0 | ssh {% if page.platform_code == "azure" %}azureuser{% elsif page.platform_code == "gcp" %}user{% else %}ubuntu{% endif %}@1.2.3.4
 └ 🎈 ~ Common: Kubernetes Master Node addresses for SSH (0.00 seconds)
 ```
-{%- endif %}
+{% endif %}
 
 {%- if page.platform_code == "kind" %}
 


### PR DESCRIPTION
## Description
- Update getting started:  bare metal installation.
  - Actualize example of finishing installation
  - Notes to wait for Ingress controller readiness
- Replace `sudo kubectl` to `sudo /opt/deckhouse/bin/kubectl` in other getting started

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update getting started.
impact_level: low
```
