### PR TITLE
[candi] Convert InitConfiguration configOverrides to a set of ModuleConfig's during bootstrap

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -340,7 +340,7 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		if err != nil {
 			return err
 		}
-		if err := operations.InstallDeckhouse(kubeCl, deckhouseInstallConfig); err != nil {
+		if err := operations.InstallDeckhouse(kubeCl, deckhouseInstallConfig, metaConfig); err != nil {
 			return err
 		}
 

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -71,7 +71,7 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 			return err
 		}
 
-		return operations.InstallDeckhouse(kubeCl, installConfig)
+		return operations.InstallDeckhouse(kubeCl, installConfig, metaConfig)
 	}
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -26,7 +26,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -136,6 +135,30 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 			},
 		},
 		{
+			Name: `ConfigMap "deckhouse-bootstrap-lock"`,
+			Manifest: func() interface{} {
+				return &apiv1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deckhouse-bootstrap-lock",
+						Namespace: "d8-system",
+					},
+				}
+			},
+			CreateFunc: func(manifest interface{}) error {
+				cm := manifest.(*apiv1.ConfigMap)
+				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+					Create(context.TODO(), cm, metav1.CreateOptions{})
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				return nil
+			},
+		},
+		{
 			Name:     `Admin ClusterRole "cluster-admin"`,
 			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRole() },
 			CreateFunc: func(manifest interface{}) error {
@@ -169,28 +192,6 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 			UpdateFunc: func(manifest interface{}) error {
 				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Update(context.TODO(), manifest.(*apiv1.ServiceAccount), metav1.UpdateOptions{})
 				return err
-			},
-		},
-		{
-			Name:     `ConfigMap "deckhouse"`,
-			Manifest: func() interface{} { return manifests.DeckhouseConfigMap(cfg.DeckhouseConfig) },
-			CreateFunc: func(manifest interface{}) error {
-				// check cm existing for prevent error
-				// deckhouse create manifests: create resource: admission webhook "validate-cm.deckhouse-config-webhook.deckhouse.io" denied the request:
-				// changing ConfigMap/deckhouse is not allowed for kubernetes-admin. Use ModuleConfig resources to configure Deckhouse.
-				// after restart bootstrap
-				cm := manifest.(*apiv1.ConfigMap)
-				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-					Get(context.TODO(), cm.GetName(), metav1.GetOptions{})
-				if k8serror.IsNotFound(err) {
-					_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-						Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
-					return err
-				}
-				return err
-			},
-			UpdateFunc: func(manifest interface{}) error {
-				return nil
 			},
 		},
 	}

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -250,7 +250,7 @@ func WaitForSSHConnectionOnMaster(sshClient *ssh.Client) error {
 	})
 }
 
