### PR TITLE
[cloud-provider-openstack] Fix descovery security groups and error in hybrib clusters

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
@@ -269,8 +269,8 @@ func (d *Discoverer) getAdditionalSecurityGroups(ctx context.Context, provider *
 
 	allPages, err := groups.List(client, groups.ListOpts{}).AllPages()
 	if err != nil {
-		if errors.Is(err, gophercloud.ErrDefault404{}) {
-			d.logger.Infoln("Cloud does not support security groups. Return empty array")
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			d.logger.Infoln("Cloud does not support security groups. Returns empty array")
 			return make([]string, 0), nil
 		}
 

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
@@ -29,9 +29,10 @@ import (
 )
 
 type Discoverer struct {
-	logger   *log.Entry
-	authOpts gophercloud.AuthOptions
-	region   string
+	logger       *log.Entry
+	authOpts     gophercloud.AuthOptions
+	region       string
+	moduleConfig []byte
 }
 
 func NewDiscoverer(logger *log.Entry) *Discoverer {
@@ -45,10 +46,13 @@ func NewDiscoverer(logger *log.Entry) *Discoverer {
 		logger.Fatalf("Cannnot get OS_REGION env")
 	}
 
+	moduleConfig := os.Getenv("MODULE_CONFIG")
+
 	return &Discoverer{
-		logger:   logger,
-		region:   region,
-		authOpts: authOpts,
+		logger:       logger,
+		region:       region,
+		authOpts:     authOpts,
+		moduleConfig: []byte(moduleConfig),
 	}
 }
 
@@ -82,9 +86,16 @@ func (d *Discoverer) InstanceTypes(ctx context.Context) ([]v1alpha1.InstanceType
 
 func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryData []byte) ([]byte, error) {
 	var discoveryData OpenstackCloudDiscoveryData
-	err := json.Unmarshal(cloudProviderDiscoveryData, &discoveryData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal cloud provider discovery data: %v", err)
+
+	if len(cloudProviderDiscoveryData) == 0 {
+		cloudProviderDiscoveryData = d.moduleConfig
+	}
+
+	if len(cloudProviderDiscoveryData) > 0 {
+		err := json.Unmarshal(cloudProviderDiscoveryData, &discoveryData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cloud provider discovery data: %v", err)
+		}
 	}
 
 	provider, err := newProvider(d.authOpts, d.logger)

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/discoverer.go
@@ -258,6 +258,11 @@ func (d *Discoverer) getAdditionalSecurityGroups(ctx context.Context, provider *
 
 	allPages, err := groups.List(client, groups.ListOpts{}).AllPages()
 	if err != nil {
+		if errors.Is(err, gophercloud.ErrDefault404{}) {
+			d.logger.Infoln("Cloud does not support security groups. Return empty array")
+			return make([]string, 0), nil
+		}
+
 		return nil, fmt.Errorf("failed to list security groups: %v", err)
 	}
 

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
@@ -122,6 +122,11 @@ spec:
             secretKeyRef:
               key: region
               name: cloud-data-discoverer
+        - name: MODULE_CONFIG
+          valueFrom:
+            secretKeyRef:
+              key: moduleConfig
+              name: cloud-data-discoverer
         livenessProbe:
           httpGet:
             path: /healthz

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/secret.yaml
@@ -21,3 +21,14 @@ data:
 {{- if hasKey .Values.cloudProviderOpenstack.internal.connection "caCert" }}
   ca.crt: {{ .Values.cloudProviderOpenstack.internal.connection.caCert | b64enc | quote }}
 {{- end }}
+
+  # additionals config
+  {{- $internal := .Values.cloudProviderOpenstack.internal }}
+  {{- $openstackValues := dict }}
+  {{- if hasKey $internal "instances" }}
+    {{- $_ := set $openstackValues "instances" $internal.instances }}
+  {{- end }}
+  {{- if hasKey $internal "zones" }}
+    {{- $_ := set $openstackValues "zones" $internal.instances }}
+  {{- end }}
+  moduleConfig: {{ $openstackValues | toJson | b64enc | quote }}

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/secret.yaml
@@ -29,6 +29,6 @@ data:
     {{- $_ := set $openstackValues "instances" $internal.instances }}
   {{- end }}
   {{- if hasKey $internal "zones" }}
-    {{- $_ := set $openstackValues "zones" $internal.instances }}
+    {{- $_ := set $openstackValues "zones" $internal.zones }}
   {{- end }}
   moduleConfig: {{ $openstackValues | toJson | b64enc | quote }}

--- a/go_lib/cloud-data/apis/v1alpha1/openstack_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1alpha1/openstack_cloud_provider_discovery_data.go
@@ -18,14 +18,14 @@ type OpenStackCloudProviderDiscoveryData struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	Kind       string `json:"kind,omitempty"`
 
-	Flavors                  []string                                        `json:"flavors,omitempty"`
-	AdditionalNetworks       []string                                        `json:"additionalNetworks,omitempty"`
-	AdditionalSecurityGroups []string                                        `json:"additionalSecurityGroups,omitempty"`
-	DefaultImageName         string                                          `json:"defaultImageName,omitempty"`
-	Images                   []string                                        `json:"images,omitempty"`
-	MainNetwork              string                                          `json:"mainNetwork,omitempty"`
-	Zones                    []string                                        `json:"zones,omitempty"`
-	VolumeTypes              []OpenStackCloudProviderDiscoveryDataVolumeType `json:"volumeTypes,omitempty"`
+	Flavors                  []string                                        `json:"flavors"`
+	AdditionalNetworks       []string                                        `json:"additionalNetworks"`
+	AdditionalSecurityGroups []string                                        `json:"additionalSecurityGroups"`
+	DefaultImageName         string                                          `json:"defaultImageName"`
+	Images                   []string                                        `json:"images"`
+	MainNetwork              string                                          `json:"mainNetwork"`
+	Zones                    []string                                        `json:"zones"`
+	VolumeTypes              []OpenStackCloudProviderDiscoveryDataVolumeType `json:"volumeTypes"`
 }
 
 type OpenStackCloudProviderDiscoveryDataVolumeType struct {

--- a/go_lib/cloud-data/reconciler.go
+++ b/go_lib/cloud-data/reconciler.go
@@ -297,14 +297,17 @@ func (c *Reconciler) discoveryDataReconcile(ctx context.Context) {
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
+	var cloudDiscoveryData []byte
+
 	secret, err := c.k8sClient.CoreV1().Secrets("kube-system").Get(cctx, "d8-provider-cluster-configuration", metav1.GetOptions{})
-	if err != nil {
+	// d8-provider-cluster-configuration can not be exist in hybrid clusters
+	if err != nil && !errors.IsNotFound(err) {
 		c.logger.Errorf("Failed to get 'd8-provider-cluster-configuration' secret: %v\n", err)
 		c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(1.0)
 		return
+	} else {
+		cloudDiscoveryData = secret.Data["cloud-provider-discovery-data.json"]
 	}
-
-	cloudDiscoveryData := secret.Data["cloud-provider-discovery-data.json"]
 
 	discoveryData, err := c.discoverer.DiscoveryData(ctx, cloudDiscoveryData)
 	if err != nil {

--- a/go_lib/cloud-data/reconciler.go
+++ b/go_lib/cloud-data/reconciler.go
@@ -301,10 +301,12 @@ func (c *Reconciler) discoveryDataReconcile(ctx context.Context) {
 
 	secret, err := c.k8sClient.CoreV1().Secrets("kube-system").Get(cctx, "d8-provider-cluster-configuration", metav1.GetOptions{})
 	// d8-provider-cluster-configuration can not be exist in hybrid clusters
-	if err != nil && !errors.IsNotFound(err) {
-		c.logger.Errorf("Failed to get 'd8-provider-cluster-configuration' secret: %v\n", err)
-		c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(1.0)
-		return
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			c.logger.Errorf("Failed to get 'd8-provider-cluster-configuration' secret: %v\n", err)
+			c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(1.0)
+			return
+		}
 	} else {
 		cloudDiscoveryData = secret.Data["cloud-provider-discovery-data.json"]
 	}


### PR DESCRIPTION
## Description
Handle 404 error for security groups. Some clouds don't have security groups.
Getting settings from openstack module settings if d8-provider-cluster config secret does not exist. It would be in hybrid clusters.
 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Have errors
```
{"level":"error","msg":"Failed to get 'd8-provider-cluster-configuration' secret: secrets \"d8-provider-cluster-configuration\" not found\n","time":"2023-07-26T11:01:48Z"}
```

```
{"level":"error","msg":"Getting discovery data error: failed to get additional security groups: failed to list security groups: Resource not found: [GET https://api-3.uu/network/v2.0/security-groups], error message: {\"NeutronError\": {\"type\": \"HTTPNotFound\", \"message\": \"The resource could not be found.\", \"detail\": \"\"}}\n","time":"2023-07-26T09:37:49Z"}
```

## Why do we need it in the patch release (if we do)?

Have errors
```
{"level":"error","msg":"Failed to get 'd8-provider-cluster-configuration' secret: secrets \"d8-provider-cluster-configuration\" not found\n","time":"2023-07-26T11:01:48Z"}
```

```
{"level":"error","msg":"Getting discovery data error: failed to get additional security groups: failed to list security groups: Resource not found: [GET https://api-3.uu/network/v2.0/security-groups], error message: {\"NeutronError\": {\"type\": \"HTTPNotFound\", \"message\": \"The resource could not be found.\", \"detail\": \"\"}}\n","time":"2023-07-26T09:37:49Z"}
```


<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manual testing proofs
![image](https://github.com/deckhouse/deckhouse/assets/30695496/5bf3dbdf-e4b3-4a65-9e67-5da8ad4e6405)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/fa93dbca-ee7b-4d74-8e3b-adaf1a608ef8)


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: 
impact: Fix discovery security groups and errors in hybrid clusters.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
