### PR TITLE
[operator-trivy] Remove upmeter probes from trivy scanning

### DIFF
--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
   {{- with (include "nodeSelector" . | fromJson) }}
   scanJob.nodeSelector: {{ .nodeSelector | toJson | quote }}
   {{- end }}
+  # Skip upmeter probes in vulnerability scanning
+  # https://github.com/deckhouse/deckhouse/blob/v1.49.0/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_statefulset.go#L138
+  skipResourceByLabels: upmeter-group,upmeter-probe
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
When upmeter and operator-trivy modules are enabled - trivy trying to scan upmeter probes image, [which doesn't exist](https://github.com/deckhouse/deckhouse/blob/main/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_statefulset.go#L164).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Scanning of upmeter probes generates errors in operator-trivy:
```
2023-07-22T07:39:47.908Z	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
	* unable to inspect the image (registry.k8s.io/upmeter-nonexistent:3.1415): Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
	* containerd socket not found: /run/containerd/containerd.sock
	* unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
	* GET https://europe-west4-docker.pkg.dev/v2/k8s-artifacts-prod/images/upmeter-nonexistent/manifests/3.1415: MANIFEST_UNKNOWN: Failed to fetch "3.1415"
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
No error about non-existed images

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: fix
summary:  Remove upmeter probes from trivy scanning.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
