### PR TITLE
[cloud-provider-openstack] added a command to get the list of networks

### DIFF
--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -298,7 +298,7 @@ apiVersions:
                     type: string
                   description: |
                     Paths to networks that VirtualMachines' secondary NICs will connect to.
-                    `openstack network list`
+                    Get a list of all available networks: `openstack network list`.
                   example:
                     - "BGP-network-VLAN-3894"
                     - "External-VLAN-3699"

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -438,7 +438,7 @@ apiVersions:
           externalNetworkName: &externalNetworkName
             description: |
               The name of the network for external connections.
-              `openstack network list`
+              Get a list of all available networks: `openstack network list`.
             type: string
       standardWithNoRouter:
         description: |

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -290,7 +290,7 @@ apiVersions:
                   type: string
                   description: |
                     Path to the network that VirtualMachines' primary NICs will connect to (default gateway).
-                    `openstack network list`
+                    Get a list of all available networks: `openstack network list`.
                   x-doc-required: true
                 additionalNetworks:
                   type: array

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -290,6 +290,7 @@ apiVersions:
                   type: string
                   description: |
                     Path to the network that VirtualMachines' primary NICs will connect to (default gateway).
+                    `openstack network list`
                   x-doc-required: true
                 additionalNetworks:
                   type: array
@@ -297,6 +298,7 @@ apiVersions:
                     type: string
                   description: |
                     Paths to networks that VirtualMachines' secondary NICs will connect to.
+                    `openstack network list`
                   example:
                     - "BGP-network-VLAN-3894"
                     - "External-VLAN-3699"
@@ -436,6 +438,7 @@ apiVersions:
           externalNetworkName: &externalNetworkName
             description: |
               The name of the network for external connections.
+              `openstack network list`
             type: string
       standardWithNoRouter:
         description: |

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -237,7 +237,7 @@ apiVersions:
           externalNetworkName: &externalNetworkName_ru
             description: |
               Имя сети для внешнего взаимодействия.
-              `openstack network list`
+              Получить список доступных сетей: `openstack network list`.
       standardWithNoRouter:
         description: |
           Настройки для схемы размещения [`StandardWithNoRouter`](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/layouts.html#standardwithnorouter).

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -156,7 +156,7 @@ apiVersions:
                 mainNetwork:
                   description: |
                     Путь до сети, которая будет подключена к виртуальной машине как основная (шлюз по умолчанию).
-                    `openstack network list`
+                    Получить список доступных сетей: `openstack network list`.
                 additionalNetworks:
                   description: |
                     Список сетей, которые будут подключены к инстансу.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -156,9 +156,11 @@ apiVersions:
                 mainNetwork:
                   description: |
                     Путь до сети, которая будет подключена к виртуальной машине как основная (шлюз по умолчанию).
+                    `openstack network list`
                 additionalNetworks:
                   description: |
                     Список сетей, которые будут подключены к инстансу.
+                    `openstack network list`
                 networksWithSecurityDisabled:
                   description: |
                     Список сетей из параметров `mainNetwork` и `additionalNetworks`, в которых **НЕЛЬЗЯ** настраивать `SecurityGroups` и `AllowedAddressPairs` на портах.
@@ -235,6 +237,7 @@ apiVersions:
           externalNetworkName: &externalNetworkName_ru
             description: |
               Имя сети для внешнего взаимодействия.
+              `openstack network list`
       standardWithNoRouter:
         description: |
           Настройки для схемы размещения [`StandardWithNoRouter`](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/layouts.html#standardwithnorouter).


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added description about getting openstack network list.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: chore 
summary: added description about getting openstack network list
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
