### PR TITLE
[cloud-provider-aws] Pull ec2_describe_tags binary from the Deckhouse repository

### DIFF
--- a/modules/007-registrypackages/images/ec2-describe-tags/README.md
+++ b/modules/007-registrypackages/images/ec2-describe-tags/README.md
@@ -1,0 +1,3 @@
+AWS ec2-describe-tags as a standalone executable.
+Used during bootstrap process of AWS nodes networks.
+

--- a/modules/007-registrypackages/images/ec2-describe-tags/scripts/install
+++ b/modules/007-registrypackages/images/ec2-describe-tags/scripts/install
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+mkdir -p /opt/deckhouse/bin
+cp -f ec2_describe_tags /opt/deckhouse/bin

--- a/modules/007-registrypackages/images/ec2-describe-tags/scripts/uninstall
+++ b/modules/007-registrypackages/images/ec2-describe-tags/scripts/uninstall
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+rm -f /opt/deckhouse/bin/ec2_describe_tags

--- a/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
@@ -27,6 +27,8 @@ git:
       setup:
       - '**/*'
 shell:
+  beforeInstall:
+  - apk add --no-cache curl
   setup:
   - curl -sfL -o /ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.2/ec2_describe_tags
   - chmod +x /ec2_describe_tags /install /uninstall

--- a/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
@@ -1,0 +1,32 @@
+{{- $version := "0.0.1" }}
+{{- $image_version := $version | replace "." "-" }}
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+from: {{ $.Images.BASE_SCRATCH }}
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+  add: /
+  to: /
+  includePaths:
+  - ec2_describe_tags
+  - install
+  - uninstall
+  before: setup
+docker:
+  LABEL:
+    distro: all
+    version: all
+    curl: {{ $version }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+from: {{ $.Images.BASE_ALPINE }}
+git:
+  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+    to: /
+    stageDependencies:
+      setup:
+      - '**/*'
+shell:
+  setup:
+  - curl -sfL -o /ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.2/ec2_describe_tags
+  - chmod +x /ec2_describe_tags /install /uninstall

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -347,6 +347,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"crictl127":                 "imageHash-registrypackages-crictl127",
 		"d8Curl801":                 "imageHash-registrypackages-d8Curl801",
 		"drbd924":                   "imageHash-registrypackages-drbd924",
+		"ec2DescribeTags001":        "imageHash-registrypackages-ec2DescribeTags001",
 		"inotifyToolsCentos73149":   "imageHash-registrypackages-inotifyToolsCentos73149",
 		"inotifyToolsCentos831419":  "imageHash-registrypackages-inotifyToolsCentos831419",
 		"inotifyToolsCentos9322101": "imageHash-registrypackages-inotifyToolsCentos9322101",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`ec2_describe_tags` binary is now built as a Deckhouse registry package. This package is now used instead of pulling the binary from github during AWS nodes networks bootstrap.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
See #5300 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: chore
summary: ec2_describe_tags binary is pulled from a deckhouse registry package instead of github
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
