### PR TITLE
[cloud-provider-openstack] Remove duplicates from additional security groups

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
@@ -243,7 +243,7 @@ func (d *Discoverer) getAdditionalNetworks(ctx context.Context, provider *gopher
 		networkNames = append(networkNames, network.Name)
 	}
 
-	return networkNames, nil
+	return removeDuplicates(networkNames), nil
 }
 
 func (d *Discoverer) getAdditionalSecurityGroups(ctx context.Context, provider *gophercloud.ProviderClient) ([]string, error) {
@@ -272,7 +272,7 @@ func (d *Discoverer) getAdditionalSecurityGroups(ctx context.Context, provider *
 		groupNames = append(groupNames, group.Name)
 	}
 
-	return groupNames, nil
+	return removeDuplicates(groupNames), nil
 }
 
 func (d *Discoverer) getImages(ctx context.Context, provider *gophercloud.ProviderClient) ([]string, error) {
@@ -371,6 +371,10 @@ func removeDuplicates(list []string) []string {
 	)
 
 	for _, elem := range list {
+		if elem == "" {
+			continue
+		}
+
 		if _, ok := keys[elem]; !ok {
 			keys[elem] = struct{}{}
 			uniqueList = append(uniqueList, elem)

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer_test.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer_test.go
@@ -16,6 +16,10 @@ func TestRemoveDuplicates(t *testing.T) {
 		want []string
 	}{
 		{
+			args: []string{"1", ""},
+			want: []string{"1"},
+		},
+		{
 			args: []string{"1", "1"},
 			want: []string{"1"},
 		},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove duplicates from additional security groups in cloud-data-discoverer.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deckhouse fails with error:

```
{"binding":"kubernetes","binding.name":"cloud_provider_discovery_data","event.id":"24e0e923-aead-460e-a7e5-5741351f676a","hook":"030-cloud-provider-openstack/hooks/discover.go","hook.type":"module","level":"error","module":"cloud-provider-openstack","msg":"Module hook failed, requeue task to retry after delay. Failed count is 238. Error: module hook '030-cloud-provider-openstack/hooks/discover.go' failed: failed to validate 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: Loading schema file: Document validation failed:\n---\n{\"apiVersion\":\"deckhouse.io/v1alpha1\",\"kind\":\"OpenStackCloudProviderDiscoveryData\",\"flavors\":[\"Standard-4-12\",\"Advanced-12-24\",\"Basic-1-2-40\",\"Basic-1-2-20\",\"Advanced-8-16-100\",\"Standard-6-24\",\"152-FZ-8-32\",\"Standard-2-2\",\"Advanced-8-8\",\"Advanced-16-64-50\",\"Standard-6-6\",\"Advanced-16-32-50\",\"Advanced-8-24\",\"Advanced-12-36\",\"Advanced-12-12\",\"Standard-6-12\",\"Advanced-8-32-50\",\"Basic-1-4-50\",\"Advanced-8-16-160\",\"Advanced-16-48\",\"Standard-2-6\",\"Standard-4-8-80\",\"Standard-6-18\",\"Advanced-16-16\",\"152-FZ-16-32\",\"Standard-2-4-50\",\"Standard-2-8-50\",\"152-FZ-16-64\",\"Standard-2-4-40\",\"Basic-1-1-10\",\"Standard-4-16-50\",\"Standard-4-4\",\"Advanced-12-48\"],\"additionalNetworks\":[\"JiraConfluence\",\"ext-net\",\"dev-kubernetes-cluster\",\"load.city.online\",\"sftp\",\"tech_load_network\",\"ResourcePlan\",\"ClickHouse7888\",\"vpn_int_network\",\"prod.city.online\",\"network_flant\",\"FOR-TEST-VM_network\",\"jira.city.online\",\"development_vpc_net\"],\"additionalSecurityGroups\":[\"tech_d8_egress\",\"ssh\",\"postgres-cluster\",\"in_http_8090_confluence\",\"ssh+www\",\"ssh+www\",\"tech_master\",\"tech_front\",\"tech_system\",\"tech_intercluster\",\"in_https_443\",\"in_http_80\",\"SecGroup_Postgre-Conflu_interconnectivity\",\"out_any_all\",\"SecGroup_Postgre-Conflu\",\"all\",\"sftp-server\",\"tech_inter_cloud\",\"in_RDP\",\"ssh_for_ResourcePlan_Local\",\"SecGroup_ClickHouse7888\",\"tech_ssh_access\",\"default\",\"tech_www\",\"ssh-www-jira\",\"vpn\",\"selenium\",\"rdp-group\",\"tech_bastion\",\"sftp-develop\",\"rPlan_Postgre_Interconnect\",\"tech_autotest\",\"tech_gitlab\",\"tech_back\",\"tech_openvpn\"],\"defaultImageName\":\"ubuntu-20-04-cloud-amd64\",\"images\":[\"ambari-2.7.3.0.202307171607.gitda4bd505\",\"ambari-2.6.1.5.202307171607.gitda4bd505\",\"insight.202307171607.gitda4bd505\",\"ambari-2.6.2.2.202307171607.gitda4bd505\",\"ambari-2.6.0.0.202307171607.gitda4bd505\",\"dummy.202307171607.gitda4bd505\",\"arenadata.202307171607.gitda4bd505\",\"arenadata-worker.202307171607.gitda4bd505\",\"Opensearch-2-alma-2023-07-17_09-32-39\",\"arenadata.202307170734.gite5f41108\",\"arenadata-worker.202307170734.gite5f41108\",\"packer_build_DockerRegistry.202307131020.git848cdadf\",\"almalinux-9-v1.26.5.202307120949.git8886ff53.dev\",\"Redis-5--1.13.20-alma-2023-07-12_09-42-05\",\"arenadata-worker.202307061329.gitfa850531\",\"dummy.202307061329.gitfa850531\",\"ambari-2.6.2.2.202307061329.gitfa850531\",\"ambari-2.6.0.0.202307061329.gitfa850531\",\"ambari-2.7.3.0.202307061329.gitfa850531\",\"ambari-2.6.1.5.202307061329.gitfa850531\",\"arenadata.202307061329.gitfa850531\",\"insight.202307061329.gitfa850531\",\"Redis-5--1.13.20-alma-2023-07-10_11-56-45\",\"sentry-ubuntu-image.202302171243.gitc139c388\",\"Opensearch-2-alma-2023-07-07_10-03-35\",\"almalinux-9-v1.24.15.202307061058.gitbd4f1108.dev\",\"packer_build_DockerRegistry_202307041530\",\"insight.202307041025.git28894395\",\"dummy.202307041025.git28894395\",\"arenadata-worker.202307041025.git28894395\",\"arenadata.202307041025.git28894395\",\"packer_build_DockerRegistry_202307031840\",\"packer_build_JH_GPU_202307031400\",\"packer_build_JH_GPU_202306301300\",\"Redis-6.2-alma-2023-06-23_01-09-25\",\"PostgreSQL-14--1.13.19-alma-2023-06-22_10-41-01\",\"PostgreSQL-12--1.13.19-alma-2023-06-22_10-40-54\",\"PostgreSQL-13--1.13.19-alma-2023-06-22_10-40-57\",\"PostgreSQL-11--1.13.19-alma-2023-06-22_10-40-46\",\"PostgreSQL-10--1.13.19-alma-2023-06-22_10-34-25\",\"PostgresProEnterprise-11--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-12--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-12--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-13--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-11--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-12--1.13.19--2023-06-22_10-34-25\",\"PostgresPro-13--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-11--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-10--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-13--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-14--1.13.19--2023-06-22_10-34-25\",\"PostgresProEnterprise-1C-10--1.13.19--2023-06-22_10-34-25\",\"GaleraMySQL-v5dot7--1.13.19-alma-2023-06-22_10-18-20\",\"Clickhouse-22--1.13.19-alma-2023-06-22_10-18-20\",\"GaleraMySQL-v8dot0--1.13.19-alma-2023-06-22_10-18-20\",\"Clickhouse-21--1.13.19-alma-2023-06-22_10-18-20\",\"MySQL-v5dot7--1.13.19-alma-2023-06-22_10-18-20\",\"MySQL-v8dot0--1.13.19-alma-2023-06-22_10-18-20\",\"MongoDB-v4dot0--1.13.19-alma-2023-06-22_10-18-20\",\"Redis-5--1.13.19-alma-2023-06-22_10-18-20\",\"Tarantool-v2dot10--1.13.19--2023-06-22_10-18-20\",\"Clickhouse-20--1.13.19--2023-06-22_10-18-20\",\"packer_build_DockerRegistry_202306220930\",\"GaleraMySQL-v8dot0--1.13.19-alma-2023-06-20_05-32-04\",\"MySQL-v5dot7--1.13.19-alma-2023-06-20_05-32-04\",\"GaleraMySQL-v5dot7--1.13.19-alma-2023-06-20_05-32-04\",\"MySQL-v8dot0--1.13.19-alma-2023-06-20_05-32-04\",\"MongoDB-v4dot0--1.13.19-alma-2023-06-20_05-32-04\",\"Clickhouse-21--1.13.19-alma-2023-06-20_05-32-04\",\"Redis-5--1.13.19-alma-2023-06-20_05-32-04\",\"Clickhouse-22--1.13.19-alma-2023-06-20_05-32-04\",\"Tarantool-v2dot10--1.13.19--2023-06-20_05-32-04\",\"Clickhouse-20--1.13.19--2023-06-20_05-32-04\",\"PostgreSQL-13--1.13.19-alma-2023-06-20_04-05-33\",\"PostgreSQL-14--1.13.19-alma-2023-06-20_04-05-35\",\"PostgreSQL-12--1.13.19-alma-2023-06-20_04-05-26\",\"PostgreSQL-11--1.13.19-alma-2023-06-20_04-05-16\",\"PostgreSQL-10--1.13.19-alma-2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-14--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-13--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-12--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-10--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-14--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-13--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-13--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-14--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-12--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-12--1.13.19--2023-06-20_03-58-54\",\"PostgresPro-11--1.13.19--2023-06-20_03-58-54\",\"PostgresProEnterprise-1C-10--1.13.19--2023-06-20_03-58-54\",\"packer_build_DockerRegistry_202306201730\",\"almalinux-9-v1.24.15.202306161245.git70b9ece9.dev\",\"almalinux-9-v1.24.15.202306161128.git9e203649.dev\",\"almalinux-9-v1.24.9.202306160754.git7100ceab\",\"almalinux-9-v1.25.6.202306160754.git7100ceab\",\"almalinux-9-v1.23.13.202306160754.git7100ceab\",\"PostgreSQL-14--1.13.18-alma-2023-06-15_11-39-09\",\"PostgreSQL-13--1.13.18-alma-2023-06-15_11-38-58\",\"PostgreSQL-12--1.13.18-alma-2023-06-15_11-38-22\",\"PostgreSQL-11--1.13.18-alma-2023-06-15_11-38-10\",\"Redis-5--1.13.18-alma-2023-06-15_11-39-24\",\"Tarantool-v2dot10--1.13.18--2023-06-15_11-39-28\",\"PostgreSQL-10--1.13.18-alma-2023-06-15_11-35-46\",\"PostgresProEnterprise-1C-14--1.13.18--2023-06-15_11-35-45\",\"PostgresProEnterprise-1C-13--1.13.18--2023-06-15_11-35-23\",\"PostgresProEnterprise-1C-12--1.13.18--2023-06-15_11-33-27\",\"PostgresProEnterprise-14--1.13.18--2023-06-15_11-33-02\",\"PostgresProEnterprise-11--1.13.18--2023-06-15_11-31-38\",\"PostgresProEnterprise-1C-11--1.13.18--2023-06-15_11-33-19\",\"PostgresProEnterprise-1C-10--1.13.18--2023-06-15_11-33-11\",\"PostgresProEnterprise-12--1.13.18--2023-06-15_11-32-21\",\"PostgresProEnterprise-13--1.13.18--2023-06-15_11-32-25\",\"PostgresPro-14--1.13.18--2023-06-15_11-29-07\",\"PostgresPro-13--1.13.18--2023-06-15_11-29-01\",\"PostgresProEnterprise-10--1.13.18--2023-06-15_11-29-37\",\"MySQL-v5dot7--1.13.18-alma-2023-06-15_11-22-39\",\"Clickhouse-22--1.13.18-alma-2023-06-15_11-22-39\",\"GaleraMySQL-v5dot7--1.13.18-alma-2023-06-15_11-22-39\",\"GaleraMySQL-v8dot0--1.13.18-alma-2023-06-15_11-22-40\",\"MySQL-v8dot0--1.13.18-alma-2023-06-15_11-22-39\",\"Clickhouse-21--1.13.18-alma-2023-06-15_11-22-39\",\"MongoDB-v4dot0--1.13.18-alma-2023-06-15_11-22-39\",\"PostgresPro-11--1.13.18--2023-06-15_11-22-39\",\"Clickhouse-20--1.13.18--2023-06-15_11-22-39\",\"PostgresPro-12--1.13.18--2023-06-15_11-22-39\",\"almalinux-9-v1.23.13.202306150626.git979882fb.dev\",\"almalinux-9-v1.24.9.202306131126.git9a224bb2\",\"almalinux-9-v1.23.13.202306141433.git9507844c.dev\",\"almalinux-9-v1.23.13.202306140817.git060526f4.dev\",\"almalinux-9-v1.23.13.202306131315.git0a29dd8b.dev\",\"packer_build_DockerRegistry_202306131600\",\"almalinux-9-v1.24.9.202306131136.gita01e3422.dev\",\"Tarantool-v2dot10--1.13.17--2023-06-06_04-42-18\",\"Redis-5--1.13.17-alma-2023-06-06_04-41-02\",\"MongoDB-v4dot0--1.13.17-alma-2023-06-06_04-05-14\",\"Clickhouse-21--1.13.17-alma-2023-06-06_03-30-49\",\"Clickhouse-22--1.13.17-alma-2023-06-06_03-30-49\",\"Clickhouse-20--1.13.17--2023-06-06_03-30-49\",\"GaleraMySQL-v8dot0--1.13.17-alma-2023-06-06_03-16-37\",\"MySQL-v5dot7--1.13.17-alma-2023-06-06_03-16-37\",\"MySQL-v8dot0--1.13.17-alma-2023-06-06_03-16-37\",\"GaleraMySQL-v5dot7--1.13.17-alma-2023-06-06_03-16-37\",\"PostgreSQL-14--1.13.17-alma-2023-06-06_02-56-35\",\"PostgreSQL-13--1.13.17-alma-2023-06-06_02-56-30\",\"PostgreSQL-11--1.13.17-alma-2023-06-06_02-56-15\",\"PostgreSQL-12--1.13.17-alma-2023-06-06_02-56-28\",\"PostgreSQL-10--1.13.17-alma-2023-06-06_02-50-19\",\"PostgresPro-13--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-11--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-11--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-14--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-14--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-10--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-1C-13--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-10--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-12--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-13--1.13.17--2023-06-06_02-50-18\",\"PostgresPro-11--1.13.17--2023-06-06_02-50-18\",\"PostgresProEnterprise-14--1.13.17--2023-06-06_02-50-19\",\"PostgreSQL-14--1.13.17-alma-2023-06-02_11-27-15\",\"packer_build_DockerRegistry_202306011600\",\"Clickhouse-22--1.13.16-alma-2023-06-01_05-51-30\",\"Clickhouse-21--1.13.16-alma-2023-06-01_05-51-30\",\"Clickhouse-20--1.13.16--2023-06-01_05-51-30\",\"packer_build_JH_GPU_202305261400\",\"almalinux-9-v1.25.10.202305260852.git8a4be3bf.dev\",\"astra-or-1.7-vdi-202305251407.git06ac0d14\",\"almalinux-9-v1.24.9.202305220831.git5ea06013\",\"almalinux-9-v1.23.13.202305220831.git5ea06013\",\"almalinux-9-v1.23.13.202305170935.git6e2d8563\",\"almalinux-9-v1.24.9.202305170935.git6e2d8563\",\"opensuse-leap-15.4-202305101900.gitc6492fe3\",\"packer_build_k8sController_202304281700\",\"almalinux-9-v1.23.13.202304280932.git458ee2d5\",\"almalinux-9-v1.24.9.202304280932.git458ee2d5\",\"Opensearch-2-alma-2023-04-27_12-17-15\",\"kafka-almalinux-91.202304241302.gitcf252bf1\",\"packer_build_JH_GPU_202304211630\",\"FreeBSD-13.2\",\"Opensearch-2-alma-2023-04-19_09-11-38\",\"almalinux-9-v1.24.9.202304141500.git963625d0\",\"packer_build_JH_GPU_202304171730\",\"packer_build_k8sController_202304071200\",\"kafka-almalinux-91.202304131114.git39b98629\",\"kafka-almalinux-91.202304122007.gitbf42ef2f\",\"PostgresPro-14--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-12--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-11--1.13.15--2023-04-11_07-41-27\",\"PostgresPro-13--1.13.15--2023-04-11_07-41-27\",\"packer_build_DockerRegistry_202304101300\",\"packer_build_DeployServer_202304071200\",\"packer_build_MLFLOW_202304071200\",\"packer_build_JH_GPU_202304071200\",\"packer_build_DockerRegistry_202304070930\",\"almalinux-9-v1.24.9.202304051306.git3f549049\",\"almalinux-9-v1.23.13.202304051306.git3f549049\",\"ambari-2.6.0.0.202304050621.git525510fa.dev\",\"packer_build_JH_GPU_202303311700\",\"packer_build_k8sController_202303311700\",\"packer_build_MLFLOW_202303311700\",\"packer_build_DeployServer_202303311700\",\"MySQL-v8dot0--1.13.15-alma-2023-03-30_07-46-47\",\"GaleraMySQL-v5dot7--1.13.15-alma-2023-03-30_07-46-47\",\"MySQL-v5dot7--1.13.15-alma-2023-03-30_07-46-47\",\"GaleraMySQL-v8dot0--1.13.15-alma-2023-03-30_07-46-47\",\"almalinux-9-v1.24.9.202303290731.git4a42b46b\",\"almalinux-9-v1.23.13.202303290731.git4a42b46b\",\"PostgreSQL-14--1.13.15-alma-2023-03-28_05-13-04\",\"Tarantool-v2dot10--1.13.15--2023-03-28_05-09-14\",\"PostgresProEnterprise-1C-11--1.13.15--2023-03-28_04-55-32\",\"Redis-5--1.13.15-alma-2023-03-28_05-00-42\",\"PostgreSQL-13--1.13.15-alma-2023-03-28_04-54-41\",\"PostgreSQL-11--1.13.15-alma-2023-03-28_04-50-55\",\"PostgreSQL-12--1.13.15-alma-2023-03-28_04-55-18\",\"PostgreSQL-10--1.13.15-alma-2023-03-28_04-50-44\",\"PostgresProEnterprise-1C-13--1.13.15--2023-03-28_04-49-07\",\"PostgresProEnterprise-1C-10--1.13.15--2023-03-28_04-44-31\",\"PostgresProEnterprise-1C-14--1.13.15--2023-03-28_04-49-07\",\"PostgresProEnterprise-1C-12--1.13.15--2023-03-28_04-47-47\",\"PostgresProEnterprise-13--1.13.15--2023-03-28_04-42-28\",\"PostgresProEnterprise-12--1.13.15--2023-03-28_04-42-06\",\"PostgresProEnterprise-14--1.13.15--2023-03-28_04-42-29\",\"PostgresProEnterprise-11--1.13.15--2023-03-28_04-41-17\",\"PostgresProEnterprise-10--1.13.15--2023-03-28_04-40-23\",\"MongoDB-v4dot0--1.13.15-alma-2023-03-28_04-31-23\",\"ambari-2.7.3.0.202303221424.git731b4606\",\"ambari-2.6.1.5.202303221424.git731b4606\",\"ambari-2.6.2.2.202303221424.git731b4606\",\"dummy.202303221424.git731b4606\",\"arenadata.202303221424.git731b4606\",\"insight.202303221424.git731b4606\",\"arenadata-worker.202303221424.git731b4606\",\"opensuse-leap-15.4-202303221516.git73f3582c\",\"FreeBSD-12.4\",\"FreeBSD-13.1\",\"Opensearch-2-alma-2023-03-17_08-48-17\",\"Redis-6.2-alma-2023-03-17_08-38-36\",\"Mongodb-6-alma-2023-03-17_08-28-40\",\"packer_build_k8sController_v1.0\",\"packer_build_DeployServer_v1.03\",\"alse-vanilla-1.7.3uu1-vkcloud-adv-mg9.1.2\",\"alse-vanilla-1.7.3-vkcloud-base-mg8.2.1\",\"Astra Linux SE 1.7.2 Orel GUI\",\"packer_build_JH_GPU_v1.15\",\"RO732_MIN-STD\",\"RO732_MIN-CRT\",\"sentry-ubuntu-image.202302170627.gita61ff2ac\",\"sentry-ubuntu-image.202302170723.gitc17927a9\",\"almalinux-9-v1.24.9.202302130900.git6dc96b46.dev\",\"almalinux-9-v1.23.13.202302100713.gitf3a303d1.dev\",\"almalinux-9-v1.22.9.202302100713.gitf3a303d1.dev\",\"alt-server-8sp-cloud-rev1.3.1-20221229-x86_64\",\"alt-server-10-rev20230208-x86_64\",\"packer_build_MLFLOW_v2.1.4\",\"packer_build_JH_GPU_v1.13\",\"packer_build_JH_GPU_v1.12\",\"packer_build_MLFLOW_v2.1.2\",\"packer_build_JH_GPU_v1.08\",\"sentry-0.1\",\"Opensearch-2-alma-2022-12-14_05-28-56\",\"Mongodb-6-alma-2022-12-14_04-46-21\",\"Redis-6.2-alma-2022-12-14_02-50-52\",\"Mongodb-6-alma-2022-12-12_08-53-51\",\"packer_build_DeployServer_v1.02\",\"Redis-6.2-alma-2022-11-28_01-16-09\",\"Opensearch2-almalinux8.202211250914.git4ce04292\",\"Windows-Server-2022StdCore-ru.202211\",\"packer_build_JH_GPU_v1.07\",\"packer_build_MLFLOW_v1.03\",\"Windows-Server-2022StdCore-en.202211\",\"Windows-Server-2019Std-en.202211\",\"Windows-Server-2019Std-ru.202211\",\"Windows-Server-2022Std-ru.202211\",\"Windows-Server-2022Std-en.202211\",\"Windows-Server-2016Std-en.202211\",\"Windows-Server-2016Std-ru.202211\",\"Opensearch2-almalinux8.202211221000.gitbdbfe30c.dev\",\"Windows-Server-2012R2Std-ru.202211\",\"Windows-Server-2012R2Std-en.202211\",\"packer_build_JH_GPU_v1.06\",\"packer_build_JH_GPU_v1.05\",\"Debian11.4\",\"almalinux-9-v1.23.13.202211021406.git84ce35f0.dev\",\"packer_build_MLFlow.202211031046.git2bf12643.dev\",\"packer_build_DeployServer_v1.01\",\"alse-vanilla-1.7.2-vkcloud-base-mg8.0.0\",\"Redis-6.2-alma-2022-10-18_08-46-37\",\"almalinux-9-v1.23.6.202210120842.git899594d6.dev\",\"almalinux-9-v1.22.9.202210120842.git899594d6.dev\",\"packer_build_DeployServer_v1.00\",\"Almalinux-9-v1.23.6-k8s-mcs-Oct- 7-12:40:46.021-\",\"Almalinux-8-v1.21.4-k8s-mcs-Oct- 7-12:24:32.429-\",\"Almalinux-9-v1.22.9-k8s-mcs-Oct- 7-12:24:35.201-\",\"packer_build_MLFLOW_v1.02\",\"packer_build_JH_GPU_v1.04\",\"packer_build_JH_GPU_v1.03\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-20-14:47:39.386-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-20-14:47:48.435-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-20-14:47:44.123-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-20-10:19:11.934-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-20-10:19:21.584-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-20-10:19:16.725-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-19-12:06:03.688-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-19-12:08:49.709-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-19-12:08:37.588-\",\"Almalinux-9-v1.22.9-k8s-mcs-Sep-16-12:09:15.206-\",\"Almalinux-8-v1.21.4-k8s-mcs-Sep-16-11:19:14.725-\",\"Almalinux-9-v1.23.6-k8s-mcs-Sep-16-11:19:33.801-\",\"ubuntu-20-4-develop\",\"packer_build_JH_GPU_v1.02\",\"Clickhouse-22--1.13.3-alma-2022-09-13_12-36-08\",\"packer_build_MLFLOW_v1.01\",\"packer_build_JH_GPU_v1.01\",\"packer_build_JH_GPU_v1\",\"Ubuntu-20.04-Jupyterhub_GPU\",\"packer-build-Jupyterhub_v2.4\",\"Ubuntu-22.04-202208\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug-12-07:34:16.668-\",\"Almalinux-9-v1.22.9-k8s-mcs-Aug-12-07:33:57.593-\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug-11-17:13:26.539-\",\"Almalinux-9-v1.22.9-k8s-mcs-Aug-11-17:12:55.631-\",\"Redis-6.2-alma-2022-08-11_02-34-29\",\"Almalinux-9-v1.23.6-k8s-mcs-\",\"Almalinux-9-v1.22.9-k8s-mcs-\",\"Almalinux-9-v1.23.6-k8s-mcs-Aug- 2-09:38:33.516-ea91ada\",\"Ubuntu-20.04-Mlflow\",\"Almalinux-9-v1.23.6-k8s-mcs-Jul-27-16:34:28.117-ea91ada\",\"Ubuntu-20.04-Jupyterhub_v3\",\"Almalinux-9-v1.23.6-mcs.5\",\"Almalinux-9-v1.22.9-mcs.2\",\"Ubuntu-18.04-Jupyterhub\",\"Almalinux-8-v1.21.4-mcs.10\",\"Almalinux-9-v1.22.9-mcs.1\",\"Clickhouse-21--1.12.24-alma-2022-06-21_04-18-28\",\"AlmaLinux-9\",\"GaleraMySQL-v5dot6--1.12.23--2022-04-29_02-40-08\",\"Almalinux-8-v1.22.6-mcs.8\",\"Tarantool-v2--1.12.23--2022-04-27_12-21-37\",\"MySQL-v5dot6--1.12.23--2022-04-27_12-13-07\",\"Clickhouse-19--1.12.23--2022-04-27_12-10-52\",\"GaleraMySQL-v5dot6--1.12.23--2022-04-27_12-11-22\",\"PostgreSQL-v9dot6--1.12.20--2022-03-11_12-28-55\",\"Almalinux-8-v1.22.6-mcs.5\",\"Almalinux-8-v1.21.4-mcs.9\",\"Almalinux-8-v1.22.6-mcs.4\",\"PostgreSQL-v9dot6--1.12.20--2022-03-03_06-26-24\",\"Almalinux-8-v1.22.6-mcs.2\",\"Almalinux-8-v1.21.4-mcs.4\",\"Almalinux-8-v1.21.4-mcs.3\",\"ubuntu-20-04-cloud-amd64\",\"AlmaLinux-8.5\",\"centos7-sahara-ambari-2.7.3.0-2022-01-14-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-12-16-prod.raw\",\"Ubuntu-18.04-Marketplace-OpenJDK-v2\",\"Ubuntu-18.04-Marketplace-Basic-v2\",\"Windows-Server-2022StdCore-en.202111\",\"Windows-Server-2022StdCore-ru.202111\",\"Windows-Server-2022Std-ru.202111\",\"Windows-Server-2022Std-en.202111\",\"centos7-sahara-ambari-2.7.3.0-2021-11-08-prod.raw\",\"Centos-8-v1.20.4-mcs.9\",\"centos7-sahara-ambari-2.7.3.0-2021-09-29-prod.raw\",\"Centos-8-v1.19.4-mcs.9\",\"Centos-8-v1.18.12-mcs.8\",\"Centos-8-v1.17.8-mcs.7\",\"centos7-sahara-ambari-2.7.3.0-2021-08-19-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-07-30-prod.raw\",\"CentOS-8.4-202107\",\"CentOS-7.9-202107\",\"centos7-sahara-ambari-2.7.3.0-2021-07-01-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-25-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-25-prod.raw\",\"Windows-Server-2019-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2019-SERVERSTANDARD-en-US.202106\",\"Windows-Server-2016-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2016-SERVERSTANDARD-en-US.202106\",\"Windows-Server-2012-R2-SERVERSTANDARD-ru-RU.202106\",\"Windows-Server-2012-R2-SERVERSTANDARD-en-US.202106\",\"centos7-sahara-ambari-2.7.3.0-2021-06-16-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-15-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-06-01-prod.raw\",\"centos7-sahara-ambari-2.7.3.0-2021-06-01-prod.raw\",\"Windows-Server-2019Std-ru.202105\",\"Windows-Server-2019Std-en.202105\",\"Windows-Server-2016Std-ru.202105\",\"Windows-Server-2016Std-en.202105\",\"Windows-Server-2012R2Std-ru.202105\",\"Windows-Server-2012R2Std-en.202105\",\"Clickhouse-20-2021-05-14_11-54-46\",\"Windows-Server-2019Std-ru.202104\",\"Windows-Server-2019Std-en.202104\",\"Windows-Server-2016Std-ru.202104\",\"Windows-Server-2016Std-en.202104\",\"Windows-Server-2012R2Std-ru.202104\",\"Windows-Server-2012R2Std-en.202104\",\"centos7-sahara-ambari-2.7.3.0-2021-03-03-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2021-03-03-prod.raw\",\"centos7-sahara-ambari-2.6.0.0-2021-03-03-prod.raw\",\"Centos-8-v1.16.4-mcs.6\",\"centos7-sahara-ambari-2.6.0.0-2021-01-18-prod\",\"Windows-Server-2019Std-ru.202012\",\"Windows-Server-2019Std-en.202012\",\"Windows-Server-2016Std-ru.202012\",\"Windows-Server-2016Std-en.202012\",\"Windows-Server-2012R2Std-ru.202012\",\"Windows-Server-2012R2Std-en.202012\",\"centos7-sahara-ambari-2.7.3.0-2020-12-22-prod.raw\",\"centos7-sahara-ambari-2.6.2.2-2020-12-22-prod.raw\",\"centos7-sahara-ambari-2.6.1.5-2020-12-17-prod\",\"Windows-Server-2019Std-ru.202011\",\"Windows-Server-2019Std-en.202011\",\"Windows-Server-2016Std-ru.202011\",\"Windows-Server-2016Std-en.202011\",\"Windows-Server-2012R2Std-ru.202011\",\"Windows-Server-2012R2Std-en.202011\",\"centos7-sahara-ambari-2.7.3.0-2020-09-30-prod\",\"Ubuntu-20.04.1-202008\",\"Windows-Server-2016Std-ru.202006\",\"Windows-Server-2016Std-en.202006\",\"Windows-Server-2012R2Std-ru.202006\",\"Windows-Server-2012R2Std-en.202006\",\"Windows-Server-2019Std-ru.202006\",\"Windows-Server-2019Std-en.202006\",\"Fedora-Atomic-28-v1.14.6-mcs.2\",\"Fedora-Atomic-28-v1.15.3-mcs.2\",\"Debian-10.1-202004\",\"CentOS-8.1-202004\",\"Fedora-Atomic-28-v1.15.3-mcs.1\",\"Fedora-Atomic-28-v1.16.4-mcs.1\",\"Windows-Server-2019-SERVERDATACENTER-en-US.202003\",\"Windows-Server-2016-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2019-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2016-SERVERDATACENTER-en-US.202003\",\"Windows-Server-2012-R2-SERVERDATACENTER-ru-RU.202003\",\"Windows-Server-2012-R2-SERVERDATACENTER-en-US.202003\",\"Ubuntu-19.10-202003\",\"CentOS-8.1-202003\",\"Ubuntu-18.04-202003\",\"CentOS-7.7-202003\",\"Ubuntu-16.04-202003\",\"CentOS-8.0-201910\",\"CentOS-7.7-201910\",\"Ubuntu-19.04-201910\",\"Ubuntu-16.04-201910\",\"Ubuntu-18.04-201910\",\"Debian-10.1-201910\",\"Fedora-Atomic-28-v1.14.6-mcs.1\",\"MongoDB-4.0\",\"Fedora-Atomic-28-v1.14.4-mcs.2\",\"Fedora-Atomic-28-v1.14.4-mcs.1\",\"Fedora-Atomic-28-v1.13.3-mcs.1\",\"Fedora-Atomic-28-v1.11.5-mcs.3\",\"CentOS-7.6-201903\",\"Ubuntu-16.04-Standard\",\"Fedora-Atomic-28-v1.11.5-mcs.1\",\"Fedora-Atomic-28-v1.12.3-mcs.1\",\"Fedora-Atomic-28-v1.10.11-mcs.1\",\"Debian-9.4.201812\",\"Ubuntu-18.04-Marketplace-OpenJDK\",\"Ubuntu-18.04-Marketplace-Basic\",\"Ubuntu-18.04-Standard\",\"Ubuntu-18.04-MachineLearning\",\"Bitrix-CentOS7.5-installation\",\"CentOS-7.5-Standard\",\"Bitrix-CentOS7.5-installation.2405\",\"openSUSE-42.3-Standard\",\"CentOS-7.4-Standard\",\"FreeBSD-10.3\"],\"mainNetwork\":\"network_flant\",\"zones\":[\"GZ1\",\"MS1\"],\"volumeTypes\":[{\"id\":\"e7886624-2d95-4175-b14a-d256d6961bd6\",\"name\":\"high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"3b22f0ca-8682-4c3e-ae95-aaa969823d06\",\"name\":\"ceph-ssd\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"f631a3ba-a98e-4954-b3a1-4028d5e5ae81\",\"name\":\"ceph-hdd\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"8d39c9db-0293-48c0-8d44-015a2f6788ff\",\"name\":\"ko1-high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"bf800b7c-9ae0-4cda-b9c5-fae283b3e9fd\",\"name\":\"dp1-high-iops\",\"extraSpecs\":{\"mcs:disk_class\":\"high_iops_disk\"},\"isPublic\":true},{\"id\":\"74101409-a462-4f03-872a-7de727a178b8\",\"name\":\"ko1-ssd\",\"description\":\"SSD for KO\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"eadd8860-f5a4-45e1-ae27-8c58094257e0\",\"name\":\"dp1-ssd\",\"description\":\"Fast iops on SSD in DP1\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"48372c05-c842-4f6e-89ca-09af3868b2c4\",\"name\":\"ssd\",\"description\":\"Fast iops on SSD\",\"extraSpecs\":{\"mcs:disk_class\":\"ssd\"},\"isPublic\":true},{\"id\":\"a75c3502-4de6-4876-a457-a6c4594c067a\",\"name\":\"ms1\",\"description\":\"Ceph storage in VarshavkaMs1 datacenter\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"ebf5922e-42af-4f97-8f23-716340290de2\",\"name\":\"dp1\",\"description\":\"Ceph storage in DataPro datacenter\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true},{\"id\":\"a6e853c1-78ad-4c18-93f9-2bba317a1d13\",\"name\":\"ceph\",\"extraSpecs\":{\"mcs:disk_class\":\"hdd\"},\"isPublic\":true}]}\n\n1error occurred:\n\t* additionalSecurityGroups shouldn't contain duplicates\n\n","queue":"main","task.id":"be49ee5c-c908-4f0b-b105-1859962603b0","time":"2023-07-19T11:19:12Z","watchEvent":"Added"}
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Deckhouse fails with the error (see above).


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Remove duplicates from additional security groups in cloud-data-discoverer.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
