### PR TITLE
[deckhouse] Update release delay without configuring notification.

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/notification.go
+++ b/modules/002-deckhouse/hooks/internal/updater/notification.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/tidwall/gjson"
 
 	"github.com/deckhouse/deckhouse/modules/002-deckhouse/hooks/internal/apis/v1alpha1"
 )
@@ -62,7 +63,7 @@ func (a *Auth) Fill(req *http.Request) {
 func ParseNotificationConfigFromValues(input *go_hook.HookInput) (*NotificationConfig, error) {
 	webhook, ok := input.Values.GetOk("deckhouse.update.notification.webhook")
 	if !ok {
-		return nil, nil // no notification
+		webhook = gjson.Result{}
 	}
 
 	var minimalTime v1alpha1.Duration

--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -108,7 +108,7 @@ func (du *DeckhouseUpdater) checkPatchReleaseConditions(predictedRelease *Deckho
 }
 
 func (du *DeckhouseUpdater) checkReleaseNotification(predictedRelease *DeckhouseRelease, updateWindows update.Windows) bool {
-	if du.inManualMode || du.releaseData.Notified {
+	if du.releaseData.Notified {
 		return true
 	}
 
@@ -127,18 +127,20 @@ func (du *DeckhouseUpdater) checkReleaseNotification(predictedRelease *Deckhouse
 
 	version := fmt.Sprintf("%d.%d", predictedRelease.Version.Major(), predictedRelease.Version.Minor())
 	msg := fmt.Sprintf("New Deckhouse Release %s is available. Release will be applied at: %s", version, releaseApplyTime.Format(time.RFC850))
-	data := webhookData{
-		Version:       fmt.Sprintf("%d.%d", predictedRelease.Version.Major(), predictedRelease.Version.Minor()),
-		Requirements:  predictedRelease.Requirements,
-		ChangelogLink: predictedRelease.ChangelogLink,
-		ApplyTime:     releaseApplyTime.Format(time.RFC3339),
-		Message:       msg,
-	}
+	if du.notificationConfig.WebhookURL != "" {
+		data := webhookData{
+			Version:       fmt.Sprintf("%d.%d", predictedRelease.Version.Major(), predictedRelease.Version.Minor()),
+			Requirements:  predictedRelease.Requirements,
+			ChangelogLink: predictedRelease.ChangelogLink,
+			ApplyTime:     releaseApplyTime.Format(time.RFC3339),
+			Message:       msg,
+		}
 
-	err := sendWebhookNotification(du.notificationConfig, data)
-	if err != nil {
-		du.input.LogEntry.Errorf("Send deckhouse release notification failed: %s", err)
-		return false
+		err := sendWebhookNotification(du.notificationConfig, data)
+		if err != nil {
+			du.input.LogEntry.Errorf("Send deckhouse release notification failed: %s", err)
+			return false
+		}
 	}
 
 	du.changeNotifiedFlag(true)
@@ -187,7 +189,7 @@ func (du *DeckhouseUpdater) checkMinorReleaseConditions(predictedRelease *Deckho
 
 	// check: Notification
 	if du.notificationConfig != nil {
-		passed = du.checkReleaseNotification(predictedRelease, updateWindows)
+		passed = du.checkReleaseNotification(predictedRelease, updateWindows) //
 		if !passed {
 			return false
 		}

--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -189,7 +189,7 @@ func (du *DeckhouseUpdater) checkMinorReleaseConditions(predictedRelease *Deckho
 
 	// check: Notification
 	if du.notificationConfig != nil {
-		passed = du.checkReleaseNotification(predictedRelease, updateWindows) //
+		passed = du.checkReleaseNotification(predictedRelease, updateWindows)
 		if !passed {
 			return false
 		}


### PR DESCRIPTION
## Description
Deckhouse has feature to control notifications about updates. There is parameter [minimalNotificationTime](https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime). But some users use pull model to get information about releases. They can't be sure that they get information about release and this information will be in their internal system for required period of time.

## Why do we need it, and what problem does it solve?
If it fixes an issue https://github.com/deckhouse/deckhouse/issues/5147

## What is the expected result?
We made it possible to configure minimalNotificationTime without configuring the notification webhook.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Made it possible to configure minimalNotificationTime without configuring the notification webhook.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
