### PR TITLE
[monitoring-applications]change expression to process_virtual_memory

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
@@ -6091,7 +6091,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "rate(process_virtual_memory_bytes{node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])",
+              "expr": "process_virtual_memory_bytes{node=~\"$node\",job=\"node-exporter\"}",
               "hide": false,
               "intervalFactor": 1,
               "legendFormat": "Processes virtual memory size in bytes",
@@ -6107,7 +6107,7 @@
               "step": 240
             },
             {
-              "expr": "rate(process_virtual_memory_bytes{node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])",
+              "expr": "process_virtual_memory_bytes{node=~\"$node\",job=\"node-exporter\"}",
               "hide": false,
               "intervalFactor": 1,
               "legendFormat": "Processes virtual memory size in bytes",
@@ -6115,7 +6115,7 @@
               "step": 240
             },
             {
-              "expr": "rate(process_virtual_memory_max_bytes{node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])",
+              "expr": "process_virtual_memory_max_bytes{node=~\"$node\",job=\"node-exporter\"}",
               "hide": false,
               "intervalFactor": 1,
               "legendFormat": "Maximum amount of virtual memory available in bytes",


### PR DESCRIPTION
## Description

In the expression we used rate for gauge metrics, I changed it to a standard expression to see in bytes how much virtual memory is being processed now.

## Why do we need it, and what problem does it solve?

Fixes the dashboard in Grafana.

## What is the expected result?
we can see process virtual memory


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-applications
type: fix 
summary: Change expression to `process_virtual_memory`.
impact_level:  low
```
