### PR TITLE
[cloud-provider-openstack] Fix creating long name of backup secret in state migration

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/migrate/migrate_terraform_state.go
@@ -83,6 +83,11 @@ func processSecretsList(secretList *v1.SecretList, terraformStateDataKey string,
 	for _, secret := range secretList.Items {
 		input.LogEntry.Infof("Proceeding with Secret/%s/%s", TerraformStateNamespace, secret.ObjectMeta.Name)
 		backupSecretName := secret.ObjectMeta.Name + "-backup"
+		// dirty hack, we cannot create secret with label value > 63
+		if len(backupSecretName) > 63 {
+			// remove '-terraform' suffix it will be enough
+			backupSecretName = strings.Replace(backupSecretName, "-terraform", "", 1)
+		}
 
 		secretBackupExists, err := isSecretBackupExists(backupSecretName, TerraformStateNamespace, kubeCl, input)
 		if secretBackupExists && err == nil {

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 
 require (
 	github.com/deckhouse/deckhouse/go_lib/cloud-data v0.0.0
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/validate v0.19.12
 	github.com/slok/kubewebhook/v2 v2.5.0

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 
 require (
 	github.com/deckhouse/deckhouse/go_lib/cloud-data v0.0.0
-	github.com/docker/distribution v2.8.2+incompatible
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/validate v0.19.12
 	github.com/slok/kubewebhook/v2 v2.5.0


### PR DESCRIPTION
## Description
Reduce backup state secret length for openstack state migration. 

## Why do we need it, and what problem does it solve?
During migration backup secret can not be created for clusters with long prefix and Deckhouse queue will be stuck.

## Why do we need it in the patch release (if we do)?

During migration backup secret can not be created for clusters with long prefix and Deckhouse queue will be stuck.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manual test proofs
![image](https://github.com/deckhouse/deckhouse/assets/30695496/a385d7f3-b529-4f71-97e7-eb6c4c40bddf)

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Fix creating long name of backup secret in state.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
