### PR TITLE
[log-shipper] Add tenantID option for Loki

### DIFF
--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -109,6 +109,9 @@ type CommonTLSSpec struct {
 }
 
 type LokiSpec struct {
+	// TenantID is used only for GrafanaCloud. When running Loki locally, a tenant ID is not required.
+	TenantID string `json:"tenantID,omitempty"`
+
 	Endpoint string `json:"endpoint,omitempty"`
 
 	Auth LokiAuthSpec `json:"auth,omitempty"`
@@ -177,12 +180,12 @@ type Buffer struct {
 type BufferType = string
 
 const (
-	// Events are buffered on disk.
+	// BufferTypeDisk specifies that events are buffered on disk.
 	// This is less performant, but more durable. Data that has been synchronized to disk will not be lost if Vector is restarted forcefully or crashes.
 	// Data is synchronized to disk every 500ms.
 	BufferTypeDisk BufferType = "Disk"
 
-	// Events are buffered in memory.
+	// BufferTypeMemory specifies that events are buffered in memory.
 	// This is more performant, but less durable. Data will be lost if Vector is restarted forcefully or crashes.
 	BufferTypeMemory BufferType = "Memory"
 )
@@ -190,12 +193,12 @@ const (
 type BufferWhenFull = string
 
 const (
-	// 	Drops the event instead of waiting for free space in buffer.
+	// BufferWhenFullDropNewest makes vector dropping the event instead of waiting for free space in buffer.
 	// The event will be intentionally dropped. This mode is typically used when performance is the highest priority,
 	// and it is preferable to temporarily lose events rather than cause a slowdown in the acceptance/consumption of events.
 	BufferWhenFullDropNewest BufferWhenFull = "DropNewest"
 
-	// Wait for free space in the buffer.
+	// BufferWhenFullBlock makes vector waiting for free space in the buffer.
 	// This applies backpressure up the topology, signalling that sources should slow down the acceptance/consumption of events. This means that while no data is lost, data will pile up at the edge.
 	BufferWhenFullBlock BufferWhenFull = "Block"
 )

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -129,6 +129,12 @@ spec:
                                       - password
                             - required:
                                 - token
+                    tenantID:
+                      type: string
+                      description: |
+                        ID of a tenant.
+
+                        This option is used only for GrafanaCloud. When running Loki locally, a tenant ID is not required.
                     endpoint:
                       type: string
                       description: |

--- a/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
@@ -24,6 +24,12 @@ spec:
                           description: Токен для Bearer-аутентификации.
                         user:
                           description: Имя пользователя, используемое при Basic-аутентификации.
+                    tenantID:
+                      type: string
+                      description: |
+                        ID тенанта.
+
+                        Эта опция используется только для GrafanaCloud. Для локально запущенного Loki опция ни на что не влияет.
                     endpoint:
                       description: |
                         URL для подключения к Loki.

--- a/modules/460-log-shipper/hooks/generate_config_test.go
+++ b/modules/460-log-shipper/hooks/generate_config_test.go
@@ -137,6 +137,7 @@ spec:
 		Entry("File to Vector", "file-to-vector"),
 		Entry("File to Kafka", "file-to-kafka"),
 		Entry("File to Kafka with client certificate authentication", "file-to-kafka-tls"),
+		Entry("File to Loki", "file-to-loki"),
 		Entry("File to Splunk", "file-to-splunk"),
 		Entry("Two sources to single destination", "many-to-one"),
 		Entry("Throttle Transform with filter", "throttle-with-filter"),

--- a/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
@@ -33,6 +33,8 @@ type Loki struct {
 
 	Encoding Encoding `json:"encoding,omitempty"`
 
+	TenantID string `json:"tenant_id,omitempty"`
+
 	Endpoint string `json:"endpoint"`
 
 	Auth LokiAuth `json:"auth,omitempty"`
@@ -125,6 +127,7 @@ func NewLoki(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Loki {
 		TLS:      tls,
 		Labels:   labels,
 		Endpoint: spec.Endpoint,
+		TenantID: spec.TenantID,
 		Encoding: Encoding{
 			Codec:           "text",
 			TimestampFormat: "rfc3339",

--- a/modules/460-log-shipper/hooks/testdata/file-to-loki/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-loki/manifests.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-source
+spec:
+  type: File
+  file:
+    include: ["/var/log/kube-audit/audit.log"]
+  destinationRefs:
+    - test-loki-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-loki-dest
+spec:
+  type: Loki
+  loki:
+    endpoint: http://192.168.1.1:9000
+    tenantID: "{{ test }}"
+  extraLabels:
+    foo: bar
+    app: "{{ ap_p[0].a }}"
+  buffer:
+    type: Memory
+    memory:
+      maxEvents: 4096
+    whenFull: DropNewest

--- a/modules/460-log-shipper/hooks/testdata/file-to-loki/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-loki/result.json
@@ -1,0 +1,81 @@
+{
+  "sources": {
+    "cluster_logging_config/test-source": {
+      "type": "file",
+      "include": [
+        "/var/log/kube-audit/audit.log"
+      ]
+    }
+  },
+  "transforms": {
+    "transform/destination/test-loki-dest/00_parse_json": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_local_timezone"
+      ],
+      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
+      "type": "remap"
+    },
+    "transform/source/test-source/00_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "cluster_logging_config/test-source"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "type": "remap"
+    },
+    "transform/source/test-source/01_local_timezone": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/00_clean_up"
+      ],
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "type": "remap"
+    }
+  },
+  "sinks": {
+    "destination/cluster/test-loki-dest": {
+      "type": "loki",
+      "inputs": [
+        "transform/destination/test-loki-dest/00_parse_json"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "buffer": {
+        "type": "memory",
+        "max_events": 4096,
+        "when_full": "drop_newest"
+      },
+      "encoding": {
+        "only_fields": [
+          "message"
+        ],
+        "codec": "text",
+        "timestamp_format": "rfc3339"
+      },
+      "tenant_id": "{{ test }}",
+      "endpoint": "http://192.168.1.1:9000",
+      "tls": {
+        "verify_hostname": true,
+        "verify_certificate": true
+      },
+      "labels": {
+        "app": "{{ parsed_data.ap_p[0].a }}",
+        "container": "{{ container }}",
+        "foo": "bar",
+        "host": "{{ host }}",
+        "image": "{{ image }}",
+        "namespace": "{{ namespace }}",
+        "node": "{{ node }}",
+        "pod": "{{ pod }}",
+        "pod_ip": "{{ pod_ip }}",
+        "pod_labels_*": "{{ pod_labels }}",
+        "pod_owner": "{{ pod_owner }}",
+        "stream": "{{ stream }}"
+      },
+      "remove_label_fields": true,
+      "out_of_order_action": "rewrite_timestamp"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add tenantID option

## Why do we need it, and what problem does it solve?
Closes  https://github.com/deckhouse/deckhouse/issues/5248

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: feature
summary:  Add tenantID option for Loki (may be required for Grafana Cloud)
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
