### PR TITLE
[cloud-provider-openstack] Fix openapi scheme for d8-cloud-provider-discovery-data secret

### DIFF
--- a/ee/candi/cloud-providers/openstack/openapi/cloud_provider_discovery_data.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cloud_provider_discovery_data.yaml
@@ -27,7 +27,6 @@ apiVersions:
           - OpenStackCloudProviderDiscoveryData
       mainNetwork:
         type: string
-        minLength: 1
         description: |
           The path to the network that will serve as the primary network (the default gateway) for connecting to the virtual machine.
       additionalNetworks:
@@ -52,7 +51,6 @@ apiVersions:
         uniqueItems: true
       defaultImageName:
         type: string
-        minLength: 1
         description: Virtual machine image name used by default.
       images:
         type: array


### PR DESCRIPTION
## Description

Fix OpenAPI scheme for `d8-cloud-provider-discovery-data` secret. The `mainNetwork` and `defaultImageName` parameters can be empty.

## Why do we need it, and what problem does it solve?
In hybrid clusters, Deckhouse can get stuck in error.

## Why do we need it in the patch release (if we do)?
In hybrid clusters, Deckhouse can get stuck in error.

## What is the expected result?
![image](https://github.com/deckhouse/deckhouse/assets/30695496/df0aaab4-3844-4a3b-a867-a74c94d417da)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Fix OpenAPI scheme for `d8-cloud-provider-discovery-data` secret.
impact_level: default
```
