### PR TITLE
[external-module-manager] Add CA certificate option to an ExternalModuleSource

### DIFF
--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -18,6 +18,9 @@ spec:
                       description: Адрес репозитория образов контейнеров.
                     dockerCfg:
                       description: Строка с токеном доступа к container registry в Base64.
+                    ca:
+                      description: |
+                        Корневой сертификат (В формате PEM), которым можно проверить сертификат registry при работе по HTTPS (если registry использует самоподписанные SSL-сертификаты).
             status:
               properties:
                 syncTime:

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -47,6 +47,10 @@ spec:
                     dockerCfg:
                       type: string
                       description: Container registry access token in Base64.
+                    ca:
+                      type: string
+                      description: |
+                        Root CA certificate (PEM format) to validate the registry’s HTTPS certificate (if self-signed certificates are used).
             status:
               type: object
               properties:

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -129,6 +129,10 @@ func handleSource(input *go_hook.HookInput, dc dependency.Container) error {
 			opts = append(opts, cr.WithDisabledAuth())
 		}
 
+		if ex.Spec.Registry.CA != "" {
+			opts = append(opts, cr.WithCA(ex.Spec.Registry.CA))
+		}
+
 		regCli, err := dc.GetRegistryClient(ex.Spec.Registry.Repo, opts...)
 		if err != nil {
 			sc.Msg = err.Error()

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -40,6 +40,7 @@ type ExternalModuleSourceSpec struct {
 	Registry struct {
 		Repo      string `json:"repo"`
 		DockerCFG string `json:"dockerCfg"`
+		CA        string `json:"ca"`
 	} `json:"registry"`
 	ReleaseChannel string `json:"releaseChannel"`
 }


### PR DESCRIPTION
## Description
Add custom CA certificate handling on external modules pulling.

## Why do we need it, and what problem does it solve?
Without CA registry with self-signed certificate will return an error, like `x509: certificate signed by unknown authority`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: feature
summary: Support custom CA for ExternalModuleSource.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
