### PR TITLE
[external-modules-manager] Cleanup deleted modules

### DIFF
--- a/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
+++ b/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
@@ -71,11 +71,11 @@ func (m *Module) SetSource(source string) {
 	if source == "" {
 		source = "Embedded"
 	}
-	m.Labels["source-type"] = "embedded"
+	m.Labels["type"] = "embedded"
 
 	if source != "Embedded" {
 		source = "External: " + source
-		m.Labels["source-type"] = "external"
+		m.Labels["type"] = "external"
 	}
 
 	m.Properties.Source = source

--- a/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
+++ b/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
@@ -70,10 +70,12 @@ func (m *Module) SetWeight(weight int) {
 func (m *Module) SetSource(source string) {
 	if source == "" {
 		source = "Embedded"
+		m.Labels["source-type"] = "embedded"
 	}
 
 	if source != "Embedded" {
 		source = "External: " + source
+		m.Labels["source-type"] = "external"
 	}
 
 	m.Properties.Source = source

--- a/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
+++ b/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
@@ -70,8 +70,8 @@ func (m *Module) SetWeight(weight int) {
 func (m *Module) SetSource(source string) {
 	if source == "" {
 		source = "Embedded"
-		m.Labels["source-type"] = "embedded"
 	}
+	m.Labels["source-type"] = "embedded"
 
 	if source != "Embedded" {
 		source = "External: " + source

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -59,7 +59,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "check_deckhouse_release",
-			Crontab: "13 3 * * *",
+			Crontab: "*/1  * * *",
 		},
 	},
 }, cleanupReleases)
@@ -88,7 +88,7 @@ func cleanupReleases(input *go_hook.HookInput) error {
 		}
 	}
 
-	// for disabled/absent modules - delete all ExternalModuleRelease resources
+	// for absent modules - delete all ExternalModuleRelease resources
 	for moduleName, releases := range moduleReleases {
 		if enabledModules.Has(moduleName) {
 			continue
@@ -143,20 +143,7 @@ func filterDeprecatedRelease(obj *unstructured.Unstructured) (go_hook.FilterResu
 
 // returns only Disabled modules
 func filterExternalModule(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	state, found, err := unstructured.NestedString(obj.Object, "properties", "state")
-	if err != nil {
-		return "", err
-	}
-	if !found {
-		// if field is not set by any reason - return Module to avoid wrong deletion
-		return obj.GetName(), nil
-	}
-
-	if state == "Enabled" {
-		return obj.GetName(), nil
-	}
-
-	return nil, nil
+	return obj.GetName(), nil
 }
 
 type deprecatedRelease struct {

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -59,7 +59,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "check_deckhouse_release",
-			Crontab: "*/1  * * *",
+			Crontab: "13 3 * * *",
 		},
 	},
 }, cleanupReleases)

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -51,7 +51,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ExecuteHookOnEvents:          pointer.Bool(false),
 			ExecuteHookOnSynchronization: pointer.Bool(false),
 			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"source-type": "external"},
+				MatchLabels: map[string]string{"type": "external"},
 			},
 			FilterFunc: filterExternalModule,
 		},

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -59,14 +59,14 @@ kind: Module
 metadata:
   name: echoserver
   labels:
-    source-type: "external"
+    type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: hellow
   labels:
-    source-type: "external"
+    type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease
@@ -118,7 +118,7 @@ kind: Module
 metadata:
   name: testmodule
   labels:
-    source-type: "external"
+    type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -121,13 +121,6 @@ metadata:
     source-type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
-kind: Module
-metadata:
-  name: hellow
-  labels:
-    source-type: "external"
----
-apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease
 metadata:
   name: testmodule-v0.0.1
@@ -146,16 +139,6 @@ spec:
   version: 0.0.6
 status:
   phase: Deployed
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ExternalModuleRelease
-metadata:
-  name: hellow-v0.0.3
-spec:
-  moduleName: hellow
-  version: 0.0.3
-status:
-  phase: Deployed
 `)
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("13 3 * * *"))
@@ -168,10 +151,7 @@ status:
 			Expect(rele1.Exists()).To(BeFalse())
 
 			test1 := f.KubernetesGlobalResource("ExternalModuleRelease", "testmodule-v0.0.1")
-			Expect(test1.Exists()).To(BeFalse())
-
-			hel1 := f.KubernetesGlobalResource("ExternalModuleRelease", "hellow-v0.0.3")
-			Expect(hel1.Exists()).To(BeTrue())
+			Expect(test1.Exists()).To(BeTrue())
 		})
 	})
 })

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -119,8 +119,6 @@ metadata:
   name: testmodule
   labels:
     source-type: "external"
-properties:
-  state: Disabled
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module


### PR DESCRIPTION
## Description
Delete ExternalModuleReleases for absent modules

## Why do we need it, and what problem does it solve?
If an external module was deleted - we have to cleanup all it's releases

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: feature
summary: Cleanup ExternalModuleReleases for deleted external modules.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
