### PR TITLE
[deckhouse-controller] Fix change-registry CA handling for connecting to registry

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -53,6 +53,7 @@ const (
 
 func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTag string, insecure bool) error {
 	ctx := context.Background()
+	log.SetReportCaller(true)
 	logEntry := log.WithField("operator.component", "ChangeRegistry")
 
 	nameOpts := newNameOptions(insecure)

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
@@ -320,7 +320,7 @@ func Test_checkBearerSupport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := checkBearerSupport(tt.args.ctx, reg); (err != nil) != tt.wantErr {
+			if err := checkBearerSupport(tt.args.ctx, reg, http.DefaultTransport); (err != nil) != tt.wantErr {
 				t.Errorf("checkBearerSupport() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
@@ -21,7 +21,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -108,12 +110,11 @@ func checkContainersHost(containers []v1.Container, host string, deckhouseTag st
 func TestNewImagePullSecretData(t *testing.T) {
 	type args struct {
 		authConfig authn.AuthConfig
-		caFile     string
 	}
 	tests := []struct {
 		name      string
 		newRepo   string
-		caContent []byte
+		caContent string
 		insecure  bool
 		args      args
 		want      map[string]string
@@ -138,59 +139,15 @@ func TestNewImagePullSecretData(t *testing.T) {
 					Username: "test",
 					Password: "test",
 				},
-				caFile: "/tmp/change-registry-ca-test.pem",
 			},
-			newRepo: "registry.example.com/deckhouse",
-			caContent: []byte(`
------BEGIN CERTIFICATE-----
-MIIDqjCCApICCQC5+/3MLrlWRzANBgkqhkiG9w0BAQsFADCBljELMAkGA1UEBhMC
-TUgxEjAQBgNVBAgMCURlY2tob3VzZTESMBAGA1UEBwwJRGVja2hvdXNlMRIwEAYD
-VQQKDAlEZWNraG91c2UxEjAQBgNVBAsMCURlY2tob3VzZTESMBAGA1UEAwwJRGVj
-a2hvdXNlMSMwIQYJKoZIhvcNAQkBFhRjb250YWN0QGRlY2tob3VzZS5pbzAeFw0y
-MzA2MTYxMjQwMjNaFw0yODA2MTQxMjQwMjNaMIGWMQswCQYDVQQGEwJNSDESMBAG
-A1UECAwJRGVja2hvdXNlMRIwEAYDVQQHDAlEZWNraG91c2UxEjAQBgNVBAoMCURl
-Y2tob3VzZTESMBAGA1UECwwJRGVja2hvdXNlMRIwEAYDVQQDDAlEZWNraG91c2Ux
-IzAhBgkqhkiG9w0BCQEWFGNvbnRhY3RAZGVja2hvdXNlLmlvMIIBIjANBgkqhkiG
-9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvelLA8XRx8LzSPFcqvoV/M68fnhrcykASl/a
-MaRVoKn9Ms/vNvPzkW8X2ushD3tuWJw1JHwb3vUw2eK2K+LdSu/swLodwOf/tMp7
-JX7NuhI0XLFMEpoSfAhbGdyYUaSHEbJkOCF9ZXlp7dtW2dEYefJn4a8+ZXCSQJYP
-TMj08IrztzU9jnWi6nwupB+ItYvMhjNT8tlnCXaZebQMXKpBuH7F0acnojCnOQmT
-qZCvh7bl2EbK4zM9Q0iUSx4MYnC+mQ3x0l525toetmGMqwV1GlTLGD9/t5Cc4q3l
-6mDbkytuKsZeZpkEgmOtdjoESkdAepDiBej1eQvS0i0AiyAFBwIDAQABMA0GCSqG
-SIb3DQEBCwUAA4IBAQAo8oAwmz5wyxljxXqOoWLMlit7MVU/jfUwFCFFCK+pqI2V
-/kQBBH5ZJRZ0AF3k4cuA+vJc+Cwlu25c5KJrl+CgDQQ+pdrHqbw+hLnkRsA6a9kn
-5UBpLuOj2ALuYvxsGVp2DvxVkpKGU2fcbtPbQFY3n7yK1SW64nTCk5dS30gU61pU
-SdpwTLz+GMV14jWRh+TQWO135tFZSuuUwPWzx6k68raQVxPi2fFu949BT5gl1L2Y
-e4f/w8EYFkBiGlZo2RguL3fFMouOo65CPxYj2jA1Y9D2AUG0L/3+CIe+RKCn4HML
-oFmKNcjIX7fCuW8fGd+DwdUQ9cR8JV9si/gjdZzu
------END CERTIFICATE-----`),
+			newRepo:   "registry.example.com/deckhouse",
+			caContent: testCaContent,
 			want: map[string]string{
 				".dockerconfigjson": `{"auths":{"registry.example.com":{"auth":"dGVzdDp0ZXN0"}}}`,
 				"address":           "registry.example.com",
 				"path":              "/deckhouse",
 				"scheme":            "https",
-				"ca": `-----BEGIN CERTIFICATE-----
-MIIDqjCCApICCQC5+/3MLrlWRzANBgkqhkiG9w0BAQsFADCBljELMAkGA1UEBhMC
-TUgxEjAQBgNVBAgMCURlY2tob3VzZTESMBAGA1UEBwwJRGVja2hvdXNlMRIwEAYD
-VQQKDAlEZWNraG91c2UxEjAQBgNVBAsMCURlY2tob3VzZTESMBAGA1UEAwwJRGVj
-a2hvdXNlMSMwIQYJKoZIhvcNAQkBFhRjb250YWN0QGRlY2tob3VzZS5pbzAeFw0y
-MzA2MTYxMjQwMjNaFw0yODA2MTQxMjQwMjNaMIGWMQswCQYDVQQGEwJNSDESMBAG
-A1UECAwJRGVja2hvdXNlMRIwEAYDVQQHDAlEZWNraG91c2UxEjAQBgNVBAoMCURl
-Y2tob3VzZTESMBAGA1UECwwJRGVja2hvdXNlMRIwEAYDVQQDDAlEZWNraG91c2Ux
-IzAhBgkqhkiG9w0BCQEWFGNvbnRhY3RAZGVja2hvdXNlLmlvMIIBIjANBgkqhkiG
-9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvelLA8XRx8LzSPFcqvoV/M68fnhrcykASl/a
-MaRVoKn9Ms/vNvPzkW8X2ushD3tuWJw1JHwb3vUw2eK2K+LdSu/swLodwOf/tMp7
-JX7NuhI0XLFMEpoSfAhbGdyYUaSHEbJkOCF9ZXlp7dtW2dEYefJn4a8+ZXCSQJYP
-TMj08IrztzU9jnWi6nwupB+ItYvMhjNT8tlnCXaZebQMXKpBuH7F0acnojCnOQmT
-qZCvh7bl2EbK4zM9Q0iUSx4MYnC+mQ3x0l525toetmGMqwV1GlTLGD9/t5Cc4q3l
-6mDbkytuKsZeZpkEgmOtdjoESkdAepDiBej1eQvS0i0AiyAFBwIDAQABMA0GCSqG
-SIb3DQEBCwUAA4IBAQAo8oAwmz5wyxljxXqOoWLMlit7MVU/jfUwFCFFCK+pqI2V
-/kQBBH5ZJRZ0AF3k4cuA+vJc+Cwlu25c5KJrl+CgDQQ+pdrHqbw+hLnkRsA6a9kn
-5UBpLuOj2ALuYvxsGVp2DvxVkpKGU2fcbtPbQFY3n7yK1SW64nTCk5dS30gU61pU
-SdpwTLz+GMV14jWRh+TQWO135tFZSuuUwPWzx6k68raQVxPi2fFu949BT5gl1L2Y
-e4f/w8EYFkBiGlZo2RguL3fFMouOo65CPxYj2jA1Y9D2AUG0L/3+CIe+RKCn4HML
-oFmKNcjIX7fCuW8fGd+DwdUQ9cR8JV9si/gjdZzu
------END CERTIFICATE-----`,
+				"ca":                testCaContent,
 			},
 		},
 	}
@@ -207,13 +164,7 @@ oFmKNcjIX7fCuW8fGd+DwdUQ9cR8JV9si/gjdZzu
 				t.Fatal(err)
 			}
 
-			if tt.args.caFile != "" && len(tt.caContent) > 0 {
-				if err := os.WriteFile(tt.args.caFile, tt.caContent, 0755); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			got, err := newImagePullSecretData(newRepo, tt.args.authConfig, tt.args.caFile)
+			got, err := newImagePullSecretData(newRepo, tt.args.authConfig, tt.caContent)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newImagePullSecretData() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -375,3 +326,75 @@ func Test_checkBearerSupport(t *testing.T) {
 		})
 	}
 }
+
+func Test_getCAContent(t *testing.T) {
+	type args struct {
+		caFile string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      string
+		wantErr   bool
+		caContent string
+	}{
+		{
+			name: "read ca file",
+			args: args{
+				caFile: filepath.Join(t.TempDir(), "ca.crt"),
+			},
+			want:      strings.TrimSpace(testCaContent),
+			caContent: testCaContent,
+		},
+		{
+			name: "no ca file",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.caFile != "" && len(tt.caContent) > 0 {
+				if err := os.WriteFile(tt.args.caFile, []byte(tt.caContent), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := getCAContent(tt.args.caFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getCAContent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getCAContent() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+const (
+	testCaContent = `
+-----BEGIN CERTIFICATE-----
+MIIDqjCCApICCQC5+/3MLrlWRzANBgkqhkiG9w0BAQsFADCBljELMAkGA1UEBhMC
+TUgxEjAQBgNVBAgMCURlY2tob3VzZTESMBAGA1UEBwwJRGVja2hvdXNlMRIwEAYD
+VQQKDAlEZWNraG91c2UxEjAQBgNVBAsMCURlY2tob3VzZTESMBAGA1UEAwwJRGVj
+a2hvdXNlMSMwIQYJKoZIhvcNAQkBFhRjb250YWN0QGRlY2tob3VzZS5pbzAeFw0y
+MzA2MTYxMjQwMjNaFw0yODA2MTQxMjQwMjNaMIGWMQswCQYDVQQGEwJNSDESMBAG
+A1UECAwJRGVja2hvdXNlMRIwEAYDVQQHDAlEZWNraG91c2UxEjAQBgNVBAoMCURl
+Y2tob3VzZTESMBAGA1UECwwJRGVja2hvdXNlMRIwEAYDVQQDDAlEZWNraG91c2Ux
+IzAhBgkqhkiG9w0BCQEWFGNvbnRhY3RAZGVja2hvdXNlLmlvMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvelLA8XRx8LzSPFcqvoV/M68fnhrcykASl/a
+MaRVoKn9Ms/vNvPzkW8X2ushD3tuWJw1JHwb3vUw2eK2K+LdSu/swLodwOf/tMp7
+JX7NuhI0XLFMEpoSfAhbGdyYUaSHEbJkOCF9ZXlp7dtW2dEYefJn4a8+ZXCSQJYP
+TMj08IrztzU9jnWi6nwupB+ItYvMhjNT8tlnCXaZebQMXKpBuH7F0acnojCnOQmT
+qZCvh7bl2EbK4zM9Q0iUSx4MYnC+mQ3x0l525toetmGMqwV1GlTLGD9/t5Cc4q3l
+6mDbkytuKsZeZpkEgmOtdjoESkdAepDiBej1eQvS0i0AiyAFBwIDAQABMA0GCSqG
+SIb3DQEBCwUAA4IBAQAo8oAwmz5wyxljxXqOoWLMlit7MVU/jfUwFCFFCK+pqI2V
+/kQBBH5ZJRZ0AF3k4cuA+vJc+Cwlu25c5KJrl+CgDQQ+pdrHqbw+hLnkRsA6a9kn
+5UBpLuOj2ALuYvxsGVp2DvxVkpKGU2fcbtPbQFY3n7yK1SW64nTCk5dS30gU61pU
+SdpwTLz+GMV14jWRh+TQWO135tFZSuuUwPWzx6k68raQVxPi2fFu949BT5gl1L2Y
+e4f/w8EYFkBiGlZo2RguL3fFMouOo65CPxYj2jA1Y9D2AUG0L/3+CIe+RKCn4HML
+oFmKNcjIX7fCuW8fGd+DwdUQ9cR8JV9si/gjdZzu
+-----END CERTIFICATE-----
+`
+)

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -45,10 +45,11 @@ func DefineHelperCommands(kpApp *kingpin.Application) {
 		caFile := changeRegistryCommand.Flag("ca-file", "Path to registry CA.").ExistingFile()
 
 		insecure := changeRegistryCommand.Flag("insecure", "Use HTTP while connecting to new registry.").Bool()
+		dryRun := changeRegistryCommand.Flag("dry-run", "Don't change deckhouse resources, only print them.").Default("false").Bool()
 
 		newImageTag := changeRegistryCommand.Flag("new-deckhouse-tag", "New tag that will be used for deckhouse deployment image (by default current tag from deckhouse deployment will be used).").String()
 		changeRegistryCommand.Action(func(c *kingpin.ParseContext) error {
-			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *insecure)
+			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *insecure, *dryRun)
 		})
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix handling CA for change registry command in deckhouse-controller
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix custom CA using while connecting to registry with change-registry command
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
This bug may affect UX
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
change-registry works with custom CA
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary:  Fix change-registry CA handling for connecting to registry.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
