### PR TITLE
[control-plane-manager] Add CustomResourceValidationExpressions feature gate

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -6,6 +6,9 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- if semverCompare "< 1.23" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "EphemeralContainers=true" | join "," }}
 {{- end }}
+{{- if semverCompare "< 1.25" .clusterConfiguration.kubernetesVersion }}
+    {{- $featureGates = list $featureGates "CustomResourceValidationExpressions=true" | join "," }}
+{{- end }}
 {{- if semverCompare "< 1.27" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "DaemonSetUpdateSurge=true" | join "," }}
 {{- end }}

--- a/modules/021-kube-proxy/images/init-container/entrypoint/main.go
+++ b/modules/021-kube-proxy/images/init-container/entrypoint/main.go
@@ -116,10 +116,6 @@ func main() {
 		featureGates["DaemonSetUpdateSurge"] = true
 	}
 
-	if kubernetesVersion.LessThan(semver.MustParse("1.25")) {
-		featureGates["CustomResourceValidationExpressions"] = true
-	}
-
 	kubeProxyConfig := &v1alpha1.KubeProxyConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeProxyConfiguration",

--- a/modules/021-kube-proxy/images/init-container/entrypoint/main.go
+++ b/modules/021-kube-proxy/images/init-container/entrypoint/main.go
@@ -112,9 +112,12 @@ func main() {
 	}
 
 	// The DaemonSetUpdateSurge feature gate has been removed in Kubernetes v1.27.
-	k8s127, _ := semver.NewVersion("1.27")
-	if kubernetesVersion.LessThan(k8s127) {
+	if kubernetesVersion.LessThan(semver.MustParse("1.27")) {
 		featureGates["DaemonSetUpdateSurge"] = true
+	}
+
+	if kubernetesVersion.LessThan(semver.MustParse("1.25")) {
+		featureGates["CustomResourceValidationExpressions"] = true
 	}
 
 	kubeProxyConfig := &v1alpha1.KubeProxyConfiguration{

--- a/modules/021-kube-proxy/images/init-container/entrypoint/main.go
+++ b/modules/021-kube-proxy/images/init-container/entrypoint/main.go
@@ -112,7 +112,8 @@ func main() {
 	}
 
 	// The DaemonSetUpdateSurge feature gate has been removed in Kubernetes v1.27.
-	if kubernetesVersion.LessThan(semver.MustParse("1.27")) {
+	k8s127, _ := semver.NewVersion("1.27")
+	if kubernetesVersion.LessThan(k8s127) {
 		featureGates["DaemonSetUpdateSurge"] = true
 	}
 


### PR DESCRIPTION
## Description
Add x-kuberenetes-validation for CRDs.
This feature gate is disabled before 1.25, we can enable and use it from 1.23

## Why do we need it, and what problem does it solve?
Much easier then validating webhooks - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
You can add to a CRD:
```
x-kubernetes-validations:
  - messageExpression: '"CRI forbidden: " + self'
    rule: self != 'Docker'
```

result:
```
kubectl apply -f /tmp/testng
The NodeGroup "worker-test" is invalid: spec.cri.type: Invalid value: "string": CRI forbidden:: Docker
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Add feature-gate CustomResourceValidationExpressions.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
