### PR TITLE
[operator-trivy] Distroless

### DIFF
--- a/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
@@ -2,10 +2,14 @@ ARG BASE_DISTROLESS
 ARG BASE_GOLANG_20_ALPINE
 
 FROM $BASE_GOLANG_20_ALPINE AS build
-ARG SOURCE_REPO
-ENV SOURCE_REPO=${SOURCE_REPO}
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+ARG SOURCE_REPO
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+
 WORKDIR /src
 RUN apk add --update --no-cache patch git
 RUN git clone --depth 1 --branch v0.0.6 ${SOURCE_REPO}/aquasecurity/k8s-node-collector.git .
@@ -13,7 +17,7 @@ RUN git clone --depth 1 --branch v0.0.6 ${SOURCE_REPO}/aquasecurity/k8s-node-col
 COPY patches/001-change-node-collector-config.patch /src
 RUN patch -p1 < 001-change-node-collector-config.patch
 
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o node-collector ./cmd/node-collector/main.go
+RUN go build -ldflags '-s -w -extldflags "-static"' -o node-collector ./cmd/node-collector/main.go
 
 FROM $BASE_DISTROLESS
 COPY --from=build /src/node-collector /usr/local/bin/

--- a/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
@@ -1,17 +1,21 @@
-ARG BASE_ALPINE
-ARG BASE_GOLANG_19_ALPINE
+ARG BASE_DISTROLESS
+ARG BASE_GOLANG_20_ALPINE
 
-FROM $BASE_GOLANG_19_ALPINE AS build
+FROM $BASE_GOLANG_20_ALPINE AS build
+ARG SOURCE_REPO
+ENV SOURCE_REPO=${SOURCE_REPO}
 WORKDIR /src
-RUN apk add --update --no-cache patch
-RUN wget https://github.com/aquasecurity/k8s-node-collector/archive/refs/tags/v0.0.6.tar.gz -O - | tar -xz --strip-components=1
+RUN apk add --update --no-cache patch git
+RUN git clone --depth 1 --branch v0.0.6 ${SOURCE_REPO}/aquasecurity/k8s-node-collector.git .
 
 COPY patches/001-change-node-collector-config.patch /src
 RUN patch -p1 < 001-change-node-collector-config.patch
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o node-collector ./cmd/node-collector/main.go
 
-FROM $BASE_ALPINE
+RUN chown 64535:64535 node-collector
+RUN chmod 0700 node-collector
+
+FROM $BASE_DISTROLESS
 COPY --from=build /src/node-collector /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/node-collector" ]
-ENV LANG=C.UTF-8

--- a/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
@@ -4,6 +4,8 @@ ARG BASE_GOLANG_20_ALPINE
 FROM $BASE_GOLANG_20_ALPINE AS build
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 WORKDIR /src
 RUN apk add --update --no-cache patch git
 RUN git clone --depth 1 --branch v0.0.6 ${SOURCE_REPO}/aquasecurity/k8s-node-collector.git .

--- a/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
@@ -15,9 +15,6 @@ RUN patch -p1 < 001-change-node-collector-config.patch
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o node-collector ./cmd/node-collector/main.go
 
-RUN chown 64535:64535 node-collector
-RUN chmod 0700 node-collector
-
 FROM $BASE_DISTROLESS
 COPY --from=build /src/node-collector /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/node-collector" ]

--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -1,11 +1,12 @@
-ARG BASE_ALPINE
-ARG BASE_GOLANG_19_ALPINE
+ARG BASE_DISTROLESS
+ARG BASE_GOLANG_20_ALPINE
 
-FROM $BASE_GOLANG_19_ALPINE AS build
+FROM $BASE_GOLANG_20_ALPINE AS build
+ARG SOURCE_REPO
+ENV SOURCE_REPO=${SOURCE_REPO}
 WORKDIR /src
-RUN apk add --update --no-cache patch
-RUN wget https://github.com/aquasecurity/trivy-operator/archive/refs/tags/v0.14.0.tar.gz -O - | tar -xz --strip-components=1 && \
-    go mod vendor
+RUN apk add --update --no-cache patch git
+RUN git clone --depth 1 --branch v0.14.0 ${SOURCE_REPO}/aquasecurity/trivy-operator.git .
 
 COPY patches/001-add-registry-secret-as-dockerconfigjson.patch /src
 COPY patches/002-skip-some-checks.patch /src
@@ -17,7 +18,9 @@ RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
 
 RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go
 
-FROM $BASE_ALPINE
+RUN chown 64535:64535 operator-trivy
+RUN chmod 0700 operator-trivy
+
+FROM $BASE_DISTROLESS
 COPY --from=build /src/operator-trivy /
 ENTRYPOINT [ "/operator-trivy" ]
-ENV LANG=C.UTF-8

--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -4,6 +4,8 @@ ARG BASE_GOLANG_20_ALPINE
 FROM $BASE_GOLANG_20_ALPINE AS build
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 WORKDIR /src
 RUN apk add --update --no-cache patch git
 RUN git clone --depth 1 --branch v0.14.0 ${SOURCE_REPO}/aquasecurity/trivy-operator.git .

--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -14,6 +14,9 @@ WORKDIR /src
 RUN apk add --update --no-cache patch git
 RUN git clone --depth 1 --branch v0.14.0 ${SOURCE_REPO}/aquasecurity/trivy-operator.git .
 
+# some patches are applied to dependencies
+RUN go mod vendor
+
 COPY patches/001-add-registry-secret-as-dockerconfigjson.patch /src
 COPY patches/002-skip-some-checks.patch /src
 COPY patches/003-fix-node-selector.patch /src

