### PR TITLE
[linstor] fixes in nodegroupconfigurations for DRBD install and linstor components update script

### DIFF
--- a/modules/041-linstor/hack/update.sh
+++ b/modules/041-linstor/hack/update.sh
@@ -40,7 +40,7 @@ while read name repo; do
       # convert v9.X.X to 9.X.X
       drbd_version=${current_tag#*v}
       # convert 9.X.X to 9XX
-      drbd_undotted_version=$(echo $drbd_version | sed 's/\.//g')
+      drbd_version_undotted=$(tr -d . <<< "$drbd_version")
     elif [ "$name" = PIRAEUS_OPERATOR ]; then
       current_tag=$(curl -fLsS "https://api.github.com/repos/${shortrepo}/tags" | jq -r '.[] | .name' | grep "v${piraeus_operator_major_ver}.*" | sort -V | tail -n1)
     else
@@ -61,6 +61,6 @@ echo "Applying changes:"
 (set -x; sed -e "$sed_regex" -i $targets)
 if [ -n "$drbd_version" ]; then
   (set -x; sed -e "/^      drbdVersion:/,/default:/{/^\([[:space:]]*default: \).*/s//\1\"${drbd_version}\"/}" -i openapi/values.yaml)
-  (set -x; sed 's/$version := "[0-9]\+\.[0-9]\+\.[0-9]"/$version := "'$drbd_version'"/' -i modules/007-registrypackages/images/drbd/werf.inc.yaml)
-  (set -x; sed 's/drbd[0-9]\+/drbd'$drbd_undotted_version'/' -i modules/041-linstor/templates/nodegroupconfiguration-drbd-install-*-like.yaml)
+  (set -x; sed 's/$version[[:space:]]+:=[[:space:]]+"[0-9]\+\.[0-9]\+\.[0-9]\+"/$version := "'$drbd_version'"/' -i modules/007-registrypackages/images/drbd/werf.inc.yaml)
+  (set -x; sed 's/drbd[0-9]\+/drbd'$drbd_version_undotted'/' -i modules/041-linstor/templates/nodegroupconfiguration-drbd-install-*-like.yaml)
 fi

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -101,7 +101,7 @@ spec:
     SPAAS_URL="https://${SPAAS_IP}:2020"
 
     attempt=0
-    until [ `d8-curl -kIs $SPAAS_URL'/api/v1/hello' | grep -q 'HTTP/2 405' && echo 1 || echo 0` == 1 ]
+    until [[ "$(d8-curl -ks -w '%{http_code}' -o /dev/null $SPAAS_URL'/api/v1/hello')" == "200" ]]
     do
       if [ $attempt -gt 60 ]; then
         bb-log-info "SPAAS service isn't accessible, can't continue DRBD building"
@@ -123,6 +123,7 @@ spec:
     echo 'drbd' | tee -a /etc/modules
     depmod
     modprobe drbd
+    modprobe dm-thin-pool
 
     if [ -e "/proc/drbd" ]; then
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -106,7 +106,7 @@ spec:
     SPAAS_URL="https://${SPAAS_IP}:2020"
 
     attempt=0
-    until [ `d8-curl -kIs $SPAAS_URL'/api/v1/hello' | grep -q 'HTTP/2 405' && echo 1 || echo 0` == 1 ]
+    until [[ "$(d8-curl -ks -w '%{http_code}' -o /dev/null $SPAAS_URL'/api/v1/hello')" == "200" ]]
     do
       if [ $attempt -gt 60 ]; then
         bb-log-info "SPAAS service isn't accessible, can't continue DRBD building"
@@ -128,6 +128,7 @@ spec:
     echo 'drbd' | tee -a /etc/modules
     depmod
     modprobe drbd
+    modprobe dm-thin-pool
 
     if [ -e "/proc/drbd" ]; then
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -103,7 +103,7 @@ spec:
     SPAAS_URL="https://${SPAAS_IP}:2020"
 
     attempt=0
-    until [ `d8-curl -kIs $SPAAS_URL'/api/v1/hello' | grep -q 'HTTP/2 405' && echo 1 || echo 0` == 1 ]
+    until [[ "$(d8-curl -ks -w '%{http_code}' -o /dev/null $SPAAS_URL'/api/v1/hello')" == "200" ]]
     do
       if [ $attempt -gt 60 ]; then
         bb-log-info "SPAAS service isn't accessible, can't continue DRBD building"
@@ -125,6 +125,7 @@ spec:
     echo 'drbd' | tee -a /etc/modules
     depmod
     modprobe drbd
+    modprobe dm-thin-pool
 
     if [ -e "/proc/drbd" ]; then
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We have some conditions in nodegroupconfigurations that not matches our code style. 
Potentially there can be problems with load dm-thin-pool module, that needed for lwm thin pool support.
Also, we need some additions in linstor components update script

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This PR will fix conditions in nodegroupconfigurations that not matches our code style, force dm-thin-pool kernel module load and fix linstor components update script

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Some changes for unified code base, confidence about lvm-thin support and updated script for linstor components update.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Fixes in nodegroupconfigurations for DRBD install and linstor components update script.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
