### PR TITLE
[cloud-providers-openstack] documentation improvement. 

### DIFF
--- a/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
@@ -82,6 +82,8 @@ provider:
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   domainName: users
+  # [<en>] OS_USER_DOMAIN_NAME variable from openrc.
+  # [<ru>] Переменная OS_USER_DOMAIN_NAME из openrc.
   password: *!CHANGE_PASSWORD*
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.

--- a/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
@@ -82,8 +82,8 @@ provider:
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   domainName: users
-  # [<en>] OS_USER_DOMAIN_NAME variable from openrc.
-  # [<ru>] Переменная OS_USER_DOMAIN_NAME из openrc.
+  # [<en>] OS_USER_DOMAIN_NAME variable from the openrc file.
+  # [<ru>] Переменная OS_USER_DOMAIN_NAME из файла openrc.
   password: *!CHANGE_PASSWORD*
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -181,6 +181,8 @@ apiVersions:
               We recommend using the fastest disks provided by the provider in all cases.
 
               If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `ru-1a` disk type, while master-1, master-3 will have the `ru-1b` disk type
+              openstack availability zone list
+              openstack volume type list
             x-examples:
             - ru-1a: fast-ru-1a
               ru-1b: fast-ru-1b
@@ -321,6 +323,8 @@ apiVersions:
 
 
                 If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `ru-1a` disk type, while worker-1, worker-3 will have the `ru-1b` disk type.
+                openstack availability zone list
+                openstack volume type list
               x-examples:
                 - ru-1a: fast-ru-1a
                   ru-1b: fast-ru-1b
@@ -527,6 +531,7 @@ apiVersions:
             type: string
             description: |
               The domain name.
+              OS_USER_DOMAIN_NAME variable from openrc.
           tenantName:
             type: string
             description: |

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -181,8 +181,8 @@ apiVersions:
               We recommend using the fastest disks provided by the provider in all cases.
 
               If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `ru-1a` disk type, while master-1, master-3 will have the `ru-1b` disk type
-              openstack availability zone list
-              openstack volume type list
+              `openstack availability zone list`
+              `openstack volume type list`
             x-examples:
             - ru-1a: fast-ru-1a
               ru-1b: fast-ru-1b
@@ -323,8 +323,8 @@ apiVersions:
 
 
                 If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `ru-1a` disk type, while worker-1, worker-3 will have the `ru-1b` disk type.
-                openstack availability zone list
-                openstack volume type list
+                `openstack availability zone list`
+                `openstack volume type list`
               x-examples:
                 - ru-1a: fast-ru-1a
                   ru-1b: fast-ru-1b
@@ -531,7 +531,8 @@ apiVersions:
             type: string
             description: |
               The domain name.
-              OS_USER_DOMAIN_NAME variable from openrc.
+
+              `OS_USER_DOMAIN_NAME` variable from openrc.
           tenantName:
             type: string
             description: |

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -21,7 +21,7 @@ apiVersions:
         layout: Standard
         sshPublicKey: "<SSH_PUBLIC_KEY>"
         zones:
-          - ru-3a
+          - eu-3a
         standard:
           internalNetworkDNSServers:
             - 8.8.8.8
@@ -34,7 +34,7 @@ apiVersions:
           tenantID: '<TENANT_ID>'
           username: '<USERNAME>'
           password: '<PASSWORD>'
-          region: 'ru-3'
+          region: 'eu-3'
         masterNodeGroup:
           replicas: 1
           instanceClass:
@@ -42,7 +42,7 @@ apiVersions:
             flavorName: m1.large
             imageName: "debian-11-genericcloud-amd64-20220911-1135"
           volumeTypeMap:
-            ru-3a: "fast.ru-3a"
+            eu-3a: "fast.eu-3a"
         nodeGroups:
           - name: front
             replicas: 2
@@ -58,8 +58,8 @@ apiVersions:
                 - sec_group_1
                 - sec_group_2
             zones:
-              - ru-1a
-              - ru-1b
+              - eu-1a
+              - eu-1b
     additionalProperties: false
     required: [apiVersion, kind, layout, provider, sshPublicKey, masterNodeGroup]
     properties:
@@ -180,12 +180,14 @@ apiVersions:
 
               We recommend using the fastest disks provided by the provider in all cases.
 
-              If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `ru-1a` disk type, while master-1, master-3 will have the `ru-1b` disk type
-              `openstack availability zone list`
-              `openstack volume type list`
+              If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `eu-1a` disk type, while master-1, master-3 will have the `eu-1b` disk type.
+
+              Useful commands:
+              - `openstack availability zone list`
+              - `openstack volume type list`
             x-examples:
-            - ru-1a: fast-ru-1a
-              ru-1b: fast-ru-1b
+            - eu-1a: fast-eu-1a
+              eu-1b: fast-eu-1b
             type: object
             minProperties: 1
             additionalProperties:
@@ -321,13 +323,14 @@ apiVersions:
               description: |
                 A dictionary of disk types for root drive.
 
+                If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `eu-1a` disk type, while worker-1, worker-3 will have the `eu-1b` disk type.
 
-                If the value specified in `replicas` exceeds the number of elements in the dictionary, the nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then worker-0, worker-2, worker-4 will have the `ru-1a` disk type, while worker-1, worker-3 will have the `ru-1b` disk type.
-                `openstack availability zone list`
-                `openstack volume type list`
+                Useful commands:
+                - `openstack availability zone list`
+                - `openstack volume type list`
               x-examples:
