### PR TITLE
[user-authn] Use global discovered publishAPI cert by default

### DIFF
--- a/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
+++ b/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
@@ -140,6 +140,21 @@ Multiline
 
 			Context("With https mode 'Global'", func() {
 				BeforeEach(func() {
+					hec.ValuesSet("userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA", "test_cert")
+					hec.ValuesSet("userAuthn.publishAPI.https.mode", "Global")
+				})
+
+				It("Should add k8s_ca_pem param with publishedAPIKubeconfigGeneratorMasterCA for first cluster", func() {
+					Expect(hec.RenderError).ToNot(HaveOccurred())
+
+					jsonBytes := assertCreateConfig(hec)
+
+					Expect(gjson.GetBytes(jsonBytes, "clusters.0.k8s_ca_pem").String()).To(Equal("test_cert"))
+				})
+			})
+
+			Context("With https mode 'Global' and kubeconfigGeneratorMasterCA", func() {
+				BeforeEach(func() {
 					hec.ValuesSet("userAuthn.publishAPI.https.mode", "Global")
 					hec.ValuesSet("userAuthn.publishAPI.https.global.kubeconfigGeneratorMasterCA", "kubeconfigGeneratorMasterCAText")
 				})

--- a/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
@@ -40,13 +40,13 @@ clusters:
   {{- $_ := set $publish_api_cluster "description" $publish_api_master_url }}
 
   {{- if eq .Values.userAuthn.publishAPI.https.mode "Global" }}
+{{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA }}
     {{- if hasKey .Values.userAuthn.publishAPI.https "global" }}
       {{- if hasKey .Values.userAuthn.publishAPI.https.global "kubeconfigGeneratorMasterCA" }}
 {{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.publishAPI.https.global.kubeconfigGeneratorMasterCA }}
-      {{- else }}
-{{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA }}
       {{- end }}
     {{- end }}
+
   {{- else if eq .Values.userAuthn.publishAPI.https.mode "SelfSigned" }}
 {{- $_ := set $publish_api_cluster "masterCA" (.Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA | default $.Values.global.discovery.kubernetesCA) }}
   {{- end }}


### PR DESCRIPTION
## Description
Fix bug when discovered CA is not added to kubconfigs

## Why do we need it, and what problem does it solve?
Without it, users cannot connect to kube-apiserver with the publish API feature when selfsigned certificates are used.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Use global discovered publishAPI cert by default for generated kubeconfigs
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
