### PR TITLE
[go_lib] Add test that original sans are not mutated

### DIFF
--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -50,20 +50,23 @@ const (
 //	PublicDomainSAN(value)
 func DefaultSANs(sans []string) SANsGenerator {
 	return func(input *go_hook.HookInput) []string {
+		res := make([]string, 0, len(sans))
+
 		clusterDomain := input.Values.Get("global.discovery.clusterDomain").String()
 		publicDomain := input.Values.Get("global.modules.publicDomainTemplate").String()
 
-		for index, san := range sans {
+		for _, san := range sans {
 			switch {
 			case strings.HasPrefix(san, publicDomainPrefix) && publicDomain != "":
-				sans[index] = getPublicDomainSAN(san, publicDomain)
+				san = getPublicDomainSAN(san, publicDomain)
 
 			case strings.HasPrefix(san, clusterDomainPrefix) && clusterDomain != "":
-				sans[index] = getClusterDomainSAN(san, clusterDomain)
+				san = getClusterDomainSAN(san, clusterDomain)
 			}
-		}
 
-		return sans
+			res = append(res, san)
+		}
+		return res
 	}
 }
 

--- a/go_lib/hooks/tls_certificate/internal_tls_test.go
+++ b/go_lib/hooks/tls_certificate/internal_tls_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls_certificate
+
+import (
+	"testing"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/stretchr/testify/require"
+)
+
+func testGetClusterDomainValues(t *testing.T, domain string) *go_hook.PatchableValues {
+	patchableValues, err := go_hook.NewPatchableValues(map[string]interface{}{
+		"global": map[string]interface{}{
+			"discovery": map[string]interface{}{
+				"clusterDomain": domain,
+			},
+		},
+	})
+	require.NoError(t, err)
+	return patchableValues
+}
+
+func TestDefaultSANs(t *testing.T) {
+	orig := []string{
+		"conversion-webhook-handler.d8-system.svc",
+		ClusterDomainSAN("conversion-webhook-handler.d8-system.svc"),
+	}
+	f := DefaultSANs(orig)
+
+	patchableValues1 := testGetClusterDomainValues(t, "example1.com")
+	res1 := f(&go_hook.HookInput{Values: patchableValues1})
+
+	require.Equal(t, []string{
+		"conversion-webhook-handler.d8-system.svc",
+		"conversion-webhook-handler.d8-system.svc.example1.com",
+	}, res1)
+
+	patchableValues2 := testGetClusterDomainValues(t, "example2.com")
+	res2 := f(&go_hook.HookInput{Values: patchableValues2})
+
+	require.Equal(t, []string{
+		"conversion-webhook-handler.d8-system.svc",
+		"conversion-webhook-handler.d8-system.svc.example2.com",
+	}, res2)
+}


### PR DESCRIPTION
## Description
Fix the bug when certificates stay the same even after a domain change

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/4881

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: go_lib
type: fix
summary: Add test that original sans are not mutated
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
