### PR TITLE
[global] Add .ModulePath to werf.inc.yaml

### DIFF
--- a/candi/bashible/bundles/debian/all/003_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/bundles/debian/all/003_install_mandatory_packages.sh.tpl
@@ -19,7 +19,7 @@ if bb-is-debian-version? 9 || bb-is-debian-version? 10 || bb-is-debian-version? 
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} virt-what"
   KUBERNETES_DEPENDENCIES="${KUBERNETES_DEPENDENCIES} conntrack"
 else
-  bb-rp-install "virt-what:{{ .images.registrypackages.virtWhatDebian1151Deb9u1 }}" "conntrack:{{ .images.registrypackages.conntrackDebian1462 }}"
+  bb-rp-install "virt-what:{{ .images.registrypackages.virtWhatDebian1191 }}" "conntrack:{{ .images.registrypackages.conntrackDebian1462 }}"
 fi
 
 bb-apt-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
@@ -35,7 +35,7 @@ from: {{ $.Images.BASE_GOLANG_17_BUSTER }}
 from: {{ $.Images.BASE_GOLANG_BUSTER }}
     {{- end }}
 git:
-- add: /ee/modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
@@ -35,7 +35,7 @@ from: {{ $.Images.BASE_GOLANG_17_BUSTER }}
 from: {{ $.Images.BASE_GOLANG_BUSTER }}
     {{- end }}
 git:
-- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -11,7 +11,7 @@ docker:
   ENTRYPOINT: ["/discoverer"]
 ---
 {{ $discovererAbsPath := "/deckhouse/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" }}
-{{ $discovererRelPath := "ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" }}
+{{ $discovererRelPath := printf "%see/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromCacheVersion: "2023-03-24.2"
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -11,7 +11,7 @@ docker:
   ENTRYPOINT: ["/discoverer"]
 ---
 {{ $discovererAbsPath := "/deckhouse/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" }}
-{{ $discovererRelPath := printf "%see/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" .ModulePath }}
+{{ $discovererRelPath := printf "%s/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromCacheVersion: "2023-03-24.2"
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}

--- a/ee/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_ALPINE }}
     {{- end }}
 git:
-- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/ee/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_ALPINE }}
     {{- end }}
 git:
-- add: /ee/modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: {{ .ModulePath | trimSuffix "/" }}/candi/cloud-providers/openstack
+- add: {{ .ModulePath | default "/" }}candi/cloud-providers/openstack
   to: /deckhouse/candi/cloud-providers/openstack
 import:
 - artifact: terraform-provider-openstack

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /ee/candi/cloud-providers/openstack
+- add: {{ .ModulePath | trimSuffix "/" }}/candi/cloud-providers/openstack
   to: /deckhouse/candi/cloud-providers/openstack
 import:
 - artifact: terraform-provider-openstack

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: {{ .ModulePath | default "/" }}candi/cloud-providers/openstack
+- add: /{{ .ModulePath }}candi/cloud-providers/openstack
   to: /deckhouse/candi/cloud-providers/openstack
 import:
 - artifact: terraform-provider-openstack

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /ee/candi/cloud-providers/vsphere
+- add: /{{ .ModulePath }}candi/cloud-providers/vsphere
   to: /deckhouse/candi/cloud-providers/vsphere
 import:
 - artifact: terraform-provider-vsphere

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -55,7 +55,7 @@ properties:
     x-examples: [ dev ]
   deckhouseEdition:
     type: string
-    enum: [Unknown, CE, FE, EE ]
+    enum: [Unknown, CE, FE, EE, CSE ]
     x-examples: [ FE ]
   enabledModules:
     type: array

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/modules/000-common/images/kubernetes/werf.inc.yaml
+++ b/modules/000-common/images/kubernetes/werf.inc.yaml
@@ -18,7 +18,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
 git:
-- add: /{{ .ModulePath }}/modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}/modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/000-common/images/kubernetes/werf.inc.yaml
+++ b/modules/000-common/images/kubernetes/werf.inc.yaml
@@ -18,7 +18,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
 git:
-- add: /modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}/modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -34,10 +34,10 @@ git:
 - add: /
   to: /available_hooks
   includePaths:
-  - 'modules/*/webhooks/'
-  - 'ee/modules/*/webhooks/'
+  - '{{ .ModulePath }}modules/*/webhooks/'
+  - '{{ .ModulePath }}ee/modules/*/webhooks/'
   # - 'ee/fe/modules/*/webhooks/'
