### PR TITLE
[node-manager] create alert if node has no config checksum annotation

### DIFF
--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -582,6 +582,9 @@ func calculateNodeStatus(node updateApprovalNode, ng updateNodeGroup, desiredChe
 	case node.IsApproved:
 		return "Approved"
 
+	case node.ConfigurationChecksum == "":
+		return "UpdateFailedNoConfigChecksum"
+
 	case node.ConfigurationChecksum != desiredChecksum:
 		return "ToBeUpdated"
 
@@ -595,7 +598,7 @@ func calculateNodeStatus(node updateApprovalNode, ng updateNodeGroup, desiredChe
 
 var metricStatuses = []string{
 	"WaitingForApproval", "Approved", "DrainingForDisruption", "WaitingForDisruptionApproval",
-	"WaitingForManualDisruptionApproval", "DisruptionApproved", "ToBeUpdated", "UpToDate",
+	"WaitingForManualDisruptionApproval", "DisruptionApproved", "ToBeUpdated", "UpToDate", "UpdateFailedNoConfigChecksum",
 }
 
 func setNodeStatusesMetrics(input *go_hook.HookInput, nodeName, nodeGroup, nodeStatus string) {

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -50,14 +50,14 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		shared.ConfigurationChecksumHookConfig(),
 		{
 			Name:                   "ngs",
-			WaitForSynchronization: pointer.BoolPtr(false),
+			WaitForSynchronization: pointer.Bool(false),
 			ApiVersion:             "deckhouse.io/v1",
 			Kind:                   "NodeGroup",
 			FilterFunc:             updateApprovalNodeGroupFilter,
 		},
 		{
 			Name:                   "nodes",
-			WaitForSynchronization: pointer.BoolPtr(false),
+			WaitForSynchronization: pointer.Bool(false),
 			ApiVersion:             "v1",
 			Kind:                   "Node",
 			LabelSelector: &v1.LabelSelector{
@@ -489,7 +489,7 @@ func updateApprovalNodeGroupFilter(obj *unstructured.Unstructured) (go_hook.Filt
 		if ng.Spec.Disruptions.Automatic.DrainBeforeApproval != nil {
 			ung.Disruptions.Automatic.DrainBeforeApproval = ng.Spec.Disruptions.Automatic.DrainBeforeApproval
 		} else {
-			ung.Disruptions.Automatic.DrainBeforeApproval = pointer.BoolPtr(true)
+			ung.Disruptions.Automatic.DrainBeforeApproval = pointer.Bool(true)
 		}
 	}
 

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -131,12 +131,9 @@
         Most likely, there is a problem with the `update_approval` hook of the `node-manager` module.
 
 
-  - alert: D8NodeGroupProblematicNodeGroupConfiguration
+  - alert: D8ProblematicNodeGroupConfiguration
     expr: |
-      max by (node,node_group) (
-          node_group_node_status{status="UpdateFailedNoConfigChecksum"} *
-          on(node) group_left() (max by(node) ((kube_node_status_condition{condition="Ready", status="true"} == 1)))
-      ) > 0
+      max by (status, node_group, node) (node_group_node_status{status="UpdateFailedNoConfigChecksum"}) == 1
     for: 5m
     labels:
       tier: cluster

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -130,6 +130,30 @@
 
         Most likely, there is a problem with the `update_approval` hook of the `node-manager` module.
 
+
+  - alert: D8NodeGroupProblematicNodeGroupConfiguration
+    expr: |
+      max by (node,node_group) (
+          node_group_node_status{status="UpdateFailedNoConfigChecksum"} *
+          on(node) group_left() (max by(node) ((kube_node_status_condition{condition="Ready", status="true"} == 1)))
+      ) > 0
+    for: 5m
+    labels:
+      tier: cluster
+      severity_level: "8"
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: The {{ $labels.node }} Node cannot begin the update.
+      description: |
+        There is a new update for Nodes of the {{ $labels.node_group }} group; Nodes have learned about the update. However, {{ $labels.node }} Node cannot be updated.
+
+        Node {{ $labels.node }} has no `node.deckhouse.io/configuration-checksum` annotation.
+        Perhaps the bootstrap process of the Node did not complete correctly. Check the `cloud-init` logs (/var/log/cloud-init-output.log) of the Node.
+        There is probably a problematic NodeGroupConfiguration resource for {{ $labels.node_group }} NodeGroup.
+
   - alert: NodeRequiresDisruptionApprovalForUpdate
     expr: |
       max by (node,node_group) (


### PR DESCRIPTION
## Description
A new `D8ProblematicNodeGroupConfiguration` alert is sent when a Node without proper `node.deckhouse.io/configuration-checksum` annotation is detected during update approval process in `node-manager` module.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
See #3300

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: alert fired if Node has no config checksum annotation during NodeGroup update
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
