### PR TITLE
[cloud-provider-openstack] Fix migration from openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3 for bastion hosts

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
@@ -26,7 +26,8 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 )
 
-const TerraformStateDataKey = "node-tf-state.json"
+const TerraformNodeStateDataKey = "node-tf-state.json"
+const TerraformClusterStateDataKey = "cluster-tf-state.json"
 const TerraformStateNamespace = "d8-system"
 const OpenstackV2ResourceType = "openstack_blockstorage_volume_v2"
 const OpenstackV3ResourceType = "openstack_blockstorage_volume_v3"
@@ -41,23 +42,45 @@ func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Co
 		return fmt.Errorf("could not initialize Kubernetes client: %v", err)
 	}
 
-	terraformStateLabels := map[string]string{
+	terraformNodeStateLabels := map[string]string{
 		"node.deckhouse.io/terraform-state": "",
 	}
-
-	terraformStateSecrets, err := kubeCl.CoreV1().
-		Secrets(TerraformStateNamespace).
-		List(context.TODO(), metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(terraformStateLabels))})
-	if err != nil {
-		return fmt.Errorf("failed to get Terraform state secrets in namespace %s with labels %s. The migration process has been aborted", TerraformStateNamespace, terraformStateLabels)
+	terraformClusterStateLabels := map[string]string{
+		"name": "d8-cluster-terraform-state",
 	}
 
-	if terraformStateSecrets.Items == nil {
+	terraformNodeStateSecrets, err := kubeCl.CoreV1().
+		Secrets(TerraformStateNamespace).
+		List(context.TODO(), metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(terraformNodeStateLabels))})
+	if err != nil {
+		return fmt.Errorf("failed to get Terraform state secrets in namespace %s with labels %s. The migration process has been aborted", TerraformStateNamespace, terraformNodeStateLabels)
+	}
+	terraformClusterStateSecrets, err := kubeCl.CoreV1().
+		Secrets(TerraformStateNamespace).
+		List(context.TODO(), metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(terraformClusterStateLabels))})
+	if err != nil {
+		return fmt.Errorf("failed to get Terraform state secrets in namespace %s with labels %s. The migration process has been aborted", TerraformStateNamespace, terraformClusterStateLabels)
+	}
+
+	if terraformNodeStateSecrets.Items == nil && terraformClusterStateSecrets.Items == nil {
 		input.LogEntry.Infof("Terraform state not found. Migration is not needed.")
 		return nil
 	}
 
