### PR TITLE
Change expression in Grafana dashboard for Ip_Forwarding

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
@@ -11667,7 +11667,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "rate(node_netstat_Ip_Forwarding{node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])",
+              "expr": "node_netstat_Ip_Forwarding{node=~\"$node\",job=\"node-exporter\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Forwarding - IP forwarding",
@@ -11697,7 +11697,7 @@
             {
               "$$hashKey": "object:1957",
               "format": "short",
-              "label": "datagrams",
+              "label": "counter",
               "logBase": 1,
               "max": null,
               "min": "0",


### PR DESCRIPTION
## Description

Dashboard: Kubernetes Cluster / Node / Network Netstat / Netstat IP Forwarding

The expression contains "rate" for metric which can be only "1" or "2".

RFC2011 https://datatracker.ietf.org/doc/html/rfc2011
says that:

ipForwarding OBJECT-TYPE
    SYNTAX      INTEGER {
                    forwarding(1),    -- acting as a router
                    notForwarding(2)  -- NOT acting as a router
                }

Also we can find indication of that in the source of netstat: https://sourceforge.net/p/net-tools/code/ci/master/tree/statistics.c

So we shouldn't use "rate" for this value.

## Why do we need it, and what problem does it solve?

It fixes the issue for Grafana dashboard

## Why do we need it in the patch release (if we do)?

It's not urgent.

## What is the expected result?

We will see a correct value on the dashboard. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-applications
type: fix 
summary: change expression for ip_forwarding
impact_level:  low
```
