### PR TITLE
[distroless] monitoring kubernetes

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -122,7 +122,7 @@ securityContext:
 {{- define "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" -}}
 {{- /* Template context with .Values, .Chart, etc */ -}}
 {{- /* List of capabilities */ -}}
-securityContext:
+securityContext :
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -122,7 +122,7 @@ securityContext:
 {{- define "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" -}}
 {{- /* Template context with .Values, .Chart, etc */ -}}
 {{- /* List of capabilities */ -}}
-securityContext :
+securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -3,11 +3,14 @@ ARG BASE_DISTROLESS
 FROM $BASE_GOLANG_17_ALPINE as artifact
 RUN apk add --no-cache make git patch
 
-ARG SOURCE_REPO
-ENV SOURCE_REPO=${SOURCE_REPO}
-
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+ARG SOURCE_REPO
+
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --no-cache make git patch
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \
   git clone --depth 1 --branch v2.6.0 ${SOURCE_REPO}/kubernetes/kube-state-metrics/ /src/kube-state-metrics
@@ -16,5 +19,5 @@ RUN make build-local && \
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /src/kube-state-metrics/kube-state-metrics /bin/kube-state-metrics
-USER 64535
+
 ENTRYPOINT ["/bin/kube-state-metrics"]

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -10,8 +10,11 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 RUN mkdir -p /src/kube-state-metrics && \
   git clone --depth 1 --branch v2.6.0 ${SOURCE_REPO}/kubernetes/kube-state-metrics/ /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
