### PR TITLE
[chore] Set Kubernetes 1.27 version status as a preview

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -160,7 +160,7 @@ k8s:
       snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
       livenessprobe: v2.9.0@sha256:2b10b24dafdc3ba94a03fc94d9df9941ca9d6a9207b927f5dfd21d59fbe05ba0
   '1.27':
-    status: available
+    status: preview
     patch: 1
     bashible: *bashible_k8s_ge_1_23
     ccm:


### PR DESCRIPTION
## Description
Set Kubernetes 1.27 version status as a preview.

## Why do we need it, and what problem does it solve?
Mark Kubernetes 1.27 as a preview version, which is not suitable for production environments yet.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: candi
type: chore
summary: Set Kubernetes 1.27 version status as a preview.
impact_level: low
```
