### PR TITLE
[ingress-nginx] added namespase in SetSSLExpireTime

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
@@ -6,12 +6,14 @@ WORKDIR /src/
 COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
+COPY patches/metrics-SetSSLExpireTime.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v1.1.3 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
     patch -p1 < /lua-info.patch && \
     patch -p1 < /makefile.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /metrics-SetSSLExpireTime.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-1-1/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-1/patches/README.md
@@ -39,3 +39,9 @@ Without this fix, redirects don't work if using behindL7Proxy controller and a l
 Backported from 1.2 version.
 
 https://github.com/kubernetes/ingress-nginx/pull/8468
+
+### metrics SetSSLExpireTime
+
+Fixes namespace which is given by metric nginx_ingress_controller_ssl_expire_time_seconds.
+
+https://github.com/kubernetes/ingress-nginx/pull/10274

--- a/modules/402-ingress-nginx/images/controller-1-1/patches/metrics-SetSSLExpireTime.patch
+++ b/modules/402-ingress-nginx/images/controller-1-1/patches/metrics-SetSSLExpireTime.patch
@@ -1,0 +1,12 @@
+diff --git a/internal/ingress/metric/collectors/controller.go b/internal/ingress/metric/collectors/controller.go
+index e4e2655c8..4d85191ee 100644
+--- a/internal/ingress/metric/collectors/controller.go
++++ b/internal/ingress/metric/collectors/controller.go
+@@ -269,6 +269,7 @@ func (cm *Controller) SetSSLExpireTime(servers []*ingress.Server) {
+ 			}
+ 			labels["host"] = s.Hostname
+ 			labels["secret_name"] = s.SSLCert.Name
++			labels["namespace"] = s.SSLCert.Namespace
+ 
+ 			cm.sslExpireTime.With(labels).Set(float64(s.SSLCert.ExpireTime.Unix()))
+ 		}

--- a/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
@@ -6,12 +6,14 @@ WORKDIR /src/
 COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
+COPY patches/metrics-SetSSLExpireTime.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v1.6.4 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
     patch -p1 < /lua-info.patch && \
     patch -p1 < /makefile.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /metrics-SetSSLExpireTime.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
@@ -26,3 +26,9 @@ https://github.com/kubernetes/ingress-nginx/pull/4367
 ### Makefile
 
 Run the build locally, not inside the container.
+
+### metrics SetSSLExpireTime
+
+Fixes namespace which is given by metric nginx_ingress_controller_ssl_expire_time_seconds.
+
+https://github.com/kubernetes/ingress-nginx/pull/10274

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/metrics-SetSSLExpireTime.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/metrics-SetSSLExpireTime.patch
@@ -1,0 +1,12 @@
+diff --git a/internal/ingress/metric/collectors/controller.go b/internal/ingress/metric/collectors/controller.go
+index e4e2655c8..4d85191ee 100644
+--- a/internal/ingress/metric/collectors/controller.go
++++ b/internal/ingress/metric/collectors/controller.go
+@@ -269,6 +269,7 @@ func (cm *Controller) SetSSLExpireTime(servers []*ingress.Server) {
+ 			}
+ 			labels["host"] = s.Hostname
+ 			labels["secret_name"] = s.SSLCert.Name
++			labels["namespace"] = s.SSLCert.Namespace
+ 
+ 			cm.sslExpireTime.With(labels).Set(float64(s.SSLCert.ExpireTime.Unix()))
+ 		}


### PR DESCRIPTION
## Description
added namespase in SetSSLExpireTime
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
now the metric in the namespace label gives the value of where the controller is located but not the ingress itself, which is misleading for an engineer who studies the NGINXCertificateExpiry alert created on the basis of the nginx_ingress_controller_ssl_expire_time_seconds metric.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix 
summary: fixed nginx_ingress_controller_ssl_expire_time_seconds
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
