### PR TITLE
[candi](bashible) Revert migration to cgroupfs driver for containerd cri

### DIFF
--- a/candi/bashible/common-steps/node-group/002_migrate_containerd_to_cgroupfs.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_migrate_containerd_to_cgroupfs.sh.tpl
@@ -1,0 +1,86 @@
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .cri "Containerd" }}
+# Migration already done
+if [ -f /var/lib/bashible/cgroup_config ]; then
+  # If there is a file /var/lib/bashible/cgroup_config, then we use the cgroup driver value from the file.
+  exit 0
+else
+  # We must restore the file /var/lib/bashible/cgroup_config because when we removed Docker CRI support,
+  # we removed containerd migration to cgroupfs too.
+  if [[ -f /var/lib/kubelet/config.yaml ]]; then
+    if cat /var/lib/kubelet/config.yaml | grep -q "cgroupDriver: cgroupfs"; then
+      # If there is no file /var/lib/bashible/cgroup_config, but we understand that cgroupfs is used,
+      # then we create a file.
+      echo "cgroupfs" > /var/lib/bashible/cgroup_config
+    else
+      # If there is no file /var/lib/bashible/cgroup_config, but we understand that systemd is used,
+      # then we skip the migration and do nothing.
+      exit 0
+    fi
+  fi
+fi
+# Bashible run on node bootstrap
+if [ "${FIRST_BASHIBLE_RUN}" == "yes" ]; then
+  echo "cgroupfs" > /var/lib/bashible/cgroup_config
+  exit 0
+fi
+
+bb-event-on 'containerd-cgroup-migration-changed' '_containerd_cgroup_migration_service'
+function _containerd_cgroup_migration_service() {
+  systemctl daemon-reload
+  systemctl enable d8-containerd-cgroup-migration.service
+}
+
+bb-sync-file /etc/systemd/system/d8-containerd-cgroup-migration.service - containerd-cgroup-migration-changed << EOF
+[Unit]
+Description=Containerd cgroup config migration
+Before=network.target
+[Service]
+type=simple
+ExecStart=/opt/deckhouse/bin/d8-containerd-cgroup-migration.sh
+[Install]
+WantedBy=multi-user.target
+EOF
+
+mkdir -p /opt/deckhouse/bin
+
+bb-sync-file /opt/deckhouse/bin/d8-containerd-cgroup-migration.sh - << "EOF"
+#!/bin/bash
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Migration already done
+if [ -f /var/lib/bashible/cgroup_config ]; then
+  exit 0
+fi
+
+echo 'cgroupfs' > /var/lib/bashible/cgroup_config
+sed -i 's/SystemdCgroup = true/SystemdCgroup = false/g' /etc/containerd/config.toml
+sed -i 's/cgroupDriver: systemd/cgroupDriver: cgroupfs/g' /var/lib/kubelet/config.yaml
+EOF
+chmod +x /opt/deckhouse/bin/d8-containerd-cgroup-migration.sh
+{{- end }}

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -38,6 +38,12 @@ bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
     {{- end }}
   {{- end }}
 
+systemd_cgroup=true
+# Overriding cgroup type from external config file
+if [ -f /var/lib/bashible/cgroup_config ] && [ "$(cat /var/lib/bashible/cgroup_config)" == "cgroupfs" ]; then
+  systemd_cgroup=false
+fi
+
 # generated using `containerd config default` by containerd version `containerd containerd.io 1.4.3 269548fa27e0089a8b8278fc4fc781d7f65a939b`
 bb-sync-file /etc/containerd/deckhouse.toml - << EOF
 version = 2
@@ -130,7 +136,7 @@ oom_score = 0
           privileged_without_host_devices = false
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-            SystemdCgroup = false
+            SystemdCgroup = ${systemd_cgroup}
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Revert migration to cgroupfs driver for containerd cri.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We must migrate containerd to cgroupfs. This migration was deleted by mistake after removing Docker CRI support (#4960).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Revert migration to cgroupfs driver for containerd cri.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
