### PR TITLE
[documentation] Remove the unnecessary user directive from the nginx.conf

### DIFF
--- a/modules/810-documentation/images/web/nginx.conf
+++ b/modules/810-documentation/images/web/nginx.conf
@@ -1,4 +1,3 @@
-user nginx;
 worker_processes auto;
 
 error_log /dev/stderr warn;


### PR DESCRIPTION
## Description
Remove the unnecessary user directive from the `nginx.conf`, as the container works in unprivileged mode.

## Why do we need it, and what problem does it solve?
Remove the warning:
```
2023/08/18 15:30:22 [warn] 1#1: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: documentation
type: chore
summary: Remove the unnecessary user directive from the `nginx.conf`, as the container works in unprivileged mode.
impact_level: low
```
