### PR TITLE
[cloud-provider-openstack] Fix OpenAPI spec

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
@@ -129,7 +129,6 @@ properties:
               - OpenStackCloudProviderDiscoveryData
           mainNetwork:
             type: string
-            minLength: 1
             description: |
               The path to the network that will serve as the primary network (the default gateway) for connecting to the virtual machine.
           additionalNetworks:
@@ -154,7 +153,6 @@ properties:
             uniqueItems: true
           defaultImageName:
             type: string
-            minLength: 1
             description: Virtual machine image name used by default.
           images:
             type: array


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove `minLength: 1` requirement from `mainNetwork` and `defaultImageName` properties.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deckhouse fails with error:

```
2023-07-31T08:51:55Z [error][cloud-provider-openstack] - Module hook failed, requeue task to retry after delay. Failed count is 8049. Error: module hook '030-cloud-provider-openstack/hooks/discover.go' failed: failed to validate 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: Loading schema file: Document validation failed:
---
{"apiVersion":"deckhouse.io/v1alpha1","kind":"OpenStackCloudProviderDiscoveryData","flavors":["m1.tiny","BL1.1-512","BL1.1-1024","BL1.1-2048","BL1.2-4096","BL1.2-8192","BL1.4-16384","BL1.6-32768","BL1.8-49152","BL1.10-65536","SL1.1-1024","SL1.1-2048","SL1.2-4096","SL1.2-8192","SL1.4-16384","SL1.6-32768","SL1.8-32768","SL1.12-49152","SL1.16-65536","SL1.24-98304","SGX1.1-4096-0-2034EPC","SGX1.2-8192-0-4071EPC","SGX1.4-16384-0-8143EPC","SGX1.8-32768-0-16286EPC","SGX1.16-65536-0-32572EPC","SGX1.24-98304-0-65144EPC","SGX1.1-4096-32-2034EPC","SGX1.2-8192-64-4071EPC","SGX1.4-16384-128-8143EPC","SGX1.8-32768-256-16286EPC","SGX1.16-65536-512-32572EPC","SGX1.24-98304-1024-65144EPC","BL1.1-512-5","BL1.1-1024-8","BL1.1-2048-16","BL1.2-4096-32","BL1.2-8192-64","BL1.4-16384-128","BL1.6-32768-256","BL1.8-49152-384","BL1.10-65536-512","SL1.1-1024-8","SL1.1-2048-16","SL1.2-4096-32","SL1.2-8192-64","SL1.4-16384-128","SL1.6-32768-256","SL1.8-32768-384","SL1.12-49152-512","SL1.16-65536-768","SL1.24-98304-1024","SL1.36-131072-1280","m1.small","PL2.12-98304","PL2.14-131072","PL2.16-163840","PL2.20-196608","PL2.24-229376","PL2.32-327680","CPU1.4-8192","CPU1.8-16384","CPU1.16-32768","CPU1.24-49152","CPU1.12-24576","PL2.12-98304-768","PL2.14-131072-1024","PL2.16-163840-1280","PL2.20-196608-1536","PL2.24-229376-1952","CPU1.4-8192-128","CPU1.8-16384-192","CPU1.16-32768-384","CPU1.24-49152-512","CPU1.12-24576-256","m1.medium","GL2.8-24576-0-1GPU","GL2.14-49152-0-2GPU","GL2.28-98304-0-4GPU","m1.large","RAM1.2-16384","RAM1.4-32768","RAM1.8-65536","RAM1.16-131072","RAM1.2-16384-64","RAM1.4-32768-128","RAM1.8-65536-256","RAM1.16-131072-512","c4m8d50","m1.xlarge","PRC10.1-512","PRC10.1-1024","PRC10.2-2048","PRC10.2-4096","PRC10.4-8192","PRC20.1-512","PRC20.1-1024","PRC20.2-2048","PRC20.2-4096","PRC20.4-8192","PRC50.1-512","PRC50.1-1024","PRC50.2-2048","PRC50.2-4096","PRC50.4-8192"],"additionalNetworks":["network_l3vpn","k8s_l3vpn","l3_to_dedicated","external-network","k8s-external-access"],"additionalSecurityGroups":[],"defaultImageName":"","images":["Fedora 36 64-bit","Debian 11 (Bullseye) 64-bit","Ubuntu 22.04 LTS 64-bit","Ubuntu 18.04 LTS 64-bit","Ubuntu 20.04 LTS 64-bit","Ubuntu 22.04 LTS MKS 64-bit gpu-node","Oracle Linux 8 64-bit","Ubuntu 22.04 LTS MKS 64-bit node","Ubuntu 18.04 LTS MKS 64-bit gpu-node","Ubuntu 18.04 LTS MKS 64-bit node","Ubuntu 18.04 LTS MKS 64-bit master","Ubuntu 22.04 LTS Machine Learning 64-bit","CentOS 9 Stream 64-bit","Debian 10 (Buster) 64-bit","CentOS 7 Minimal 64-bit","CentOS 7 64-bit","CentOS 8 Stream 64-bit","ubuntu-22-04-cloud-amd64-static-routes","ubuntu-22-04-cloud-amd64","ubuntu-20-04-cloud-amd64","Fedora 34 64-bit","Debian 9 (Stretch) 64-bit","Fedora 35 64-bit","Ubuntu 16.04 LTS 64-bit","Windows Server 2019 Standard","blank-simple-image","Windows Server 2016 Standard","Windows Server 2012 R2 Standard","Fedora 33 64-bit","Fedora CoreOS (Stable) 64-bit","Ubuntu 18.04 LTS Machine Learning 64-bit","CentOS 8 64-bit","selectel-rescue-kernel","selectel-rescue-initrd","Fedora 32 64-bit","Windows Server 2016 Machine Learning","CoreOS","Ubuntu 18.04 LTS Intel VTune 64-bit"],"mainNetwork":"","zones":["ru-3a"],"volumeTypes":[{"id":"de922498-6af2-4972-840d-36c5e6790b87","name":"basicssd.ru-3b","description":"cluster1.ru-3","isPublic":true},{"id":"0db30fd0-0527-4082-84bf-852827993213","name":"iso.ru-3b","description":"cluster2.ru-3","isPublic":true},{"id":"52cb3250-dbea-4ba6-bbde-b5607f1ca545","name":"basic.ru-3b","description":"cluster2.ru-3","isPublic":true},{"id":"bbc41cd5-d112-4e19-a781-baf44fb690d3","name":"fast.ru-3b","description":"cluster2.ru-3","isPublic":true},{"id":"669c3c07-83e3-4e44-8499-d13d379e79ee","name":"universal.ru-3b","description":"cluster2.ru-3","isPublic":true},{"id":"ce80ecbd-385a-4e5a-aed9-8b6e5f3359ba","name":"iso.ru-3a","description":"cluster1.ru-3","isPublic":true},{"id":"b82dcef4-a977-4311-add4-dd08c847da2b","name":"iso","description":"cluster1.ru-3","isPublic":true},{"id":"f42f37b2-062f-4ce2-a6b3-28ca5e619030","name":"basic.ru-3a","description":"cluster1.ru-3","isPublic":true},{"id":"9c16598e-342b-4ff2-b948-8c05cf8f1490","name":"fast.ru-3a","description":"cluster1.ru-3","isPublic":true},{"id":"fca113dd-a80f-4996-be54-cf2515d4ddee","name":"universal.ru-3a","description":"cluster1.ru-3","isPublic":true}]}

2 errors occurred:
	* mainNetwork should be at least 1 chars long
	* defaultImageName should be at least 1 chars long
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Deckhouse fails with error (see above).

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Remove 'minLength: 1' requirement from mainNetwork and defaultImageName properties in OpenAPI specification.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