-- add: /modules/002-deckhouse/images/webhook-handler/entrypoint.sh
+- add: /{{ .ModulePath }}/modules/002-deckhouse/images/webhook-handler/entrypoint.sh
   to: /entrypoint.sh
 - add: /shell_lib/semver.sh
   to: /frameworks/shell/semver.sh

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -31,7 +31,7 @@ ansible:
         name:
           - python3
 git:
-- add: /
+- add: /{{ .ModulePath }}
   to: /available_hooks
   includePaths:
   - '{{ .ModulePath }}modules/*/webhooks/'
@@ -39,9 +39,9 @@ git:
   # - 'ee/fe/modules/*/webhooks/'
 - add: /{{ .ModulePath }}/modules/002-deckhouse/images/webhook-handler/entrypoint.sh
   to: /entrypoint.sh
-- add: /shell_lib/semver.sh
-  to: /frameworks/shell/semver.sh
-- add: /python_lib
+- add: /{{ .ModulePath }}/shell_lib/semver.sh
+  to: /{{ .ModulePath }}/frameworks/shell/semver.sh
+- add: /{{ .ModulePath }}/python_lib
   to: /frameworks/python
 docker:
   ENV:

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -34,14 +34,14 @@ git:
 - add: /{{ .ModulePath }}
   to: /available_hooks
   includePaths:
-  - '{{ .ModulePath }}modules/*/webhooks/'
-  - '{{ .ModulePath }}ee/modules/*/webhooks/'
+  - 'modules/*/webhooks/'
+  - 'ee/modules/*/webhooks/'
   # - 'ee/fe/modules/*/webhooks/'
-- add: /{{ .ModulePath }}/modules/002-deckhouse/images/webhook-handler/entrypoint.sh
+- add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/entrypoint.sh
   to: /entrypoint.sh
-- add: /{{ .ModulePath }}/shell_lib/semver.sh
-  to: /{{ .ModulePath }}/frameworks/shell/semver.sh
-- add: /{{ .ModulePath }}/python_lib
+- add: /{{ .ModulePath }}shell_lib/semver.sh
+  to: /{{ .ModulePath }}frameworks/shell/semver.sh
+- add: /{{ .ModulePath }}python_lib
   to: /frameworks/python
 docker:
   ENV:

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ .Images.BASE_ALPINE }}
 git:
-  - add: /
+  - add: /{{ .ModulePath }}
     to: /deckhouse
     includePaths:
       - modules/*/openapi
@@ -47,7 +47,7 @@ docker:
   ENTRYPOINT: ["/deckhouse-config-webhook"]
 ---
 {{ $webhookAbsPath := "/deckhouse/modules/003-deckhouse-config/images/deckhouse-config-webhook" }}
-{{ $webhookRelPath := "modules/003-deckhouse-config/images/deckhouse-config-webhook" }}
+{{ $webhookRelPath := printf "%smodules/003-deckhouse-config/images/deckhouse-config-webhook" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:
@@ -77,7 +77,7 @@ git:
       - go.sum
     setup:
       - "**/*.go"
-- add: /
+- add: /{{ .ModulePath }}
   to: /deckhouse
   includePaths:
     - dhctl/go.mod

--- a/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: {{ .ModulePath | default "/" }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: {{ .ModulePath | trimSuffix "/" }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: {{ .ModulePath | trimSuffix "/" }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: {{ .ModulePath | default "/" }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -29,7 +29,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_GOLANG_19_BULLSEYE }}
 git:
-- add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     install:

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -29,7 +29,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_GOLANG_19_BULLSEYE }}
 git:
-- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     install:

--- a/modules/007-registrypackages/images/crictl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/crictl/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/crictl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/crictl/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/crictl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/crictl/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/crictl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/crictl/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/d8-curl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-curl/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/d8-curl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-curl/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/inotify-tools-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/inotify-tools-centos/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}{{ $centos_version }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/inotify-tools-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/inotify-tools-centos/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}{{ $centos_version }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/inotify-tools-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/inotify-tools-centos/werf.inc.yaml
@@ -22,7 +22,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}{{ $centos_version }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/jq/werf.inc.yaml
+++ b/modules/007-registrypackages/images/jq/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/jq/werf.inc.yaml
+++ b/modules/007-registrypackages/images/jq/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-- add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
@@ -23,7 +23,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 git:
-- add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
@@ -23,7 +23,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 git:
-- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubectl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubectl/werf.inc.yaml
@@ -23,7 +23,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 git:
-- add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubectl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubectl/werf.inc.yaml
@@ -23,7 +23,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 git:
-- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -25,7 +25,7 @@ artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 fromCacheVersion: 20230426
 from: {{ $.Images.BASE_SCRATCH }}
 git:
-- add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -25,7 +25,7 @@ artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 fromCacheVersion: 20230426
 from: {{ $.Images.BASE_SCRATCH }}
 git:
-- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -40,7 +40,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-- add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -40,7 +40,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-- add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
   stageDependencies:
     setup:

--- a/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
+++ b/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
@@ -26,7 +26,7 @@ git:
     stageDependencies:
       setup:
       - '**/*'
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
     to: /src
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
+++ b/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
+++ b/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
@@ -21,12 +21,12 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:
       - '**/*'
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
     to: /src
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.15-1+deb9u1" }}
+{{- $version := "1.19-1" }}
 {{- $image_version := $version | replace "." "-" | replace "+" "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}

--- a/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
@@ -21,7 +21,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 git:
-  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  - add: /{{ .ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
     stageDependencies:
       setup:

--- a/modules/021-cni-cilium/images/cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/cilium/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if eq $type "virtualization" }}
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-virt-builder-artifact
 git:
-- add: /modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/021-cni-cilium/images/cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/cilium/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if eq $type "virtualization" }}
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-virt-builder-artifact
 git:
-- add: /{{ .ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/021-cni-cilium/images/cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/cilium/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if eq $type "virtualization" }}
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-virt-builder-artifact
 git:
-- add: /modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/021-kube-proxy/images/kube-proxy/werf.inc.yaml
+++ b/modules/021-kube-proxy/images/kube-proxy/werf.inc.yaml
@@ -1,7 +1,7 @@
 artifact: {{ .ModuleName }}/distroless-kube-proxy-artifact
 from: {{ .Images.BASE_ALPINE }}
 git:
-- add: /modules/021-kube-proxy/images/kube-proxy
+- add: /{{ .ModulePath }}modules/021-kube-proxy/images/kube-proxy
   to: /workdir/
   includePaths:
   - '**/file-filter'

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
 git:
-- add: /modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
 git:
-- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
@@ -10,7 +10,7 @@ docker:
   ENTRYPOINT: ["/discoverer"]
 ---
 {{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-aws/images/cloud-data-discoverer" }}
-{{ $discovererRelPath := "modules/030-cloud-provider-aws/images/cloud-data-discoverer" }}
+{{ $discovererRelPath := printf "%smodules/030-cloud-provider-aws/images/cloud-data-discoverer" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
@@ -31,7 +31,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
   {{- end }}
 git:
-  - add: /modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  - add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches
     stageDependencies:
       install:

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
@@ -31,7 +31,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
   {{- end }}
 git:
-  - add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches
     stageDependencies:
       install:

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
 docker:
   ENTRYPOINT: ["/discoverer"]
 ---
-{{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-azure/images/cloud-data-discoverer" }}
-{{ $discovererRelPath := "modules/030-cloud-provider-azure/images/cloud-data-discoverer" }}
+{{ $discovererAbsPath := "/{{ .ModulePath }}deckhouse/modules/030-cloud-provider-azure/images/cloud-data-discoverer" }}
+{{ $discovererRelPath := printf "%smodules/030-cloud-provider-azure/images/cloud-data-discoverer" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -9,7 +9,7 @@ import:
 docker:
   ENTRYPOINT: ["/discoverer"]
 ---
-{{ $discovererAbsPath := "/{{ .ModulePath }}deckhouse/modules/030-cloud-provider-azure/images/cloud-data-discoverer" }}
+{{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-azure/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%smodules/030-cloud-provider-azure/images/cloud-data-discoverer" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
 docker:
   ENTRYPOINT: ["/discoverer"]
 ---
-{{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/" }}
-{{ $discovererRelPath := "modules/030-cloud-provider-gcp/images/cloud-data-discoverer/" }}
+{{ $discovererAbsPath := "/{{ .ModulePath }}deckhouse/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/" }}
+{{ $discovererRelPath := printf "%smodules/030-cloud-provider-gcp/images/cloud-data-discoverer/" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -9,7 +9,7 @@ import:
 docker:
   ENTRYPOINT: ["/discoverer"]
 ---
-{{ $discovererAbsPath := "/{{ .ModulePath }}deckhouse/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/" }}
+{{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/" }}
 {{ $discovererRelPath := printf "%smodules/030-cloud-provider-gcp/images/cloud-data-discoverer/" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -26,7 +26,7 @@ from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_18_ALPINE }}
     {{- end }}
 git:
-- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -26,7 +26,7 @@ from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_18_ALPINE }}
     {{- end }}
 git:
-- add: /modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -12,7 +12,7 @@ docker:
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
-- add: /modules/030-{{ .ModuleName }}/images/{{ .ImageName }}
+- add: /{{ .ModulePath }}modules/030-{{ .ModuleName }}/images/{{ .ImageName }}
   to: /src
   excludePaths:
     - "**/*.md"

--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -1,7 +1,7 @@
 artifact: {{ .ModuleName }}/distroless-cni-flannel-artifact
 from: {{ .Images.BASE_ALPINE }}
 git:
-- add: /modules/035-cni-flannel/images/flanneld
+- add: /{{ .ModulePath }}modules/035-cni-flannel/images/flanneld
   to: /workdir/
   includePaths:
   - '**/file-filter'
@@ -22,7 +22,7 @@ shell:
 artifact: {{ .ModuleName }}/entrypoint-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
-- add: /modules/035-cni-flannel/images/flanneld/entrypoint/
+- add: /{{ .ModulePath }}modules/035-cni-flannel/images/flanneld/entrypoint/
   to: /workdir/
 shell:
   install:

--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -22,7 +22,7 @@ shell:
 artifact: {{ .ModuleName }}/entrypoint-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
-- add: /modules/035-cni-flannel/images/flanneld/entrypoint/
+- add: /{{ .ModulePath }}modules/035-cni-flannel/images/flanneld/entrypoint/
   to: /workdir/
 shell:
   install:

--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -22,7 +22,7 @@ shell:
 artifact: {{ .ModuleName }}/entrypoint-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
-- add: /{{ .ModulePath }}modules/035-cni-flannel/images/flanneld/entrypoint/
+- add: /modules/035-cni-flannel/images/flanneld/entrypoint/
   to: /workdir/
 shell:
   install:

--- a/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
@@ -23,7 +23,7 @@ docker:
 artifact: {{ $.ModuleName }}/controller-artifact
 from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
 git:
-  - add: /modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/controller
+  - add: /{{ .ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/controller
     to: /
     stageDependencies:
       install:

--- a/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
@@ -23,7 +23,7 @@ docker:
 artifact: {{ $.ModuleName }}/controller-artifact
 from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
 git:
-  - add: /{{ .ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/controller
+  - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/controller
     to: /
     stageDependencies:
       install:

--- a/modules/040-control-plane-manager/images/kube-apiserver-healthcheck/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-apiserver-healthcheck/werf.inc.yaml
@@ -16,7 +16,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
 git:
-- add: /modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/
+- add: /{{ .ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/
   to: /src
   includePaths:
   - go.mod

--- a/modules/040-control-plane-manager/images/kubernetes-api-proxy/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kubernetes-api-proxy/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_NGINX_ALPINE }}
 git:
-- add: /modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/kubernetes-api-proxy-reloader
+- add: /{{ .ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/kubernetes-api-proxy-reloader
   to: /kubernetes-api-proxy-reloader
 shell:
   beforeInstall:

--- a/modules/040-node-manager/images/bashible-apiserver/werf.inc.yaml
+++ b/modules/040-node-manager/images/bashible-apiserver/werf.inc.yaml
@@ -2,7 +2,7 @@
 artifact: apiserver
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
 git:
-- add: /modules/040-node-manager/images/bashible-apiserver
+- add: /{{ .ModulePath }}modules/040-node-manager/images/bashible-apiserver
   to: /src
   excludePaths:
   - "**/*.md"
@@ -49,7 +49,7 @@ import:
   before: setup
 git:
 {{ .Files.Get (printf "tools/build_includes/candi-%s.yaml" .Env) | replace "/deckhouse/candi" "/bashible/templates" }}
-- add: /candi/bashible
+- add: /{{ .ModulePath }}candi/bashible
   to: /bashible/templates/bashible
   stageDependencies:
     beforeSetup:
@@ -61,7 +61,7 @@ git:
   excludePaths:
   - "**/bootstrap.sh.tpl"
   - "**/cluster-bootstrap"
-- add: /candi/cloud-providers
+- add: /{{ .ModulePath }}candi/cloud-providers
   to: /bashible/templates/cloud-providers
   stageDependencies:
     beforeSetup:

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -15,7 +15,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
 git:
-- add: /modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -15,7 +15,7 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
 git:
-- add: /{{ .ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -17,7 +17,7 @@ import:
   to: /root/.terraformrc
   before: setup
 git:
-- add: /
+- add: /{{ .ModulePath }}
   to: /deckhouse
   includePaths:
     - "candi/openapi"

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/aws
+- add: /{{ .ModulePath }}candi/cloud-providers/aws
   to: /deckhouse/candi/cloud-providers/aws
 import:
 - artifact: terraform-provider-aws

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/azure
+- add: /{{ .ModulePath }}candi/cloud-providers/azure
   to: /deckhouse/candi/cloud-providers/azure
 import:
 - artifact: terraform-provider-azure

--- a/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/gcp
+- add: /{{ .ModulePath }}candi/cloud-providers/gcp
   to: /deckhouse/candi/cloud-providers/gcp
 import:
 - artifact: terraform-provider-gcp

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/yandex
+- add: /{{ .ModulePath }}candi/cloud-providers/yandex
   to: /deckhouse/candi/cloud-providers/yandex
 import:
 - artifact: terraform-provider-yandex

--- a/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
@@ -15,7 +15,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_GOLANG_19_BULLSEYE }}
 git:
-- add: /{{ .ModulePath }}modules/101-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ $.ModulePath }}modules/101-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
@@ -15,7 +15,7 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_GOLANG_19_BULLSEYE }}
 git:
-- add: /modules/101-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+- add: /{{ .ModulePath }}modules/101-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
   stageDependencies:
     install:

--- a/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
@@ -22,7 +22,7 @@ shell:
 artifact: {{ .ModuleName }}/failover-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
-- add: /{{ .ModulePath }}modules/402-ingress-nginx/images/proxy-failover-iptables/failover/
+- add: /{{ $.ModulePath }}modules/402-ingress-nginx/images/proxy-failover-iptables/failover/
   to: /workdir/
 shell:
   install:

--- a/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
@@ -1,7 +1,7 @@
 artifact: {{ .ModuleName }}/distroless-proxy-failover-iptables-artifact
 from: {{ .Images.BASE_ALPINE }}
 git:
-- add: /modules/402-ingress-nginx/images/proxy-failover-iptables
+- add: /{{ .ModulePath }}modules/402-ingress-nginx/images/proxy-failover-iptables
   to: /workdir/
   includePaths:
   - '**/file-filter'
@@ -22,7 +22,7 @@ shell:
 artifact: {{ .ModuleName }}/failover-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
-- add: /modules/402-ingress-nginx/images/proxy-failover-iptables/failover/
+- add: /{{ .ModulePath }}modules/402-ingress-nginx/images/proxy-failover-iptables/failover/
   to: /workdir/
 shell:
   install:

--- a/modules/490-virtualization/images/artifact/werf.inc.yaml
+++ b/modules/490-virtualization/images/artifact/werf.inc.yaml
@@ -5,7 +5,7 @@
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $builderImage }}
 git:
-  - add: /modules/490-{{ $.ModuleName }}/images/{{ $.ImageName }}
+  - add: /{{ .ModulePath }}modules/490-{{ $.ModuleName }}/images/{{ $.ImageName }}
     to: /
     stageDependencies:
       setup:

--- a/modules/490-virtualization/images/artifact/werf.inc.yaml
+++ b/modules/490-virtualization/images/artifact/werf.inc.yaml
@@ -5,7 +5,7 @@
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $builderImage }}
 git:
-  - add: /{{ .ModulePath }}modules/490-{{ $.ModuleName }}/images/{{ $.ImageName }}
+  - add: /{{ $.ModulePath }}modules/490-{{ $.ModuleName }}/images/{{ $.ImageName }}
     to: /
     stageDependencies:
       setup:

--- a/modules/491-containerized-data-importer/images/artifact/werf.inc.yaml
+++ b/modules/491-containerized-data-importer/images/artifact/werf.inc.yaml
@@ -5,7 +5,7 @@
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $builderImage }}
 git:
-  - add: /modules/491-{{ $.ModuleName }}/images/{{ $.ImageName }}
+  - add: /{{ .ModulePath }}modules/491-{{ $.ModuleName }}/images/{{ $.ImageName }}
     to: /
     stageDependencies:
       setup:

--- a/modules/491-containerized-data-importer/images/artifact/werf.inc.yaml
+++ b/modules/491-containerized-data-importer/images/artifact/werf.inc.yaml
@@ -5,7 +5,7 @@
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $builderImage }}
 git:
-  - add: /{{ .ModulePath }}modules/491-{{ $.ModuleName }}/images/{{ $.ImageName }}
+  - add: /{{ $.ModulePath }}modules/491-{{ $.ModuleName }}/images/{{ $.ImageName }}
     to: /
     stageDependencies:
       setup:

--- a/modules/810-documentation/images/web/werf.inc.yaml
+++ b/modules/810-documentation/images/web/werf.inc.yaml
@@ -7,7 +7,7 @@ ansible:
   - name: "Copy nginx.conf"
     copy:
       content: |
-        {{- .Files.Get "modules/810-documentation/images/web/nginx.conf" | nindent 8 }}
+        {{- .Files.Get (printf "%smodules/810-documentation/images/web/nginx.conf" .ModulePath) | nindent 8 }}
       dest: /etc/nginx/nginx.conf
 import:
 - artifact: {{ .ModuleName }}/{{ .ImageName }}/static
@@ -139,15 +139,15 @@ ansible:
         chdir: /srv/jekyll-data/documentation/
     - copy:
         content: |
-          {{- .Files.Get "modules/810-documentation/images/web/_config.yml" | nindent 10 }}
+          {{- .Files.Get (printf "%smodules/810-documentation/images/web/_config.yml" .ModulePath) | nindent 10 }}
         dest: /tmp/_config_additional.yml
     - copy:
         content: |
-          {{- .Files.Get "modules/810-documentation/images/web/site/_data/topnav.yml" | nindent 10 }}
+          {{- .Files.Get (printf "%smodules/810-documentation/images/web/site/_data/topnav.yml" .ModulePath) | nindent 10 }}
         dest: /srv/jekyll-data/documentation/_data/topnav.yml
     - copy:
         content: |
-          {{- .Files.Get "modules/810-documentation/images/web/site/_includes/footer.html" | nindent 10 }}
+          {{- .Files.Get (printf "%smodules/810-documentation/images/web/site/_includes/footer.html" .ModulePath) | nindent 10 }}
         dest: /srv/jekyll-data/site/_includes/footer.html
     - name: "Creating additional config..."
       shell: |
@@ -178,7 +178,7 @@ ansible:
         cp -Rf /app/_site/site/en /app/_site/documentation/
         rm -rf /app/_site/documentation/compare/
 git:
-- add: /docs
+- add: /{{ .ModulePath }}docs
   to: /srv/jekyll-data
   owner: jekyll
   group: jekyll
@@ -198,7 +198,7 @@ git:
   stageDependencies:
     install: ['site/Gemfile','site/Gemfile.lock']
     setup: '**/*'
-- add: /
+- add: /{{ .ModulePath }}
   to: /comparison
   owner: jekyll
   group: jekyll
@@ -207,7 +207,7 @@ git:
   includePaths:
   - modules/**/docs/README.md
   - ee/modules/**/docs/README.md
-- add: /ee/fe
+- add: /{{ .ModulePath }}ee/fe
   to: /comparison/fe
   owner: jekyll
   group: jekyll
@@ -215,4 +215,4 @@ git:
     setup: ['**/*']
   includePaths:
   - modules/**/docs/README.md
-{{ tpl (.Files.Get "docs/documentation/werf-git-section.inc.yaml") . }}
+{{ tpl (.Files.Get (printf "%sdocs/documentation/werf-git-section.inc.yaml" .ModulePath)) . }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -368,7 +368,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"kubelet1274":               "imageHash-registrypackages-kubelet1274",
 		"kubernetesCni120":          "imageHash-registrypackages-kubernetesCni120",
 		"tomlMerge01":               "imageHash-registrypackages-tomlMerge01",
-		"virtWhatDebian1151Deb9u1":  "imageHash-registrypackages-virtWhatDebian1151Deb9u1",
+		"virtWhatDebian1191":        "imageHash-registrypackages-virtWhatDebian1191",
 	},
 	"runtimeAuditEngine": map[string]interface{}{
 		"falco":         "imageHash-runtimeAuditEngine-falco",


### PR DESCRIPTION
## Description
For build CSE version we need to use .ModulePath in werf.inc.yaml files instead off full path to files from git.

 Debian virt-what pacjkage updated to v1.19.1 becuse old version does not exist in the repo

## Why do we need it, and what problem does it solve?
CSE support

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: chore
summary: Add .ModulePath to werf.inc.yaml
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