-	for _, secret := range terraformStateSecrets.Items {
+	err = processSecretsList(terraformNodeStateSecrets, TerraformNodeStateDataKey, kubeCl, input)
+	if err != nil {
+		return err
+	}
+	err = processSecretsList(terraformClusterStateSecrets, TerraformClusterStateDataKey, kubeCl, input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func processSecretsList(secretList *v1.SecretList, terraformStateDataKey string, kubeCl k8s.Client, input *go_hook.HookInput) error {
+	for _, secret := range secretList.Items {
 		input.LogEntry.Infof("Proceeding with Secret/%s/%s", TerraformStateNamespace, secret.ObjectMeta.Name)
 		backupSecretName := secret.ObjectMeta.Name + "-backup"
 
@@ -66,9 +89,9 @@ func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Co
 			input.LogEntry.Infof("Secret backup with name %s/%s already exists! Migration is not needed for Secret/%s/%s", TerraformStateNamespace, backupSecretName, TerraformStateNamespace, secret.ObjectMeta.Name)
 			continue
 		}
-		terraformStateRaw, ok := secret.Data[TerraformStateDataKey]
+		terraformStateRaw, ok := secret.Data[terraformStateDataKey]
 		if !ok {
-			return fmt.Errorf("key %s not found in Secret/%s/%s. ", TerraformStateDataKey, TerraformStateNamespace, secret.ObjectMeta.Name)
+			return fmt.Errorf("key %s not found in Secret/%s/%s. ", terraformStateDataKey, TerraformStateNamespace, secret.ObjectMeta.Name)
 		}
 
 		if !gjson.ValidBytes(terraformStateRaw) {
@@ -121,7 +144,7 @@ func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Co
 			return err
 		}
 
-		secret.Data[TerraformStateDataKey] = newTerraformState.Bytes()
+		secret.Data[terraformStateDataKey] = newTerraformState.Bytes()
 		_, err = kubeCl.CoreV1().
 			Secrets(TerraformStateNamespace).
 			Update(context.TODO(), &secret, metav1.UpdateOptions{})
@@ -129,7 +152,6 @@ func openstackTerraformStateMigration(input *go_hook.HookInput, dc dependency.Co
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -141,7 +163,7 @@ func isSecretBackupExists(backupSecretName string, namespace string, kubeCl k8s.
 	input.LogEntry.Debugf("Function isSecretBackupExists: Get secret. err=%s", err)
 
 	if errors.IsNotFound(err) {
-		input.LogEntry.Debugf("Function isSecretBackupExists: errors.IsNotFound(err) = %t. secret \"%s\" not found'. Return false and nil", errors.IsNotFound(err), backupSecretName)
+		input.LogEntry.Debugf("Function isSecretBackupExists: errors.IsNotFound(err) = %t. secret \"%s\" not found. Return false and nil", errors.IsNotFound(err), backupSecretName)
 		return false, nil
 	}
 

--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-func createTerraformStateSecret(secretName string, terraformState string, nodeGroup string, secretType string) error {
+func createTerraformStateSecret(secretName string, terraformStateDataKey string, terraformState string, nodeGroup string, secretType string) error {
 	var secretTemplate = `
 ---
 apiVersion: v1
@@ -43,7 +43,7 @@ type: Opaque
 	// terraformState := fmt.Sprintf(terraformState, nodeName)
 
 	secretYaml := fmt.Sprintf(secretTemplate,
-		TerraformStateDataKey, base64.StdEncoding.EncodeToString([]byte(terraformState)),
+		terraformStateDataKey, base64.StdEncoding.EncodeToString([]byte(terraformState)),
 		TestKey, base64.StdEncoding.EncodeToString([]byte(TestData)),
 		secretName, nodeGroup, secretType, secretName)
 
@@ -84,13 +84,13 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 
 	})
 
-	Context("Single master with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformStateDataKey+" contains old data", func() {
+	Context("Single master with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformNodeStateDataKey+" contains old data", func() {
 		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
 		nodeName := "master-0"
 
 		BeforeEach(func() {
 			f.KubeStateSet("")
-			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, oldTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
+			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, TerraformNodeStateDataKey, oldTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
 			Expect(err).To(BeNil())
 			f.BindingContexts.Set(f.GenerateOnStartupContext())
 			f.RunHook()
@@ -106,7 +106,7 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 				Get(context.TODO(), "d8-node-terraform-state-"+nodeName+"-backup", metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(secret.Data).NotTo(BeNil())
-			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TerraformNodeStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
 			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 		})
 
@@ -116,7 +116,7 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 				Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(secret.Data).NotTo(BeNil())
-			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TerraformNodeStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
 			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
@@ -130,9 +130,9 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 
 		BeforeEach(func() {
 			f.KubeStateSet("")
-			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, newTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
+			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, TerraformNodeStateDataKey, newTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
 			Expect(err).To(BeNil())
-			err = createTerraformStateSecret("d8-node-terraform-state-"+nodeName+"-backup", oldTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state-backup")
+			err = createTerraformStateSecret("d8-node-terraform-state-"+nodeName+"-backup", TerraformNodeStateDataKey, oldTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state-backup")
 			Expect(err).To(BeNil())
 			f.BindingContexts.Set(f.GenerateOnStartupContext())
 			f.RunHook()
@@ -148,7 +148,7 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 				Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(secret.Data).NotTo(BeNil())
-			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TerraformNodeStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
 			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 		})
 
@@ -157,13 +157,13 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 		})
 	})
 
-	Context("Single master with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformStateDataKey+" contains new data, no migration was done", func() {
+	Context("Single master with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformNodeStateDataKey+" contains new data, no migration was done", func() {
 		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
 		nodeName := "master-0"
 
 		BeforeEach(func() {
 			f.KubeStateSet("")
-			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, newTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
+			err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, TerraformNodeStateDataKey, newTerraformStateWithRootDiskSize, "master", "node.deckhouse.io/terraform-state")
 			Expect(err).To(BeNil())
 			f.BindingContexts.Set(f.GenerateOnStartupContext())
 			f.RunHook()
@@ -179,7 +179,7 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 				Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(secret.Data).NotTo(BeNil())
-			Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TerraformNodeStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
 			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 		})
 
@@ -196,7 +196,7 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 		})
 	})
 
-	Context("Multi master and other CloudPermanent nodes with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformStateDataKey+" contains old data", func() {
+	Context("Multi master and other CloudPermanent nodes with root size: Secret with terraform state exists in "+TerraformStateNamespace+" namespace, field "+TerraformNodeStateDataKey+" contains old data", func() {
 		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
 		nodeNames := []string{"master-0", "master-1", "master-2", "test-0", "front-0", "front-1"}
 		terraformStateBackupLabels := map[string]string{
@@ -206,9 +206,12 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 		BeforeEach(func() {
 			f.KubeStateSet("")
 			for _, nodeName := range nodeNames {
-				err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, oldTerraformStateWithRootDiskSize, strings.Split(nodeName, "-")[0], "node.deckhouse.io/terraform-state")
+				err := createTerraformStateSecret("d8-node-terraform-state-"+nodeName, TerraformNodeStateDataKey, oldTerraformStateWithRootDiskSize, strings.Split(nodeName, "-")[0], "node.deckhouse.io/terraform-state")
 				Expect(err).To(BeNil())
 			}
+
+			err := createTerraformStateSecret("d8-cluster-terraform-state", TerraformClusterStateDataKey, oldTerraformStateWithRootDiskSize, "d8-cluster-terraform-state", "test")
+			Expect(err).To(BeNil())
 
 			f.BindingContexts.Set(f.GenerateOnStartupContext())
 			f.RunHook()
@@ -225,15 +228,24 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 					Get(context.TODO(), "d8-node-terraform-state-"+nodeName+"-backup", metav1.GetOptions{})
 				Expect(err).To(BeNil())
 				Expect(secret.Data).NotTo(BeNil())
-				Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
+				Expect(secret.Data[TerraformNodeStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
 				Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 				Expect(secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]).To(BeEquivalentTo(strings.Split(nodeName, "-")[0]))
 			}
+
+			secret, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-cluster-terraform-state-backup", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(secret.Data).NotTo(BeNil())
+			Expect(secret.Data[TerraformClusterStateDataKey]).To(MatchJSON(oldTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+
 			terraformStateBackupSecrets, err := dependency.TestDC.K8sClient.CoreV1().
 				Secrets(TerraformStateNamespace).
 				List(context.TODO(), metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(metav1.SetAsLabelSelector(terraformStateBackupLabels))})
 			Expect(err).To(BeNil())
-			Expect(len(terraformStateBackupSecrets.Items)).To(BeEquivalentTo(6))
+			Expect(len(terraformStateBackupSecrets.Items)).To(BeEquivalentTo(7))
 		})
 
 		It("Hook should migrate Terraform state", func() {
@@ -243,12 +255,21 @@ var _ = Describe("Global :: migrate_terraform_state ::", func() {
 					Get(context.TODO(), "d8-node-terraform-state-"+nodeName, metav1.GetOptions{})
 				Expect(err).To(BeNil())
 				Expect(secret.Data).NotTo(BeNil())
-				Expect(secret.Data[TerraformStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+				Expect(secret.Data[TerraformNodeStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
 				Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
 				Expect(secret.ObjectMeta.Labels["node.deckhouse.io/node-group"]).To(BeEquivalentTo(strings.Split(nodeName, "-")[0]))
-				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
-				Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name master.", OpenstackV2ResourceType))
 			}
+
+			secret, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets(TerraformStateNamespace).
+				Get(context.TODO(), "d8-cluster-terraform-state", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(secret.Data).NotTo(BeNil())
+			Expect(secret.Data[TerraformClusterStateDataKey]).To(MatchJSON(newTerraformStateWithRootDiskSize))
+			Expect(secret.Data[TestKey]).To(BeEquivalentTo(TestData))
+
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name kubernetes_data.", OpenstackV2ResourceType))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Found resourceType = %s with name master.", OpenstackV2ResourceType))
 		})
 
 	})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix migration from openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3 for Bastion hosts by adding d8-cluster-terraform-state migration.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now, migration from openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3 does not work for bastion hosts whose state is located at d8-cluster-terraform-state. This PR fixed it.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Migration from openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3 did not work properly now.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Migration from openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3 worked for all resources.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Fix migration from `openstack_blockstorage_volume_v2` to `openstack_blockstorage_volume_v3` for bastion hosts.
impact_level: default
```