-RUN make build-local
+RUN make build-local && \
+    chown -R 64535:64535 /src/kube-state-metrics && \
+    chmod 0700 /src/kube-state-metrics/kube-state-metrics
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /src/kube-state-metrics/kube-state-metrics /bin/kube-state-metrics
+USER 64535
 ENTRYPOINT ["/bin/kube-state-metrics"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -9,7 +9,9 @@ ENV GOPROXY=${GOPROXY}
 WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
+    chown -R 64535:64535 /src/ && \
+    chmod 0700 /src/loop
 
 FROM $BASE_DISTROLESS
 

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -22,6 +22,4 @@ FROM $BASE_ALPINE
 COPY --from=artifact /src/loop /
 COPY --from=artifact /var/run/node-exporter-textfile /var/run/node-exporter-textfile
 
-RUN ls -la /var/run/node-exporter-textfile
-
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -4,12 +4,18 @@ ARG BASE_DISTROLESS
 FROM $BASE_GOLANG_19_ALPINE as artifact
 
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+ARG SOURCE_REPO
+
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
+    go build -ldflags="-s -w" -o loop main.go && \
     chown -R 64535:64535 /src/ && \
     chmod 0700 /src/loop
 

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_GOLANG_19_ALPINE
 ARG BASE_DISTROLESS
-ARG BASE_ALPINE
 
 FROM $BASE_GOLANG_19_ALPINE as artifact
 
@@ -12,14 +11,10 @@ COPY exporter/ /src/
 RUN apk add --no-cache git && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
     chown -R 64535:64535 /src/ && \
-    chmod 0700 /src/loop && \
-    mkdir -p /var/run/node-exporter-textfile && \
-    chown -R 64535:64535 /var/run/node-exporter-textfile && \
-    chmod 0600 /var/run/node-exporter-textfile
+    chmod 0700 /src/loop
 
-FROM $BASE_ALPINE
+FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
-COPY --from=artifact /var/run/node-exporter-textfile /var/run/node-exporter-textfile
 
-ENTRYPOINT ["while :; do sleep 1; done;"]
+ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -6,12 +6,10 @@ FROM $BASE_GOLANG_19_ALPINE as artifact
 WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
-    chown -R 64535:64535 /src/ && \
-    chmod 0700 /src/loop
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go
 
 FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
-USER 64535
+
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -22,4 +22,4 @@ FROM $BASE_ALPINE
 COPY --from=artifact /src/loop /
 COPY --from=artifact /var/run/node-exporter-textfile /var/run/node-exporter-textfile
 
-ENTRYPOINT ["/loop"]
+ENTRYPOINT ["while :; do sleep 1; done;"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -7,15 +7,11 @@ WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
-    mkdir -p /var/run/node-exporter-textfile/ && \
-    chown -R 64535:64535 /var/run/node-exporter-textfile/ && \
     chown -R 64535:64535 /src/ && \
-    chmod 0600 -R /var/run/node-exporter-textfile && \
     chmod 0700 /src/loop
 
 FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
-COPY --from=artifact /var/run/node-exporter-textfile/ /var/run/node-exporter-textfile/
 USER 64535
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -22,4 +22,6 @@ FROM $BASE_ALPINE
 COPY --from=artifact /src/loop /
 COPY --from=artifact /var/run/node-exporter-textfile /var/run/node-exporter-textfile
 
+RUN ls -la /var/run/node-exporter-textfile
+
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_GOLANG_19_ALPINE
 ARG BASE_DISTROLESS
+ARG BASE_ALPINE
 
 FROM $BASE_GOLANG_19_ALPINE as artifact
 
@@ -16,7 +17,7 @@ RUN apk add --no-cache git && \
     chown -R 64535:64535 /var/run/node-exporter-textfile && \
     chmod 0600 /var/run/node-exporter-textfile
 
-FROM $BASE_DISTROLESS
+FROM $BASE_ALPINE
 
 COPY --from=artifact /src/loop /
 COPY --from=artifact /var/run/node-exporter-textfile /var/run/node-exporter-textfile

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -9,9 +9,7 @@ ENV GOPROXY=${GOPROXY}
 WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
-    chown -R 64535:64535 /src/ && \
-    chmod 0700 /src/loop
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go
 
 FROM $BASE_DISTROLESS
 

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -6,9 +6,12 @@ FROM $BASE_GOLANG_19_ALPINE as artifact
 WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
+    chown -R 64535:64535 /src/ && \
+    chmod 0700 /src/loop
 
 FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
+USER 64535
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -19,5 +19,6 @@ RUN apk add --no-cache git && \
 FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
+COPY --from=artifact /var/run/node-exporter-textfile /var/run/node-exporter-textfile
 
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -7,11 +7,14 @@ WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
+    mkdir -p /var/run/node-exporter-textfile/ && \
+    chown -R 64535:64535 /var/run/node-exporter-textfile/ && \
     chown -R 64535:64535 /src/ && \
     chmod 0700 /src/loop
 
 FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
+COPY --from=artifact /var/run/node-exporter-textfile/ /src/loop
 USER 64535
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -10,11 +10,12 @@ RUN apk add --no-cache git && \
     mkdir -p /var/run/node-exporter-textfile/ && \
     chown -R 64535:64535 /var/run/node-exporter-textfile/ && \
     chown -R 64535:64535 /src/ && \
+    chmod 0600 -R /var/run/node-exporter-textfile && \
     chmod 0700 /src/loop
 
 FROM $BASE_DISTROLESS
 
 COPY --from=artifact /src/loop /
-COPY --from=artifact /var/run/node-exporter-textfile/ /src/loop
+COPY --from=artifact /var/run/node-exporter-textfile/ /var/run/node-exporter-textfile/
 USER 64535
 ENTRYPOINT ["/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -3,6 +3,9 @@ ARG BASE_DISTROLESS
 
 FROM $BASE_GOLANG_19_ALPINE as artifact
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 WORKDIR /src/
 COPY exporter/ /src/
 RUN apk add --no-cache git && \

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -11,7 +11,10 @@ COPY exporter/ /src/
 RUN apk add --no-cache git && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o loop main.go && \
     chown -R 64535:64535 /src/ && \
-    chmod 0700 /src/loop
+    chmod 0700 /src/loop && \
+    mkdir -p /var/run/node-exporter-textfile && \
+    chown -R 64535:64535 /var/run/node-exporter-textfile && \
+    chmod 0600 /var/run/node-exporter-textfile
 
 FROM $BASE_DISTROLESS
 

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -9,12 +9,14 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
+    chown -R 64535:64535 /node_exporter/ && \
+    chmod 0700 /node_exporter/node_exporter
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /node_exporter/node_exporter /bin
 
 EXPOSE      9100
-USER        nobody
+USER        64535
 
 ENTRYPOINT  [ "/bin/node_exporter" ]

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -12,9 +12,7 @@ ENV GOPROXY=${GOPROXY}
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
-    chown -R 64535:64535 /node_exporter/ && \
-    chmod 0700 /node_exporter/node_exporter
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /node_exporter/node_exporter /bin

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -12,7 +12,10 @@ ENV GOPROXY=${GOPROXY}
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
+    chown -R 64535:64535 /node_exporter/ && \
+    chmod 0700 /node_exporter/node_exporter
+
 FROM $BASE_DISTROLESS
 COPY --from=artifact /node_exporter/node_exporter /bin
 

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -10,7 +10,7 @@ ARG GOPROXY
 ENV GOPROXY=${GOPROXY}
 
 RUN apk add --no-cache git
-RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
+RUN git clone --depth 1 --branch v1.6.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
     chown -R 64535:64535 /node_exporter/ && \

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -9,14 +9,11 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
-    chown -R 64535:64535 /node_exporter/ && \
-    chmod 0700 /node_exporter/node_exporter
-
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go
 FROM $BASE_DISTROLESS
 COPY --from=artifact /node_exporter/node_exporter /bin
 
 EXPOSE      9100
-USER        64535
+USER        nobody
 
 ENTRYPOINT  [ "/bin/node_exporter" ]

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -12,7 +12,9 @@ ENV GOPROXY=${GOPROXY}
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
+    chown -R 64535:64535 /node_exporter/ && \
+    chmod 0700 /node_exporter/node_exporter
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /node_exporter/node_exporter /bin

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -6,6 +6,9 @@ FROM $BASE_GOLANG_19_ALPINE as artifact
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v0.18.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
@@ -14,6 +17,5 @@ FROM $BASE_DISTROLESS
 COPY --from=artifact /node_exporter/node_exporter /bin
 
 EXPOSE      9100
-USER        nobody
 
 ENTRYPOINT  [ "/bin/node_exporter" ]

--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -3,16 +3,19 @@ ARG BASE_GOLANG_19_ALPINE
 
 FROM $BASE_GOLANG_19_ALPINE as artifact
 
-ARG SOURCE_REPO
-ENV SOURCE_REPO=${SOURCE_REPO}
-
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+ARG SOURCE_REPO
+
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 RUN apk add --no-cache git
 RUN git clone --depth 1 --branch v1.6.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
+RUN go build -ldflags="-s -w" -o node_exporter node_exporter.go && \
     chown -R 64535:64535 /node_exporter/ && \
     chmod 0700 /node_exporter/node_exporter
 

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "kube-state-metrics")) | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
       - name: kube-state-metrics
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "FOWNER")) | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
         - '--collector.filesystem.fs-types-exclude'
         - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
         - '--collector.textfile.directory'
