### PR TITLE
[igress-nginx] protobuf-exporter update

### DIFF
--- a/modules/402-ingress-nginx/images/protobuf-exporter/pkg/vault/vault.go
+++ b/modules/402-ingress-nginx/images/protobuf-exporter/pkg/vault/vault.go
@@ -28,19 +28,20 @@ import (
 const labelsSeparator = byte(255)
 
 type MetricsVault struct {
-	metrics []ConstMetricCollector
-	now     func() time.Time
+	metrics        []ConstMetricCollector
+	now            func() time.Time
+	scrapeInterval time.Duration
 }
 
-func NewVault() *MetricsVault {
-	return &MetricsVault{now: time.Now}
+func NewVault(scrapeInterval time.Duration) *MetricsVault {
+	return &MetricsVault{now: time.Now, scrapeInterval: scrapeInterval}
 }
 
 func (v *MetricsVault) RegisterMappings(mappings []Mapping) error {
 	for _, mapping := range mappings {
 		switch mapping.Type {
 		case CounterMapping:
-			collector := NewConstCounterCollector(mapping)
+			collector := NewConstCounterCollector(mapping, v.scrapeInterval)
 			v.metrics = append(v.metrics, collector)
 
 			if err := prometheus.Register(collector); err != nil {

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -286,6 +286,9 @@ spec:
           readOnly: true
       - image: {{ include "helm_lib_module_image" (list $context "protobufExporter") }}
         name: protobuf-exporter
+        env:
+        - name: PROMETHEUS_SCRAPE_INTERVAL
+          value: {{ $context.Values.global.discovery.prometheusScrapeInterval | default 30 }}s
         resources:
           requests:
             memory: 20Mi


### PR DESCRIPTION
## Description
Protobuf exporter is updated to expose a zero value counter metric for PROMETHEUS_SCRAPE_INTERVAL time when a new counter metric is added to the collector. After PROMETHEUS_SCRAPE_INTERVAL the zero metric is updated with real accumulated counter value.
Closes #5592 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
This approach allows us to smooth the Prometheus problem when in can't calculate `rate` derivatives for uninitiated metrics (when a new metric is created with non-zero value, Prometheus's rate function isn't triggered).
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
New counter metrics are created with zero values for the duration of PROMETHEUS_SCRAPE_INTERVAL value, then they get updated with real values (stored in temporary collector).
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: Ingress-nginx
type: feature
summary: Update protobuf-exporter collector so that new counter metrics are initiated with 0 values.
impact: All ingress nginx pods will be recreated.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
