### PR TITLE
[external-module-manager] Fix race condition while handling source on Deckhouse startup

### DIFF
--- a/modules/005-external-module-manager/hooks/apply_release_test.go
+++ b/modules/005-external-module-manager/hooks/apply_release_test.go
@@ -54,7 +54,7 @@ external-module-manager:
 			_ = os.Mkdir(tmpDir+"/modules", 0777)
 			_ = os.Setenv("EXTERNAL_MODULES_DIR", tmpDir)
 
-			st := f.KubeStateSet(`
+			f.KubeStateSet(`
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease
@@ -67,7 +67,7 @@ status:
   phase: Pending
 `)
 
-			f.BindingContexts.Set(st)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
 
@@ -115,7 +115,7 @@ status:
 			_ = os.Mkdir(tmpDir+"/modules", 0777)
 			_ = os.Setenv("EXTERNAL_MODULES_DIR", tmpDir)
 
-			st := f.KubeStateSet(`
+			f.KubeStateSet(`
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease
@@ -129,7 +129,7 @@ status:
   phase: Pending
 `)
 
-			f.BindingContexts.Set(st)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
 
@@ -150,6 +150,7 @@ status:
 
 		Context("ExternalModuleRelease was changed with another weight", func() {
 			BeforeEach(func() {
+				f.KubeStateSet(``) // Empty cluster
 				st := f.KubeStateSet(`
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -49,6 +49,7 @@ import (
 )
 
 const (
+	defaultReleaseChannel       = "stable"
 	defaultExternalModuleWeight = 900
 )
 
@@ -95,7 +96,7 @@ func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 	}
 
 	if newex.Spec.ReleaseChannel == "" {
-		newex.Spec.ReleaseChannel = "stable"
+		newex.Spec.ReleaseChannel = defaultReleaseChannel
 	}
 
 	return newex, nil


### PR DESCRIPTION
## Description
Execute `apply_releases` only before helm and on Kubernetes events. Skip synchronization.

Now the `handle_sources.go` will always be executed before the `apply_release.go` hook on the Deckhouse startup.

## Why do we need it, and what problem does it solve?
There are two hooks:
* [apply_release.go](https://github.com/deckhouse/deckhouse/blob/main/modules/005-external-module-manager/hooks/apply_release.go)
* [handle_sources.go](https://github.com/deckhouse/deckhouse/blob/main/modules/005-external-module-manager/hooks/handle_sources.go)

Both hooks have the Kubernetes binding and are executed on Synchronization. If it were `shell-operator`, everything would work well because there was only a single queue, and all synchronization tasks were executed [one after another](https://github.com/flant/shell-operator/blob/1d4c4d9320a89fbe348409750631b372671ae958/pkg/shell-operator/operator.go#L449-L465). However, `addon-operator` is tricky, and [all synchronization tasks are executed in parallel](https://github.com/flant/addon-operator/blob/4869aab10238af2fa9e0990e12e644f066c591ae/pkg/addon-operator/operator.go#L1255).

It means the first hook tries to download files and put them on a disk while the second hook AT THE SAME TIME tries to check that on the disk everything is fine.

We don't see this behavior, or see it very rarely, because the handle_sources.go hook executed by schedule bindings and synchronize the filesystem beforehand.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Fix race condition while handling source on Deckhouse startup
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
