### PR TITLE
[runtime-audit-engine] Alert if replicas are not available

### DIFF
--- a/ee/modules/650-runtime-audit-engine/monitoring/prometheus-rules/runtime-audit-engine.yaml
+++ b/ee/modules/650-runtime-audit-engine/monitoring/prometheus-rules/runtime-audit-engine.yaml
@@ -5,7 +5,7 @@
     expr: |
       kube_daemonset_status_desired_number_scheduled{daemonset="runtime-audit-engine", namespace="d8-runtime-audit-engine", job="kube-state-metrics"}
       -
-      kube_daemonset_status_current_number_scheduled{daemonset="runtime-audit-engine", namespace="d8-runtime-audit-engine", job="kube-state-metrics"}
+      kube_daemonset_status_number_available{daemonset="runtime-audit-engine", namespace="d8-runtime-audit-engine", job="kube-state-metrics"}
       > 0
     labels:
       severity_level: "4"

--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -33,7 +33,7 @@
     expr: |
       kube_daemonset_status_desired_number_scheduled{daemonset="log-shipper-agent", namespace="d8-log-shipper", job="kube-state-metrics"}
       -
-      kube_daemonset_status_current_number_scheduled{daemonset="log-shipper-agent", namespace="d8-log-shipper", job="kube-state-metrics"}
+      kube_daemonset_status_number_available{daemonset="log-shipper-agent", namespace="d8-log-shipper", job="kube-state-metrics"}
       > 0
     labels:
       severity_level: "7"


### PR DESCRIPTION
## Description
Change alert condition

## Why do we need it, and what problem does it solve?
If pods are in CrashLoopBackOff state, there is no alert

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: Alert if replicas are not available
---
section: log-shipper
type: fix
summary: Alert if replicas are not available
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