-                - ru-1a: fast-ru-1a
-                  ru-1b: fast-ru-1b
+                - eu-1a: fast-eu-1a
+                  eu-1b: fast-eu-1b
               type: object
               minProperties: 1
               additionalProperties:
@@ -532,7 +535,7 @@ apiVersions:
             description: |
               The domain name.
 
-              `OS_USER_DOMAIN_NAME` variable from openrc.
+              `OS_USER_DOMAIN_NAME` variable from the openrc file.
           tenantName:
             type: string
             description: |

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -89,6 +89,8 @@ apiVersions:
               Если значение, указанное в `replicas`, превышает количество элементов в словаре, то master-узлы, чьи номера превышают
               длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
               диска `ru-1a` будут master-0, master-2 и master-4, а с типом диска `ru-1b` будут master-1 и master-3.
+              openstack availability zone list
+              openstack volume type list
       nodeGroups:
         description: |
           Массив дополнительных NodeGroup для создания статичных узлов (например, для выделенных frontend-узлов или шлюзов).
@@ -168,6 +170,8 @@ apiVersions:
                 Если значение, указанное в `replicas`, превышает количество элементов в словаре, то узлы, чьи номера превышают
                 длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
                 диска `ru-1a` будут worker-0, worker-2 и worker-4, а с типом диска `ru-1b` будут worker-1 и worker-3.
+                openstack availability zone list
+                openstack volume type list
       layout:
         description: |
           Название схемы размещения.
@@ -290,6 +294,7 @@ apiVersions:
           domainName:
             description: |
               Имя домена.
+              Переменная OS_USER_DOMAIN_NAME из openrc.
           tenantName:
             description: |
               Имя проекта.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -88,9 +88,11 @@ apiVersions:
 
               Если значение, указанное в `replicas`, превышает количество элементов в словаре, то master-узлы, чьи номера превышают
               длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
-              диска `ru-1a` будут master-0, master-2 и master-4, а с типом диска `ru-1b` будут master-1 и master-3.
-              `openstack availability zone list`
-              `openstack volume type list`
+              диска `eu-1a` будут master-0, master-2 и master-4, а с типом диска `eu-1b` будут master-1 и master-3.
+
+              Полезные команды:
+              - `openstack availability zone list`
+              - `openstack volume type list`
       nodeGroups:
         description: |
           Массив дополнительных NodeGroup для создания статичных узлов (например, для выделенных frontend-узлов или шлюзов).
@@ -167,11 +169,14 @@ apiVersions:
             volumeTypeMap:
               description: |
                 Словарь типов дисков для загрузочного диска.
+
                 Если значение, указанное в `replicas`, превышает количество элементов в словаре, то узлы, чьи номера превышают
                 длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
-                диска `ru-1a` будут worker-0, worker-2 и worker-4, а с типом диска `ru-1b` будут worker-1 и worker-3.
-                `openstack availability zone list`
-                `openstack volume type list`
+                диска `eu-1a` будут worker-0, worker-2 и worker-4, а с типом диска `eu-1b` будут worker-1 и worker-3.
+
+                Полезные команды:
+                - `openstack availability zone list`
+                - `openstack volume type list`
       layout:
         description: |
           Название схемы размещения.
@@ -295,7 +300,7 @@ apiVersions:
             description: |
               Имя домена.
 
-              Переменная `OS_USER_DOMAIN_NAME` из openrc.
+              Переменная `OS_USER_DOMAIN_NAME` из файла openrc.
           tenantName:
             description: |
               Имя проекта.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -89,8 +89,8 @@ apiVersions:
               Если значение, указанное в `replicas`, превышает количество элементов в словаре, то master-узлы, чьи номера превышают
               длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
               диска `ru-1a` будут master-0, master-2 и master-4, а с типом диска `ru-1b` будут master-1 и master-3.
-              openstack availability zone list
-              openstack volume type list
+              `openstack availability zone list`
+              `openstack volume type list`
       nodeGroups:
         description: |
           Массив дополнительных NodeGroup для создания статичных узлов (например, для выделенных frontend-узлов или шлюзов).
@@ -170,8 +170,8 @@ apiVersions:
                 Если значение, указанное в `replicas`, превышает количество элементов в словаре, то узлы, чьи номера превышают
                 длину словаря, получают значения, начиная с начала словаря. Если для словаря из примера указано `replicas: 5`, то с типом
                 диска `ru-1a` будут worker-0, worker-2 и worker-4, а с типом диска `ru-1b` будут worker-1 и worker-3.
-                openstack availability zone list
-                openstack volume type list
+                `openstack availability zone list`
+                `openstack volume type list`
       layout:
         description: |
           Название схемы размещения.
@@ -294,7 +294,8 @@ apiVersions:
           domainName:
             description: |
               Имя домена.
-              Переменная OS_USER_DOMAIN_NAME из openrc.
+
+              Переменная `OS_USER_DOMAIN_NAME` из openrc.
           tenantName:
             description: |
               Имя проекта.


### PR DESCRIPTION
## Description
Documentation improvement. Added commands to help filling `domainName` and `volumeTypeMap`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cloud-providers-openstack
type: fix 
summary: Add commands to help filling `domainName` and `volumeTypeMap`.
impact_level: low 
```
