### PR TITLE
[candi][cloud-provider-yandex] fixed router metric if have additionalNetworks

### DIFF
--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -21,6 +21,15 @@ function ip_in_subnet(){
   return $?
 }
 
+if [ -f "/etc/netplan/50-cloud-init.yaml" ]; then
+  if [ -f "/etc/netplan/01-netcfg.yaml" ]; then
+    rm /etc/netplan/01-netcfg.yaml
+  fi
+  if [ -f "/etc/netplan/00-installer-config.yaml" ]; then
+    rm /etc/netplan/00-installer-config.yaml
+  fi
+fi
+
 if ! metadata="$(curl -sH Metadata-Flavor:Google 169.254.169.254/computeMetadata/v1/instance/?recursive=true 2>/dev/null)"; then
   echo "Can't get network cidr from metadata"
   exit 1

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -23,7 +23,7 @@ function ip_in_subnet(){
 
 if [ -f "/etc/netplan/50-cloud-init.yaml" ]; then
   if [ -f "/etc/netplan/00-installer-config.yaml" ]; then
-    rm /etc/netplan/00-installer-config.yaml
+    rm -f /etc/netplan/00-installer-config.yaml
   fi
 fi
 

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -22,9 +22,6 @@ function ip_in_subnet(){
 }
 
 if [ -f "/etc/netplan/50-cloud-init.yaml" ]; then
-  if [ -f "/etc/netplan/01-netcfg.yaml" ]; then
-    rm /etc/netplan/01-netcfg.yaml
-  fi
   if [ -f "/etc/netplan/00-installer-config.yaml" ]; then
     rm /etc/netplan/00-installer-config.yaml
   fi


### PR DESCRIPTION
## Description
Fix #5229.

## Why do we need it, and what problem does it solve?
Close: https://github.com/deckhouse/deckhouse/issues/5229
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
The PR [fixes](https://github.com/deckhouse/deckhouse/issues/5229) Ubuntu 22.04 bootstrap.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix 
summary: Fix router metric if the `additionalNetworks` parameter is specified.
impact_level: default 
```
