### PR TITLE
[helm-lib] Fix X.509 certificate common name generation

### DIFF
--- a/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "istio-api-proxy") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
   issuerRef:

--- a/ee/modules/502-delivery/templates/argocd/server/d8-ingress.yaml
+++ b/ee/modules/502-delivery/templates/argocd/server/d8-ingress.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-argocd") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "argocd") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "argocd") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "argocd") }}
   issuerRef:

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.5.1
-digest: sha256:2d89cfed6f742bd23e1584106069de6679f738884f2edd00d1e75e3db0b432d6
-generated: "2023-07-13T16:54:26.844325994+03:00"
+  version: 1.6.0
+digest: sha256:dd073e0f6d3bfefbd497493d294c8bd4fd17d43820d3a6ef27a60d3a44f70a54
+generated: "2023-07-26T19:58:22.21658+08:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.5.1"
+    version: "1.6.0"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.5.1
+version: 1.6.0

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -16,6 +16,8 @@
 | **Module Ephemeral Storage** |
 | [helm_lib_module_ephemeral_storage_logs_with_extra](#helm_lib_module_ephemeral_storage_logs_with_extra) |
 | [helm_lib_module_ephemeral_storage_only_logs](#helm_lib_module_ephemeral_storage_only_logs) |
+| **Module Generate Common Name** |
+| [helm_lib_module_generate_common_name](#helm_lib_module_generate_common_name) |
 | **Module Https** |
 | [helm_lib_module_uri_scheme](#helm_lib_module_uri_scheme) |
 | [helm_lib_module_https_mode](#helm_lib_module_https_mode) |
@@ -194,6 +196,22 @@ list:
 #### Arguments
 
 -  Template context with .Values, .Chart, etc 
+
+## Module Generate Common Name
+
+### helm_lib_module_generate_common_name
+
+ returns the commonName parameter for use in the Certificate custom resource(cert-manager) 
+
+#### Usage
+
+`{{ include "helm_lib_module_generate_common_name" (list . "<name-portion>") }} `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  Name portion 
 
 ## Module Https
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_documentation_uri.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_documentation_uri.tpl
@@ -9,7 +9,7 @@
      {{- $uri = printf "%s://%s%s" (include "helm_lib_module_uri_scheme" $context) (include "helm_lib_module_public_domain" (list $context "documentation")) $path_portion -}}
   {{- else }}
      {{- $uri = printf "%s%s" $default_doc_prefix $path_portion -}}
-  {{- end }}
+  {{- end -}}
 
   {{ $uri }}
 {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_generate_common_name.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_generate_common_name.tpl
@@ -1,0 +1,13 @@
+{{- /* Usage: {{ include "helm_lib_module_generate_common_name" (list . "<name-portion>") }} */ -}}
+{{- /* returns the commonName parameter for use in the Certificate custom resource(cert-manager) */ -}}
+{{- define "helm_lib_module_generate_common_name" }}
+  {{- $context      := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $name_portion := index . 1 -}} {{- /* Name portion */ -}}
+
+  {{- $domain := include "helm_lib_module_public_domain" (list $context $name_portion) -}}
+
+  {{- $domain_length := len $domain -}}
+  {{- if le $domain_length 64 -}}
+commonName: {{ $domain }}
+  {{- end -}}
+{{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_public_domain.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_public_domain.tpl
@@ -7,13 +7,5 @@
   {{- if not (contains "%s" $context.Values.global.modules.publicDomainTemplate) }}
     {{ fail "Error!!! global.modules.publicDomainTemplate must contain \"%s\" pattern to render service fqdn!" }}
   {{- end }}
-
-  {{- $domain := printf $context.Values.global.modules.publicDomainTemplate $name_portion -}}
-
-  {{- $domain_length := len $domain -}}
-  {{- if gt $domain_length 64 -}}
-    {{ fail "domain name must be not longer than 64 characters" }}
-  {{- end -}}
-
-  {{ $domain }}
+  {{- printf $context.Values.global.modules.publicDomainTemplate $name_portion }}
 {{- end }}

--- a/modules/110-istio/templates/certificate.yaml
+++ b/modules/110-istio/templates/certificate.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "istio-ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "istio") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "istio") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "istio") }}
   issuerRef:

--- a/modules/150-user-authn/templates/dex/certificate.yaml
+++ b/modules/150-user-authn/templates/dex/certificate.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "dex") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "dex") }}
   issuerRef:

--- a/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "kubeconfig-ingress-tls") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "kubeconfig") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "kubeconfig") }}
   issuerRef:

--- a/modules/150-user-authn/templates/kubernetes-api/certificate.yaml
+++ b/modules/150-user-authn/templates/kubernetes-api/certificate.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "publish_api_certificate_name" . }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "api") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "api") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "api") }}
   issuerRef:

--- a/modules/300-prometheus/templates/grafana/ingress.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress.yaml
@@ -79,7 +79,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "grafana") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "grafana") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "grafana") }}
   - {{ include "helm_lib_module_public_domain" (list . "prometheus") }}

