### PR TITLE
[deckhouse] Step by step update when deckhouse release version.

### DIFF
--- a/modules/002-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release.go
@@ -555,7 +555,7 @@ func (dcr *DeckhouseReleaseChecker) nextVersion(actual, target *semver.Version) 
 		if r.MatchString(ver) {
 			newSemver, err := semver.NewVersion(ver)
 			if err != nil {
-				dcr.logger.Errorf("unable to parce semver from the registry Version: %v. This version will be skipped.", ver)
+				dcr.logger.Errorf("unable to parse semver from the registry Version: %v. This version will be skipped.", ver)
 				continue
 			}
 			collection = append(collection, newSemver)

--- a/modules/002-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release.go
@@ -178,8 +178,9 @@ releaseLoop:
 			input.MetricsCollector.Expire(metricUpdatingFailedGroup)
 			if err := releaseChecker.StepByStepUpdate(release.Version, newSemver); err != nil {
 				releaseChecker.logger.Errorf("step by step update failed. err: %v", err)
+				versionLable := fmt.Sprintf("%v.%v.*", release.Version.Major(), release.Version.IncMinor().Minor())
 				labels := map[string]string{
-					"releaseChannel": input.Values.Get("deckhouse.releaseChannel").String(),
+					"version": versionLable,
 				}
 				input.MetricsCollector.Set("d8_updating_is_failed", 1, labels, metrics.WithGroup(metricUpdatingFailedGroup))
 

--- a/modules/002-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release.go
@@ -491,7 +491,6 @@ func (dcr *DeckhouseReleaseChecker) CalculateReleaseDelay(ts time.Time, clusterU
 }
 
 func (dcr *DeckhouseReleaseChecker) StepByStepUpdate(actual, target *semver.Version) error {
-
 	listTags, err := dcr.registryClient.ListTags()
 	if err != nil {
 		return err
@@ -521,7 +520,6 @@ func (dcr *DeckhouseReleaseChecker) StepByStepUpdate(actual, target *semver.Vers
 }
 
 func nextVersion(list []string, actual, target *semver.Version) *semver.Version {
-
 	if actual.Major() != target.Major() {
 		return target // TODO step by step update for major version
 	}

--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -549,7 +549,7 @@ status:
 			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
 			f.RunHook()
 		})
-		It("Step by step update should not be successfully and allert fired", func() {
+		It("Step by step update should not be successfully and alert fired", func() {
 			Expect(f).NotTo(ExecuteSuccessfully())
 			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0").Exists()).To(BeTrue())
 			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(2))

--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -514,7 +514,51 @@ global:
 		})
 	})
 
-	Context("StepByStepPrepare", func() {
+	Context("StepByStepUpdateFailded", func() {
+		BeforeEach(func() {
+			dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+				"v1.31.0",
+				"v1.31.1",
+				"v1.33.0",
+				"v1.33.1",
+				"v1.34.0",
+			}, nil)
+			dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.34.0"}`}}}, nil
+				},
+				DigestStub: func() (v1.Hash, error) {
+					return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+				},
+			}, nil)
+			dependency.TestDC.CRClient.ImageMock.When("v1.32.3").Then(&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.32.3"}`}}}, nil
+				},
+			}, nil)
+			f.KubeStateSet(`
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.31.0
+spec:
+  version: "v1.31.0"
+status:
+  phase: Deployed
+`)
+			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			f.RunHook()
+		})
+		It("Step by step update should not be successfully and allert fired", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.0").Exists()).To(BeTrue())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(2))
+			Expect(f.MetricsCollector.CollectedMetrics()[1].Group).To(Equal("d8_updating_failed"))
+			Expect(*f.MetricsCollector.CollectedMetrics()[1].Value).To(Equal(float64(1)))
+		})
+	})
+
+	Context("StepByStepUpdateSuccessfully", func() {
 		BeforeEach(func() {
 			dependency.TestDC.CRClient.ListTagsMock.Return([]string{
 				"v1.31.0",
@@ -526,42 +570,40 @@ global:
 				"v1.33.0",
 				"v1.33.1",
 			}, nil)
-			dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+			dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 				LayersStub: func() ([]v1.Layer, error) {
-					return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.31.0"}`}}}, nil
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
+				},
+				DigestStub: func() (v1.Hash, error) {
+					return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
 				},
 			}, nil)
-			f.KubeStateSet("")
+			dependency.TestDC.CRClient.ImageMock.When("v1.32.3").Then(&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.32.3"}`}}}, nil
+				},
+			}, nil)
+			f.KubeStateSet(`
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.31.0
+spec:
+  version: "v1.31.0"
+status:
+  phase: Deployed
+`)
 			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
 			f.RunHook()
 		})
