### PR TITLE
[docs] Add an example of the global ModuleConfig

### DIFF
--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL.md
@@ -5,9 +5,33 @@ permalink: en/deckhouse-configure-global.html
 
 The global Deckhouse settings are stored in the `ModuleConfig/global` resource (see [Deckhouse configuration](./#deckhouse-configuration)).
 
-> The [publicDomainTemplate](#parameters-modules-publicdomaintemplate) parameter defines the DNS names template some Deckhouse modules use to create Ingress resources.
->
-> You can use the [sslip.io](https://sslip.io/) service (or similar) for testing if wildcard DNS records are unavailable to you for some reason.
+{% alert %}
+The [publicDomainTemplate](#parameters-modules-publicdomaintemplate) parameter defines the DNS names template some Deckhouse modules use to create Ingress resources.
+
+You can use the [sslip.io](https://sslip.io/) service (or similar) for testing if wildcard DNS records are unavailable to you for some reason.
+{% endalert %}
+
+Example of the `ModuleConfig/global`:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Module parameters from the "Parameters" section below.
+    modules:
+      publicDomainTemplate: '%s.kube.company.my'
+      resourcesRequests:
+        controlPlane:
+          cpu: 1000m
+          memory: 500M      
+      placement:
+        customTolerationKeys:
+        - dedicated.example.com
+    storageClass: sc-fast
+```
 
 ## Parameters
 

--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL_RU.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL_RU.md
@@ -6,9 +6,33 @@ lang: ru
 
 Глобальные настройки Deckhouse хранятся в ресурсе `ModuleConfig/global` (см. [конфигурация Deckhouse](./#конфигурация-deckhouse)).
 
-> В параметре [publicDomainTemplate](#parameters-modules-publicdomaintemplate) указывается шаблон DNS-имен, с учетом которого некоторые модули Deckhouse создают Ingress-ресурсы.
->
-> Если у вас нет возможности заводить wildcard-записи DNS, для тестирования можно воспользоваться сервисом [sslip.io](https://sslip.io) или его аналогами.
+{% alert %}
+В параметре [publicDomainTemplate](#parameters-modules-publicdomaintemplate) указывается шаблон DNS-имен, с учетом которого некоторые модули Deckhouse создают Ingress-ресурсы.
+
+Если у вас нет возможности заводить wildcard-записи DNS, для тестирования можно воспользоваться сервисом [sslip.io](https://sslip.io) или его аналогами.
+{% endalert %}
+
+Пример ресурса `ModuleConfig/global`:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      publicDomainTemplate: '%s.kube.company.my'
+      resourcesRequests:
+        controlPlane:
+          cpu: 1000m
+          memory: 500M      
+      placement:
+        customTolerationKeys:
+        - dedicated.example.com
+    storageClass: sc-fast
+```
 
 ## Параметры
 


### PR DESCRIPTION
## Description
Add an example of the global ModuleConfig.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add an example of the global ModuleConfig.
impact_level: low
```