### PR TITLE
[cloud-provider-openstack] Remove duplicates from images list in cloud-data-discoverer

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
@@ -301,7 +301,7 @@ func (d *Discoverer) getImages(ctx context.Context, provider *gophercloud.Provid
 		imageNames = append(imageNames, image.Name)
 	}
 
-	return imageNames, nil
+	return removeDuplicates(imageNames), nil
 }
 
 type OpenstackCloudDiscoveryData struct {
@@ -362,4 +362,20 @@ func RetryBackoffFunc(logger *log.Entry) gophercloud.RetryBackoffFunc {
 
 		return nil
 	}
+}
+
+func removeDuplicates(list []string) []string {
+	var (
+		keys       = make(map[string]struct{})
+		uniqueList []string
+	)
+
+	for _, elem := range list {
+		if _, ok := keys[elem]; !ok {
+			keys[elem] = struct{}{}
+			uniqueList = append(uniqueList, elem)
+		}
+	}
+
+	return uniqueList
 }

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer_test.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	tests := []struct {
+		args []string
+		want []string
+	}{
+		{
+			args: []string{"1", "1"},
+			want: []string{"1"},
+		},
+		{
+			args: []string{"1", "2", "3", "1"},
+			want: []string{"1", "2", "3"},
+		},
+		{
+			args: []string{"one", "two", "three", "four", "two", "four", "five"},
+			want: []string{"one", "two", "three", "four", "five"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			if got := removeDuplicates(test.args); !reflect.DeepEqual(got, test.want) {
+				t.Errorf("removeDuplicates() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove duplicates from images list in cloud-data-discoverer.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deckhouse fails with error:

```
{"binding":"kubernetes","binding.name":"cloud_provider_discovery_data","event.id":"795674ad-eebe-4ab9-a523-1b18490930a3","hook":"030-cloud-provider-openstack/hooks/discover.go","hook.type":"module","level":"error","module":"cloud-provider-openstack","msg":"Module hook failed, requeue task to retry after delay. Failed count is 41. Error: module hook '030-cloud-provider-openstack/hooks/discover.go' failed: failed to validate 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: Loading schema file: Document validation failed:\n---\n{\"apiVersion\":\"deckhouse.io/v1alpha1\",\"kind\":\"OpenStackCloudProviderDiscoveryData\",\"flavors\":[\"Standard-4-12\",\"Advanced-12-24\",\"Basic-1-2-40\",\"Basic-1-2-20\",\"Advanced-8-16-100\",\"Standard-6-24\",\"Standard-2-2\",\"Advanced-8-8\",\"Advanced-16-64-50\",\"Standard-6-6\",\"Advanced-16-32-50\",\"Advanced-8-24\",\"Custom-32-128\",\"Advanced-12-36\",\"Advanced-12-12\",\"Standard-6-12\",\"Advanced-8-32-50\",\"Basic-1-4-50\",\"Advanced-8-16-160\",\"Advanced-16-48\",\"Standard-2-6\",\"Standard-4-8-80\",\"Standard-6-18\",\"Advanced-16-16\",\"Standard-2-4-50\",\"Standard-2-8-50\",\"Standard-2-4-40\",\"Basic-1-1-10\",\"Standard-4-16-50\",\"Standard-4-4\",\"Advanced-12-48\"],\"additionalNetworks\":[\"ext-net\",\"vk-prod\",\"vm-network\"],\"additionalSecurityGroups\":[\"ssh\",\"vk-prod\",\"tinc\",\"nfs\",\"default\",\"percona-xtradb\",\"vm-to-kube\",\"kube\"],\"defaultImageName\":\"Ubuntu-22.04-202208\",\"images\":[\"ambari-2.7.3.0.202307171607.gitda4bd505\",\"ambari-2.6.1.5.202307171607.gitda4bd505\",\"insight.202307171607.gitda4bd505\",\"ambari-2.6.2.2.202307171607.gitda4bd505\",\"ambari-2.6.0.0.202307171607.gitda4bd505\",\"dummy.202307171607.gitda4bd505\",\"arenadata.202307171607.gitda4bd505\",\"arenadata-worker.202307171607.gitda4bd505\",\"Opensearch-2-alma-2023-07-17_09-32-39\",\"arenadata.202307170734.gite5f41108\",\"arenadata-worker.202307170734.gite5f41108\",\"packer_build_DockerRegistry.202307131020.git848cdadf\",\"packer_build_DockerRegistry.202307131020.git848cdadf\",\"almalinux-9-v1.26.5.202307120949.git8886ff53.dev\",\"Redis-5--1.13.20-alma-2023-07-12_09-42-05\",\"arenadata-worker.202307061329.gitfa850531\",\"dummy.202307061329.gitfa850531\",\"ambari-2.6.2.2.202307061329.gitfa850531\",\"ambari-2.6.0.0.202307061329.gitfa850531\",\"ambari-2.7.3.0.202307061329.gitfa850531\",\"ambari-2.6.1.5.202307061329.gitfa850531\",\"arenadata.202307061329.gitfa850531\",\"insight.202307061329.gitfa850531\",\"Redis-5--1.13.20-alma-2023-07-10_11-56-45\",\"sentry-ubuntu-image.202302171243.gitc139c388\",\"Opensearch-2-alma-2023-07-07_10-03-35\",\"almalinux-9-v1.24.15.202307061058.gitbd4f1108.dev\",\"packer_build_DockerRegistry_202307041530\",\"packer_build_DockerRegistry_202307041530\",\"insight.202307041025.git28894395\",\"dummy.202307041025.git28894395\",\"arenadata-worker.202307041025.git28894395\",\"arenadata.202307041025.git28894395\",\"packer_build_DockerRegistry_202307031840\",\"packer_build_JH_GPU_202307031400\",\"packer_build_JH_GPU_202306301300\",\"sentry-ubuntu-image.202302171243.gitc139c388\",\"Redis-6.2-alma-2023-06-23_01-09-25\",\"PostgreSQL-14--1.13.19-alma-2023-06-22_10-41-01\",\"PostgreSQL-12--1.13.19-alma-2023-06-22_10-40-54\",\"PostgreSQL-13--1.13.19-alma-2023-06-22_10-40-57\",\"PostgreSQL-11--1.13.19-alma-2023-06-22_10-40-46\",\"PostgreSQL-10--1.13.19-alma-2023-06-22_10-34-25\",\"PostgresProEnterprise-11--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-12--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-12--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-13--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-11--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-12--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-13--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-11--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-10--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-13--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-10--1.13.19--2023-06-22_10-34-25\",\"GaleraMySQL-v5dot7--1.13.19-alma-2023-06-22_10-18-20\",\"Clickhouse-22--1.13.19-alma-2023-06-22_10-18-20\",\"GaleraMySQL-v8dot0--1.13.19-alma-2023-06-22_10-18-20\",\"Clickhouse-21--1.13.19-alma-2023-06-22_10-18-20\",\"MySQL-v5dot7--1.13.19-alma-2023-06-22_10-18-20\",\"MySQL-v8dot0--1.13.19-alma-2023-06-22_10-18-20\",\"MongoDB-v4dot0--1.13.19-alma-2023-06-22_10-18-20\",\"Redis-5--1.13.19-alma-2023-06-22_10-18-20\",\"Tarantool-v2dot10--1.13.19--2023-06-22_10-18-20\",\"Clickhouse-20--1.13.19--2023-06-22_10-18-20\",\"packer_build_DockerRegistry_202306220930\",\"GaleraMySQL-v8dot0--1.13.19-alma-2023-06-20_05-32-04\",\"MySQL-v5dot7--1.13.19-alma-2023-06-20_05-32-04\",\"GaleraMySQL-v5dot7--1.13.19-alma-2023-06-20_05-32-04\",\"MySQL-v8dot0--1.13.19-alma-2023-06-20_05-32-04\",\"MongoDB-v4dot0--1.13.19-alma-2023-06-20_05-32-04\",\"Clickhouse-21--1.13.19-alma-2023-06-20_05-32-04\",\"Redis-5--1.13.19-alma-2023-06-20_05-32-04\",\"Clickhouse-22--1.13.19-alma-2023-06-20_05-32-04\",\"Tarantool-v2dot10--1.13.19--2023-06-20_05-32-04\",\"Clickhouse-20--1.13.19--2023-06-20_05-32-04\",\"PostgreSQL-13--1.13.19-alma-2023-06-20_04-05-33\",\"PostgreSQL-14--1.13.19-alma-2023-06-20_04-05-35\",\"PostgreSQL-12--1.13.19-alma-2023-06-20_04-05-26\",\"PostgreSQL-11--1.13.19-alma-2023-06-20_04-05-16\",\"PostgreSQL-10--1.13.19-alma-2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-14--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-13--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-12--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-10--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-14--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-13--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-13--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-14--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-12--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-12--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-10--1.13.19--2023-06-20_03-58-54\",\"packer_build_DockerRegistry_202306201730\",\"almalinux-9-v1.24.15.202306161245.git70b9ece9.dev\",\"almalinux-9-v1.24.15.202306161245.git70b9ece9.dev\",\"almalinux-9-v1.24.15.202306161128.git9e203649.dev\",\"almalinux-9-v1.24.9.202306160754.git7100ceab\",\"almalinux-9-v1.25.6.202306160754.git7100ceab\",\"almalinux-9-v1.23.13.202306160754.git7100ceab\",\"PostgreSQL-14--1.13.18-alma-2023-06-15_11-39-09\",\"PostgreSQL-13--1.13.18-alma-2023-06-15_11-38-58\",\"PostgreSQL-12--1.13.18-alma-2023-06-15_11-38-22\",\"PostgreSQL-11--1.13.18-alma-2023-06-15_11-38-10\",\"Redis-5--1.13.18-alma-2023-06-15_11-39-24\",\"Tarantool-v2dot10--1.13.18--2023-06-15_11-39-28\",\"PostgreSQL-10--1.13.18-alma-2023-06-15_11-35-46\",\"PostgresProEnterprise-1C-14--1.13.18--2023-06-15_11-35-45\",\"PostgresProEnterprise-1C-13--1.13.18--2023-06-15_11-35-23\",\"PostgresProEnterprise-1C-12--1.13.18--2023-06-15_11-33-27\",\"PostgresProEnterprise-14--1.13.18--2023-06-15_11-33-02\",\"PostgresProEnterprise-11--1.13.18--2023-06-15_11-31-38\",\"PostgresProEnterprise-1C-11--1.13.18--2023-06-15_11-33-19\",\"PostgresProEnterprise-1C-10--1.13.18--2023-06-15_11-33-11\",\"PostgresProEnterprise-12--1.13.18--2023-06-15_11-32-21\",\"PostgresProEnterprise-13--1.13.18--2023-06-15_11-32-25\",\"PostgresPro-14--1.13.18--2023-06-15_11-29-07\",\"PostgresPro-13--1.13.18--2023-06-15_11-29-01\",\"PostgresProEnterprise-10--1.13.18--2023-06-15_11-29-37\",\"MySQL-v5dot7--1.13.18-alma-2023-06-15_11-22-39\",\"Clickhouse-22--1.13.18-alma-2023-06-15_11-22-39\",\"GaleraMySQL-v5dot7--1.13.18-alma-2023-06-15_11-22-39\",\"GaleraMySQL-v8dot0--1.13.18-alma-2023-06-15_11-22-40\",\"MySQL-v8dot0--1.13.18-alma-2023-06-15_11-22-39\",\"Clickhouse-21--1.13.18-alma-2023-06-15_11-22-39\",\"MongoDB-v4dot0--1.13.18-alma-2023-06-15_11-22-39\",\"PostgresPro-11--1.13.18--2023-06-15_11-22-39\",\"Clickhouse-20--1.13.18--2023-06-15_11-22-39\",\"PostgresPro-12--1.13.18--2023-06-15_11-22-39\",\"almalinux-9-v1.23.13.202306150626.git979882fb.dev\",\"almalinux-9-v1.24.9.202306131126.git9a224bb2\",\"almalinux-9-v1.23.13.202306141433.git9507844c.dev\",\"almalinux-9-v1.23.13.202306140817.git060526f4.dev\",\"almalinux-9-v1.23.13.202306131315.git0a29dd8b.dev\",\"packer_build_DockerRegistry_202306131600\",\"almalinux-9-v1.24.9.202306131126.git9a224bb2\",\"almalinux-9-v1.24.9.202306131136.gita01e3422.dev\",\"Tarantool-v2dot10--1.13.17--2023-06-06_04-42-18\",\"Redis-5--1.13.17-alma-2023-06-06_04-41-02\",\"MongoDB-v4dot0--1.13.17-alma-2023-06-06_04-05-14\",\"Clickhouse-21--1.13.17-alma-2023-06-06_03-30-49\",\"Clickhouse-22--1.13.17-alma-2023-06-06_03-30-49\",\"Clickhouse-20--1.13.17--2023-06-06_03-30-49\",\"GaleraMySQL-v8dot0--1.13.17-alma-2023-06-06_03-16-37\",\"MySQL-v5dot7--1.13.17-alma-2023-06-06_03-16-37\",\"MySQL-v8dot0--1.13.17-alma-2023-06-06_03-16-37\",\"GaleraMySQL-v5dot7--1.13.17-alma-2023-06-06_03-16-37\",\"PostgreSQL-14--1.13.17-alma-2023-06-06_02-56-35\",\"PostgreSQL-13--1.13.17-alma-2023-06-06_02-56-30\",\"PostgreSQL-11--1.13.17-alma-2023-06-06_02-56-15\",\"PostgreSQL-12--1.13.17-alma-2023-06-06_02-56-28\",\"PostgreSQL-10--1.13.17-alma-2023-06-06_02-50-19\",\"PostgresPro-13--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-11--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-11--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-14--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-14--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-10--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-13--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-10--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-13--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-11--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-14--1.13.17--2023-06-06_02-50-19\",\"PostgreSQL-14--1.13.17-alma-2023-06-02_11-27-15\",\"packer_build_DockerRegistry_202306011600\",\"Clickhouse-22--1.13.16-alma-2023-06-01_05-51-30\",\"Clickhouse-21--1.13.16-alma-2023-06-01_05-51-30\",\"Clickhouse-20--1.13.16--2023-06-01_05-51-30\",\"packer_build_JH_GPU_202305261400\",\"almalinux-9-v1.25.10.202305260852.git8a4be3bf.dev\",\"astra-or-1.7-vdi-202305251407.git06ac0d14\",\"almalinux-9-v1.24.9.202305220831.git5ea06013\",\"almalinux-9-v1.23.13.202305220831.git5ea06013\",\"almalinux-9-v1.23.13.202305170935.git6e2d8563\",\"almalinux-9-v1.24.9.202305170935.git6e2d8563\",\"opensuse-leap-15.4-202305101900.gitc6492fe3\",\"packer_build_k8sController_202304281700\",\"almalinux-9-v1.23.13.202304280932.git458ee2d5\",\"almalinux-9-v1.24.9.202304280932.git458ee2d5\",\"Opensearch-2-alma-2023-04-27_12-17-15\",\"kafka-almalinux-91.202304241302.gitcf252bf1\",\"packer_build_JH_GPU_202304211630\",\"FreeBSD-13.2\",\"Opensearch-2-alma-2023-04-19_09-11-38\",\"almalinux-9-v1.24.9.202304141500.git963625d0\",\"packer_build_JH_GPU_202304171730\",\"packer_build_k8sController_202304071200\",\"kafka-almalinux-91.202304131114.git39b98629\",\"kafka-almalinux-91.202304122007.gitbf42ef2f\",\"PostgresPro-14--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-12--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-11--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-13--1.13.15--2023-04-11_07-41-27\",\"packer_build_DockerRegistry_202304101300\",\"packer_build_k8sController_202304071200\",\"packer_build_DeployServer_202304071200\",\"packer_build_MLFLOW_202304071200\",\"packer_build_JH_GPU_202304071200\",\"packer_build_DockerRegistry_202304070930\",\"almalinux-9-v1.24.9.202304051306.git3f549049\",\"almalinux-9-v1.23.13.202304051306.git3f549049\",\"ambari-2.6.0.0.202304050621.git525510fa.dev\",\"ambari-2.6.0.0.202303291357.git788748f9.dev\",\"packer_build_JH_GPU_202303311700\",\"packer_build_k8sController_202303311700\",\"packer_build_MLFLOW_202303311700\",\"packer_build_DeployServer_202303311700\",\"MySQL-v8dot0--1.13.15-alma-2023-03-30_07-46-47\",\"GaleraMySQL-v5dot7--1.13.15-alma-2023-03-30_07-46-47\",\"MySQL-v5dot7--1.13.15-alma-2023-03-30_07-46-47\",\"GaleraMySQL-v8dot0--1.13.15-alma-2023-03-30_07-46-47\",\"almalinux-9-v1.24.9.202303290731.git4a42b46b\",\"almalinux-9-v1.23.13.202303290731.git4a42b46b\",\"PostgreSQL-14--1.13.15-alma-2023-03-28_05-13-04\",\"Tarantool-v2dot10--1.13.15--2023-03-28_05-09-14\",\"PostgresProEnterprise-1C-11--1.13.15--2023-03-28_04-55-32\",\"Redis-5--1.13.15-alma-2023-03-28_05-00-42\",\"PostgreSQL-13--1.13.15-alma-2023-03-28_04-54-41\",\"PostgreSQL-11--1.13.15-alma-2023-03-28_04-50-55\",\"PostgreSQL-12--1.13.15-alma-2023-03-28_04-55-18\",\"PostgreSQL-10--1.13.15-alma-2023-03-28_04-50-44\",\"PostgresProEnterprise-1C-13--1.13.15--2023-03-28_04-49-07\",\"PostgresProEnterprise-1C-10--1.13.15--2023-03-28_04-44-31\",\"PostgresProEnterprise-1C-14--1.13.15--2023-03-28_04-49-07\",\"PostgresProEnterprise-1C-12--1.13.15--2023-03-28_04-47-47\",\"PostgresProEnterprise-13--1.13.15--2023-03-28_04-42-28\",\"PostgresProEnterprise-12--1.13.15--2023-03-28_04-42-06\",\"PostgresProEnterprise-14--1.13.15--2023-03-28_04-42-29\",\"PostgresProEnterprise-11--1.13.15--2023-03-28_04-41-17\",\"PostgresProEnterprise-10--1.13.15--2023-03-28_04-40-23\",\"MongoDB-v4dot0--1.13.15-alma-2023-03-28_04-31-23\",\"ambari-2.6.0.0.202303271603.gitf193dda9.dev\",\"ambari-2.6.0.0.202303221424.git731b4606\",\"ambari-2.7.3.0.202303221424.git731b4606\",\"ambari-2.6.1.5.202303221424.git731b4606\",\"ambari-2.6.2.2.202303221424.git731b4606\",\"dummy.202303221424.git731b4606\",\"arenadata.202303221424.git731b4606\",\"insight.202303221424.git731b4606\",\"arenadata-worker.202303221424.git731b4606\",\"opensuse-leap-15.4-202303221516.git73f3582c\",\"FreeBSD-12.4\",\"FreeBSD-13.1\",\"Opensearch-2-alma-2023-03-17_08-48-17\",\"Redis-6.2-alma-2023-03-17_08-38-36\",\"Mongodb-6-alma-2023-03-17_08-28-40\",\"packer_build_k8sController_v1.0\",\"packer_build_DeployServer_v1.03\",\"alse-vanilla-1.7.3uu1-vkcloud-adv-mg9.1.2\",\"alse-vanilla-1.7.3-vkcloud-base-mg8.2.1\",\"arenadata.202302221336.gite2334917.dev\",\"arenadata-worker.202302221336.gite2334917.dev\",\"Astra Linux SE 1.7.2 Orel GUI\",\"packer_build_JH_GPU_v1.15\",\"RO732_MIN-STD\",\"RO732_MIN-CRT\",\"sentry-ubuntu-image.202302170627.gita61ff2ac\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"almalinux-9-v1.24.9.202302130900.git6dc96b46.dev\",\"almalinux-9-v1.23.13.202302100713.gitf3a303d1.dev\",\"almalinux-9-v1.22.9.202302100713.gitf3a303d1.dev\",\"ambari-2.6.0.0.202302091536.git920581f5\",\"ambari-2.7.3.0.202302091536.git920581f5\",\"ambari-2.6.1.5.202302091536.git920581f5\",\"ambari-2.6.2.2.202302091536.git920581f5\",\"arenadata.202302091536.git920581f5\",\"arenadata-worker.202302091536.git920581f5\",\"dummy.202302091536.git920581f5\",\"insight.202302091536.git920581f5\",\"arenadata.202302091444.git57be9b4f.dev\",\"arenadata-worker.202302091444.git57be9b4f.dev\",\"arenadata.202302091325.git571ae37b.dev\",\"arenadata-worker.202302091325.git571ae37b.dev\",\"alt-server-8sp-cloud-rev1.3.1-20221229-x86_64\",\"alt-server-10-rev20230208-x86_64\",\"dummy.202302081032.gitd4a0bf97\",\"insight.202302081032.gitd4a0bf97\",\"ambari-2.6.1.5.202302081032.gitd4a0bf97\",\"ambari-2.7.3.0.202302081032.gitd4a0bf97\",\"ambari-2.6.0.0.202302081032.gitd4a0bf97\",\"ambari-2.6.2.2.202302081032.gitd4a0bf97\",\"arenadata.202302081032.gitd4a0bf97\",\"arenadata-worker.202302081032.gitd4a0bf97\",\"dummy.202302081005.gitdb228aba\",\"ambari-2.7.3.0.202302071225.git4a87ae24.dev\",\"ambari-2.7.3.0.202302071108.git195ec092.dev\",\"ambari-2.6.2.2.202302031433.git44cfeb96\",\"ambari-2.6.0.0.202302031433.git44cfeb96\",\"arenadata-worker.202302031433.git44cfeb96\",\"arenadata.202302031433.git44cfeb96\",\"ambari-2.6.1.5.202302031433.git44cfeb96\",\"ambari-2.7.3.0.202302031433.git44cfeb96\",\"insight.202302031433.git44cfeb96\",\"dummy.202302031433.git44cfeb96\",\"packer_build_MLFLOW_v2.1.4\",\"ARENADATA-4878524-2023-01-25-prod\",\"ARENADATA_WORKER-4878524-2023-01-25-prod\",\"packer_build_JH_GPU_v1.13\",\"packer_build_JH_GPU_v1.12\",\"packer_build_MLFLOW_v2.1.2\",\"packer_build_JH_GPU_v1.08\",\"packer_build_JH_GPU_v1.08\",\"sentry-0.1\",\"Opensearch-2-alma-2022-12-14_05-28-56\",\"Mongodb-6-alma-2022-12-14_04-46-21\",\"Redis-6.2-alma-2022-12-14_02-50-52\",\"Mongodb-6-alma-2022-12-12_08-53-51\",\"packer_build_DeployServer_v1.02\",\"Redis-6.2-alma-2022-11-28_01-16-09\",\"Opensearch2-almalinux8.202211250914.git4ce04292\",\"Windows-Server-2022StdCore-ru.202211\",\"packer_build_JH_GPU_v1.07\",\"packer_build_MLFLOW_v1.03\",\"Windows-Server-2022StdCore-en.202211\",\"Windows-Server-2019Std-en.202211\",\"Windows-Server-2019Std-ru.202211\",\"Windows-Server-2022Std-ru.202211\",\"Windows-Server-2022Std-en.202211\",\"Windows-Server-2019Std-en.202211\",\"Windows-Server-2016Std-en.202211\",\"Windows-Server-2016Std-ru.202211\",\"Opensearch2-almalinux8.202211221000.gitbdbfe30c.dev\",\"Windows-Server-2012R2Std-ru.202211\",\"Windows-Server-2012R2Std-en.202211\",\"packer_build_JH_GPU_v1.06\",\"packer_build_JH_GPU_v1.05\",\"AMBARI-2.6.0.0-4100884-2022-11-09-prod\",\"ARENADATA_WORKER-4100884-2022-11-09-prod\",\"DUMMY-4100884-2022-11-09-prod\",\"INSIGHT-4100884-2022-11-09-prod\",\"ARENADATA-4100884-2022-11-09-prod\",\"AMBARI-2.7.3.0-4100884-2022-11-09-prod\",\"AMBARI-2.6.2.2-4100884-2022-11-09-prod\",\"AMBARI-2.6.1.5-4100884-2022-11-09-prod\",\"Debian11.4\",\"almalinux-9-v1.23.13.202211021406.git84ce35f0.dev\",\"packer_build_MLFlow.202211031046.git2bf12643.dev\",\"packer_build_DeployServer_v1.01\",\"alse-vanilla-1.7.2-vkcloud-base-mg8.0.0\",\"Redis-6.2-alma-2022-10-18_08-46-37\",\"almalinux-9-v1.23.6.202210120842.git899594d6.dev\",\"almalinux-9-v1.22.9.202210120842.git899594d6.dev\",\"packer_build_DeployServer_v1.00\",\"Almalinux-9-v1.23.6-k8s-mcs-Oct- 7-12:40:46.021-\",\"Almalinux-8-v1.21.4-k8s-mcs-Oct- 7-12:24:32.429-\",\"Almalinux-9-v1.22.9-k8s-mcs-Oct- 7-12:24:35.201-\",\"packer_build_MLFLOW_v1.02\",\"packer_build_JH_GPU_v1.04\",\"packer_build_JH_GPU_v1.03\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-20-14:47:39.386-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-20-14:47:48.435-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-20-14:47:44.123-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-20-10:19:11.934-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-20-10:19:21.584-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-20-10:19:16.725-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-19-12:06:03.688-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-19-12:08:49.709-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-19-12:08:37.588-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-16-12:09:15.206-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-16-11:19:14.725-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-16-11:19:33.801-\",\"packer_build_JH_GPU_v1.02\",\"Clickhouse-22--1.13.3-alma-2022-09-13_12-36-08\",\"packer_build_MLFLOW_v1.01\",\"packer_build_JH_GPU_v1.01\",\"packer_build_JH_GPU_v1\",\"Ubuntu-20.04-Jupyterhub_GPU\",\"packer-build-Jupyterhub_v2.4\",\"ARENADATA-3342738-2022-08-17-prod\",\"DUMMY-3342738-2022-08-17-prod\",\"ARENADATA_WORKER-3342738-2022-08-17-prod\",\"AMBARI-2.7.3.0-3342738-2022-08-17-prod\",\"AMBARI-2.6.2.2-3342738-2022-08-17-prod\",\"AMBARI-2.6.1.5-3342738-2022-08-17-prod\",\"AMBARI-2.6.0.0-3342738-2022-08-17-prod\",\"Ubuntu-22.04-202208\",\"FreeBSD-13.1\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug-12-07:34:16.668-\",\"Almalinux-9-v1.22.9-k8s-mcs-Aug-12-07:33:57.593-\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug-11-17:13:26.539-\",\"Almalinux-9-v1.22.9-k8s-mcs-Aug-11-17:12:55.631-\",\"Redis-6.2-alma-2022-08-11_02-34-29\",\"Almalinux-9-v1.23.6-k8s-mcs-\",\"Almalinux-9-v1.22.9-k8s-mcs-\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug- 2-09:38:33.516-ea91ada\",\"Ubuntu-20.04-Mlflow\",\"Almalinux-9-v1.23.6-k8s-mcs-Jul-27-16:34:28.117-ea91ada\",\"Ubuntu-20.04-Jupyterhub_v3\",\"Almalinux-9-v1.23.6-mcs.5\",\"Almalinux-9-v1.22.9-mcs.2\",\"Ubuntu-18.04-Jupyterhub\",\"Almalinux-8-v1.21.4-mcs.10\",\"Almalinux-9-v1.22.9-mcs.1\",\"Clickhouse-21--1.12.24-alma-2022-06-21_04-18-28\",\"Almalinux-9-v1.22.9-mcs.1\",\"DUMMY-2905445-2022-06-08-prod\",\"ADB-2905121-2022-06-07-prod\",\"ADB_WORKER-2905121-2022-06-07-prod\",\"AHDP-2905121-2022-06-07-prod\",\"AMBARI-2.6.0.0-2905121-2022-06-07-prod\",\"DUMMY-2905121-2022-06-07-prod\",\"AHDP_WORKER-2905121-2022-06-07-prod\",\"AMBARI-2.7.3.0-2905121-2022-06-07-prod\",\"AMBARI-2.6.2.2-2905121-2022-06-07-prod\",\"AMBARI-2.6.1.5-2905121-2022-06-07-prod\",\"AlmaLinux-9\",\"AMBARI-2.6.2.2-2894775-2022-06-06-prod\",\"AMBARI-2.6.1.5-2894775-2022-06-06-prod\",\"AMBARI-2.6.0.0-2894775-2022-06-06-prod\",\"DUMMY-2887737-2022-06-03-prod\",\"AHDP-2887737-2022-06-03-prod\",\"ADB-2887737-2022-06-03-prod\",\"AHDP_WORKER-2887737-2022-06-03-prod\",\"ADB_WORKER-2887737-2022-06-03-prod\",\"AMBARI-2.7.3.0-2887737-2022-06-03-prod\",\"AMBARI-2.6.1.5-2887737-2022-06-03-prod\",\"AMBARI-2.6.2.2-2887737-2022-06-03-prod\",\"ADB-2885008-2022-06-02-prod\",\"AHDP_WORKER-2885008-2022-06-02-prod\",\"AHDP-2885008-2022-06-02-prod\",\"AMBARI-2.7.3.0-2885008-2022-06-02-prod\",\"ADB_WORKER-2885008-2022-06-02-prod\",\"AMBARI-2.6.0.0-2885008-2022-06-02-prod\",\"AMBARI-2.6.1.5-2885008-2022-06-02-prod\",\"AMBARI-2.6.2.2-2885008-2022-06-02-prod\",\"DUMMY-2882108-2022-06-02-prod\",\"ADB-2882108-2022-06-02-prod\",\"AHDP_WORKER-2882108-2022-06-02-prod\",\"AHDP-2882108-2022-06-02-prod\",\"AMBARI-2.7.3.0-2882108-2022-06-02-prod\",\"ADB_WORKER-2882108-2022-06-02-prod\",\"AMBARI-2.6.1.5-2882108-2022-06-02-prod\",\"AMBARI-2.6.2.2-2882108-2022-06-02-prod\",\"AMBARI-2.6.0.0-2882108-2022-06-02-prod\",\"ADB-2872302-2022-05-31-prod\",\"DUMMY-2872302-2022-05-31-prod\",\"AHDP-2872302-2022-05-31-prod\",\"AHDP_WORKER-2872302-2022-05-31-prod\",\"AMBARI-2.7.3.0-2872302-2022-05-31-prod\",\"ADB_WORKER-2872302-2022-05-31-prod\",\"AMBARI-2.6.2.2-2872302-2022-05-31-prod\",\"AMBARI-2.6.1.5-2872302-2022-05-31-prod\",\"AMBARI-2.7.3.0-2803098-2022-05-19-prod\",\"AMBARI-2.6.2.2-2803098-2022-05-19-prod\",\"AMBARI-2.6.1.5-2803098-2022-05-19-prod\",\"AMBARI-2.6.0.0-2803098-2022-05-19-prod\",\"DUMMY-2803098-2022-05-18-prod\",\"AHDP-2803098-ADCM-v2021.06.17.06-2022-05-18-prod\",\"AHDP_WORKER-2803098-2022-05-18-prod\",\"ADB-2803098-ADCM-v2021.06.17.06-2022-05-18-prod\",\"ADB_WORKER-2803098-2022-05-18-prod\",\"AHDP-2798959-ADCM-v2021.06.17.06-2022-05-18-prod\",\"ADB_WORKER-2798959-2022-05-18-prod\",\"ADB-2798959-ADCM-v2021.06.17.06-2022-05-18-prod\",\"AHDP_WORKER-2798959-2022-05-18-prod\",\"DUMMY-2798959-2022-05-18-prod\",\"AMBARI-2.6.2.2-2798959-2022-05-18-prod\",\"AMBARI-2.7.3.0-2798959-2022-05-18-prod\",\"AMBARI-2.6.1.5-2798959-2022-05-18-prod\",\"AMBARI-2.6.0.0-2798959-2022-05-18-prod\",\"GaleraMySQL-v5dot6--1.12.23--2022-04-29_02-40-08\",\"Almalinux-8-v1.22.6-mcs.8\",\"Tarantool-v2--1.12.23--2022-04-27_12-21-37\",\"MySQL-v5dot6--1.12.23--2022-04-27_12-13-07\",\"Clickhouse-19--1.12.23--2022-04-27_12-10-52\",\"GaleraMySQL-v5dot6--1.12.23--2022-04-27_12-11-22\",\"DUMMY-2703259-2022-04-20-prod\",\"AHDP-2703259-ADCM-v2021.06.17.06-2022-04-20-prod\",\"ADB-2703259-ADCM-v2021.06.17.06-2022-04-20-prod\",\"AMBARI-2.7.3.0-2703259-2022-04-20-prod\",\"AMBARI-2.6.1.5-2703259-2022-04-20-prod\",\"AMBARI-2.6.2.2-2703259-2022-04-20-prod\",\"AMBARI-2.6.0.0-2703259-2022-04-20-prod\",\"DUMMY-2645251-2022-04-12-prod\",\"AHDP-2645251-ADCM-v2021.06.17.06-2022-04-12-prod\",\"ADB-2645251-ADCM-v2021.06.17.06-2022-04-12-prod\",\"AMBARI-2.6.2.2-2645251-2022-04-12-prod\",\"AMBARI-2.7.3.0-2645251-2022-04-12-prod\",\"AMBARI-2.6.1.5-2645251-2022-04-12-prod\",\"AMBARI-2.6.0.0-2645251-2022-04-12-prod\",\"DUMMY-2640176-2022-04-11-prod\",\"ADB-2640176-ADCM-v2021.06.17.06-2022-04-11-prod\",\"AHDP-2640176-ADCM-v2021.06.17.06-2022-04-11-prod\",\"AMBARI-2.7.3.0-2640176-2022-04-11-prod\",\"AMBARI-2.6.1.5-2640176-2022-04-11-prod\",\"AMBARI-2.6.0.0-2640176-2022-04-11-prod\",\"AMBARI-2.6.2.2-2640176-2022-04-11-prod\",\"PostgreSQL-v9dot6--1.12.20--2022-03-11_12-28-55\",\"Almalinux-8-v1.22.6-mcs.5\",\"Almalinux-8-v1.21.4-mcs.9\",\"AMBARI-2.7.3.0-2434969-2022-03-04-prod\",\"ADB-2434969-ADCM-v2021.06.17.06-2022-03-04-prod\",\"ADB_WORKER-2434969-2022-03-04-prod\",\"Almalinux-8-v1.22.6-mcs.4\",\"PostgreSQL-v9dot6--1.12.20--2022-03-03_06-26-24\",\"Almalinux-8-v1.22.6-mcs.2\",\"Almalinux-8-v1.21.4-mcs.4\",\"Almalinux-8-v1.21.4-mcs.3\",\"Greenplum-oasis-2022-02-02-prod\",\"ADB-ADCM-v2021.06.17.06-2022-02-02-prod\",\"AlmaLinux-8.5\",\"centos7-sahara-ambari-2.7.3.0-2022-01-14-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-12-16-prod.raw\",\"Ubuntu-18.04-Marketplace-OpenJDK-v2\",\"Ubuntu-18.04-Marketplace-Basic-v2\",\"Windows-Server-2022StdCore-en.202111\",\"Windows-Server-2022StdCore-ru.202111\",\"Windows-Server-2022Std-ru.202111\",\"Windows-Server-2022Std-en.202111\",\"centos7-sahara-ambari-2.7.3.0-2021-11-08-prod.raw\",\"ADCM-v2021.06.17.06-2021-11-08-prod\",\"Greenplum-oasis-2021-11-08-prod\",\"Ahdp-adcm-v2021.06.17.06-2021-10-25-prod\",\"ahdp-2021-10-25-prod\",\"Centos-8-v1.20.4-mcs.9\",\"centos7-sahara-ambari-2.7.3.0-2021-09-29-prod.raw\",\"Greenplum-oasis-2021-09-19-prod\",\"ADCM-v2021.06.17.06-2021-09-18-prod\",\"Centos-8-v1.19.4-mcs.9\",\"Centos-8-v1.18.12-mcs.8\",\"Centos-8-v1.17.8-mcs.7\",\"centos7-sahara-ambari-2.7.3.0-2021-08-19-prod.raw\",\"ahdp-2021-08-19-prod\",\"Ahdp-adcm-v2021.06.17.06-2021-08-19-prod\",\"centos7-sahara-ambari-2.7.3.0-2021-07-30-prod.raw\",\"ADCM-v2021.06.17.06-2021-07-30-prod\",\"Greenplum-oasis-2021-07-30-prod\",\"Ahdp-adcm-v2020081011-2021-07-19-prod\",\"ahdp-2021-07-19-prod\",\"Greenplum-oasis-2021-07-15-prod\",\"ADCM-v2020081011-2021-07-15-prod\",\"CentOS-8.4-202107\",\"Greenplum-oasis-2021-07-08-prod\",\"ADCM-v2020081011-2021-07-08-prod\",\"CentOS-7.9-202107\",\"centos7-sahara-ambari-2.7.3.0-2021-07-01-prod.raw\",\"Greenplum-oasis-2021-06-25-prod\",\"centos7-sahara-ambari-2.6.1.5-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-25-prod.raw\",\"ADCM-v2020081011-2021-06-25-prod\",\"centos7-sahara-ambari-2.7.3.0-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-25-prod.raw\",\"ahdp-2021-06-25-prod\",\"Ahdp-adcm-v2020081011-2021-06-25-prod\",\"Greenplum-oasis_enterprise-2021-06-25-prod\",\"Greenplum-oasis-2021-06-25-prod\",\"Greenplum-oasis-2021-06-25-prod\",\"ADCM-enterprise-v2020081011-2021-06-25-prod\",\"ADCM-v2020081011-2021-06-25-prod\",\"ADCM-v2020081011-2021-06-25-prod\",\"Windows-Server-2019-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2019-SERVERSTANDARD-en-US.202106\",\"Windows-Server-2016-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2016-SERVERSTANDARD-en-US.202106\",\"Windows-Server-2012-R2-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2012-R2-SERVERSTANDARD-en-US.202106\",\"centos7-sahara-ambari-2.7.3.0-2021-06-16-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-15-prod.raw\",\"ADCM-v2020081011-2021-06-15-prod\",\"ADCM-v2020081011-2021-06-15-prod\",\"Greenplum-oasis_enterprise-2021-06-15-prod\",\"Greenplum-oasis-2021-06-15-prod\",\"ADCM-enterprise-v2020081011-2021-06-15-prod\",\"Greenplum-oasis-2021-06-15-prod\",\"Ahdp-adcm-v2020081011-2021-06-11-prod\",\"ahdp-2021-06-11-prod\",\"Ahdp-adcm-v2020081011-2021-06-01-prod\",\"ahdp-2021-06-01-prod\",\"ADCM-enterprise-v2020081011-2021-06-01-prod\",\"ADCM-v2020081011-2021-06-01-prod\",\"Greenplum-oasis_enterprise-2021-06-01-prod\",\"Greenplum-oasis-2021-06-01-prod\",\"ADCM-v2020081011-2021-06-01-prod\",\"Greenplum-oasis-2021-06-01-prod\",\"centos7-sahara-ambari-2.6.1.5-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-01-prod.raw\",\"Windows-Server-2019Std-ru.202105\",\"Windows-Server-2019Std-en.202105\",\"Windows-Server-2016Std-ru.202105\",\"Windows-Server-2016Std-en.202105\",\"Windows-Server-2012R2Std-ru.202105\",\"Windows-Server-2012R2Std-en.202105\",\"Clickhouse-20-2021-05-14_11-54-46\",\"Windows-Server-2019Std-ru.202104\",\"Windows-Server-2019Std-en.202104\",\"Windows-Server-2016Std-ru.202104\",\"Windows-Server-2016Std-en.202104\",\"Windows-Server-2012R2Std-ru.202104\",\"Windows-Server-2012R2Std-en.202104\",\"centos7-sahara-ambari-2.7.3.0-2021-03-03-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-03-03-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-03-03-prod.raw\",\"ADCM-v2020081011-2021-02-18-prod\",\"Greenplum-oasis-2021-02-18-prod\",\"Centos-8-v1.16.4-mcs.6\",\"centos7-sahara-ambari-2.6.0.0-2021-01-18-prod\",\"Windows-Server-2019Std-ru.202012\",\"Windows-Server-2019Std-en.202012\",\"Windows-Server-2016Std-ru.202012\",\"Windows-Server-2016Std-en.202012\",\"Windows-Server-2012R2Std-ru.202012\",\"Windows-Server-2012R2Std-en.202012\",\"centos7-sahara-ambari-2.7.3.0-2020-12-22-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2020-12-22-prod.raw\",\"Greenplum-default-2020-12-22-prod\",\"ADCM-v2020062514-2020-12-22-prod\",\"centos7-sahara-ambari-2.6.1.5-2020-12-17-prod\",\"Windows-Server-2019Std-ru.202011\",\"Windows-Server-2019Std-en.202011\",\"Windows-Server-2016Std-ru.202011\",\"Windows-Server-2016Std-en.202011\",\"Windows-Server-2012R2Std-ru.202011\",\"Windows-Server-2012R2Std-en.202011\",\"centos7-sahara-ambari-2.7.3.0-2020-09-30-prod\",\"Greenplum-default-2020-09-30-prod\",\"ADCM-v2020062514-2020-09-30-prod\",\"Ubuntu-20.04.1-202008\",\"Windows-Server-2016Std-ru.202006\",\"Windows-Server-2016Std-en.202006\",\"Windows-Server-2012R2Std-ru.202006\",\"Windows-Server-2012R2Std-en.202006\",\"Windows-Server-2019Std-ru.202006\",\"Windows-Server-2019Std-en.202006\",\"Fedora-Atomic-28-v1.14.6-mcs.2\",\"Fedora-Atomic-28-v1.15.3-mcs.2\",\"Debian-10.1-202004\",\"CentOS-8.1-202004\",\"Fedora-Atomic-28-v1.15.3-mcs.1\",\"Fedora-Atomic-28-v1.16.4-mcs.1\",\"Windows-Server-2019-SERVERDATACENTER-en-US.202003\",\"Windows-Server-2016-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2019-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2016-SERVERDATACENTER-en-US.202003\",\"Windows-Server-2012-R2-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2012-R2-SERVERDATACENTER-en-US.202003\",\"Ubuntu-19.10-202003\",\"Ubuntu-19.10-202003\",\"CentOS-8.1-202003\",\"Ubuntu-18.04-202003\",\"CentOS-7.7-202003\",\"Ubuntu-16.04-202003\",\"Fedora-Atomic-28-v1.16.4-mcs.1\",\"CentOS-8.0-201910\",\"CentOS-7.7-201910\",\"Ubuntu-19.04-201910\",\"Ubuntu-16.04-201910\",\"Ubuntu-18.04-201910\",\"Debian-10.1-201910\",\"Fedora-Atomic-28-v1.15.3-mcs.1\",\"Fedora-Atomic-28-v1.14.6-mcs.1\",\"MongoDB-4.0\",\"Fedora-Atomic-28-v1.14.4-mcs.2\",\"Fedora-Atomic-28-v1.14.4-mcs.1\",\"Fedora-Atomic-28-v1.13.3-mcs.1\",\"Fedora-Atomic-28-v1.11.5-mcs.3\",\"Fedora-Atomic-28-v1.13.3-mcs.1\",\"CentOS-7.6-201903\",\"Ubuntu-16.04-Standard\",\"Fedora-Atomic-28-v1.11.5-mcs.1\",\"Fedora-Atomic-28-v1.12.3-mcs.1\",\"Fedora-Atomic-28-v1.10.11-mcs.1\",\"Debian-9.4.201812\",\"Ubuntu-18.04-Marketplace-OpenJDK\",\"Ubuntu-18.04-Marketplace-Basic\",\"Ubuntu-18.04-Standard\",\"Ubuntu-18.04-MachineLearning\",\"Bitrix-CentOS7.5-installation\",\"CentOS-7.5-Standard\",\"Bitrix-CentOS7.5-installation.2405\",\"openSUSE-42.3-Standard\",\"CentOS-7.4-Standard\",\"FreeBSD-10.3\"],\"mainNetwork\":\"vk-prod\",\"zones\":[\"GZ1\",\"MS1\"],\"volumeTypes\":[{\"id\":\"e7886624-2d95-4175-b14a-d256d6961bd6\",\"name\":\"high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"3b22f0ca-8682-4c3e-ae95-aaa969823d06\",\"name\":\"ceph-ssd\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"f631a3ba-a98e-4954-b3a1-4028d5e5ae81\",\"name\":\"ceph-hdd\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"8d39c9db-0293-48c0-8d44-015a2f6788ff\",\"name\":\"ko1-high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"bf800b7c-9ae0-4cda-b9c5-fae283b3e9fd\",\"name\":\"dp1-high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"74101409-a462-4f03-872a-7de727a178b8\",\"name\":\"ko1-ssd\",\"description\":\"SSD for KO\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"eadd8860-f5a4-45e1-ae27-8c58094257e0\",\"name\":\"dp1-ssd\",\"description\":\"Fast iops on SSD in DP1\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"48372c05-c842-4f6e-89ca-09af3868b2c4\",\"name\":\"ssd\",\"description\":\"Fast iops on SSD\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"a75c3502-4de6-4876-a457-a6c4594c067a\",\"name\":\"ms1\",\"description\":\"Ceph storage in VarshavkaMs1 datacenter\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"ebf5922e-42af-4f97-8f23-716340290de2\",\"name\":\"dp1\",\"description\":\"Ceph storage in DataPro datacenter\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"a6e853c1-78ad-4c18-93f9-2bba317a1d13\",\"name\":\"ceph\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true}]}\n\n1 error occurred:\n\t* images shouldn't contain duplicates\n\n","queue":"main","task.id":"e4816561-4123-4d73-a081-f4eeb9b8df24","time":"2023-07-17T17:53:09Z","watchEvent":"Added"}
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Deckhouse fails with error:

```
{"binding":"kubernetes","binding.name":"cloud_provider_discovery_data","event.id":"795674ad-eebe-4ab9-a523-1b18490930a3","hook":"030-cloud-provider-openstack/hooks/discover.go","hook.type":"module","level":"error","module":"cloud-provider-openstack","msg":"Module hook failed, requeue task to retry after delay. Failed count is 41. Error: module hook '030-cloud-provider-openstack/hooks/discover.go' failed: failed to validate 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: Loading schema file: Document validation failed:\n---\n{\"apiVersion\":\"deckhouse.io/v1alpha1\",\"kind\":\"OpenStackCloudProviderDiscoveryData\",\"flavors\":[\"Standard-4-12\",\"Advanced-12-24\",\"Basic-1-2-40\",\"Basic-1-2-20\",\"Advanced-8-16-100\",\"Standard-6-24\",\"Standard-2-2\",\"Advanced-8-8\",\"Advanced-16-64-50\",\"Standard-6-6\",\"Advanced-16-32-50\",\"Advanced-8-24\",\"Custom-32-128\",\"Advanced-12-36\",\"Advanced-12-12\",\"Standard-6-12\",\"Advanced-8-32-50\",\"Basic-1-4-50\",\"Advanced-8-16-160\",\"Advanced-16-48\",\"Standard-2-6\",\"Standard-4-8-80\",\"Standard-6-18\",\"Advanced-16-16\",\"Standard-2-4-50\",\"Standard-2-8-50\",\"Standard-2-4-40\",\"Basic-1-1-10\",\"Standard-4-16-50\",\"Standard-4-4\",\"Advanced-12-48\"],\"additionalNetworks\":[\"ext-net\",\"vk-prod\",\"vm-network\"],\"additionalSecurityGroups\":[\"ssh\",\"vk-prod\",\"tinc\",\"nfs\",\"default\",\"percona-xtradb\",\"vm-to-kube\",\"kube\"],\"defaultImageName\":\"Ubuntu-22.04-202208\",\"images\":[\"ambari-2.7.3.0.202307171607.gitda4bd505\",\"ambari-2.6.1.5.202307171607.gitda4bd505\",\"insight.202307171607.gitda4bd505\",\"ambari-2.6.2.2.202307171607.gitda4bd505\",\"ambari-2.6.0.0.202307171607.gitda4bd505\",\"dummy.202307171607.gitda4bd505\",\"arenadata.202307171607.gitda4bd505\",\"arenadata-worker.202307171607.gitda4bd505\",\"Opensearch-2-alma-2023-07-17_09-32-39\",\"arenadata.202307170734.gite5f41108\",\"arenadata-worker.202307170734.gite5f41108\",\"packer_build_DockerRegistry.202307131020.git848cdadf\",\"packer_build_DockerRegistry.202307131020.git848cdadf\",\"almalinux-9-v1.26.5.202307120949.git8886ff53.dev\",\"Redis-5--1.13.20-alma-2023-07-12_09-42-05\",\"arenadata-worker.202307061329.gitfa850531\",\"dummy.202307061329.gitfa850531\",\"ambari-2.6.2.2.202307061329.gitfa850531\",\"ambari-2.6.0.0.202307061329.gitfa850531\",\"ambari-2.7.3.0.202307061329.gitfa850531\",\"ambari-2.6.1.5.202307061329.gitfa850531\",\"arenadata.202307061329.gitfa850531\",\"insight.202307061329.gitfa850531\",\"Redis-5--1.13.20-alma-2023-07-10_11-56-45\",\"sentry-ubuntu-image.202302171243.gitc139c388\",\"Opensearch-2-alma-2023-07-07_10-03-35\",\"almalinux-9-v1.24.15.202307061058.gitbd4f1108.dev\",\"packer_build_DockerRegistry_202307041530\",\"packer_build_DockerRegistry_202307041530\",\"insight.202307041025.git28894395\",\"dummy.202307041025.git28894395\",\"arenadata-worker.202307041025.git28894395\",\"arenadata.202307041025.git28894395\",\"packer_build_DockerRegistry_202307031840\",\"packer_build_JH_GPU_202307031400\",\"packer_build_JH_GPU_202306301300\",\"sentry-ubuntu-image.202302171243.gitc139c388\",\"Redis-6.2-alma-2023-06-23_01-09-25\",\"PostgreSQL-14--1.13.19-alma-2023-06-22_10-41-01\",\"PostgreSQL-12--1.13.19-alma-2023-06-22_10-40-54\",\"PostgreSQL-13--1.13.19-alma-2023-06-22_10-40-57\",\"PostgreSQL-11--1.13.19-alma-2023-06-22_10-40-46\",\"PostgreSQL-10--1.13.19-alma-2023-06-22_10-34-25\",\"PostgresProEnterprise-11--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-12--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-12--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-13--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-11--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-12--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-13--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-11--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-10--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-13--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-10--1.13.19--2023-06-22_10-34-25\",\"GaleraMySQL-v5dot7--1.13.19-alma-2023-06-22_10-18-20\",\"Clickhouse-22--1.13.19-alma-2023-06-22_10-18-20\",\"GaleraMySQL-v8dot0--1.13.19-alma-2023-06-22_10-18-20\",\"Clickhouse-21--1.13.19-alma-2023-06-22_10-18-20\",\"MySQL-v5dot7--1.13.19-alma-2023-06-22_10-18-20\",\"MySQL-v8dot0--1.13.19-alma-2023-06-22_10-18-20\",\"MongoDB-v4dot0--1.13.19-alma-2023-06-22_10-18-20\",\"Redis-5--1.13.19-alma-2023-06-22_10-18-20\",\"Tarantool-v2dot10--1.13.19--2023-06-22_10-18-20\",\"Clickhouse-20--1.13.19--2023-06-22_10-18-20\",\"packer_build_DockerRegistry_202306220930\",\"GaleraMySQL-v8dot0--1.13.19-alma-2023-06-20_05-32-04\",\"MySQL-v5dot7--1.13.19-alma-2023-06-20_05-32-04\",\"GaleraMySQL-v5dot7--1.13.19-alma-2023-06-20_05-32-04\",\"MySQL-v8dot0--1.13.19-alma-2023-06-20_05-32-04\",\"MongoDB-v4dot0--1.13.19-alma-2023-06-20_05-32-04\",\"Clickhouse-21--1.13.19-alma-2023-06-20_05-32-04\",\"Redis-5--1.13.19-alma-2023-06-20_05-32-04\",\"Clickhouse-22--1.13.19-alma-2023-06-20_05-32-04\",\"Tarantool-v2dot10--1.13.19--2023-06-20_05-32-04\",\"Clickhouse-20--1.13.19--2023-06-20_05-32-04\",\"PostgreSQL-13--1.13.19-alma-2023-06-20_04-05-33\",\"PostgreSQL-14--1.13.19-alma-2023-06-20_04-05-35\",\"PostgreSQL-12--1.13.19-alma-2023-06-20_04-05-26\",\"PostgreSQL-11--1.13.19-alma-2023-06-20_04-05-16\",\"PostgreSQL-10--1.13.19-alma-2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-14--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-13--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-12--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-10--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-14--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-13--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-13--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-14--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-12--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-12--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-10--1.13.19--2023-06-20_03-58-54\",\"packer_build_DockerRegistry_202306201730\",\"almalinux-9-v1.24.15.202306161245.git70b9ece9.dev\",\"almalinux-9-v1.24.15.202306161245.git70b9ece9.dev\",\"almalinux-9-v1.24.15.202306161128.git9e203649.dev\",\"almalinux-9-v1.24.9.202306160754.git7100ceab\",\"almalinux-9-v1.25.6.202306160754.git7100ceab\",\"almalinux-9-v1.23.13.202306160754.git7100ceab\",\"PostgreSQL-14--1.13.18-alma-2023-06-15_11-39-09\",\"PostgreSQL-13--1.13.18-alma-2023-06-15_11-38-58\",\"PostgreSQL-12--1.13.18-alma-2023-06-15_11-38-22\",\"PostgreSQL-11--1.13.18-alma-2023-06-15_11-38-10\",\"Redis-5--1.13.18-alma-2023-06-15_11-39-24\",\"Tarantool-v2dot10--1.13.18--2023-06-15_11-39-28\",\"PostgreSQL-10--1.13.18-alma-2023-06-15_11-35-46\",\"PostgresProEnterprise-1C-14--1.13.18--2023-06-15_11-35-45\",\"PostgresProEnterprise-1C-13--1.13.18--2023-06-15_11-35-23\",\"PostgresProEnterprise-1C-12--1.13.18--2023-06-15_11-33-27\",\"PostgresProEnterprise-14--1.13.18--2023-06-15_11-33-02\",\"PostgresProEnterprise-11--1.13.18--2023-06-15_11-31-38\",\"PostgresProEnterprise-1C-11--1.13.18--2023-06-15_11-33-19\",\"PostgresProEnterprise-1C-10--1.13.18--2023-06-15_11-33-11\",\"PostgresProEnterprise-12--1.13.18--2023-06-15_11-32-21\",\"PostgresProEnterprise-13--1.13.18--2023-06-15_11-32-25\",\"PostgresPro-14--1.13.18--2023-06-15_11-29-07\",\"PostgresPro-13--1.13.18--2023-06-15_11-29-01\",\"PostgresProEnterprise-10--1.13.18--2023-06-15_11-29-37\",\"MySQL-v5dot7--1.13.18-alma-2023-06-15_11-22-39\",\"Clickhouse-22--1.13.18-alma-2023-06-15_11-22-39\",\"GaleraMySQL-v5dot7--1.13.18-alma-2023-06-15_11-22-39\",\"GaleraMySQL-v8dot0--1.13.18-alma-2023-06-15_11-22-40\",\"MySQL-v8dot0--1.13.18-alma-2023-06-15_11-22-39\",\"Clickhouse-21--1.13.18-alma-2023-06-15_11-22-39\",\"MongoDB-v4dot0--1.13.18-alma-2023-06-15_11-22-39\",\"PostgresPro-11--1.13.18--2023-06-15_11-22-39\",\"Clickhouse-20--1.13.18--2023-06-15_11-22-39\",\"PostgresPro-12--1.13.18--2023-06-15_11-22-39\",\"almalinux-9-v1.23.13.202306150626.git979882fb.dev\",\"almalinux-9-v1.24.9.202306131126.git9a224bb2\",\"almalinux-9-v1.23.13.202306141433.git9507844c.dev\",\"almalinux-9-v1.23.13.202306140817.git060526f4.dev\",\"almalinux-9-v1.23.13.202306131315.git0a29dd8b.dev\",\"packer_build_DockerRegistry_202306131600\",\"almalinux-9-v1.24.9.202306131126.git9a224bb2\",\"almalinux-9-v1.24.9.202306131136.gita01e3422.dev\",\"Tarantool-v2dot10--1.13.17--2023-06-06_04-42-18\",\"Redis-5--1.13.17-alma-2023-06-06_04-41-02\",\"MongoDB-v4dot0--1.13.17-alma-2023-06-06_04-05-14\",\"Clickhouse-21--1.13.17-alma-2023-06-06_03-30-49\",\"Clickhouse-22--1.13.17-alma-2023-06-06_03-30-49\",\"Clickhouse-20--1.13.17--2023-06-06_03-30-49\",\"GaleraMySQL-v8dot0--1.13.17-alma-2023-06-06_03-16-37\",\"MySQL-v5dot7--1.13.17-alma-2023-06-06_03-16-37\",\"MySQL-v8dot0--1.13.17-alma-2023-06-06_03-16-37\",\"GaleraMySQL-v5dot7--1.13.17-alma-2023-06-06_03-16-37\",\"PostgreSQL-14--1.13.17-alma-2023-06-06_02-56-35\",\"PostgreSQL-13--1.13.17-alma-2023-06-06_02-56-30\",\"PostgreSQL-11--1.13.17-alma-2023-06-06_02-56-15\",\"PostgreSQL-12--1.13.17-alma-2023-06-06_02-56-28\",\"PostgreSQL-10--1.13.17-alma-2023-06-06_02-50-19\",\"PostgresPro-13--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-11--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-11--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-14--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-14--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-10--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-13--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-10--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-13--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-11--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-14--1.13.17--2023-06-06_02-50-19\",\"PostgreSQL-14--1.13.17-alma-2023-06-02_11-27-15\",\"packer_build_DockerRegistry_202306011600\",\"Clickhouse-22--1.13.16-alma-2023-06-01_05-51-30\",\"Clickhouse-21--1.13.16-alma-2023-06-01_05-51-30\",\"Clickhouse-20--1.13.16--2023-06-01_05-51-30\",\"packer_build_JH_GPU_202305261400\",\"almalinux-9-v1.25.10.202305260852.git8a4be3bf.dev\",\"astra-or-1.7-vdi-202305251407.git06ac0d14\",\"almalinux-9-v1.24.9.202305220831.git5ea06013\",\"almalinux-9-v1.23.13.202305220831.git5ea06013\",\"almalinux-9-v1.23.13.202305170935.git6e2d8563\",\"almalinux-9-v1.24.9.202305170935.git6e2d8563\",\"opensuse-leap-15.4-202305101900.gitc6492fe3\",\"packer_build_k8sController_202304281700\",\"almalinux-9-v1.23.13.202304280932.git458ee2d5\",\"almalinux-9-v1.24.9.202304280932.git458ee2d5\",\"Opensearch-2-alma-2023-04-27_12-17-15\",\"kafka-almalinux-91.202304241302.gitcf252bf1\",\"packer_build_JH_GPU_202304211630\",\"FreeBSD-13.2\",\"Opensearch-2-alma-2023-04-19_09-11-38\",\"almalinux-9-v1.24.9.202304141500.git963625d0\",\"packer_build_JH_GPU_202304171730\",\"packer_build_k8sController_202304071200\",\"kafka-almalinux-91.202304131114.git39b98629\",\"kafka-almalinux-91.202304122007.gitbf42ef2f\",\"PostgresPro-14--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-12--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-11--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-13--1.13.15--2023-04-11_07-41-27\",\"packer_build_DockerRegistry_202304101300\",\"packer_build_k8sController_202304071200\",\"packer_build_DeployServer_202304071200\",\"packer_build_MLFLOW_202304071200\",\"packer_build_JH_GPU_202304071200\",\"packer_build_DockerRegistry_202304070930\",\"almalinux-9-v1.24.9.202304051306.git3f549049\",\"almalinux-9-v1.23.13.202304051306.git3f549049\",\"ambari-2.6.0.0.202304050621.git525510fa.dev\",\"ambari-2.6.0.0.202303291357.git788748f9.dev\",\"packer_build_JH_GPU_202303311700\",\"packer_build_k8sController_202303311700\",\"packer_build_MLFLOW_202303311700\",\"packer_build_DeployServer_202303311700\",\"MySQL-v8dot0--1.13.15-alma-2023-03-30_07-46-47\",\"GaleraMySQL-v5dot7--1.13.15-alma-2023-03-30_07-46-47\",\"MySQL-v5dot7--1.13.15-alma-2023-03-30_07-46-47\",\"GaleraMySQL-v8dot0--1.13.15-alma-2023-03-30_07-46-47\",\"almalinux-9-v1.24.9.202303290731.git4a42b46b\",\"almalinux-9-v1.23.13.202303290731.git4a42b46b\",\"PostgreSQL-14--1.13.15-alma-2023-03-28_05-13-04\",\"Tarantool-v2dot10--1.13.15--2023-03-28_05-09-14\",\"PostgresProEnterprise-1C-11--1.13.15--2023-03-28_04-55-32\",\"Redis-5--1.13.15-alma-2023-03-28_05-00-42\",\"PostgreSQL-13--1.13.15-alma-2023-03-28_04-54-41\",\"PostgreSQL-11--1.13.15-alma-2023-03-28_04-50-55\",\"PostgreSQL-12--1.13.15-alma-2023-03-28_04-55-18\",\"PostgreSQL-10--1.13.15-alma-2023-03-28_04-50-44\",\"PostgresProEnterprise-1C-13--1.13.15--2023-03-28_04-49-07\",\"PostgresProEnterprise-1C-10--1.13.15--2023-03-28_04-44-31\",\"PostgresProEnterprise-1C-14--1.13.15--2023-03-28_04-49-07\",\"PostgresProEnterprise-1C-12--1.13.15--2023-03-28_04-47-47\",\"PostgresProEnterprise-13--1.13.15--2023-03-28_04-42-28\",\"PostgresProEnterprise-12--1.13.15--2023-03-28_04-42-06\",\"PostgresProEnterprise-14--1.13.15--2023-03-28_04-42-29\",\"PostgresProEnterprise-11--1.13.15--2023-03-28_04-41-17\",\"PostgresProEnterprise-10--1.13.15--2023-03-28_04-40-23\",\"MongoDB-v4dot0--1.13.15-alma-2023-03-28_04-31-23\",\"ambari-2.6.0.0.202303271603.gitf193dda9.dev\",\"ambari-2.6.0.0.202303221424.git731b4606\",\"ambari-2.7.3.0.202303221424.git731b4606\",\"ambari-2.6.1.5.202303221424.git731b4606\",\"ambari-2.6.2.2.202303221424.git731b4606\",\"dummy.202303221424.git731b4606\",\"arenadata.202303221424.git731b4606\",\"insight.202303221424.git731b4606\",\"arenadata-worker.202303221424.git731b4606\",\"opensuse-leap-15.4-202303221516.git73f3582c\",\"FreeBSD-12.4\",\"FreeBSD-13.1\",\"Opensearch-2-alma-2023-03-17_08-48-17\",\"Redis-6.2-alma-2023-03-17_08-38-36\",\"Mongodb-6-alma-2023-03-17_08-28-40\",\"packer_build_k8sController_v1.0\",\"packer_build_DeployServer_v1.03\",\"alse-vanilla-1.7.3uu1-vkcloud-adv-mg9.1.2\",\"alse-vanilla-1.7.3-vkcloud-base-mg8.2.1\",\"arenadata.202302221336.gite2334917.dev\",\"arenadata-worker.202302221336.gite2334917.dev\",\"Astra Linux SE 1.7.2 Orel GUI\",\"packer_build_JH_GPU_v1.15\",\"RO732_MIN-STD\",\"RO732_MIN-CRT\",\"sentry-ubuntu-image.202302170627.gita61ff2ac\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"almalinux-9-v1.24.9.202302130900.git6dc96b46.dev\",\"almalinux-9-v1.23.13.202302100713.gitf3a303d1.dev\",\"almalinux-9-v1.22.9.202302100713.gitf3a303d1.dev\",\"ambari-2.6.0.0.202302091536.git920581f5\",\"ambari-2.7.3.0.202302091536.git920581f5\",\"ambari-2.6.1.5.202302091536.git920581f5\",\"ambari-2.6.2.2.202302091536.git920581f5\",\"arenadata.202302091536.git920581f5\",\"arenadata-worker.202302091536.git920581f5\",\"dummy.202302091536.git920581f5\",\"insight.202302091536.git920581f5\",\"arenadata.202302091444.git57be9b4f.dev\",\"arenadata-worker.202302091444.git57be9b4f.dev\",\"arenadata.202302091325.git571ae37b.dev\",\"arenadata-worker.202302091325.git571ae37b.dev\",\"alt-server-8sp-cloud-rev1.3.1-20221229-x86_64\",\"alt-server-10-rev20230208-x86_64\",\"dummy.202302081032.gitd4a0bf97\",\"insight.202302081032.gitd4a0bf97\",\"ambari-2.6.1.5.202302081032.gitd4a0bf97\",\"ambari-2.7.3.0.202302081032.gitd4a0bf97\",\"ambari-2.6.0.0.202302081032.gitd4a0bf97\",\"ambari-2.6.2.2.202302081032.gitd4a0bf97\",\"arenadata.202302081032.gitd4a0bf97\",\"arenadata-worker.202302081032.gitd4a0bf97\",\"dummy.202302081005.gitdb228aba\",\"ambari-2.7.3.0.202302071225.git4a87ae24.dev\",\"ambari-2.7.3.0.202302071108.git195ec092.dev\",\"ambari-2.6.2.2.202302031433.git44cfeb96\",\"ambari-2.6.0.0.202302031433.git44cfeb96\",\"arenadata-worker.202302031433.git44cfeb96\",\"arenadata.202302031433.git44cfeb96\",\"ambari-2.6.1.5.202302031433.git44cfeb96\",\"ambari-2.7.3.0.202302031433.git44cfeb96\",\"insight.202302031433.git44cfeb96\",\"dummy.202302031433.git44cfeb96\",\"packer_build_MLFLOW_v2.1.4\",\"ARENADATA-4878524-2023-01-25-prod\",\"ARENADATA_WORKER-4878524-2023-01-25-prod\",\"packer_build_JH_GPU_v1.13\",\"packer_build_JH_GPU_v1.12\",\"packer_build_MLFLOW_v2.1.2\",\"packer_build_JH_GPU_v1.08\",\"packer_build_JH_GPU_v1.08\",\"sentry-0.1\",\"Opensearch-2-alma-2022-12-14_05-28-56\",\"Mongodb-6-alma-2022-12-14_04-46-21\",\"Redis-6.2-alma-2022-12-14_02-50-52\",\"Mongodb-6-alma-2022-12-12_08-53-51\",\"packer_build_DeployServer_v1.02\",\"Redis-6.2-alma-2022-11-28_01-16-09\",\"Opensearch2-almalinux8.202211250914.git4ce04292\",\"Windows-Server-2022StdCore-ru.202211\",\"packer_build_JH_GPU_v1.07\",\"packer_build_MLFLOW_v1.03\",\"Windows-Server-2022StdCore-en.202211\",\"Windows-Server-2019Std-en.202211\",\"Windows-Server-2019Std-ru.202211\",\"Windows-Server-2022Std-ru.202211\",\"Windows-Server-2022Std-en.202211\",\"Windows-Server-2019Std-en.202211\",\"Windows-Server-2016Std-en.202211\",\"Windows-Server-2016Std-ru.202211\",\"Opensearch2-almalinux8.202211221000.gitbdbfe30c.dev\",\"Windows-Server-2012R2Std-ru.202211\",\"Windows-Server-2012R2Std-en.202211\",\"packer_build_JH_GPU_v1.06\",\"packer_build_JH_GPU_v1.05\",\"AMBARI-2.6.0.0-4100884-2022-11-09-prod\",\"ARENADATA_WORKER-4100884-2022-11-09-prod\",\"DUMMY-4100884-2022-11-09-prod\",\"INSIGHT-4100884-2022-11-09-prod\",\"ARENADATA-4100884-2022-11-09-prod\",\"AMBARI-2.7.3.0-4100884-2022-11-09-prod\",\"AMBARI-2.6.2.2-4100884-2022-11-09-prod\",\"AMBARI-2.6.1.5-4100884-2022-11-09-prod\",\"Debian11.4\",\"almalinux-9-v1.23.13.202211021406.git84ce35f0.dev\",\"packer_build_MLFlow.202211031046.git2bf12643.dev\",\"packer_build_DeployServer_v1.01\",\"alse-vanilla-1.7.2-vkcloud-base-mg8.0.0\",\"Redis-6.2-alma-2022-10-18_08-46-37\",\"almalinux-9-v1.23.6.202210120842.git899594d6.dev\",\"almalinux-9-v1.22.9.202210120842.git899594d6.dev\",\"packer_build_DeployServer_v1.00\",\"Almalinux-9-v1.23.6-k8s-mcs-Oct- 7-12:40:46.021-\",\"Almalinux-8-v1.21.4-k8s-mcs-Oct- 7-12:24:32.429-\",\"Almalinux-9-v1.22.9-k8s-mcs-Oct- 7-12:24:35.201-\",\"packer_build_MLFLOW_v1.02\",\"packer_build_JH_GPU_v1.04\",\"packer_build_JH_GPU_v1.03\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-20-14:47:39.386-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-20-14:47:48.435-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-20-14:47:44.123-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-20-10:19:11.934-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-20-10:19:21.584-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-20-10:19:16.725-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-19-12:06:03.688-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-19-12:08:49.709-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-19-12:08:37.588-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-16-12:09:15.206-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-16-11:19:14.725-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-16-11:19:33.801-\",\"packer_build_JH_GPU_v1.02\",\"Clickhouse-22--1.13.3-alma-2022-09-13_12-36-08\",\"packer_build_MLFLOW_v1.01\",\"packer_build_JH_GPU_v1.01\",\"packer_build_JH_GPU_v1\",\"Ubuntu-20.04-Jupyterhub_GPU\",\"packer-build-Jupyterhub_v2.4\",\"ARENADATA-3342738-2022-08-17-prod\",\"DUMMY-3342738-2022-08-17-prod\",\"ARENADATA_WORKER-3342738-2022-08-17-prod\",\"AMBARI-2.7.3.0-3342738-2022-08-17-prod\",\"AMBARI-2.6.2.2-3342738-2022-08-17-prod\",\"AMBARI-2.6.1.5-3342738-2022-08-17-prod\",\"AMBARI-2.6.0.0-3342738-2022-08-17-prod\",\"Ubuntu-22.04-202208\",\"FreeBSD-13.1\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug-12-07:34:16.668-\",\"Almalinux-9-v1.22.9-k8s-mcs-Aug-12-07:33:57.593-\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug-11-17:13:26.539-\",\"Almalinux-9-v1.22.9-k8s-mcs-Aug-11-17:12:55.631-\",\"Redis-6.2-alma-2022-08-11_02-34-29\",\"Almalinux-9-v1.23.6-k8s-mcs-\",\"Almalinux-9-v1.22.9-k8s-mcs-\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug- 2-09:38:33.516-ea91ada\",\"Ubuntu-20.04-Mlflow\",\"Almalinux-9-v1.23.6-k8s-mcs-Jul-27-16:34:28.117-ea91ada\",\"Ubuntu-20.04-Jupyterhub_v3\",\"Almalinux-9-v1.23.6-mcs.5\",\"Almalinux-9-v1.22.9-mcs.2\",\"Ubuntu-18.04-Jupyterhub\",\"Almalinux-8-v1.21.4-mcs.10\",\"Almalinux-9-v1.22.9-mcs.1\",\"Clickhouse-21--1.12.24-alma-2022-06-21_04-18-28\",\"Almalinux-9-v1.22.9-mcs.1\",\"DUMMY-2905445-2022-06-08-prod\",\"ADB-2905121-2022-06-07-prod\",\"ADB_WORKER-2905121-2022-06-07-prod\",\"AHDP-2905121-2022-06-07-prod\",\"AMBARI-2.6.0.0-2905121-2022-06-07-prod\",\"DUMMY-2905121-2022-06-07-prod\",\"AHDP_WORKER-2905121-2022-06-07-prod\",\"AMBARI-2.7.3.0-2905121-2022-06-07-prod\",\"AMBARI-2.6.2.2-2905121-2022-06-07-prod\",\"AMBARI-2.6.1.5-2905121-2022-06-07-prod\",\"AlmaLinux-9\",\"AMBARI-2.6.2.2-2894775-2022-06-06-prod\",\"AMBARI-2.6.1.5-2894775-2022-06-06-prod\",\"AMBARI-2.6.0.0-2894775-2022-06-06-prod\",\"DUMMY-2887737-2022-06-03-prod\",\"AHDP-2887737-2022-06-03-prod\",\"ADB-2887737-2022-06-03-prod\",\"AHDP_WORKER-2887737-2022-06-03-prod\",\"ADB_WORKER-2887737-2022-06-03-prod\",\"AMBARI-2.7.3.0-2887737-2022-06-03-prod\",\"AMBARI-2.6.1.5-2887737-2022-06-03-prod\",\"AMBARI-2.6.2.2-2887737-2022-06-03-prod\",\"ADB-2885008-2022-06-02-prod\",\"AHDP_WORKER-2885008-2022-06-02-prod\",\"AHDP-2885008-2022-06-02-prod\",\"AMBARI-2.7.3.0-2885008-2022-06-02-prod\",\"ADB_WORKER-2885008-2022-06-02-prod\",\"AMBARI-2.6.0.0-2885008-2022-06-02-prod\",\"AMBARI-2.6.1.5-2885008-2022-06-02-prod\",\"AMBARI-2.6.2.2-2885008-2022-06-02-prod\",\"DUMMY-2882108-2022-06-02-prod\",\"ADB-2882108-2022-06-02-prod\",\"AHDP_WORKER-2882108-2022-06-02-prod\",\"AHDP-2882108-2022-06-02-prod\",\"AMBARI-2.7.3.0-2882108-2022-06-02-prod\",\"ADB_WORKER-2882108-2022-06-02-prod\",\"AMBARI-2.6.1.5-2882108-2022-06-02-prod\",\"AMBARI-2.6.2.2-2882108-2022-06-02-prod\",\"AMBARI-2.6.0.0-2882108-2022-06-02-prod\",\"ADB-2872302-2022-05-31-prod\",\"DUMMY-2872302-2022-05-31-prod\",\"AHDP-2872302-2022-05-31-prod\",\"AHDP_WORKER-2872302-2022-05-31-prod\",\"AMBARI-2.7.3.0-2872302-2022-05-31-prod\",\"ADB_WORKER-2872302-2022-05-31-prod\",\"AMBARI-2.6.2.2-2872302-2022-05-31-prod\",\"AMBARI-2.6.1.5-2872302-2022-05-31-prod\",\"AMBARI-2.7.3.0-2803098-2022-05-19-prod\",\"AMBARI-2.6.2.2-2803098-2022-05-19-prod\",\"AMBARI-2.6.1.5-2803098-2022-05-19-prod\",\"AMBARI-2.6.0.0-2803098-2022-05-19-prod\",\"DUMMY-2803098-2022-05-18-prod\",\"AHDP-2803098-ADCM-v2021.06.17.06-2022-05-18-prod\",\"AHDP_WORKER-2803098-2022-05-18-prod\",\"ADB-2803098-ADCM-v2021.06.17.06-2022-05-18-prod\",\"ADB_WORKER-2803098-2022-05-18-prod\",\"AHDP-2798959-ADCM-v2021.06.17.06-2022-05-18-prod\",\"ADB_WORKER-2798959-2022-05-18-prod\",\"ADB-2798959-ADCM-v2021.06.17.06-2022-05-18-prod\",\"AHDP_WORKER-2798959-2022-05-18-prod\",\"DUMMY-2798959-2022-05-18-prod\",\"AMBARI-2.6.2.2-2798959-2022-05-18-prod\",\"AMBARI-2.7.3.0-2798959-2022-05-18-prod\",\"AMBARI-2.6.1.5-2798959-2022-05-18-prod\",\"AMBARI-2.6.0.0-2798959-2022-05-18-prod\",\"GaleraMySQL-v5dot6--1.12.23--2022-04-29_02-40-08\",\"Almalinux-8-v1.22.6-mcs.8\",\"Tarantool-v2--1.12.23--2022-04-27_12-21-37\",\"MySQL-v5dot6--1.12.23--2022-04-27_12-13-07\",\"Clickhouse-19--1.12.23--2022-04-27_12-10-52\",\"GaleraMySQL-v5dot6--1.12.23--2022-04-27_12-11-22\",\"DUMMY-2703259-2022-04-20-prod\",\"AHDP-2703259-ADCM-v2021.06.17.06-2022-04-20-prod\",\"ADB-2703259-ADCM-v2021.06.17.06-2022-04-20-prod\",\"AMBARI-2.7.3.0-2703259-2022-04-20-prod\",\"AMBARI-2.6.1.5-2703259-2022-04-20-prod\",\"AMBARI-2.6.2.2-2703259-2022-04-20-prod\",\"AMBARI-2.6.0.0-2703259-2022-04-20-prod\",\"DUMMY-2645251-2022-04-12-prod\",\"AHDP-2645251-ADCM-v2021.06.17.06-2022-04-12-prod\",\"ADB-2645251-ADCM-v2021.06.17.06-2022-04-12-prod\",\"AMBARI-2.6.2.2-2645251-2022-04-12-prod\",\"AMBARI-2.7.3.0-2645251-2022-04-12-prod\",\"AMBARI-2.6.1.5-2645251-2022-04-12-prod\",\"AMBARI-2.6.0.0-2645251-2022-04-12-prod\",\"DUMMY-2640176-2022-04-11-prod\",\"ADB-2640176-ADCM-v2021.06.17.06-2022-04-11-prod\",\"AHDP-2640176-ADCM-v2021.06.17.06-2022-04-11-prod\",\"AMBARI-2.7.3.0-2640176-2022-04-11-prod\",\"AMBARI-2.6.1.5-2640176-2022-04-11-prod\",\"AMBARI-2.6.0.0-2640176-2022-04-11-prod\",\"AMBARI-2.6.2.2-2640176-2022-04-11-prod\",\"PostgreSQL-v9dot6--1.12.20--2022-03-11_12-28-55\",\"Almalinux-8-v1.22.6-mcs.5\",\"Almalinux-8-v1.21.4-mcs.9\",\"AMBARI-2.7.3.0-2434969-2022-03-04-prod\",\"ADB-2434969-ADCM-v2021.06.17.06-2022-03-04-prod\",\"ADB_WORKER-2434969-2022-03-04-prod\",\"Almalinux-8-v1.22.6-mcs.4\",\"PostgreSQL-v9dot6--1.12.20--2022-03-03_06-26-24\",\"Almalinux-8-v1.22.6-mcs.2\",\"Almalinux-8-v1.21.4-mcs.4\",\"Almalinux-8-v1.21.4-mcs.3\",\"Greenplum-oasis-2022-02-02-prod\",\"ADB-ADCM-v2021.06.17.06-2022-02-02-prod\",\"AlmaLinux-8.5\",\"centos7-sahara-ambari-2.7.3.0-2022-01-14-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-12-16-prod.raw\",\"Ubuntu-18.04-Marketplace-OpenJDK-v2\",\"Ubuntu-18.04-Marketplace-Basic-v2\",\"Windows-Server-2022StdCore-en.202111\",\"Windows-Server-2022StdCore-ru.202111\",\"Windows-Server-2022Std-ru.202111\",\"Windows-Server-2022Std-en.202111\",\"centos7-sahara-ambari-2.7.3.0-2021-11-08-prod.raw\",\"ADCM-v2021.06.17.06-2021-11-08-prod\",\"Greenplum-oasis-2021-11-08-prod\",\"Ahdp-adcm-v2021.06.17.06-2021-10-25-prod\",\"ahdp-2021-10-25-prod\",\"Centos-8-v1.20.4-mcs.9\",\"centos7-sahara-ambari-2.7.3.0-2021-09-29-prod.raw\",\"Greenplum-oasis-2021-09-19-prod\",\"ADCM-v2021.06.17.06-2021-09-18-prod\",\"Centos-8-v1.19.4-mcs.9\",\"Centos-8-v1.18.12-mcs.8\",\"Centos-8-v1.17.8-mcs.7\",\"centos7-sahara-ambari-2.7.3.0-2021-08-19-prod.raw\",\"ahdp-2021-08-19-prod\",\"Ahdp-adcm-v2021.06.17.06-2021-08-19-prod\",\"centos7-sahara-ambari-2.7.3.0-2021-07-30-prod.raw\",\"ADCM-v2021.06.17.06-2021-07-30-prod\",\"Greenplum-oasis-2021-07-30-prod\",\"Ahdp-adcm-v2020081011-2021-07-19-prod\",\"ahdp-2021-07-19-prod\",\"Greenplum-oasis-2021-07-15-prod\",\"ADCM-v2020081011-2021-07-15-prod\",\"CentOS-8.4-202107\",\"Greenplum-oasis-2021-07-08-prod\",\"ADCM-v2020081011-2021-07-08-prod\",\"CentOS-7.9-202107\",\"centos7-sahara-ambari-2.7.3.0-2021-07-01-prod.raw\",\"Greenplum-oasis-2021-06-25-prod\",\"centos7-sahara-ambari-2.6.1.5-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-25-prod.raw\",\"ADCM-v2020081011-2021-06-25-prod\",\"centos7-sahara-ambari-2.7.3.0-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-25-prod.raw\",\"ahdp-2021-06-25-prod\",\"Ahdp-adcm-v2020081011-2021-06-25-prod\",\"Greenplum-oasis_enterprise-2021-06-25-prod\",\"Greenplum-oasis-2021-06-25-prod\",\"Greenplum-oasis-2021-06-25-prod\",\"ADCM-enterprise-v2020081011-2021-06-25-prod\",\"ADCM-v2020081011-2021-06-25-prod\",\"ADCM-v2020081011-2021-06-25-prod\",\"Windows-Server-2019-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2019-SERVERSTANDARD-en-US.202106\",\"Windows-Server-2016-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2016-SERVERSTANDARD-en-US.202106\",\"Windows-Server-2012-R2-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2012-R2-SERVERSTANDARD-en-US.202106\",\"centos7-sahara-ambari-2.7.3.0-2021-06-16-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-15-prod.raw\",\"ADCM-v2020081011-2021-06-15-prod\",\"ADCM-v2020081011-2021-06-15-prod\",\"Greenplum-oasis_enterprise-2021-06-15-prod\",\"Greenplum-oasis-2021-06-15-prod\",\"ADCM-enterprise-v2020081011-2021-06-15-prod\",\"Greenplum-oasis-2021-06-15-prod\",\"Ahdp-adcm-v2020081011-2021-06-11-prod\",\"ahdp-2021-06-11-prod\",\"Ahdp-adcm-v2020081011-2021-06-01-prod\",\"ahdp-2021-06-01-prod\",\"ADCM-enterprise-v2020081011-2021-06-01-prod\",\"ADCM-v2020081011-2021-06-01-prod\",\"Greenplum-oasis_enterprise-2021-06-01-prod\",\"Greenplum-oasis-2021-06-01-prod\",\"ADCM-v2020081011-2021-06-01-prod\",\"Greenplum-oasis-2021-06-01-prod\",\"centos7-sahara-ambari-2.6.1.5-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-01-prod.raw\",\"Windows-Server-2019Std-ru.202105\",\"Windows-Server-2019Std-en.202105\",\"Windows-Server-2016Std-ru.202105\",\"Windows-Server-2016Std-en.202105\",\"Windows-Server-2012R2Std-ru.202105\",\"Windows-Server-2012R2Std-en.202105\",\"Clickhouse-20-2021-05-14_11-54-46\",\"Windows-Server-2019Std-ru.202104\",\"Windows-Server-2019Std-en.202104\",\"Windows-Server-2016Std-ru.202104\",\"Windows-Server-2016Std-en.202104\",\"Windows-Server-2012R2Std-ru.202104\",\"Windows-Server-2012R2Std-en.202104\",\"centos7-sahara-ambari-2.7.3.0-2021-03-03-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-03-03-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-03-03-prod.raw\",\"ADCM-v2020081011-2021-02-18-prod\",\"Greenplum-oasis-2021-02-18-prod\",\"Centos-8-v1.16.4-mcs.6\",\"centos7-sahara-ambari-2.6.0.0-2021-01-18-prod\",\"Windows-Server-2019Std-ru.202012\",\"Windows-Server-2019Std-en.202012\",\"Windows-Server-2016Std-ru.202012\",\"Windows-Server-2016Std-en.202012\",\"Windows-Server-2012R2Std-ru.202012\",\"Windows-Server-2012R2Std-en.202012\",\"centos7-sahara-ambari-2.7.3.0-2020-12-22-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2020-12-22-prod.raw\",\"Greenplum-default-2020-12-22-prod\",\"ADCM-v2020062514-2020-12-22-prod\",\"centos7-sahara-ambari-2.6.1.5-2020-12-17-prod\",\"Windows-Server-2019Std-ru.202011\",\"Windows-Server-2019Std-en.202011\",\"Windows-Server-2016Std-ru.202011\",\"Windows-Server-2016Std-en.202011\",\"Windows-Server-2012R2Std-ru.202011\",\"Windows-Server-2012R2Std-en.202011\",\"centos7-sahara-ambari-2.7.3.0-2020-09-30-prod\",\"Greenplum-default-2020-09-30-prod\",\"ADCM-v2020062514-2020-09-30-prod\",\"Ubuntu-20.04.1-202008\",\"Windows-Server-2016Std-ru.202006\",\"Windows-Server-2016Std-en.202006\",\"Windows-Server-2012R2Std-ru.202006\",\"Windows-Server-2012R2Std-en.202006\",\"Windows-Server-2019Std-ru.202006\",\"Windows-Server-2019Std-en.202006\",\"Fedora-Atomic-28-v1.14.6-mcs.2\",\"Fedora-Atomic-28-v1.15.3-mcs.2\",\"Debian-10.1-202004\",\"CentOS-8.1-202004\",\"Fedora-Atomic-28-v1.15.3-mcs.1\",\"Fedora-Atomic-28-v1.16.4-mcs.1\",\"Windows-Server-2019-SERVERDATACENTER-en-US.202003\",\"Windows-Server-2016-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2019-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2016-SERVERDATACENTER-en-US.202003\",\"Windows-Server-2012-R2-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2012-R2-SERVERDATACENTER-en-US.202003\",\"Ubuntu-19.10-202003\",\"Ubuntu-19.10-202003\",\"CentOS-8.1-202003\",\"Ubuntu-18.04-202003\",\"CentOS-7.7-202003\",\"Ubuntu-16.04-202003\",\"Fedora-Atomic-28-v1.16.4-mcs.1\",\"CentOS-8.0-201910\",\"CentOS-7.7-201910\",\"Ubuntu-19.04-201910\",\"Ubuntu-16.04-201910\",\"Ubuntu-18.04-201910\",\"Debian-10.1-201910\",\"Fedora-Atomic-28-v1.15.3-mcs.1\",\"Fedora-Atomic-28-v1.14.6-mcs.1\",\"MongoDB-4.0\",\"Fedora-Atomic-28-v1.14.4-mcs.2\",\"Fedora-Atomic-28-v1.14.4-mcs.1\",\"Fedora-Atomic-28-v1.13.3-mcs.1\",\"Fedora-Atomic-28-v1.11.5-mcs.3\",\"Fedora-Atomic-28-v1.13.3-mcs.1\",\"CentOS-7.6-201903\",\"Ubuntu-16.04-Standard\",\"Fedora-Atomic-28-v1.11.5-mcs.1\",\"Fedora-Atomic-28-v1.12.3-mcs.1\",\"Fedora-Atomic-28-v1.10.11-mcs.1\",\"Debian-9.4.201812\",\"Ubuntu-18.04-Marketplace-OpenJDK\",\"Ubuntu-18.04-Marketplace-Basic\",\"Ubuntu-18.04-Standard\",\"Ubuntu-18.04-MachineLearning\",\"Bitrix-CentOS7.5-installation\",\"CentOS-7.5-Standard\",\"Bitrix-CentOS7.5-installation.2405\",\"openSUSE-42.3-Standard\",\"CentOS-7.4-Standard\",\"FreeBSD-10.3\"],\"mainNetwork\":\"vk-prod\",\"zones\":[\"GZ1\",\"MS1\"],\"volumeTypes\":[{\"id\":\"e7886624-2d95-4175-b14a-d256d6961bd6\",\"name\":\"high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"3b22f0ca-8682-4c3e-ae95-aaa969823d06\",\"name\":\"ceph-ssd\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"f631a3ba-a98e-4954-b3a1-4028d5e5ae81\",\"name\":\"ceph-hdd\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"8d39c9db-0293-48c0-8d44-015a2f6788ff\",\"name\":\"ko1-high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"bf800b7c-9ae0-4cda-b9c5-fae283b3e9fd\",\"name\":\"dp1-high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"74101409-a462-4f03-872a-7de727a178b8\",\"name\":\"ko1-ssd\",\"description\":\"SSD for KO\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"eadd8860-f5a4-45e1-ae27-8c58094257e0\",\"name\":\"dp1-ssd\",\"description\":\"Fast iops on SSD in DP1\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"48372c05-c842-4f6e-89ca-09af3868b2c4\",\"name\":\"ssd\",\"description\":\"Fast iops on SSD\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"a75c3502-4de6-4876-a457-a6c4594c067a\",\"name\":\"ms1\",\"description\":\"Ceph storage in VarshavkaMs1 datacenter\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"ebf5922e-42af-4f97-8f23-716340290de2\",\"name\":\"dp1\",\"description\":\"Ceph storage in DataPro datacenter\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"a6e853c1-78ad-4c18-93f9-2bba317a1d13\",\"name\":\"ceph\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true}]}\n\n1 error occurred:\n\t* images shouldn't contain duplicates\n\n","queue":"main","task.id":"e4816561-4123-4d73-a081-f4eeb9b8df24","time":"2023-07-17T17:53:09Z","watchEvent":"Added"}
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Remove duplicates from images list in `cloud-data-discoverer`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