-
-		Context("StepByStepUpdate", func() {
-			BeforeEach(func() {
-				dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
-					LayersStub: func() ([]v1.Layer, error) {
-						return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
-					},
-					DigestStub: func() (v1.Hash, error) {
-						return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
-					},
-				}, nil)
-				dependency.TestDC.CRClient.ImageMock.When("v1.32.3").Then(&fake.FakeImage{
-					LayersStub: func() ([]v1.Layer, error) {
-						return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.32.3"}`}}}, nil
-					},
-				}, nil)
-				f.KubeStateSet("")
-				f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
-				f.RunHook()
-			})
-			It("Release should not inherit cooldown from previous one", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.32.3").Exists()).To(BeTrue())
-			})
+		It("Step by step update should be successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.32.3").Exists()).To(BeTrue())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(1))
+			Expect(f.MetricsCollector.CollectedMetrics()[0].Group).To(Equal("d8_updating_failed"))
+			Expect(f.MetricsCollector.CollectedMetrics()[0].Action).To(Equal("expire"))
 		})
 	})
-
 })
 
 type fakeLayer struct {

--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -300,12 +300,12 @@ status:
 			dependency.TestDC.CRClient.ListTagsMock.Return([]string{
 				"v1.31.0",
 				"v1.31.1",
+				"v1.32.0",
+				"v1.32.1",
+				"v1.32.2",
+				"v1.32.3",
 				"v1.33.0",
 				"v1.33.1",
-				"v1.33.2",
-				"v1.33.3",
-				"v1.34.0",
-				"v1.34.1",
 			}, nil)
 			dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 				LayersStub: func() ([]v1.Layer, error) {
@@ -382,46 +382,6 @@ status:
 				Expect(f).To(ExecuteSuccessfully())
 				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.2").Exists()).To(BeTrue())
 				rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.31.2")
-				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).Exists()).To(BeTrue())
-				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).String()).To(Equal("2030-05-05T15:15:15Z"))
-			})
-		})
-
-		Context("StepByStepUpdate", func() {
-			BeforeEach(func() {
-				dependency.TestDC.CRClient.ListTagsMock.Return([]string{
-					"v1.31.0",
-					"v1.31.1",
-					"v1.33.0",
-					"v1.33.1",
-					"v1.33.2",
-					"v1.33.3",
-					"v1.34.0",
-					"v1.34.1",
-				}, nil)
-				dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
-					LayersStub: func() ([]v1.Layer, error) {
-						return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.3"}`}}}, nil
-					},
-					DigestStub: func() (v1.Hash, error) {
-						return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
-					},
-					ConfigFileStub: func() (*v1.ConfigFile, error) {
-						return &v1.ConfigFile{
-							Config: v1.Config{
-								Labels: map[string]string{"cooldown": "2030-05-05T15:15:15Z"},
-							},
-						}, nil
-					},
-				}, nil)
-				f.KubeStateSet("")
-				f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
-				f.RunHook()
-			})
-			It("Release should not inherit cooldown from previous one", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.33.3").Exists()).To(BeTrue())
-				rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.33.3")
 				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).Exists()).To(BeTrue())
 				Expect(rl.Field(`metadata.annotations.release\.deckhouse\.io/cooldown`).String()).To(Equal("2030-05-05T15:15:15Z"))
 			})
@@ -554,6 +514,54 @@ global:
 		})
 	})
 
