### PR TITLE
[cloud-provider-*] Add rbac Role to access `d8-provider-cluster-configuration` and `d8-cloud-provider-discovery-data` secrets

### DIFF
--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -24,6 +24,37 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: d8:cloud-provider-aws:cloud-data-discoverer:secret-reader
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - d8-provider-cluster-configuration
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - d8-cloud-provider-discovery-data
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: d8:cloud-provider-aws:cloud-data-discoverer
@@ -36,6 +67,21 @@ subjects:
 - kind: ServiceAccount
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-aws
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: d8:cloud-provider-aws:cloud-data-discoverer:secret-reader
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: d8:cloud-provider-aws:cloud-data-discoverer:secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: cloud-data-discoverer
+    namespace: d8-cloud-provider-aws
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -24,6 +24,37 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: d8:cloud-provider-azure:cloud-data-discoverer:secret-reader
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - d8-provider-cluster-configuration
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - d8-cloud-provider-discovery-data
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: d8:cloud-provider-azure:cloud-data-discoverer
@@ -36,6 +67,21 @@ subjects:
 - kind: ServiceAccount
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-azure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: d8:cloud-provider-azure:cloud-data-discoverer:secret-reader
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: d8:cloud-provider-azure:cloud-data-discoverer:secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: cloud-data-discoverer
+    namespace: d8-cloud-provider-azure
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -24,6 +24,37 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: d8:cloud-provider-gcp:cloud-data-discoverer:secret-reader
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - d8-provider-cluster-configuration
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - d8-cloud-provider-discovery-data
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: d8:cloud-provider-gcp:cloud-data-discoverer
@@ -36,6 +67,21 @@ subjects:
 - kind: ServiceAccount
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-gcp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: d8:cloud-provider-gcp:cloud-data-discoverer:secret-reader
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: d8:cloud-provider-gcp:cloud-data-discoverer:secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: cloud-data-discoverer
+    namespace: d8-cloud-provider-gcp
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add rbac Role to access `d8-provider-cluster-configuration` and `d8-cloud-provider-discovery-data` secrets.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deckhouse fails with error:

```
{"level":"error","msg":"Failed to get 'd8-provider-cluster-configuration' secret: secrets \"d8-provider-cluster-configuration\" is forbidden: User \"system:serviceaccount:d8-cloud-provider-aws:cloud-data-discoverer\" cannot get resource \"secrets\" in API group \"\" in the namespace \"kube-system\"\n","time":"2023-07-20T10:11:11Z"}
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Deckhouse fails with error (see above).

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: Add rbac Role to access d8-provider-cluster-configuration and d8-cloud-provider-discovery-data secrets.
impact_level: default
---
section: cloud-provider-azure
type: fix
summary: Add rbac Role to access d8-provider-cluster-configuration and d8-cloud-provider-discovery-data secrets.
impact_level: default
---
section: cloud-provider-gcp
type: fix
summary: Add rbac Role to access d8-provider-cluster-configuration and d8-cloud-provider-discovery-data secrets.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