-        - '/host/textfile*/*.prom'
+        - '/host/textfile*/'
         - '--collector.netstat.fields'
         - '^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_.*|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$'
         volumeMounts:
@@ -104,7 +104,7 @@ spec:
           mountPropagation: HostToContainer
         - name: textfile-1
           readOnly: true
-          mountPath: /host/textfile-1
+          mountPath: /host/textfile-kubelet-eviction-thresholds-exporter
           mountPropagation: HostToContainer
         resources:
           requests:
@@ -124,7 +124,7 @@ spec:
         - name: root
           readOnly:  true
           mountPath: /host/
-        - name: textfile-1
+        - name: textfile-kubelet-eviction-thresholds-exporter
           mountPath: /var/run/node-exporter-textfile
         - name: dockersock
           mountPath: /var/run/docker.sock
@@ -192,6 +192,6 @@ spec:
           medium: Memory
         name: kube
       - emptyDir:
-        name: textfile-1
+        name: textfile-kubelet-eviction-thresholds-exporter
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -67,12 +67,11 @@ spec:
       serviceAccountName: node-exporter
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-#TODO: we need to run it from the deckhouse user, but it's not clear it how
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeExporter") }}
         name: node-exporter
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME")) | nindent 8 }}
         args:
         - '--web.listen-address=127.0.0.1:9101'
         - '--path.rootfs=/host/root'
@@ -98,6 +97,7 @@ spec:
         - name: root
           readOnly:  true
           mountPath: /host/root
+          mountPropagation: HostToContainer
         - name: textfile
           readOnly: true
           mountPath: /host/textfile

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -102,7 +102,7 @@ spec:
           readOnly: true
           mountPath: /host/textfile
           mountPropagation: HostToContainer
-        - name: textfile-1
+        - name: textfile-kubelet-eviction-thresholds-exporter
           readOnly: true
           mountPath: /host/textfile-kubelet-eviction-thresholds-exporter
           mountPropagation: HostToContainer

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -122,6 +122,7 @@ spec:
           mountPath: /host/
         - name: textfile
           mountPath: /var/run/node-exporter-textfile
+          mountPropagation: HostToContainer
         - name: dockersock
           mountPath: /var/run/docker.sock
         - name: containerddir

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "FOWNER")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_ADMIN")) | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
         - '--collector.filesystem.ignored-fs-types'
         - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
         - '--collector.textfile.directory'
