### PR TITLE
[deckhouse] Deckhouse-config-webhook can't start if external-module-m…

### DIFF
--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -99,9 +99,11 @@ spec:
           - name: webhook-certs
             mountPath: /etc/webhook/certs
             readOnly: true
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
           - mountPath: /deckhouse/external-modules
             name: external-modules
             readOnly: true
+{{- end }}
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
@@ -112,7 +114,9 @@ spec:
       - name: webhook-certs
         secret:
           secretName: deckhouse-config-webhook-tls
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
       - name: external-modules
         hostPath:
           path: /var/lib/deckhouse/external-modules
           type: Directory
+{{- end }}

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -77,9 +77,9 @@ spec:
           value: deckhouse,deckhouse-generated-config-do-not-edit
         - name: ALLOWED_USERS
           value: "system:serviceaccount:d8-system:deckhouse"
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
         - name: MODULES_DIR
           value: "/deckhouse/modules:/deckhouse/external-modules/modules"
-{{- if (.Values.global.enabledModules | has "external-module-manager") }}
         - name: EXTERNAL_MODULES_DIR
           value: "/deckhouse/external-modules/"
 {{- end }}

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -79,8 +79,10 @@ spec:
           value: "system:serviceaccount:d8-system:deckhouse"
         - name: MODULES_DIR
           value: "/deckhouse/modules:/deckhouse/external-modules/modules"
+{{- if (.Values.global.enabledModules | has "external-module-manager") }}
         - name: EXTERNAL_MODULES_DIR
           value: "/deckhouse/external-modules/"
+{{- end }}
         - name: GLOBAL_HOOKS_DIR
           value: "/deckhouse/global-hooks"
         ports:

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -82,6 +82,9 @@ spec:
           value: "/deckhouse/modules:/deckhouse/external-modules/modules"
         - name: EXTERNAL_MODULES_DIR
           value: "/deckhouse/external-modules/"
+{{- else }}
+        - name: MODULES_DIR
+          value: "/deckhouse/modules"
 {{- end }}
         - name: GLOBAL_HOOKS_DIR
           value: "/deckhouse/global-hooks"


### PR DESCRIPTION
## Description
Deckhouse-config-webhook can't start if external-module-manager disabled.

## Why do we need it, and what problem does it solve?
Deckhouse-config-webhook deployment is stuck in containerCreating status, because /var/lib/deckhouse/external-modules/modules doesn't exist.

fix issue https://github.com/deckhouse/deckhouse/issues/5227

## What is the expected result?
Deckhouse-config-webhook successfully started without external-module-manager

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: deckhouse-config-webhook
type: fix
summary: Deckhouse-config-webhook successfully started without external-module-manager.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
