### PR TITLE
Mount containerd socket into okmeter pods

### DIFF
--- a/modules/500-okmeter/templates/daemonset.yaml
+++ b/modules/500-okmeter/templates/daemonset.yaml
@@ -79,6 +79,9 @@ spec:
         - name: dockersocket
           mountPath: /var/run/docker.sock
           readOnly: true
+        - name: containerdsocket
+          mountPath: /run/containerd/containerd.sock
+          readOnly: true
         - name: hostproc
           mountPath: /host/proc
           readOnly: true
@@ -94,6 +97,9 @@ spec:
       - name: dockersocket
         hostPath:
           path: /var/run/docker.sock
+      - name: containerdsocket
+        hostPath:
+          path: /run/containerd/containerd.sock
       - name: hostproc
         hostPath:
           path: /proc


### PR DESCRIPTION
## Description
Mount containerd socket into okmeter daemonset pods

## Why do we need it, and what problem does it solve?
There is containerd support in the recent version of okagent software. To okagent be capable of collecting container information from the containerd, we need to provide it with the containerd socket the same way as it was done for docker.

```changes
section: okmeter
type: feature
summary: Mount containerd socket into okmeter daemonset pods to meet the requirement for containerd monitoring feature
impact: Rolling upgrade of the okmeter daemonset. This will cause a short disruption in node monitoring.
impact_level: default
```