-        - '/host/textfile'
+        - '/host/textfile*/*.prom'
         - '--collector.netstat.fields'
         - '^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_.*|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$'
         volumeMounts:
@@ -101,6 +101,10 @@ spec:
         - name: textfile
           readOnly: true
           mountPath: /host/textfile
+          mountPropagation: HostToContainer
+        - name: textfile-1
+          readOnly: true
+          mountPath: /host/textfile-1
           mountPropagation: HostToContainer
         resources:
           requests:
@@ -120,7 +124,7 @@ spec:
         - name: root
           readOnly:  true
           mountPath: /host/
-        - name: textfile
+        - name: textfile-1
           mountPath: /var/run/node-exporter-textfile
         - name: dockersock
           mountPath: /var/run/docker.sock
@@ -189,3 +193,5 @@ spec:
         name: kube
       imagePullSecrets:
       - name: deckhouse-registry
+      - emptyDir:
+        name: textfile-1

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -191,7 +191,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: kube
-      imagePullSecrets:
-      - name: deckhouse-registry
       - emptyDir:
         name: textfile-1
+      imagePullSecrets:
+      - name: deckhouse-registry

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_ADMIN")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "FOWNER" "SYS_ADMIN")) | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:
@@ -122,7 +122,6 @@ spec:
           mountPath: /host/
         - name: textfile
           mountPath: /var/run/node-exporter-textfile
-          mountPropagation: HostToContainer
         - name: dockersock
           mountPath: /var/run/docker.sock
         - name: containerddir

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "FOWNER" "SYS_ADMIN")) | nindent 8 }}
+        {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -90,7 +90,7 @@ spec:
         - '--collector.filesystem.fs-types-exclude'
         - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
         - '--collector.textfile.directory'
-        - '/host/textfile*/'
+        - '/host/textfile*'
         - '--collector.netstat.fields'
         - '^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_.*|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$'
         volumeMounts:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "SYS_TIME")) | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -193,5 +193,5 @@ spec:
         name: kube
       imagePullSecrets:
       - name: deckhouse-registry
-      - emptyDir:
+      - emptyDir: {}
         name: textfile-1

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: node-exporter
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeExporter") }}
         name: node-exporter
@@ -110,7 +110,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -101,6 +101,7 @@ spec:
         - name: textfile
           readOnly: true
           mountPath: /host/textfile
+          mountPropagation: HostToContainer
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -193,5 +193,5 @@ spec:
         name: kube
       imagePullSecrets:
       - name: deckhouse-registry
-      - emptyDir: {}
+      - emptyDir:
         name: textfile-1

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -79,15 +79,15 @@ spec:
         - '--no-collector.wifi'
         - '--collector.ntp.server-is-local'
         - '--collector.processes'
-        - '--collector.filesystem.ignored-mount-points'
+        - '--collector.filesystem.mount-points-exclude'
         - '(^/(dev|proc|sys|run)($|/))|(^/var/lib/docker/)|(^/var/lib/containerd/)|(/kubelet/)'
 # we want to ignore veth devices. Justification - https://github.com/prometheus-operator/kube-prometheus/pull/1224
 # veth.* - for veth interfaces.
 # [a-f0-9]{15} - for OVN veth interfaces.
 # lxc.* - for Cilium veth interfaces.
         - '--collector.netclass.ignored-devices=^(veth.*|lxc.*|[a-f0-9]{15})$'
-        - '--collector.netdev.ignored-devices=^(veth.*|lxc.*|[a-f0-9]{15})$'
-        - '--collector.filesystem.ignored-fs-types'
+        - '--collector.netdev.device-exclude=^(veth.*|lxc.*|[a-f0-9]{15})$'
+        - '--collector.filesystem.fs-types-exclude'
         - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
         - '--collector.textfile.directory'
         - '/host/textfile*/*.prom'

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -67,6 +67,7 @@ spec:
       serviceAccountName: node-exporter
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+#TODO: we need to run it from the deckhouse user, but it's not clear it how
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeExporter") }}

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: node-exporter
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeExporter") }}
         name: node-exporter

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: node-exporter
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeExporter") }}
         name: node-exporter


### PR DESCRIPTION
## Description
kube-state-metrics, node-exporter are now based on minimal image. Bumped a version node-exporter to 1.6.1
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We'd like to base our images on a distroless image.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
We use scratch along with a minimal number of files from Alpine packages. We pass files in packages though an rsync whitelist.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: feature
summary: Images are based on a distroless image. Bumped a version node-exporter to 1.6.1
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
