### PR TITLE
[distroless] monitoring-kubernetes

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache make git patch
 
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \
-  git clone https://github.com/kubernetes/kube-state-metrics/ /src/kube-state-metrics
+  git clone --depth 1 --branch v2.6.0 https://github.com/kubernetes/kube-state-metrics/ /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
 RUN make build-local
 

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache make git patch
 
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \
-  git clone https://github.com/kubernetes/kube-state-metrics/archive/v2.6.0.tar.gz -O - | tar -xz --strip-components=1 -C /src/kube-state-metrics
+  wget https://github.com/kubernetes/kube-state-metrics/archive/v2.6.0.tar.gz -O - | tar -xz --strip-components=1 -C /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
 RUN make build-local
 

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache make git patch
 
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \
-  wget https://github.com/kubernetes/kube-state-metrics/archive/v2.6.0.tar.gz -O - | tar -xz --strip-components=1 -C /src/kube-state-metrics
+  git clone https://github.com/kubernetes/kube-state-metrics/ /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
 RUN make build-local
 

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -1,15 +1,14 @@
-ARG BASE_ALPINE
 ARG BASE_GOLANG_17_ALPINE
-ARG BASE_SCRATCH
+ARG BASE_DISTROLESS
 FROM $BASE_GOLANG_17_ALPINE as artifact
 RUN apk add --no-cache make git patch
 
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \
-  wget https://github.com/kubernetes/kube-state-metrics/archive/v2.6.0.tar.gz -O - | tar -xz --strip-components=1 -C /src/kube-state-metrics
+  git clone https://github.com/kubernetes/kube-state-metrics/archive/v2.6.0.tar.gz -O - | tar -xz --strip-components=1 -C /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
 RUN make build-local
 
-FROM $BASE_SCRATCH
+FROM $BASE_DISTROLESS
 COPY --from=artifact /src/kube-state-metrics/kube-state-metrics /bin/kube-state-metrics
 ENTRYPOINT ["/bin/kube-state-metrics"]

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -1,8 +1,8 @@
 # Based on https://github.com/prometheus/node_exporter/blob/v0.18.1/Dockerfile
-ARG BASE_ALPINE
+ARG BASE_DISTROLESS
 FROM prom/node-exporter:v0.18.1@sha256:a2f29256e53cc3e0b64d7a472512600b2e9410347d53cdc85b49f659c17e02ee as artifact
 
-FROM $BASE_ALPINE
+FROM $BASE_DISTROLESS
 COPY --from=artifact /bin/node_exporter /bin
 
 EXPOSE      9100


### PR DESCRIPTION
## Description
kube-state-metrics, node-exporter are now based on minimal image.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We'd like to base our images on a distroless image.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
We use scratch along with a minimal number of files from Alpine packages. We pass files in packages though an rsync whitelist.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: feature
summary: Images are based on a distroless image.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
