### PR TITLE
[cloud-provider-openstack] Fix discover volume types hooks incorrect fallback to storage classes in another modules.

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/hooks/discover.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover.go
@@ -48,14 +48,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Kind:       "StorageClass",
 			FilterFunc: applyStorageClassFilter,
 			LabelSelector: &meta.LabelSelector{
-				MatchExpressions: []meta.LabelSelectorRequirement{
-					{
-						Key:      "heritage",
-						Operator: meta.LabelSelectorOpIn,
-						Values: []string{
-							"deckhouse",
-						},
-					},
+				MatchLabels: map[string]string{
+					"heritage": "deckhouse",
+					"module":   "cloud-provider-openstack",
 				},
 			},
 		},

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_test.go
@@ -44,36 +44,37 @@ metadata:
   annotations:
     meta.helm.sh/release-name: cloud-provider-openstack
     meta.helm.sh/release-namespace: d8-system
-  managedFields:
-    - manager: deckhouse-controller
-      operation: Update
-      apiVersion: storage.k8s.io/v1
-      time: '2023-06-01T06:09:25Z'
-      fieldsType: FieldsV1
-      fieldsV1:
-        f:allowVolumeExpansion: {}
-        f:metadata:
-          f:annotations:
-            .: {}
-            f:meta.helm.sh/release-name: {}
-            f:meta.helm.sh/release-namespace: {}
-          f:labels:
-            .: {}
-            f:app.kubernetes.io/managed-by: {}
-            f:heritage: {}
-            f:module: {}
-        f:parameters:
-          .: {}
-          f:type: {}
-        f:provisioner: {}
-        f:reclaimPolicy: {}
-        f:volumeBindingMode: {}
   selfLink: /apis/storage.k8s.io/v1/storageclasses/default
 provisioner: cinder.csi.openstack.org
 parameters:
   type: __DEFAULT__
 reclaimPolicy: Delete
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+---
+allowVolumeExpansion: true
+allowedTopologies:
+- matchLabelExpressions:
+  - key: node.deckhouse.io/group
+    values:
+    - system
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    meta.helm.sh/release-name: local-path-provisioner
+    meta.helm.sh/release-namespace: d8-system
+  creationTimestamp: "2022-11-24T16:33:07Z"
+  labels:
+    app: local-path-provisioner
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    module: local-path-provisioner
+  name: localpath-system
+  resourceVersion: "106273"
+  uid: 86533f89-b78a-4cd2-a7b7-5c2a4a77a163
+provisioner: deckhouse.io/localpath-system
+reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer
 ---
 apiVersion: storage.k8s.io/v1
@@ -91,31 +92,6 @@ metadata:
     meta.helm.sh/release-name: cloud-provider-openstack
     meta.helm.sh/release-namespace: d8-system
     storageclass.kubernetes.io/is-default-class: 'true'
-  managedFields:
-    - manager: deckhouse-controller
-      operation: Update
-      apiVersion: storage.k8s.io/v1
-      time: '2023-06-01T06:09:25Z'
-      fieldsType: FieldsV1
-      fieldsV1:
-        f:allowVolumeExpansion: {}
-        f:metadata:
-          f:annotations:
-            .: {}
-            f:meta.helm.sh/release-name: {}
-            f:meta.helm.sh/release-namespace: {}
-            f:storageclass.kubernetes.io/is-default-class: {}
-          f:labels:
-            .: {}
-            f:app.kubernetes.io/managed-by: {}
-            f:heritage: {}
-            f:module: {}
-        f:parameters:
-          .: {}
-          f:type: {}
-        f:provisioner: {}
-        f:reclaimPolicy: {}
-        f:volumeBindingMode: {}
   selfLink: /apis/storage.k8s.io/v1/storageclasses/ceph-ssd
 provisioner: cinder.csi.openstack.org
 parameters:
@@ -280,7 +256,7 @@ data:
 			b.RunHook()
 		})
 
-		It("Should discover all volumeTypes and no default", func() {
+		It("Should discover all volumeTypes only for storage classes where deployed by cloud-provider-openstack module and no default", func() {
 			Expect(b).To(ExecuteSuccessfully())
 			Expect(b.ValuesGet("cloudProviderOpenstack.internal.storageClasses").String()).To(MatchJSON(`
 [


### PR DESCRIPTION
## Description
Fix discover volume types hooks wrong fallback to storage classes in another modules. Hook should fallback for `cloud-provider` openstack only.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deckhouse fail with error
```
{"binding":"ConvergeModules","event.type":"OperatorStartup","level":"error","module":"cloud-provider-openstack","msg":"ModuleRun failed in phase 'CanRunHelm'. Requeue task to retry after delay. Failed count is 80. Error: helm upgrade failed: rendered manifests contain a resource that already exists. Unable to continue with update: StorageClass \"localpath-system\" in namespace \"\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-name\" must equal \"cloud-provider-openstack\": current value is \"local-path-provisioner\"\n","queue":"main","task.id":"e64405ea-4232-46b8-8651-b46812621bbf","time":"2023-07-17T12:29:56Z"}
```

## Why do we need it in the patch release (if we do)?

Deckhouse fail with error
```
{"binding":"ConvergeModules","event.type":"OperatorStartup","level":"error","module":"cloud-provider-openstack","msg":"ModuleRun failed in phase 'CanRunHelm'. Requeue task to retry after delay. Failed count is 80. Error: helm upgrade failed: rendered manifests contain a resource that already exists. Unable to continue with update: StorageClass \"localpath-system\" in namespace \"\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-name\" must equal \"cloud-provider-openstack\": current value is \"local-path-provisioner\"\n","queue":"main","task.id":"e64405ea-4232-46b8-8651-b46812621bbf","time":"2023-07-17T12:29:56Z"}
```

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manual testing proofs
![image](https://github.com/deckhouse/deckhouse/assets/30695496/d4a65522-2687-4bfa-a66f-6fda0bc1f250)


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Fix discover volume types hooks incorrect fallback to storage classes in another modules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
