### PR TITLE
[preflight-check] Checking the availability of the localhost domain (#5207)

### DIFF
--- a/candi/bashible/preflight/check_localhost.sh
+++ b/candi/bashible/preflight/check_localhost.sh
@@ -1,0 +1,20 @@
+{{- /*
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+if ! getent ahosts localhost; then
+  echo "FAIL localhost is unavailable"
+  exit 1
+fi

--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -17,9 +17,10 @@ package app
 import "gopkg.in/alecthomas/kingpin.v2"
 
 var (
-	PreflightSkipAll               = false
-	PreflightSkipSSHForword        = false
-	PreflightSkipAvailabilityPorts = false
+	PreflightSkipAll                = false
+	PreflightSkipSSHForword         = false
+	PreflightSkipAvailabilityPorts  = false
+	PreflightSkipResolvingLocalhost = false
 )
 
 func DefinePreflight(cmd *kingpin.CmdClause) {
@@ -32,4 +33,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag("preflight-skip-availability-ports-check", "Skip availability ports preflight check").
 		Envar(configEnvName("PREFLIGHT_SKIP_AVAILABILITY_PORTS_CHECK")).
 		BoolVar(&PreflightSkipAvailabilityPorts)
+	cmd.Flag("preflight-skip-resolving-localhost-check", "Skip resolving the localhost domain").
+		Envar(configEnvName("PREFLIGHT_SKIP_RESOLVING_LOCALHOST_CHECK")).
+		BoolVar(&PreflightSkipResolvingLocalhost)
 }

--- a/dhctl/pkg/preflight/domain.go
+++ b/dhctl/pkg/preflight/domain.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
+)
+
+func (pc *PreflightCheck) CheckLocalhostDomain() error {
+	if app.PreflightSkipResolvingLocalhost {
+		log.InfoLn("Resolving the localhost domain preflight check was skipped")
+		return nil
+	}
+
+	log.DebugLn("Checking resolving the localhost domain")
+
+	file, err := template.RenderAndSavePreflightCheckLocalhostScript()
+	if err != nil {
+		return err
+	}
+
+	scriptCmd := pc.sshClient.UploadScript(file)
+	out, err := scriptCmd.Execute()
+	if err != nil {
+		log.ErrorLn(strings.Trim(string(out), "\n"))
+		if ee, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("check_localhost.sh: %w, %s", err, string(ee.Stderr))
+		}
+		return fmt.Errorf("check_localhost.sh: %w", err)
+	}
+
+	log.DebugLn(string(out))
+	log.InfoLn("Checking resolving the localhost domain success")
+	return nil
+}

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -36,7 +36,6 @@ func (pc *PreflightCheck) StaticCheck() error {
 			log.InfoLn("Preflight checks were skipped")
 			return nil
 		}
-    
 		err := pc.CheckSSHTunel()
 		if err != nil {
 			return err
@@ -46,6 +45,13 @@ func (pc *PreflightCheck) StaticCheck() error {
 		if err != nil {
 			return err
 		}
+
+		err = pc.CheckLocalhostDomain()
+		if err != nil {
+			return err
+		}
+
+
 		return nil
 	})
 }

--- a/dhctl/pkg/template/preflight.go
+++ b/dhctl/pkg/template/preflight.go
@@ -16,10 +16,19 @@ package template
 
 import "github.com/deckhouse/deckhouse/dhctl/pkg/log"
 
-const checkPortsScriptPath = candiBashibleDir + "/preflight/check_ports.sh"
+const (
+	checkPortsScriptPath     = candiBashibleDir + "/preflight/check_ports.sh"
+	checkLocalhostScriptPath = candiBashibleDir + "/preflight/check_localhost.sh"
+)
 
 func RenderAndSavePreflightCheckPortsScript() (string, error) {
 	log.DebugLn("Start render check ports script")
 
 	return RenderAndSaveTemplate("check_ports.sh", checkPortsScriptPath, map[string]interface{}{})
+}
+
+func RenderAndSavePreflightCheckLocalhostScript() (string, error) {
+	log.DebugLn("Start render check localhost script")
+
+	return RenderAndSaveTemplate("check_localhost.sh", checkLocalhostScriptPath, map[string]interface{}{})
 }


### PR DESCRIPTION
## Description
Checking the availability of the localhost domain
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
issue #5207 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Preventing failures before bootstrap execution
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Checking the availability of the localhost domain
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
