### PR TITLE
Fixed old csi mount cleaner

### DIFF
--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -39,22 +39,14 @@ exit 0
 
 {{- else }}
 
-if ! mount | grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/'; then
+# not in pipeline to avoid capturing mount's non-zero exit code in the if expression
+mount_output="$(mount)"
+
+if grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/' <<< "$mount_output"; then
   echo 'No mounts of form "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/" present. No-op...'
   disable_systemd_units
   exit 0
 fi
-
-bb-event-on 'old-csi-mount-cleaner' '_on_old_csi_mount_cleaner_changed'
-_on_old_csi_mount_cleaner_changed() {
-  {{- if ne .runType "ImageBuilding" }}
-  systemctl daemon-reload
-  systemctl restart old-csi-mount-cleaner.timer
-  systemctl restart old-csi-mount-cleaner
-  {{- end }}
-  systemctl enable old-csi-mount-cleaner.timer
-  systemctl enable old-csi-mount-cleaner
-}
 
 bb-sync-file /var/lib/bashible/old-csi-mount-cleaner.sh - << "EOF"
 #!/bin/bash
@@ -108,5 +100,13 @@ ExecStart=/var/lib/bashible/old-csi-mount-cleaner.sh
 [Install]
 WantedBy=multi-user.target
 EOF
+
+  {{- if ne .runType "ImageBuilding" }}
+systemctl daemon-reload
+systemctl restart old-csi-mount-cleaner.timer
+systemctl restart old-csi-mount-cleaner
+  {{- end }}
+systemctl enable old-csi-mount-cleaner.timer
+systemctl enable old-csi-mount-cleaner
 
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Removed `mount` call from the pipeline to avoid capturing the non-zero exit code of a mount command in an `if` expression. 
2. Added non-conditional start and enable of a systemd service and a systemd timer.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes to https://github.com/deckhouse/deckhouse/pull/5153

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The feature introduced in https://github.com/deckhouse/deckhouse/pull/5153 is not working properly.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Mount deletion service is correctly created and enabled.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix old csi mount cleaner
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
