### PR TITLE
[ci][site] Ignore Certificate readiness when deploy

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -121,6 +121,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $.Chart.Name }}-{{ .Lang }}-cert
+  annotations:
+    werf.io/fail-mode: IgnoreAndContinueDeployProcess
+    werf.io/track-termination-mode: NonBlocking
 spec:
   certificateOwnerRef: false
   secretName: tls-{{ .URL }}


### PR DESCRIPTION
## Description
Ignore Certificate readiness for the site when deploy.

## What is the expected result?
Site deploy process must not fail if Certificates are not in a ready state.

## Changelog entries
```changes
section: ci
type: chore
summary: Ignore Certificate readiness for the site when deploy.
impact_level: low
```
