### PR TITLE
[preflight-check] Checking the server hostname (#5072)

### DIFF
--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -12,17 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function check_hostname(){
-    local server_hostname=$(hostname -s)
-    bb-log-info "Check hostname: $server_hostname"
-    if hostname -s|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
-        bb-log-info "SUCCESS"
-        exit 0
-    fi
-    bb-log-error "FAIL Hostname '$server_hostname' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
-    exit 1
-}
-
-check_hostname
-exit $?
+if ! hostname -s|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
+  bb-log-error "FAIL Hostname '$(hostname -s)' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+  exit 1
+fi
 

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -15,7 +15,7 @@
 function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
-    local r='^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,1})$'
+    local r='^[a-z0-9]{1}[a-z0-9\-\.]{0,61}[a-z0-9]{1}$'
     if [[ $a =~ $r ]]; then
         bb-log-info "SUCCESS"
         exit 0

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -16,12 +16,12 @@ function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
     local r='^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,1})$'
-    [[ $a =~ $r ]]
-    if [ $? -ne 0 ]; then
-        bb-log-error "Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
-        exit 1
+    if [[ $a =~ $r ]]; then
+        bb-log-info "SUCCESS"
+        exit 0
     fi
-    exit 0
+    bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+    exit 1
 }
 
 check_hostname

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -20,7 +20,7 @@ function check_hostname(){
     [[ $a =~ $r ]]
     if [ $? -ne 0 ]; then
         echo ' FAIL'
-        echo "Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+        bb-log-error "Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
         exit 1
     fi
     echo ' SUCCESS'

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 function check_hostname(){
-    local server_hostname=$(hostname)
+    local server_hostname=$(hostname -s)
     bb-log-info "Check hostname: $server_hostname"
-    if hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
+    if hostname -s|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
         bb-log-info "SUCCESS"
         exit 0
     fi

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -15,13 +15,13 @@
 function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
-    local r='^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$'
-    if [[ $a =~ $r ]]; then
-        bb-log-info "SUCCESS"
-        exit 0
+    hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$'
+    if [ $? -ne 0 ]; then
+        bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+        exit 1
     fi
-    bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
-    exit 1
+    bb-log-info "SUCCESS"
+    exit 0
 }
 
 check_hostname

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -13,17 +13,14 @@
 # limitations under the License.
 
 function check_hostname(){
-    echo -n "Check hostname: "
     local a=`hostname`
-    echo -n "$a"
+    bb-log-info "Check hostname: $a"
     local r='^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,1})$'
     [[ $a =~ $r ]]
     if [ $? -ne 0 ]; then
-        echo ' FAIL'
         bb-log-error "Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
         exit 1
     fi
-    echo ' SUCCESS'
     exit 0
 }
 

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -15,8 +15,7 @@
 function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
-    if hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1
-; then
+    if hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
         bb-log-info "SUCCESS"
         exit 0
     fi

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -15,7 +15,7 @@
 function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
-    local r='^[a-z0-9]{1}[a-z0-9\-\.]{0,61}[a-z0-9]{1}$'
+    local r='^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$'
     if [[ $a =~ $r ]]; then
         bb-log-info "SUCCESS"
         exit 0

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -15,13 +15,13 @@
 function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
-    hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
-        exit 1
+    if hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1
+; then
+        bb-log-info "SUCCESS"
+        exit 0
     fi
-    bb-log-info "SUCCESS"
-    exit 0
+    bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+    exit 1
 }
 
 check_hostname

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -1,0 +1,32 @@
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function check_hostname(){
+    echo -n "Check hostname: "
+    local a=`hostname`
+    echo -n "$a"
+    local r='^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,1})$'
+    [[ $a =~ $r ]]
+    if [ $? -ne 0 ]; then
+        echo ' FAIL'
+        echo "Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+        exit 1
+    fi
+    echo ' SUCCESS'
+    exit 0
+}
+
+check_hostname
+exit $?
+

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 function check_hostname(){
-    local a=`hostname`
-    bb-log-info "Check hostname: $a"
+    local server_hostname=$(hostname)
+    bb-log-info "Check hostname: $server_hostname"
     if hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
         bb-log-info "SUCCESS"
         exit 0
     fi
-    bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+    bb-log-error "FAIL Hostname '$server_hostname' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
     exit 1
 }
 

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -15,7 +15,7 @@
 function check_hostname(){
     local a=`hostname`
     bb-log-info "Check hostname: $a"
-    hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$'
+    hostname|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         bb-log-error "FAIL Hostname '$a' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
         exit 1


### PR DESCRIPTION
## Description
Checking the server hostname for compliance with Kubernetes and Deckhouse requirements
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
issue #5072 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Preventing failures before bootstrap execution
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Checking the server hostname for compliance with Kubernetes and Deckhouse requirements
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
