### PR TITLE
Revert "[bashible] fixed wait apt update (#5314)"

### DIFF
--- a/candi/bashible/bashbooster/50_apt.sh
+++ b/candi/bashible/bashbooster/50_apt.sh
@@ -62,7 +62,7 @@ bb-apt-update() {
     export DEBIAN_FRONTEND=noninteractive
     bb-flag? apt-updated && return 0
     bb-log-info 'Updating apt cache'
-    apt-get -o Acquire::http::Timeout=120 update
+    apt-get update
     bb-flag-set apt-updated
 }
 

--- a/candi/bashible/bundles/debian/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/debian/bootstrap.sh.tpl
@@ -1,5 +1,5 @@
 {{- /*
-# Copyright 2023 Flant JSC
+# Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,11 +31,11 @@ export no_proxy=${NO_PROXY}
 {{- else }}
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
-apt -o Acquire::http::Timeout=120 update
+apt update
 export DEBIAN_FRONTEND=noninteractive
 until apt install jq netcat-openbsd curl -y; do
   echo "Error installing packages"
-  apt -o Acquire::http::Timeout=120 update
+  apt update
   sleep 10
 done
 mkdir -p /var/lib/bashible/

--- a/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
@@ -1,5 +1,5 @@
 {{- /*
-# Copyright 2023 Flant JSC
+# Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,11 +31,11 @@ export no_proxy=${NO_PROXY}
 {{- else }}
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
-apt -o Acquire::http::Timeout=120 update
+apt update
 export DEBIAN_FRONTEND=noninteractive
 until apt install jq netcat-openbsd curl -y; do
   echo "Error installing packages"
-  apt -o Acquire::http::Timeout=120 update
+  apt update
   sleep 10
 done
 mkdir -p /var/lib/bashible/

--- a/candi/bashible/common-steps/all/080_setup_timer_to_run_bashible.sh.tpl
+++ b/candi/bashible/common-steps/all/080_setup_timer_to_run_bashible.sh.tpl
@@ -40,5 +40,4 @@ Description=Bashible service
 [Service]
 EnvironmentFile=/etc/environment
 ExecStart=/var/lib/bashible/bashible.sh --max-retries 10
-RuntimeMaxSec=3h
 EOF

--- a/ee/candi/bashible/bashbooster/50_apt_rpm.sh
+++ b/ee/candi/bashible/bashbooster/50_apt_rpm.sh
@@ -62,7 +62,7 @@ bb-apt-rpm-update() {
     export DEBIAN_FRONTEND=noninteractive
     bb-flag? apt-rpm-updated && return 0
     bb-log-info 'Updating apt cache'
-    apt-get -o Acquire::http::Timeout=120 update
+    apt-get update
     bb-flag-set apt-rpm-updated
 }
 

--- a/ee/candi/bashible/bundles/altlinux/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/altlinux/bootstrap.sh.tpl
@@ -31,10 +31,10 @@ export no_proxy=${NO_PROXY}
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
 if ! type jq 2>/dev/null || ! type curl 2>/dev/null || ! type nc 2>/dev/null; then
-  apt-get -o Acquire::http::Timeout=120 update
+  apt-get update
   until apt-get install jq netcat curl -y; do
     echo "Error installing packages"
-    apt-get -o Acquire::http::Timeout=120 update
+    apt-get update
     sleep 10
   done
 fi

--- a/ee/candi/bashible/bundles/astra/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/bootstrap.sh.tpl
@@ -1,5 +1,5 @@
 {{- /*
-# Copyright 2023 Flant JSC
+# Copyright 2022 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
 #!/bin/bash
@@ -20,11 +20,11 @@ export no_proxy=${NO_PROXY}
 {{- else }}
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
-apt -o Acquire::http::Timeout=120 update
+apt update
 export DEBIAN_FRONTEND=noninteractive
 until apt install jq netcat-openbsd curl -y; do
   echo "Error installing packages"
-  apt -o Acquire::http::Timeout=120 update
+  apt update
   sleep 10
 done
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -487,7 +487,7 @@ function bootstrap_static() {
   for ((i=1; i<=$testRunAttempts; i++)); do
     # Install http/https proxy on bastion node
     if $ssh_command -i "$ssh_private_key_path" "$ssh_user@$bastion_ip" sudo su -c /bin/bash <<ENDSSH; then
-       apt -o Acquire::http::Timeout=120 update
+       apt-get update
        apt-get install -y docker.io
        docker run -d --network host vimagick/tinyproxy
 ENDSSH


### PR DESCRIPTION
## Description
This reverts #5314 (commit 2e061f8961103ea6febcc798dbb36932bf32ffb6).

## Why do we need it, and what problem does it solve?

E2e tests in AWS fails with the following error:
```
InvalidParameterValue: User data is limited to 16384 bytes
```

### What is the expected result?
e2e tests in AWS pass.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: Reverts #5314
```
