### PR TITLE
[monitoring-kubernetes] Fix mountpoint label in kubelet-eviction-thresholds-exporter

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/exporter/main.go
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/exporter/main.go
@@ -378,6 +378,10 @@ func getMountpoint(path string) string {
 		path = _path
 	}
 
+	if path == hostPath {
+		return "/"
+	}
+
 	return strings.TrimPrefix(path, hostPath)
 }
 


### PR DESCRIPTION
## Description
I made a mistake in PR #4888. If the mount point for the requested folder is `/` then `getMountpoint()` function returns an empty string. In this case, the `mountpoint` label will be missing in the metric.

I fixed the problem and now the mountpoint is determined correctly.

I added a temporary debug output to the console into the `getMountpoint()` function on one of the worker hosts in the kubernetes cluster. And here is the result after the changes:

```shell
Path:  /host/boot/efi/EFI/ubuntu
Mountpoint:  /boot/efi

Path:  /host/var/lib/kubelet
Mountpoint: /

Path:  /host/var/lib/containerd
Mountpoint: /
```

Closes #5430

## Why do we need it, and what problem does it solve?

Currently, the alert rules `KubeletNodeFSBytesUsage`, `KubeletNodeFSInodesUsage` are invalid. Since there is no `mountpoint` label in the metric `kubelet_eviction_nodefs_inodes`, then comparison with the metric `max by (node, mountpoint) (node_filesystem_avail_bytes / node_filesystem_size_bytes)` does not work correctly.

## Why do we need it in the patch release (if we do)?

Currently, the alert rules `KubeletNodeFSBytesUsage`, `KubeletNodeFSInodesUsage` are invalid.

## What is the expected result?

In `kubelet_eviction_nodefs_bytes` metric `mountpoint` label for `/` must be equal `/`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: fix
summary: Fix absent `mountpoint` label in the `kubelet-eviction-thresholds-exporter` metrics
```