### PR TITLE
[bashible] Revert kublet cri socket path configuration for docker

### DIFF
--- a/candi/bashible/common-steps/node-group/068_configure_kubelet_systemd_unit.sh.tpl
+++ b/candi/bashible/common-steps/node-group/068_configure_kubelet_systemd_unit.sh.tpl
@@ -42,7 +42,12 @@ if [[ -z "${cri_socket_path}" ]]; then
   exit 1
 fi
 
-cri_config="--container-runtime=remote --container-runtime-endpoint=unix:${cri_socket_path}"
+# we should keep this condition because user can use NotManaged type and docker
+if grep -q "docker" <<< "${cri_socket_path}"; then
+  cri_config="--container-runtime=docker --docker-endpoint=unix://${cri_socket_path}"
+else
+  cri_config="--container-runtime=remote --container-runtime-endpoint=unix:${cri_socket_path}"
+fi
 {{- end }}
 
 bb-event-on 'bb-sync-file-changed' '_enable_kubelet_service'


### PR DESCRIPTION
## Description
Revert CRI socket path configuration for docker.

## Why do we need it, and what problem does it solve?
If nodeGroup.cri.type == "NotManaged" we try to configure kubelet cri
https://github.com/deckhouse/deckhouse/blob/main/candi/bashible/common-steps/node-group/068_configure_kubelet_systemd_unit.sh.tpl#L26C1-L37C5
And if notManaged node group contains docker nodes then kubeblet can not run in threse  nodes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
And if cri.type == notManaged node group contains docker nodes then kubeblet can not start in threse  nodes.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Revert kubelet CRI socket path configuration for docker.
impact_level: default
```