+	Context("StepByStepPrepare", func() {
+		BeforeEach(func() {
+			dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+				"v1.31.0",
+				"v1.31.1",
+				"v1.32.0",
+				"v1.32.1",
+				"v1.32.2",
+				"v1.32.3",
+				"v1.33.0",
+				"v1.33.1",
+			}, nil)
+			dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.31.0"}`}}}, nil
+				},
+			}, nil)
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			f.RunHook()
+		})
+
+		Context("StepByStepUpdate", func() {
+			BeforeEach(func() {
+				dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
+					LayersStub: func() ([]v1.Layer, error) {
+						return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
+					},
+					DigestStub: func() (v1.Hash, error) {
+						return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+					},
+				}, nil)
+				dependency.TestDC.CRClient.ImageMock.When("v1.32.3").Then(&fake.FakeImage{
+					LayersStub: func() ([]v1.Layer, error) {
+						return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.32.3"}`}}}, nil
+					},
+				}, nil)
+				f.KubeStateSet("")
+				f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+				f.RunHook()
+			})
+			It("Release should not inherit cooldown from previous one", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.32.3").Exists()).To(BeTrue())
+			})
+		})
+	})
+
 })
 
 type fakeLayer struct {
@@ -645,23 +653,4 @@ func TestKebabCase(t *testing.T) {
 
 		assert.Equal(t, result, kebabed)
 	}
-}
-
-func TestNextVersion(t *testing.T) {
-	listTags := []string{
-		"v1.31.0",
-		"v1.31.1",
-		"v1.33.0",
-		"v1.33.1",
-		"v1.33.2",
-		"v1.33.3",
-		"v1.34.0",
-		"v1.34.1",
-	}
-	actualVersion, _ := semver.NewVersion("v1.31.0")
-	targetVersion, _ := semver.NewVersion("v1.34.1")
-
-	result := nextVersion(listTags, actualVersion, targetVersion)
-
-	assert.Equal(t, result.String(), "1.33.3")
 }

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -364,6 +364,11 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
+      description: |
+        Failed to update Deckhouse.
+
+        Deckhouse image is not available in the registry or the image is corrupted. Make sure that the correct Deckhouse image {{ $labels.version }} is available in the registry.
+
       summary: Deckhouse updating is failed.
 
   - alert: D8DeckhouseWatchErrorOccurred

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -354,6 +354,18 @@
       plk_markup_format: "markdown"
       summary: Deckhouse is being updated.
 
+  - alert: DeckhouseUpdatingFailed
+    expr: max (d8_updating_is_failed) == 1
+    labels:
+      severity_level: "4"
+      tier: cluster
+      d8_module: deckhouse
+      d8_component: deckhouse
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: Deckhouse updating is failed.
+
   - alert: D8DeckhouseWatchErrorOccurred
     expr: increase(deckhouse_kubernetes_client_watch_errors_total[__SCRAPE_INTERVAL_X_2__]) > 0
     for: 1m

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -367,7 +367,10 @@
       description: |
         Failed to update Deckhouse.
 
-        Deckhouse image is not available in the registry or the image is corrupted. Make sure that the correct Deckhouse image {{ $labels.version }} is available in the registry.
+        Next version minor/path Deckhouse image is not available in the registry or the image is corrupted.
+        Actual version: {{ $labels.version }}.
+
+        Make sure that the next version Deckhouse image is available in the registry.
 
       summary: Deckhouse updating is failed.
 


### PR DESCRIPTION
## Description
When we use d8-pull.sh/d8-push.sh or dhctl mirror - we can transfer not all images and deckhouse can create DeckhouseRelease with minor version diff more than one version, for example:
```
NAME      PHASE        TRANSITIONTIME   MESSAGE
v1.47.5   Superseded   12d
v1.49.0   Deployed     3d
```

## Why do we need it, and what problem does it solve?
Updating across multiple versions can have unintended consequences that can break deckhouse functionality, as deckhouse cannot skip minor version updates.

fix #5377

## What is the expected result?
We proceed according to the following algorithm:
* a. take all tags.
* b. we choose a version one more than the current one (maximum patch).
* c. create a release with the selected version.
* d. apply the update.
* e. go back to point a until we reach the desired version.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Updating the deckhouse version by more than one minor applies updates step by step
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
