### PR TITLE
[ingress-nginx] add prestop lifecycle hook for rbac-proxy

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -339,7 +339,10 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: [ "/bin/sh", "-c", "/bin/sleep {{ $gracePeriod }}" ]
+              command:
+              - /bin/sh
+              - -c
+              - while [ $(nc 127.0.0.1 10254 -z; echo $?) -eq 0 ];do sleep 1; done
         {{- end }}
         ports:
         - containerPort: 10354

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -19,11 +19,7 @@
 {{- else if eq $crd.spec.inlet "HostWithFailover" }}
   {{- $defaultGracePeriod = 0 }}
 {{- end }}
-{{- if kindIs "invalid" $crd.spec.waitLoadBalancerOnTerminating }}
-  {{- $gracePeriod = $defaultGracePeriod }}
-{{- else }}
-  {{- $gracePeriod = $crd.spec.waitLoadBalancerOnTerminating | int }}
-{{- end }}
+{{- $gracePeriod = (kindIs "invalid" $crd.spec.waitLoadBalancerOnTerminating) | ternary $defaultGracePeriod $crd.spec.waitLoadBalancerOnTerminating }}
 {{- $defaultSSLCertificate := $crd.spec.defaultSSLCertificate | default dict }}
 {{- $defaultSSLCertificateSecretRef := $defaultSSLCertificate.secretRef | default dict }}
 

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -331,7 +331,6 @@ spec:
                   resource: daemonsets
                   subresource: prometheus-protobuf-metrics
                   name: ingress-nginx
-        {{- if gt $gracePeriod 0 }}
         lifecycle:
           preStop:
             exec:
@@ -339,7 +338,6 @@ spec:
               - /bin/sh
               - -c
               - while [ $(nc 127.0.0.1 10254 -z; echo $?) -eq 0 ];do sleep 1; done
-        {{- end }}
         ports:
         - containerPort: 10354
           name: https-metrics

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -12,11 +12,17 @@
 {{- $geoIP2 := $crd.spec.geoIP2 | default dict }}
 {{- $hostPort := $crd.spec.hostPort | default dict }}
 {{- $hostPortWithProxyProtocol := $crd.spec.hostPortWithProxyProtocol | default dict }}
+{{- $gracePeriod := 0 }}
 {{- $defaultGracePeriod := 60 }}
 {{- if $loadBalancer }}
   {{- $defaultGracePeriod = 120 }}
 {{- else if eq $crd.spec.inlet "HostWithFailover" }}
   {{- $defaultGracePeriod = 0 }}
+{{- end }}
+{{- if kindIs "invalid" $crd.spec.waitLoadBalancerOnTerminating }}
+  {{- $gracePeriod = $defaultGracePeriod }}
+{{- else }}
+  {{- $gracePeriod = $crd.spec.waitLoadBalancerOnTerminating | int }}
 {{- end }}
 {{- $defaultSSLCertificate := $crd.spec.defaultSSLCertificate | default dict }}
 {{- $defaultSSLCertificateSecretRef := $defaultSSLCertificate.secretRef | default dict }}
@@ -186,7 +192,7 @@ spec:
         - --publish-service=d8-ingress-nginx/{{ $crd.name }}-load-balancer
         {{- end }}
         # sleep before shutting down the nginx, required by cloud LoadBalancers to terminate gracefully.
-        - --shutdown-grace-period={{ $crd.spec.waitLoadBalancerOnTerminating | default $defaultGracePeriod }}
+        - --shutdown-grace-period={{ $gracePeriod }}
         {{- if or (ne $crd.spec.inlet "HostWithFailover") (and (eq $crd.spec.inlet "HostWithFailover") ($failover)) }}
         # we don't disable it if validation is disabled because it will lead to deployment rollout
         - --validating-webhook=:8443
@@ -329,6 +335,12 @@ spec:
                   resource: daemonsets
                   subresource: prometheus-protobuf-metrics
                   name: ingress-nginx
+        {{- if gt $gracePeriod 0 }}
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sh", "-c", "/bin/sleep {{ $gracePeriod }}" ]
+        {{- end }}
         ports:
         - containerPort: 10354
           name: https-metrics


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add a lifecycle preStop hook with a `while` loop checking `controller's healthz 10254 port availability` to the `kube-rbac-proxy` container of an Ingress nginx's pod, preventing it from getting instantly not ready on termination.
Also, a minor change - a possibility to set `spec.waitLoadBalancerOnTerminating` to `0` value (previously, it would render to nil and wouldn't be accounted).
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In case we use non-null value of the `--shutdown-grace-period` flag (`loadBalancer` and `hostPort` inlets) for ingress-nginx-controller, kube-rbac-proxy should continue running for the same time before exiting on shutdown. Otherwise we end up with a terminating and `not` ready pod as `kube-rbac-proxy` exits immediately and prevents liveness/readiness probes of the ingress-controller container from succeeding, rendering the container as not ready). Having a terminating and `NOT` ready pod doesn't allow k8s to apply such failover techniques as [ProxyTerminatingEndpoints](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1669-proxy-terminating-endpoints/README.md) and their [alternatives](https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#graceful-termination). It may result in a short downtime that starts as soon as the readiness probe fails 3 times (~6 seconds since deleting the pod) when the old pod is in terminating state (waiting for shutdown-grace-period), and a new one isn't come up yet.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
The `kube-rbac-proxy` container doesn't exit before the ingress-controller closes its healthz port, allowing liveness/readiness probes to succeed.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Add a lifecycle prestop hook to kube-rbac-proxy.
impact: Nginx Ingress controller pods will be recreated consecutively.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
