### PR TITLE
[virtualization] fix prevent delete namespace

### DIFF
--- a/modules/490-virtualization/templates/namespace.yaml
+++ b/modules/490-virtualization/templates/namespace.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotation:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
   name: d8-virtualization
 ---

--- a/modules/490-virtualization/templates/namespace.yaml
+++ b/modules/490-virtualization/templates/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotation:
+  annotations:
     helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
   name: d8-virtualization

--- a/modules/490-virtualization/templates/registry-secret.yaml
+++ b/modules/490-virtualization/templates/registry-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  annotation:
+  annotations:
     helm.sh/resource-policy: keep
   name: deckhouse-registry
   namespace: d8-virtualization

--- a/modules/490-virtualization/templates/registry-secret.yaml
+++ b/modules/490-virtualization/templates/registry-secret.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  annotation:
+    helm.sh/resource-policy: keep
   name: deckhouse-registry
   namespace: d8-virtualization
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}

--- a/modules/491-containerized-data-importer/templates/namespace.yaml
+++ b/modules/491-containerized-data-importer/templates/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotation:
+  annotations:
     helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
   name: d8-cdi

--- a/modules/491-containerized-data-importer/templates/namespace.yaml
+++ b/modules/491-containerized-data-importer/templates/namespace.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotation:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
   name: d8-cdi
 ---

--- a/modules/491-containerized-data-importer/templates/registry-secret.yaml
+++ b/modules/491-containerized-data-importer/templates/registry-secret.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  annotation:
+    helm.sh/resource-policy: keep
   name: deckhouse-registry
   namespace: d8-cdi
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}

--- a/modules/491-containerized-data-importer/templates/registry-secret.yaml
+++ b/modules/491-containerized-data-importer/templates/registry-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  annotation:
+  annotations:
     helm.sh/resource-policy: keep
   name: deckhouse-registry
   namespace: d8-cdi


### PR DESCRIPTION
## Description
Prevent deletion of virtualization and cdi namespaces.
<!---
  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
When module virtualization is disabled need to keep virtual machines and there affected resources.
No impact
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Not necessarily
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
When the virtualization module is disabled, active resources are preserved.
`kubectl apply -f disable-virt.yaml`

```yaml
#disable-virt.yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: virtualization
spec:
  enabled: false
```  
How can one check these changes after applying?  
Run commands for check that all affected resources of module are still present
```shell
kubectl get ns
```
Output:
```
...
d8-cdi                       Active   4h2m
...
d8-virtualization            Active   4h2m
```
You can also run the command for check existing resources
```
kubectl -n d8-virtualization get all
kubectl -n d8-cdi get all
```
  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: 490-virtualization
type: fix
summary: Prevent delete namespaces of virtualization module
impact: No impact
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
