### PR TITLE
[control-plane-manager] added a state check before changing the master node

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -35,6 +35,15 @@ Adding a master node to a static or hybrid cluster has no difference from adding
      --ssh-host <MASTER-NODE-0-HOST>
    ```
 
+1. **In the installer container**, run the following command to check the state before working:
+
+   ```bash
+   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
+     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   ```
+
+   The response should tell you that Terraform does not want to change anything.
+
 1. **In the installer container**, run the following command to start scaling:
 
    ```bash
@@ -62,6 +71,15 @@ Adding a master node to a static or hybrid cluster has no difference from adding
    docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \
      registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
+
+1. **In the installer container**, run the following command to check the state before working:
+
+   ```bash
+   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
+     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   ```
+
+   The response should tell you that Terraform does not want to change anything.
 
 1. Run the following command **in the installer container** and set `masterNodeGroup.replicas` to `1`:
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -31,8 +31,7 @@ Adding a master node to a static or hybrid cluster has no difference from adding
 1. **In the installer container**, run the following command to check the state before working:
 
    ```bash
-   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
 
    The response should tell you that Terraform does not want to change anything.
@@ -75,8 +74,7 @@ Adding a master node to a static or hybrid cluster has no difference from adding
 1. **In the installer container**, run the following command to check the state before working:
 
    ```bash
-   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
 
    The response should tell you that Terraform does not want to change anything.

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -28,13 +28,6 @@ Adding a master node to a static or hybrid cluster has no difference from adding
      registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
 
-1. **In the installer container**, run the following command and specify the required number of replicas using the `masterNodeGroup.replicas` parameter:
-
-   ```bash
-   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-     --ssh-host <MASTER-NODE-0-HOST>
-   ```
-
 1. **In the installer container**, run the following command to check the state before working:
 
    ```bash
@@ -43,6 +36,13 @@ Adding a master node to a static or hybrid cluster has no difference from adding
    ```
 
    The response should tell you that Terraform does not want to change anything.
+
+1. **In the installer container**, run the following command and specify the required number of replicas using the `masterNodeGroup.replicas` parameter:
+
+   ```bash
+   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
+     --ssh-host <MASTER-NODE-0-HOST>
+   ```
 
 1. **In the installer container**, run the following command to start scaling:
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -31,8 +31,7 @@ title: "Управление control plane: FAQ"
 1. **В контейнере с инсталлятором** выполните следующую команду, чтобы проверить состояние перед началом работы:
 
    ```bash
-   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
 
    Ответ должен сообщить вам, что Terraform не хочет ничего менять.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -28,6 +28,15 @@ title: "Управление control plane: FAQ"
      registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
 
+1. **В контейнере с инсталлятором** выполните следующую команду, чтобы проверить состояние перед началом работы:
+
+   ```bash
+   dhctl terraform check --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
+     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   ```
+
+   Ответ должен сообщить вам, что Terraform не хочет ничего менять.
+
 1. **В контейнере с инсталлятором** выполните следующую команду и укажите требуемое количество реплик в параметре `masterNodeGroup.replicas`:
 
    ```bash

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -231,6 +231,6 @@
         Terraform-state-exporter found difference between node template from cluster provider configuration and from NodeGroup `{{`{{ $labels.name }}`}}`.
         Node template is `{{`{{ $labels.status }}`}}`.
 
-        First, check what will change by running the `dhctl terraform check` command.
+        First, run the `dhctl terraform check` command to check what will change.
         Use `dhctl converge` command or manually adjust NodeGroup settings to fix the issue.
       summary: Terraform-state-exporter node template changed

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -203,7 +203,7 @@
         Terraform-state-exporter can't check difference between Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state and Terraform state.
 
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
-        First, check what will change by running the `dhctl terraform check` command.
+        First, run the `dhctl terraform check` command to check what will change.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -153,7 +153,7 @@
         Real Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
-        First, check what will change by running the `dhctl terraform check` command.
+        First, run the `dhctl terraform check` command to check what will change.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
       summary: Terraform-state-exporter node state changed
 

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -153,7 +153,7 @@
         Real Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
-        First check what will change `dhctl terraform check`.
+        First, check what will change by running the `dhctl terraform check` command.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
       summary: Terraform-state-exporter node state changed
 
@@ -175,7 +175,7 @@
         Terraform-state-exporter can't check difference between Kubernetes cluster state and Terraform state.
 
         Probably, it occurred because Terraform-state-exporter had failed to run terraform with current state and config.
-        First check what will change `dhctl terraform check`.
+        First, check what will change by running the `dhctl terraform check` command.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
@@ -203,7 +203,7 @@
         Terraform-state-exporter can't check difference between Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state and Terraform state.
 
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
-        First check what will change `dhctl terraform check`.
+        First, check what will change by running the `dhctl terraform check` command.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
@@ -231,6 +231,6 @@
         Terraform-state-exporter found difference between node template from cluster provider configuration and from NodeGroup `{{`{{ $labels.name }}`}}`.
         Node template is `{{`{{ $labels.status }}`}}`.
 
-        First check what will change `dhctl terraform check`.
+        First, check what will change by running the `dhctl terraform check` command.
         Use `dhctl converge` command or manually adjust NodeGroup settings to fix the issue.
       summary: Terraform-state-exporter node template changed

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -131,7 +131,7 @@
         Real Kubernetes cluster state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
-        First check what will change `dhctl terraform check`.
+        First, run the `dhctl terraform check` command to check what will change.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
       summary: Terraform-state-exporter cluster state changed
 

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -131,6 +131,7 @@
         Real Kubernetes cluster state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
+        First check what will change `dhctl terraform check`.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
       summary: Terraform-state-exporter cluster state changed
 
@@ -152,6 +153,7 @@
         Real Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state is `{{`{{ $labels.status }}`}}` comparing to Terraform state.
 
         It's important to make them equal.
+        First check what will change `dhctl terraform check`.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
       summary: Terraform-state-exporter node state changed
 
@@ -173,6 +175,7 @@
         Terraform-state-exporter can't check difference between Kubernetes cluster state and Terraform state.
 
         Probably, it occurred because Terraform-state-exporter had failed to run terraform with current state and config.
+        First check what will change `dhctl terraform check`.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
@@ -200,6 +203,7 @@
         Terraform-state-exporter can't check difference between Node `{{"{{ $labels.node_group }}/{{ $labels.name }}"}}` state and Terraform state.
 
         Probably, it occurred because Terraform-manager had failed to run terraform with current state and config.
+        First check what will change `dhctl terraform check`.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
@@ -227,5 +231,6 @@
         Terraform-state-exporter found difference between node template from cluster provider configuration and from NodeGroup `{{`{{ $labels.name }}`}}`.
         Node template is `{{`{{ $labels.status }}`}}`.
 
+        First check what will change `dhctl terraform check`.
         Use `dhctl converge` command or manually adjust NodeGroup settings to fix the issue.
       summary: Terraform-state-exporter node template changed

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -175,7 +175,7 @@
         Terraform-state-exporter can't check difference between Kubernetes cluster state and Terraform state.
 
         Probably, it occurred because Terraform-state-exporter had failed to run terraform with current state and config.
-        First, check what will change by running the `dhctl terraform check` command.
+        First, run the `dhctl terraform check` command to check what will change.
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}


### PR DESCRIPTION
## Description
Added info about check terraform state before changing the master node.

## Changelog entries
```changes
section: control-plane-manager
type: chore
summary: Add info about checking the terraform state before changing the master node.
impact_level: low
```
