### PR TITLE
[user-authn] Move publishAPI CA discovery logic to the hook

### DIFF
--- a/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
@@ -20,19 +20,32 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 type inputPublishAPICACert struct {
-	manifests      string
-	httpMode       string
-	publishAPIMode string
+	manifests          string
+	httpMode           string
+	publishAPIMode     string
+	kubeconfigMasterCA *string
 }
 
 var _ = Describe("User Authn hooks :: discover publish api cert ::", func() {
 	f := HookExecutionConfigInit(
-		`{"userAuthn":{"publishAPI": {"enable": true, "https":{"mode": "SelfSigned"}}, "internal": {}, "https": {"mode": "CertManager"}}}`,
+		`
+global:
+  discovery:
+    kubernetesCA: "discoveredKubernetesCA"
+userAuthn:
+  publishAPI:
+    enable: true
+    https:
+      mode: SelfSigned
+  internal: {}
+  https:
+    mode: CertManager`,
 		"",
 	)
 	selfSignedCertSecret := `
@@ -72,6 +85,10 @@ data:
 			f.ValuesSet("userAuthn.publishAPI.https.mode", in.publishAPIMode)
 			f.ValuesSet("userAuthn.https.mode", in.httpMode)
 
+			if in.kubeconfigMasterCA != nil {
+				f.ValuesSet("userAuthn.publishAPI.https.global.kubeconfigGeneratorMasterCA", *in.kubeconfigMasterCA)
+			}
+
 			f.RunHook()
 
 			Expect(f).To(ExecuteSuccessfully())
@@ -83,7 +100,7 @@ data:
 				publishAPIMode: "SelfSigned",
 				httpMode:       "CertManager",
 			},
-			"",
+			"discoveredKubernetesCA",
 		),
 		Entry("With every secret: SelfSigned",
 			inputPublishAPICACert{
@@ -99,15 +116,16 @@ data:
 				publishAPIMode: "SelfSigned",
 				httpMode:       "CertManager",
 			},
-			"",
+			"discoveredKubernetesCA",
 		),
 		Entry("On first start: SelfSigned",
 			inputPublishAPICACert{
-				manifests:      "",
-				publishAPIMode: "SelfSigned",
-				httpMode:       "CertManager",
+				manifests:          "",
+				publishAPIMode:     "SelfSigned",
+				httpMode:           "CertManager",
+				kubeconfigMasterCA: pointer.String("test"),
 			},
-			"",
+			"discoveredKubernetesCA",
 		),
 		Entry("With every secret: Global: CertManager",
 			inputPublishAPICACert{
@@ -123,7 +141,7 @@ data:
 				publishAPIMode: "Global",
 				httpMode:       "CertManager",
 			},
-			"",
+			"discoveredKubernetesCA",
 		),
 		Entry("With every secret: Global: CustomCertificate",
 			inputPublishAPICACert{
@@ -139,7 +157,7 @@ data:
 				publishAPIMode: "Global",
 				httpMode:       "CustomCertificate",
 			},
-			"",
+			"discoveredKubernetesCA",
 		),
 		Entry("With every secret: Global: OnlyInURI",
 			inputPublishAPICACert{
@@ -147,13 +165,31 @@ data:
 				publishAPIMode: "Global",
 				httpMode:       "OnlyInURI",
 			},
-			"",
+			"discoveredKubernetesCA",
 		),
 		Entry("Without secret: Global: OnlyInURI",
 			inputPublishAPICACert{
 				manifests:      "",
 				publishAPIMode: "Global",
 				httpMode:       "OnlyInURI",
+			},
+			"discoveredKubernetesCA",
+		),
+		Entry("Without secret: Global: OnlyInURI with custom CA",
+			inputPublishAPICACert{
+				manifests:          "",
+				publishAPIMode:     "Global",
+				httpMode:           "OnlyInURI",
+				kubeconfigMasterCA: pointer.String("testMasterCA"),
+			},
+			"testMasterCA",
+		),
+		Entry("Without secret: Global: OnlyInURI with custom CA empty",
+			inputPublishAPICACert{
+				manifests:          "",
+				publishAPIMode:     "Global",
+				httpMode:           "OnlyInURI",
+				kubeconfigMasterCA: pointer.String(""),
 			},
 			"",
 		),

--- a/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
+++ b/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
@@ -152,57 +152,6 @@ Multiline
 					Expect(gjson.GetBytes(jsonBytes, "clusters.0.k8s_ca_pem").String()).To(Equal("test_cert"))
 				})
 			})
-
-			Context("With https mode 'Global' and kubeconfigGeneratorMasterCA", func() {
-				BeforeEach(func() {
-					hec.ValuesSet("userAuthn.publishAPI.https.mode", "Global")
-					hec.ValuesSet("userAuthn.publishAPI.https.global.kubeconfigGeneratorMasterCA", "kubeconfigGeneratorMasterCAText")
-				})
-
-				It("Should add k8s_ca_pem param with kubeconfigGeneratorMasterCA for first cluster", func() {
-
-					Expect(hec.RenderError).ToNot(HaveOccurred())
-
-					jsonBytes := assertCreateConfig(hec)
-
-					Expect(gjson.GetBytes(jsonBytes, "clusters.0.k8s_ca_pem").String()).To(Equal("kubeconfigGeneratorMasterCAText"))
-				})
-			})
-
-			Context("With https mode 'SelfSigned'", func() {
-				BeforeEach(func() {
-					hec.ValuesSet("userAuthn.publishAPI.https.mode", "SelfSigned")
-				})
-
-				Context("publishedAPIKubeconfigGeneratorMasterCA do not set", func() {
-					It("Should add k8s_ca_pem with kubernetesCA for first cluster", func() {
-						Expect(hec.RenderError).ToNot(HaveOccurred())
-
-						jsonBytes := assertCreateConfig(hec)
-
-						Expect(gjson.GetBytes(jsonBytes, "clusters.0.k8s_ca_pem").String()).To(Equal(k8sCa))
-					})
-				})
-
-				Context("publishedAPIKubeconfigGeneratorMasterCA set", func() {
-					const publishAPIK8sCa = `--Certificate---
-Multiline
-`
-					BeforeEach(func() {
-						hec.ValuesSet("userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA", publishAPIK8sCa)
-					})
-
-					It("Should add k8s_ca_pem with publishedAPIKubeconfigGeneratorMasterCA for first cluster", func() {
-						Expect(hec.RenderError).ToNot(HaveOccurred())
-
-						jsonBytes := assertCreateConfig(hec)
-
-						Expect(gjson.GetBytes(jsonBytes, "clusters.0.k8s_ca_pem").String()).To(Equal(publishAPIK8sCa))
-					})
-				})
-
-			})
-
 		})
 
 		Context("Additional access", func() {

--- a/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
@@ -38,18 +38,7 @@ clusters:
   {{- $_ := set $publish_api_cluster "id" (include "helm_lib_module_public_domain" (list . "api")) }}
   {{- $_ := set $publish_api_cluster "client_id" "kubeconfig-generator" }}
   {{- $_ := set $publish_api_cluster "description" $publish_api_master_url }}
-
-  {{- if eq .Values.userAuthn.publishAPI.https.mode "Global" }}
-{{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA }}
-    {{- if hasKey .Values.userAuthn.publishAPI.https "global" }}
-      {{- if hasKey .Values.userAuthn.publishAPI.https.global "kubeconfigGeneratorMasterCA" }}
-{{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.publishAPI.https.global.kubeconfigGeneratorMasterCA }}
-      {{- end }}
-    {{- end }}
-
-  {{- else if eq .Values.userAuthn.publishAPI.https.mode "SelfSigned" }}
-{{- $_ := set $publish_api_cluster "masterCA" (.Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA | default $.Values.global.discovery.kubernetesCA) }}
-  {{- end }}
+  {{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA }}
 
   {{- if .Values.userAuthn.publishAPI.enable }}
 {{- include "kubeconfig_settings" (list $ "" $publish_api_cluster) }}


### PR DESCRIPTION
## Description
1. Move all complicated discovery logic to the hook
2. If the `publishAPI.https.global.kubeconfigGeneratorMasterCA` field equals to `""`, then the cert will not be added to kubeconfigs

## Why do we need it, and what problem does it solve?
Keeping logic in templates is not error-prone, and there is no way to tell the user-authn that certificates should not be added to generated kubeconfigs.

 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Move publishAPI CA discovery logic to the hook
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