--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -2,10 +2,14 @@ ARG BASE_DISTROLESS
 ARG BASE_GOLANG_20_ALPINE
 
 FROM $BASE_GOLANG_20_ALPINE AS build
-ARG SOURCE_REPO
-ENV SOURCE_REPO=${SOURCE_REPO}
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+ARG SOURCE_REPO
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+
 WORKDIR /src
 RUN apk add --update --no-cache patch git
 RUN git clone --depth 1 --branch v0.14.0 ${SOURCE_REPO}/aquasecurity/trivy-operator.git .
@@ -18,7 +22,7 @@ RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
     patch -p1 < 002-skip-some-checks.patch && \
     patch -p1 < 003-fix-node-selector.patch
 
-RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go
+RUN go build -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go
 
 RUN chown 64535:64535 operator-trivy
 RUN chmod 0700 operator-trivy

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -6,9 +6,9 @@ ARG TRIVY_VERSION=v0.44.0-flant
 ARG TRIVY_DB_VERSION=flant-latest
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
-
 ARG GOPROXY
 ENV GOPROXY=${GOPROXY}
+
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -7,6 +7,8 @@ ARG TRIVY_DB_VERSION=flant-latest
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ALPINE
+ARG BASE_DISTROLESS
 ARG BASE_GOLANG_19_BULLSEYE
 
 FROM $BASE_GOLANG_19_BULLSEYE AS build
@@ -13,7 +13,9 @@ RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity
     cd trivy && \
     CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
-FROM $BASE_ALPINE
+RUN chown 64535:64535 trivy
+RUN chmod 0700 trivy
+
+FROM $BASE_DISTROLESS
 COPY --from=build /src/trivy /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/trivy" ]
-ENV LANG=C.UTF-8

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -4,16 +4,19 @@ ARG BASE_GOLANG_19_BULLSEYE
 FROM $BASE_GOLANG_19_BULLSEYE AS build
 ARG TRIVY_VERSION=v0.44.0-flant
 ARG TRIVY_DB_VERSION=flant-latest
-ARG SOURCE_REPO
-ENV SOURCE_REPO=${SOURCE_REPO}
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+ARG SOURCE_REPO
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
     cd trivy && \
-    CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+    go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -7,7 +7,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
 data:
   scanJob.podTemplateContainerSecurityContext: '{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}'
-  scanJob.compressLogs: "true"
+  # disable log compression since it invokes binaries that are not present in a distroless image
+  # https://github.com/aquasecurity/trivy-operator/blob/f612674ba0b7c66e3796e60cc29dc0dcd978caa5/pkg/plugins/trivy/plugin.go#L1209
+  scanJob.compressLogs: "false"
   vulnerabilityReports.scanner: "Trivy"
   configAuditReports.scanner: "Trivy"
   report.recordFailedChecksOnly: "true"

--- a/ee/modules/500-operator-trivy/templates/deployment.yaml
+++ b/ee/modules/500-operator-trivy/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
       - name: "operator"
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changed all images to use distroless image by default.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Using images with nothing inside them except statically linked program improves security.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

operator-trivy runs without errors and all Jobs created by it succeed and create appropriate CRs.

```
root@klimentyev-master-0:~# kubectl -n d8-operator-trivy get pod
NAME                                        READY   STATUS      RESTARTS   AGE
operator-66c658fbb5-dg4fb                   2/2     Running     0          39m

root@klimentyev-master-0:~# kubectl -n d8-operator-trivy get vulnerabilityreports.aquasecurity.github.io -A
NAMESPACE              NAME                                                       REPOSITORY          TAG   SCANNER   AGE
d8-cni-simple-bridge   daemonset-simple-bridge-simple-bridge                      sys/deckhouse-oss         Trivy     65s
d8-descheduler         replicaset-556f7b9849                                      sys/deckhouse-oss         Trivy     18s
d8-monitoring          statefulset-prometheus-longterm-config-reloader            sys/deckhouse-oss         Trivy     64s
d8-monitoring          statefulset-prometheus-longterm-init-config-reloader       sys/deckhouse-oss         Trivy     64s
d8-monitoring          statefulset-prometheus-longterm-kube-rbac-proxy            sys/deckhouse-oss         Trivy     64s
d8-monitoring          statefulset-prometheus-longterm-prometheus                 sys/deckhouse-oss         Trivy     64s
d8-operator-trivy      replicaset-operator-66c658fbb5-kube-rbac-proxy             sys/deckhouse-oss         Trivy     14s

root@klimentyev-master-0:~# kubectl -n d8-operator-trivy get rbacassessmentreports.aquasecurity.github.io -A
NAMESPACE                    NAME                                                            SCANNER   AGE
argocd                       role-argocd-application-controller                              Trivy     2d23h
argocd                       role-argocd-applicationset-controller                           Trivy     2d23h
argocd                       role-argocd-dex-server                                          Trivy     2d23h
argocd                       role-argocd-notifications-controller                            Trivy     2d23h
argocd                       role-argocd-server                                              Trivy     2d23h
d8-admission-policy-engine   role-access-to-admission-policy-engine                          Trivy     2d23h
d8-admission-policy-engine   role-gatekeeper-manager                                         Trivy     2d23h

kubectl -n d8-operator-trivy get infraassessmentreports.aquasecurity.github.io -A
NAMESPACE     NAME                                              SCANNER   AGE
kube-system   pod-etcd-klimentyev-master-0                      Trivy     2d23h
kube-system   pod-kube-apiserver-klimentyev-master-0            Trivy     2d23h
kube-system   pod-kube-controller-manager-klimentyev-master-0   Trivy     2d23h
kube-system   pod-kube-scheduler-klimentyev-master-0            Trivy     2d23h
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature
summary: All images are now based on distroless image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
