### PR TITLE
[runtime-audit-engine] reduce size of rules-reloader container

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
@@ -12,6 +12,7 @@ RUN \
     && pip3 install -r requirements.txt \
     && curl -sSfL https://download.falco.org/packages/bin/x86_64/falco-0.35.1-x86_64.tar.gz | tar -C /tmp -xzvf - \
     && cp -f /tmp/falco-0.35.1-x86_64/usr/bin/falco /usr/bin/falco \
+    && cp -rf /tmp/falco-0.35.1-x86_64/usr/share/falco /usr/share/falco \
     # cleanup \
     && apt-get clean autoclean \
     && apt-get autoremove -y \

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
@@ -8,16 +8,15 @@ COPY requirements.txt requirements.txt
 RUN \
     chmod +x /shell-operator \
     && apt update -y \
-    && apt install -yq curl gnupg \
-    && curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \
-    && echo "deb https://download.falco.org/packages/deb stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
-    && apt update -y \
-    && apt install -yq tini falco='0.35.1' python3='3.10.6-1~22.04' python3-pip \
+    && apt install -yq curl tini python3='3.10.6-1~22.04' python3-pip \
     && pip3 install -r requirements.txt \
-    # cleanup
+    && curl -sSfL https://download.falco.org/packages/bin/x86_64/falco-0.35.1-x86_64.tar.gz | tar -C /tmp -xzvf - \
+    && cp -f /tmp/falco-0.35.1-x86_64/usr/bin/falco /usr/bin/falco \
+    # cleanup \
     && apt-get clean autoclean \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
+    && rm -rf /tmp/falco-*
 
 COPY hooks/ /hooks
 ENV SHELL_OPERATOR_HOOKS_DIR /hooks

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
@@ -29,8 +29,7 @@ RUN \
     # cleanup
     && apt-get clean autoclean \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
-    && rm -rf /tmp/falco-*
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 COPY hooks/ /hooks
 ENV SHELL_OPERATOR_HOOKS_DIR /hooks

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/Dockerfile
@@ -2,18 +2,31 @@ ARG BASE_SHELL_OPERATOR
 ARG BASE_UBUNTU
 FROM $BASE_SHELL_OPERATOR as shell-operator
 
-FROM $BASE_UBUNTU
-COPY --from=shell-operator /shell-operator /shell-operator
+FROM $BASE_UBUNTU as falco-builder
 COPY requirements.txt requirements.txt
 RUN \
-    chmod +x /shell-operator \
-    && apt update -y \
-    && apt install -yq curl tini python3='3.10.6-1~22.04' python3-pip \
+    apt update -y \
+    && apt install -yq curl python3='3.10.6-1~22.04' python3-pip \
     && pip3 install -r requirements.txt \
     && curl -sSfL https://download.falco.org/packages/bin/x86_64/falco-0.35.1-x86_64.tar.gz | tar -C /tmp -xzvf - \
     && cp -f /tmp/falco-0.35.1-x86_64/usr/bin/falco /usr/bin/falco \
     && cp -rf /tmp/falco-0.35.1-x86_64/usr/share/falco /usr/share/falco \
-    # cleanup \
+    # cleanup
+    && apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
+    && rm -rf /tmp/falco-*
+
+FROM $BASE_UBUNTU
+COPY --from=shell-operator /shell-operator /shell-operator
+COPY --from=falco-builder /usr/bin/falco /usr/bin/falco
+COPY --from=falco-builder /usr/share/falco /usr/share/falco
+COPY --from=falco-builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
+RUN \
+    chmod +x /shell-operator \
+    && apt update -y \
+    && apt install -yq curl tini python3='3.10.6-1~22.04' \
+    # cleanup
     && apt-get clean autoclean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/ \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Reduce size of the runtime-audit-engine rules-loader container.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Previous rules-loader image builds leads to 1.2G container size.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: security
type: chore
summary: reduce size of rules-reloader container
impact: runtime-audit-engine pods should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
