### PR TITLE
[chore] Fix docker compose file for running documentation

### DIFF
--- a/docs/site/docker-compose.yml
+++ b/docs/site/docker-compose.yml
@@ -33,3 +33,4 @@ services:
 networks:
   deckhouse:
     name: deckhouse
+    external: true


### PR DESCRIPTION
## Description

Fix the following error, when running `make docs`:
```
WARN[0000] a network with name deckhouse exists but was not created by compose.
Set `external: true` to use an existing network 
network deckhouse was found but has incorrect label com.docker.compose.network set to ""
```

Fix Makefile for running documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix docker-compose.yml file for running documentation.
impact_level: low
```
