### PR TITLE
[site][docs] Update VPA mode and deployment resources.

### DIFF
--- a/docs/documentation/.helm/templates/10-app.yaml
+++ b/docs/documentation/.helm/templates/10-app.yaml
@@ -69,7 +69,7 @@ spec:
     kind: Deployment
     name: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}
   updatePolicy:
-    updateMode: "Initial"
+    updateMode: "Auto"
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/docs/documentation/.helm/values.yaml
+++ b/docs/documentation/.helm/values.yaml
@@ -8,6 +8,6 @@ ingress:
 resources:
   requests:
     memory:
-      _default: 20M
-      production: 50M
+      _default: 30M
+      web-production: 50M
 

--- a/docs/site/.helm/templates/12-backend.yaml
+++ b/docs/site/.helm/templates/12-backend.yaml
@@ -75,7 +75,7 @@ spec:
     kind: Deployment
     name: backend
   updatePolicy:
-    updateMode: "Initial"
+    updateMode: "Auto"
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/docs/site/.helm/templates/14-frontend.yaml
+++ b/docs/site/.helm/templates/14-frontend.yaml
@@ -68,7 +68,7 @@ spec:
     kind: Deployment
     name: frontend
   updatePolicy:
-    updateMode: "Initial"
+    updateMode: "Auto"
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -9,8 +9,8 @@ ingress:
 resources:
   requests:
     memory:
-      _default: 20M
-      production: 50M
+      _default: 30M
+      web-production: 50M
 
 vrouter:
   defaultGroup: "v1"


### PR DESCRIPTION
## Description
Fix the use of values for resources in helm templates. Change VPA mode to Auto for the site deployments.

## Why do we need it, and what problem does it solve?
Resources were too low. Where was the bug in the helm template.

## Changelog entries
```changes
section: docs
type: chore
summary: Update VPA mode and deployment resources for the site deployments.
impact_level: low
```