--- a/modules/491-containerized-data-importer/templates/ingress.yaml
+++ b/modules/491-containerized-data-importer/templates/ingress.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "cdi-uploadproxy") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "cdi-uploadproxy") | nindent 2 }}
   dnsNames:
     - {{ include "helm_lib_module_public_domain" (list . "cdi-uploadproxy") }}
   issuerRef:

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -57,7 +57,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "hubble") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "hubble") | nindent 2 }}
   dnsNames:
     - {{ include "helm_lib_module_public_domain" (list . "hubble") }}
   issuerRef:

--- a/modules/500-dashboard/templates/dashboard/ingress.yaml
+++ b/modules/500-dashboard/templates/dashboard/ingress.yaml
@@ -64,7 +64,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "dashboard") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "dashboard") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "dashboard") }}
   issuerRef:

--- a/modules/500-openvpn/templates/openvpn/ingress.yaml
+++ b/modules/500-openvpn/templates/openvpn/ingress.yaml
@@ -56,7 +56,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "openvpn-admin") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "openvpn-admin") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "openvpn-admin") }}
   issuerRef:

--- a/modules/500-upmeter/templates/status/ingress.yaml
+++ b/modules/500-upmeter/templates/status/ingress.yaml
@@ -101,7 +101,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: ingress-tls-status
-  commonName: {{ include "helm_lib_module_public_domain" (list . "status") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "status") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "status") }}
   issuerRef:

--- a/modules/500-upmeter/templates/webui/ingress.yaml
+++ b/modules/500-upmeter/templates/webui/ingress.yaml
@@ -95,7 +95,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: ingress-tls-webui
-  commonName: {{ include "helm_lib_module_public_domain" (list . .Chart.Name) }}
+  {{ include "helm_lib_module_generate_common_name" (list . .Chart.Name) | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . .Chart.Name) }}
   issuerRef:

--- a/modules/810-documentation/templates/ingress.yaml
+++ b/modules/810-documentation/templates/ingress.yaml
@@ -59,7 +59,7 @@ metadata:
 spec:
   certificateOwnerRef: false
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  commonName: {{ include "helm_lib_module_public_domain" (list . "documentation") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "documentation") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "documentation") }}
   issuerRef:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix `helm_lib_module_public_domain` and add `helm_lib_module_generate_common_name`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deckhouse fails with error:

```
ModuleRun:main:node-manager:doStartup:OperatorStartup:failures 1392:template: node-manager/templates/monitoring.yaml:1:4: executing "node-manager/templates/monitoring.yaml" at <include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager")>: error calling include: template: node-manager/charts/deckhouse_lib_helm/templates/_monitoring_prometheus_rules.tpl:81:4: executing "helm_lib_prometheus_rules" at <include "helm_lib_prometheus_rules_recursion" (list $context $namespace "monitoring/prometheus-rules")>: error calling include: template: node-manager/charts/deckhouse_lib_helm/templates/_monitoring_prometheus_rules.tpl:18:24: executing "helm_lib_prometheus_rules_recursion" at <tpl ($context.Files.Get $path) $context>: error calling tpl: error during tpl function execution for "- name: d8.node-unmanaged\n  rules:\n    - alert: D8NodeIsUnmanaged\n      expr: max by (node) (d8_unmanaged_nodes_on_cluster) > 0\n      for: 10m\n      labels:\n        tier: cluster\n        severity_level: \"9\"\n      annotations:\n        plk_markup_format: \"markdown\"\n        plk_protocol_version: \"1\"\n        plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: \"D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes\"\n        plk_grouped_by__d8_cluster_has_unmanaged_nodes: \"D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes\"\n    {{- if .Values.global.modules.publicDomainTemplate }}\n        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include \"helm_lib_module_uri_scheme\" . }}://{{ include \"helm_lib_module_public_domain\" (list . \"documentation\") }}/modules/040-node-manager/) module.\n        description: |\n          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include \"helm_lib_module_uri_scheme\" . }}://{{ include \"helm_lib_module_public_domain\" (list . \"documentation\") }}/modules/040-node-manager/) module.\n\n          The recommended actions are as follows:\n          - Follow these instructions to clean up the node and add it to the cluster: {{ include \"helm_lib_module_uri_scheme\" . }}://{{ include \"helm_lib_module_public_domain\" (list . \"documentation\") }}/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster\n    {{- else }}\n        summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.\n        description: |\n          The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager](https://deckhouse.io/documentation/v1/modules/040-node-manager/) module.\n\n          The recommended actions are as follows:\n          - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster\n    {{- end }}\n": execution error at (node-manager/templates/monitoring.yaml:15:138): domain name must be not longer than 64 characters
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Deckhouse fails with error(see above).

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: helm-lib
type: fix
summary: Fix X.509 certificate common name generation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