-func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config) error {
+func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config, metaConfig *config.MetaConfig) error {
 	return log.Process("bootstrap", "Install Deckhouse", func() error {
 		err := bootstrap.CheckPreventBreakAnotherBootstrappedCluster(kubeCl, config)
 		if err != nil {
@@ -265,6 +265,11 @@ func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config)
 		err = cache.Global().Save(ManifestCreatedInClusterCacheKey, []byte("yes"))
 		if err != nil {
 			return fmt.Errorf("set manifests in cluster flag to cache: %v", err)
+		}
+
+		err = bootstrap.ConvertInitConfigurationToModuleConfigs(kubeCl, metaConfig)
+		if err != nil {
+			return fmt.Errorf("convert InitConfiguration: %w", err)
 		}
 
 		err = deckhouse.WaitForReadiness(kubeCl)

--- a/dhctl/pkg/operations/bootstrap/module_configs.go
+++ b/dhctl/pkg/operations/bootstrap/module_configs.go
@@ -1,0 +1,192 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/iancoleman/strcase"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/maputil"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+)
+
+// ConvertInitConfigurationToModuleConfigs turns InitConfiguration into a set of ModuleConfig's.
+// At first, it creates a mandatory "deckhouse" ModuleConfig,
+// then it checks for any module configuration overrides within InitConfiguration.configOverrides.
+// If it detects such overrides, it converts them into ModuleConfig resources as well.
+// Finally, it unlocks further bootstrap by allowing modules hooks to run with created ModuleConfig's.
+func ConvertInitConfigurationToModuleConfigs(
+	kubeCl *client.KubernetesClient,
+	metaConfig *config.MetaConfig,
+) error {
+	initConfiguration := metaConfig.DeckhouseConfig
+	err := log.Process("bootstrap", "Converting InitConfiguration to a set of ModuleConfig's", func() error {
+		// "deckhouse" ModuleConfig is mandatory.
+		dhSettings := maputil.Filter(
+			map[string]any{
+				"bundle":         initConfiguration.Bundle,
+				"logLevel":       initConfiguration.LogLevel,
+				"registryCA":     initConfiguration.RegistryCA,
+				"releaseChannel": initConfiguration.ReleaseChannel,
+			},
+			filterNonZeroValues[string, any],
+		)
+		dhModuleConfig := buildUnstructuredModuleConfigWithOverrides("deckhouse", true, dhSettings)
+		if err := createModuleConfig(kubeCl.Dynamic(), dhModuleConfig); err != nil {
+			return fmt.Errorf("create ModuleConfig: %w", err)
+		}
+
+		modulesEnabledStatuses := computeModuleEnabledStatuses(initConfiguration.ConfigOverrides)
+		for moduleName, moduleEnabled := range modulesEnabledStatuses {
+			configOverride := initConfiguration.ConfigOverrides[moduleName]
+			settings := map[string]any{}
+			if configOverride != nil {
+				var settingsIsDict bool
+				settings, settingsIsDict = configOverride.(map[string]any)
+				if !settingsIsDict {
+					return fmt.Errorf("invalid configOverride, expected a dictionary, got %T", configOverride)
+				}
+			}
+
+			mc := buildUnstructuredModuleConfigWithOverrides(moduleName, moduleEnabled, settings)
+
+			if err := createModuleConfig(kubeCl.Dynamic(), mc); err != nil {
+				return fmt.Errorf("create ModuleConfig: %w", err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("InitConfiguration conversion failed: %w", err)
+	}
+
+	err = log.Process("bootstrap", "Unlock bootstrap process", func() error {
+		if err := unlockBootstrapProcess(kubeCl); err != nil {
+			return fmt.Errorf("unlockBootstrapProcess: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// computeModuleEnabledStatuses loops over a InitConfiguration.deckhouse.configOverrides structure,
+// figuring out which ModuleConfig's should be enabled or disabled.
+// Returns a mapping of module name and a if it should be enabled or not.
+func computeModuleEnabledStatuses(configOverrides map[string]any) map[string]bool {
+	modulesEnabledStatuses := make(map[string]bool)
+	for key, override := range configOverrides {
+		moduleName := strings.TrimSuffix(key, "Enabled")
+		overrideIsEnableProperty := key != moduleName
+
+		if overrideIsEnableProperty {
+			enabled, isBool := override.(bool)
+			if isBool {
+				modulesEnabledStatuses[moduleName] = enabled
+			} else {
+				// Avoid enabling module if it's config is malformed
+				modulesEnabledStatuses[moduleName] = false
+			}
+			continue
+		}
+
+		if _, enableStatusAlreadyDefined := modulesEnabledStatuses[moduleName]; !enableStatusAlreadyDefined {
+			// Enabling module by default if it has no %moduleName%Enabled property, skipping otherwise
+			modulesEnabledStatuses[moduleName] = true
+		}
+	}
+
+	return modulesEnabledStatuses
+}
+
+// buildUnstructuredModuleConfigWithOverrides creates ModuleConfig object as unstructured.Unstructured.
+func buildUnstructuredModuleConfigWithOverrides(moduleName string, isEnabled bool, settings map[string]any) *unstructured.Unstructured {
+	moduleConfigName := strcase.ToKebab(moduleName)
+	mc := &unstructured.Unstructured{}
+	mc.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "deckhouse.io",
+		Version: "v1alpha1",
+		Kind:    "ModuleConfig",
+	})
+	mc.SetName(moduleConfigName)
+
+	// Errors are impossible here.
+	_ = unstructured.SetNestedField(mc.Object, isEnabled, "spec", "enabled")
+	_ = unstructured.SetNestedField(mc.Object, int64(1), "spec", "version")
+	if len(settings) > 0 {
+		_ = unstructured.SetNestedMap(mc.Object, settings, "spec", "settings")
+	}
+
+	return mc
+}
+
+// createModuleConfig creates unstructured ModuleConfig within the cluster.
+func createModuleConfig(kubeDynamicApi dynamic.Interface, mc *unstructured.Unstructured) error {
+	moduleConfigName := mc.GetName()
+	loop := retry.NewLoop(fmt.Sprintf("Create %q ModuleConfig", moduleConfigName), 15, time.Second*10)
+	err := loop.Run(func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		_, err := kubeDynamicApi.Resource(schema.GroupVersionResource{
+			Group:    "deckhouse.io",
+			Version:  "v1alpha1",
+			Resource: "moduleconfigs",
+		}).Create(ctx, mc, v1.CreateOptions{})
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("cannot create %q ModuleConfig: %w", moduleConfigName, err)
+	}
+	return nil
+}
+
+// unlockBootstrapProcess deletes deckhouse-bootstrap-lock ConfigMap that prevents module hooks from executing from d8-system namespace.
+func unlockBootstrapProcess(kubeCl *client.KubernetesClient) error {
+	loop := retry.NewSilentLoop("Unlock bootstrap process after ModuleConfig's creation", 25, time.Second*5)
+	err := loop.Run(func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		return kubeCl.CoreV1().
+			ConfigMaps("d8-system").
+			Delete(ctx, "deckhouse-bootstrap-lock", v1.DeleteOptions{})
+	})
+	if err != nil {
+		return fmt.Errorf("cannot delete deckhouse-bootstrap-lock ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+func filterNonZeroValues[K comparable, V any](_ K, v V) bool {
+	return !reflect.ValueOf(v).IsZero()
+}

--- a/dhctl/pkg/operations/bootstrap/module_configs_test.go
+++ b/dhctl/pkg/operations/bootstrap/module_configs_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_computeModulesEnablement(t *testing.T) {
+	type args struct {
+		configOverrides map[string]any
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]bool
+	}{
+		{
+			name: "no overrides",
+			want: map[string]bool{},
+		},
+		{
+			name: "success test",
+			args: args{configOverrides: map[string]any{
+				// Enabled and has config
+				"cniCiliumEnabled": true,
+				"cniCilium":        map[string]any{},
+
+				// Enabled without config
+				"upmeterEnabled": true,
+
+				// Implicitly enabled without "*Enabled" definition
+				"userAuthn": map[string]any{},
+
+				// Disabled without config
+				"prometeusEnabled": false,
+
+				// Disabled with config
+				"dummyEnabled": false,
+				"dummy":        map[string]any{},
+			}},
+			want: map[string]bool{
+				"cniCilium": true,
+				"upmeter":   true,
+				"userAuthn": true,
+				"prometeus": false,
+				"dummy":     false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := computeModuleEnabledStatuses(tt.args.configOverrides); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("computeModuleEnabledStatuses() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/dhctl/pkg/operations/bootstrap_test.go
+++ b/dhctl/pkg/operations/bootstrap_test.go
@@ -153,7 +153,7 @@ func TestInstallDeckhouse(t *testing.T) {
 			fakeClient := client.NewFakeKubernetesClient()
 			createReadyDeckhousePod(fakeClient)
 
-			err := InstallDeckhouse(fakeClient, conf)
+			err := InstallDeckhouse(fakeClient, conf, &config.MetaConfig{})
 
 			require.NoError(t, err, "Should install Deckhouse")
 
@@ -170,7 +170,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				err := InstallDeckhouse(fakeClient, conf)
+				err := InstallDeckhouse(fakeClient, conf, &config.MetaConfig{})
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -187,7 +187,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				err := InstallDeckhouse(fakeClient, conf)
+				err := InstallDeckhouse(fakeClient, conf, &config.MetaConfig{})
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -201,7 +201,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, clusterUUID)
 
-				err := InstallDeckhouse(fakeClient, conf)
+				err := InstallDeckhouse(fakeClient, conf, &config.MetaConfig{})
 
 				require.NoError(t, err, "Should install Deckhouse")
 

--- a/dhctl/pkg/util/maputil/maputil.go
+++ b/dhctl/pkg/util/maputil/maputil.go
@@ -41,3 +41,17 @@ func Values(m map[string]string) []string {
 
 	return keysList
 }
+
+func Filter[K comparable, V any](in map[K]V, filterFunc func(key K, val V) bool) map[K]V {
+	if len(in) == 0 || filterFunc == nil {
+		return in
+	}
+
+	out := make(map[K]V, len(in))
+	for k, v := range in {
+		if filterFunc(k, v) {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/dhctl/pkg/util/maputil/maputil_test.go
+++ b/dhctl/pkg/util/maputil/maputil_test.go
@@ -15,6 +15,7 @@
 package maputil
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -93,6 +94,59 @@ func TestExcludeKeys(t *testing.T) {
 			res := ExcludeKeys(c.mp, c.excluded...)
 
 			require.Equal(t, res, c.res)
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	type args[K comparable, V any] struct {
+		in         map[K]V
+		filterFunc func(key K, val V) bool
+	}
+	type testCase[K comparable, V any] struct {
+		name string
+		args args[K, V]
+		want map[K]V
+	}
+	tests := []testCase[string, string]{
+		{
+			name: "empty input",
+			args: args[string, string]{
+				in:         map[string]string{},
+				filterFunc: func(_, _ string) bool { return true },
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "nil input map",
+			args: args[string, string]{
+				in:         nil,
+				filterFunc: func(_, _ string) bool { return true },
+			},
+			want: nil,
+		},
+		{
+			name: "nil filter func",
+			args: args[string, string]{
+				in:         map[string]string{},
+				filterFunc: nil,
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "basic filter",
+			args: args[string, string]{
+				in:         map[string]string{"key1": "value1", "key2": "value2"},
+				filterFunc: func(_, val string) bool { return val == "value1" },
+			},
+			want: map[string]string{"key1": "value1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Filter(tt.args.in, tt.args.filterFunc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/global-hooks/deckhouse-config/await_moduleconfigs.go
+++ b/global-hooks/deckhouse-config/await_moduleconfigs.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+const bootstrapConfigMapName = "deckhouse-bootstrap-lock"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 2},
+}, dependency.WithExternalDependencies(handleBootstrapConfigMapExistence))
+
+func handleBootstrapConfigMapExistence(_ *go_hook.HookInput, dc dependency.Container) error {
+	ctx := context.Background()
+	kube, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("dc.GetK8sClient: %w", err)
+	}
+
+	_, err = kube.CoreV1().ConfigMaps("d8-system").Get(ctx, bootstrapConfigMapName, v1.GetOptions{})
+	switch {
+	case err != nil && k8serror.IsNotFound(err):
+		// Bootstrap lock lifted, can continue with hooks now.
+		return nil
+	case err != nil:
+		return fmt.Errorf("cannot get %q ConfigMap data: %w", bootstrapConfigMapName, err)
+	default:
+		return errors.New("will wait for bootstrap module configs creation")
+	}
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Deckhouse config overrides are now converted to a set of `ModuleConfig`'s during `dhctl bootstrap` execution. Modules hooks are set on hold during this process by a new global hook that continuously checks for `deckhouse-bootstrap-lock` ConfigMap existence in `d8-system` namespace. That ConfigMap acts as a marker of ongoing configuration conversion.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
See #3776 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Cluster must contain `ModuleConfig`s according to what was set in `InitConfiguration`'s `deckhouse.configOverrides` after bootstrap is completed.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: ModuleConfig's are created during cluster bootstrap according to InitConfiguration
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->

