### PR TITLE
[helm] Fix depcreated helm apis calculation

### DIFF
--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -354,7 +354,7 @@ const (
 //	 2 - if resource is unsupported for current k8s version
 //	and k8s version in which deprecation would be
 func (uvs unsupportedVersionsStore) CalculateCompatibility(currentVersion *semver.Version, resourceAPIVersion, resourceKind string) (uint, string) {
-	// check unsupported api for current k8s version
+	// check unsupported api for the current k8s version
 	currentK8SAPIsStorage, exists := uvs.getByK8sVersion(currentVersion)
 	if exists {
 		isUnsupported := currentK8SAPIsStorage.isUnsupportedByAPIAndKind(resourceAPIVersion, resourceKind)
@@ -364,7 +364,7 @@ func (uvs unsupportedVersionsStore) CalculateCompatibility(currentVersion *semve
 	}
 
 	// if api is supported - check deprecation in the next 2 minor k8s versions
-	for i := 0; i < delta; i++ {
+	for i := 1; i <= delta; i++ {
 		newMinor := currentVersion.Minor() + uint64(i)
 		nextVersion := semver.MustParse(fmt.Sprintf("%d.%d.0", currentVersion.Major(), newMinor))
 		storage, exists := uvs.getByK8sVersion(nextVersion)

--- a/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
+++ b/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
@@ -6,7 +6,7 @@
     for: "10m"
     labels:
       tier: cluster
-      severity_level: "9"
+      severity_level: "5"
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
@@ -24,7 +24,7 @@
     for: "5m"
     labels:
       tier: cluster
-      severity_level: "5"
+      severity_level: "4"
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"


### PR DESCRIPTION
## Description
Find deprecated apis for the current kubernetes version + 2
It was + 1 before

## Why do we need it, and what problem does it solve?
We want to know about deprecated helm releases before the Deckhouse release, because usually we jump over version (1.23 -> 1.25)

## Why do we need it in the patch release (if we do)?
We are using 1.25 kubernetes as default version now but some clients don't know about a problems with releases

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: helm
type: fix
summary: Find and notify deprecated helm releases for the current Kubernetes version + 2.
```
