### PR TITLE
[ci][docs] Pass a datacenter name to doc deploy environment

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -183,17 +183,20 @@ steps:
 {!{- $url := printf "deckhouse.%s.flant.com" $env -}!}
 {!{- $urlRu := printf "deckhouse.ru.%s.flant.com" $env -}!}
 {!{- $kubeConfig := "${{ secrets.KUBECONFIG_BASE64_DEV }}" -}!}
+{!{- $dcName := "dev" -}!}
 {!{- $repo := "${{ steps.check_dev_registry.outputs.web_registry_path }}" -}!}
 {!{- if or (eq $env "production") (eq $env "preproduction") -}!}
   {!{- $repo = "${{ steps.check_readonly_registry.outputs.web_registry_path }}" -}!}
   {!{- $url = "deckhouse.io" -}!}
   {!{- $urlRu = "deckhouse.ru" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD }}" -}!}
+  {!{- $dcName = "prod-hz" -}!}
 {!{- end -}!}
 {!{- if eq $env "preproduction" -}!}
   {!{- $ns = "deckhouse-web-production" -}!}
   {!{- $webEnv = "web-production" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD_SEL }}" -}!}
+  {!{- $dcName = "prod-sel" -}!}
 {!{- end -}!}
 
 # <template: deploy_doc_template>
@@ -212,6 +215,7 @@ steps:
     WERF_SET_URL: "global.url={!{ $url }!}"
     WERF_SET_URL_RU: "global.url_ru={!{ $urlRu }!}"
     WERF_SET_WEB_ENV: "web.env={!{ $webEnv }!}"
+    WERF_SET_DCNAME: "web.dc_name={!{ $dcName }!}"
 # </template: deploy_doc_template>
 {!{- end -}!}
 
@@ -222,17 +226,20 @@ steps:
 {!{- $url := printf "deckhouse.%s.flant.com" $env -}!}
 {!{- $urlRu := printf "deckhouse.ru.%s.flant.com" $env -}!}
 {!{- $kubeConfig := "${{ secrets.KUBECONFIG_BASE64_DEV }}" -}!}
+{!{- $dcName := "dev" -}!}
 {!{- $repo := "${{ steps.check_dev_registry.outputs.web_registry_path }}" -}!}
 {!{- if or (eq $env "production") (eq $env "preproduction") -}!}
   {!{- $repo = "${{ steps.check_readonly_registry.outputs.web_registry_path }}" -}!}
   {!{- $url = "deckhouse.io" -}!}
   {!{- $urlRu = "deckhouse.ru" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD }}" -}!}
+  {!{- $dcName = "prod-hz" -}!}
 {!{- end -}!}
 {!{- if eq $env "preproduction" -}!}
   {!{- $ns = "deckhouse-web-production" -}!}
   {!{- $webEnv = "web-production" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD_SEL }}" -}!}
+  {!{- $dcName = "prod-sel" -}!}
 {!{- end -}!}
 
 {!{- $siteDomainMap := printf "{\"en\" : \"%s\", \"ru\" : \"%s\"}" $url $urlRu -}!}
@@ -255,5 +262,6 @@ steps:
     WERF_SET_URL_RU: "global.url_ru={!{ $urlRu }!}"
     WERF_SET_WEB_ENV: "web.env={!{ $webEnv }!}"
     WERF_SET_DOMAIN_MAP: "global.domain_map={!{ base64.Encode $siteDomainMap }!}"
+    WERF_SET_DCNAME: "web.dc_name={!{ $dcName }!}"
 # </template: deploy_site_template>
 {!{- end -}!}

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -1396,6 +1396,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.stage.flant.com"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.stage.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-stage"
+          WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_doc_template>
       # <template: deploy_doc_template>
       - name: Deploy documentation to production
@@ -1413,6 +1414,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
+          WERF_SET_DCNAME: "web.dc_name=prod-hz"
       # </template: deploy_doc_template>
       # <template: deploy_doc_template>
       - name: Deploy documentation to preproduction
@@ -1430,6 +1432,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
+          WERF_SET_DCNAME: "web.dc_name=prod-sel"
       # </template: deploy_doc_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -2470,6 +2470,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
+          WERF_SET_DCNAME: "web.dc_name=prod-hz"
       # </template: deploy_doc_template>
       # <template: deploy_doc_template>
       - name: Deploy documentation to preproduction
@@ -2487,6 +2488,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
+          WERF_SET_DCNAME: "web.dc_name=prod-sel"
       # </template: deploy_doc_template>
       # <template: deploy_site_template>
       - name: Deploy site to production
@@ -2506,6 +2508,7 @@ jobs:
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
           WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLmlvIiwgInJ1IiA6ICJkZWNraG91c2UucnUifQ=="
+          WERF_SET_DCNAME: "web.dc_name=prod-hz"
       # </template: deploy_site_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/deploy-web-preproduction.yml
+++ b/.github/workflows/deploy-web-preproduction.yml
@@ -503,6 +503,7 @@ jobs:
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
           WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLmlvIiwgInJ1IiA6ICJkZWNraG91c2UucnUifQ=="
+          WERF_SET_DCNAME: "web.dc_name=prod-sel"
       # </template: deploy_site_template>
 
       # <template: doc_version_template>
@@ -528,6 +529,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru"
           WERF_SET_WEB_ENV: "web.env=web-production"
+          WERF_SET_DCNAME: "web.dc_name=prod-sel"
       # </template: deploy_doc_template>
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -263,6 +263,7 @@ jobs:
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.stage.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-stage"
           WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLnN0YWdlLmZsYW50LmNvbSIsICJydSIgOiAiZGVja2hvdXNlLnJ1LnN0YWdlLmZsYW50LmNvbSJ9"
+          WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_site_template>
 
       # <template: doc_version_template>
@@ -288,6 +289,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.stage.flant.com"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.stage.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-stage"
+          WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_doc_template>
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -263,6 +263,7 @@ jobs:
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-test"
           WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLnRlc3QuZmxhbnQuY29tIiwgInJ1IiA6ICJkZWNraG91c2UucnUudGVzdC5mbGFudC5jb20ifQ=="
+          WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_site_template>
 
       # <template: doc_version_template>
@@ -288,6 +289,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.test.flant.com"
           WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-test"
+          WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_doc_template>
 
       # <template: update_comment_on_finish>


### PR DESCRIPTION
## Description

Pass a datacenter name (code) to the doc deploy environment, which can be used in templates to change some data center-dependent parameters.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Pass a datacenter name to the doc deploy environment.
impact_level: low
```
