### PR TITLE
Fix doc extended monitoring label

### DIFF
--- a/modules/340-extended-monitoring/docs/CONFIGURATION.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION.md
@@ -13,28 +13,28 @@ Attach the `extended-monitoring.deckhouse.io/enabled` label to the Namespace to 
 - attaching it manually (`kubectl label namespace my-app-production extended-monitoring.deckhouse.io/enabled=""`).
 - configuring via [namespace-configurator](/documentation/v1/modules/600-namespace-configurator/) module.
 
-Any of the methods above would result in the emergence of the default metrics (+ any custom metrics with the `threshold.extended-monitoring.deckhouse.io/` prefix) for all supported Kubernetes objects in the target Namespace. Note that monitoring and standard annotations are enabled automatically for a number of [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes objects described below.
+Any of the methods above would result in the emergence of the default metrics (+ any custom metrics with the `threshold.extended-monitoring.deckhouse.io/` prefix) for all supported Kubernetes objects in the target Namespace. Note that monitoring and standard labels are enabled automatically for a number of [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes objects described below.
 
-You can also add custom annotations with the specified value to `threshold.extended-monitoring.deckhouse.io/something` Kubernetes objects, e.g., `kubectl annotate pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning-threshold=30`.
-In this case, the annotation value will replace the default one.
+You can also add custom labels with the specified value to `threshold.extended-monitoring.deckhouse.io/something` Kubernetes objects, e.g., `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning-threshold=30`.
+In this case, the label value will replace the default one.
 
-You can disable monitoring on a per-object basis by adding the `extended-monitoring.deckhouse.io/enabled=false` label to it. Thus, the default annotations will also be disabled (as well as annotation-based alerts).
+You can disable monitoring on a per-object basis by adding the `extended-monitoring.deckhouse.io/enabled=false` label to it. Thus, the default labels will also be disabled (as well as label-based alerts).
 
-### Standard annotations and supported Kubernetes objects
+### Standard labels and supported Kubernetes objects
 
-Below is the list of annotations used in Prometheus Rules and their default values.
+Below is the list of labels used in Prometheus Rules and their default values.
 
-**Caution!** All annotations:
+**Caution!** All labels:
 1. Start with a `threshold.extended-monitoring.deckhouse.io/` prefix;
 2. Have an integer value. The specified value defines the alert threshold.
 
 #### Non-namespaced Kubernetes objects
 
-Do not require a Namespace annotation and are enabled by default.
+Do not require a Namespace label and are enabled by default.
 
 ##### Node
 
-| Annotation                              | Type          | Default value  |
+| Label                                   | Type          | Default value  |
 |-----------------------------------------|---------------|----------------|
 | disk-bytes-warning                      | int (percent) | 70             |
 | disk-bytes-critical                     | int (percent) | 80             |
@@ -43,7 +43,7 @@ Do not require a Namespace annotation and are enabled by default.
 | load-average-per-core-warning           | int           | 3              |
 | load-average-per-core-critical          | int           | 10             |
 
-> **Caution!** These annotations **do not** apply to `imagefs` (`/var/lib/docker` by default) and `nodefs` (`/var/lib/kubelet` by default) volumes.
+> **Caution!** These labels **do not** apply to `imagefs` (`/var/lib/docker` by default) and `nodefs` (`/var/lib/kubelet` by default) volumes.
 The thresholds for these volumes are configured completely automatically according to the kubelet's [eviction thresholds](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/).
 The default values are available [here](https://github.com/kubernetes/kubernetes/blob/743e4fba6339237cc8d5c11413f76ea54b4cc3e8/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L22-L27); for more info, see the [exporter](https://github.com/deckhouse/deckhouse/blob/main/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop).
 
@@ -51,7 +51,7 @@ The default values are available [here](https://github.com/kubernetes/kubernetes
 
 ##### Pod
 
-| Annotation                              | Type          | Default value  |
+| Label                                   | Type          | Default value  |
 |-----------------------------------------|---------------|----------------|
 | disk-bytes-warning                      | int (percent) | 85             |
 | disk-bytes-critical                     | int (percent) | 95             |
@@ -64,14 +64,14 @@ The default values are available [here](https://github.com/kubernetes/kubernetes
 
 ##### Ingress
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | 5xx-warning            | int (percent) | 10            |
 | 5xx-critical           | int (percent) | 20            |
 
 ##### Deployment
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | replicas-not-ready     | int (count)   | 0             |
 
@@ -79,7 +79,7 @@ The threshold implies the number of unavailable replicas **in addition** to [max
 
 ##### Statefulset
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | replicas-not-ready     | int (count)   | 0             |
 
@@ -87,7 +87,7 @@ The threshold implies the number of unavailable replicas **in addition** to [max
 
 ##### DaemonSet
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | replicas-not-ready     | int (count)   | 0             |
 
@@ -95,11 +95,11 @@ The threshold implies the number of unavailable replicas **in addition** to [max
 
 ##### CronJob
 
-Note that only the deactivation using the `extended-monitoring.deckhouse.io/enabled=false` annotation is supported.
+Note that only the deactivation using the `extended-monitoring.deckhouse.io/enabled=false` label is supported.
 
 ### How does it work?
 
-The module exports specific Kubernetes object annotations to Prometheus. It allows you to improve Prometheus rules by adding the thresholds for triggering alerts.
+The module exports specific Kubernetes object labels to Prometheus. It allows you to improve Prometheus rules by adding the thresholds for triggering alerts.
 Using metrics that this module exports, you can, e.g., replace the "magic" constants in rules.
 
 Before:

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -15,26 +15,26 @@ force_searchable: true
 
 Сразу же после этого, для всех поддерживаемых Kubernetes объектов в данном Namespace в Prometheus появятся default метрики + любые кастомные с префиксом `threshold.extended-monitoring.deckhouse.io/`. Для ряда [non-namespaced](#non-namespaced-kubernetes-objects) Kubernetes объектов, описанных ниже, мониторинг и стандартные аннотации включаются автоматически.
 
-К Kubernetes объектам `threshold.extended-monitoring.deckhouse.io/что-то своё` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl annotate pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning-threshold=30`.
-В таком случае, значение из аннотации заменит значение по умолчанию.
+К Kubernetes объектам `threshold.extended-monitoring.deckhouse.io/что-то своё` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning-threshold=30`.
+В таком случае, значение из лейбла заменит значение по умолчанию.
 
-Слежение за объектом можно отключить индивидуально, поставив на него лейбл `extended-monitoring.deckhouse.io/enabled=false`. Соответственно, отключатся и аннотации по умолчанию, а также все алерты, привязанные к аннотациям.
+Слежение за объектом можно отключить индивидуально, поставив на него лейбл `extended-monitoring.deckhouse.io/enabled=false`. Соответственно, отключатся и лейблы по умолчанию, а также все алерты, привязанные к лейблам.
 
-### Стандартные аннотации и поддерживаемые Kubernetes объекты
+### Стандартные лейблы и поддерживаемые Kubernetes объекты
 
-Далее приведён список используемых в Prometheus Rules аннотаций, а также их стандартные значения.
+Далее приведён список используемых в Prometheus Rules лейблов, а также их стандартные значения.
 
-**Внимание!** Все аннотации:
+**Внимание!** Все лейблы:
 1. Начинаются с префикса `threshold.extended-monitoring.deckhouse.io/`;
 2. Имеют целочисленное значение в качестве value. Указанное в value значение устанавливает порог срабатывания алерта.
 
 #### Non-namespaced Kubernetes objects
 
-Не нуждаются в аннотации на Namespace. Включены по умолчанию.
+Не нуждаются в лейблах на Namespace. Включены по умолчанию.
 
 ##### Node
 
-| Annotation                              | Type          | Default value  |
+| Label                                   | Type          | Default value  |
 |-----------------------------------------|---------------|----------------|
 | disk-bytes-warning                      | int (percent) | 70             |
 | disk-bytes-critical                     | int (percent) | 80             |
@@ -43,7 +43,7 @@ force_searchable: true
 | load-average-per-core-warning           | int           | 3              |
 | load-average-per-core-critical          | int           | 10             |
 
-> **Важно!** Эти аннотации **не** действуют для тех разделов, в которых расположены `imagefs` (по умолчанию, — `/var/lib/docker`) и `nodefs` (по умолчанию, — `/var/lib/kubelet`).
+> **Важно!** Эти лейблы **не** действуют для тех разделов, в которых расположены `imagefs` (по умолчанию, — `/var/lib/docker`) и `nodefs` (по умолчанию, — `/var/lib/kubelet`).
 Для этих разделов пороги настраиваются полностью автоматически согласно [eviction thresholds в kubelet](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/).
 Значения по умолчанию см. [тут](https://github.com/kubernetes/kubernetes/blob/743e4fba6339237cc8d5c11413f76ea54b4cc3e8/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L22-L27), подробнее см. [экспортер](https://github.com/deckhouse/deckhouse/blob/main/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop).
 
@@ -51,7 +51,7 @@ force_searchable: true
 
 ##### Pod
 
-| Annotation                              | Type          | Default value  |
+| Label                                   | Type          | Default value  |
 |-----------------------------------------|---------------|----------------|
 | disk-bytes-warning                      | int (percent) | 85             |
 | disk-bytes-critical                     | int (percent) | 95             |
@@ -64,14 +64,14 @@ force_searchable: true
 
 ##### Ingress
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | 5xx-warning            | int (percent) | 10            |
 | 5xx-critical           | int (percent) | 20            |
 
 ##### Deployment
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | replicas-not-ready     | int (count)   | 0             |
 
@@ -79,7 +79,7 @@ force_searchable: true
 
 ##### Statefulset
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | replicas-not-ready     | int (count)   | 0             |
 
@@ -87,7 +87,7 @@ force_searchable: true
 
 ##### DaemonSet
 
-| Annotation             | Type          | Default value |
+| Label                  | Type          | Default value |
 |------------------------|---------------|---------------|
 | replicas-not-ready     | int (count)   | 0             |
 
@@ -95,11 +95,11 @@ force_searchable: true
 
 ##### CronJob
 
-Работает только выключение через аннотацию `extended-monitoring.deckhouse.io/enabled=false`.
+Работает только выключение через лейбл `extended-monitoring.deckhouse.io/enabled=false`.
 
 ### Как работает
 
-Модуль экспортирует в Prometheus специальные аннотации Kubernetes-объектов. Позволяет улучшить Prometheus-правила, путём добавления порога срабатывания для алертов.
+Модуль экспортирует в Prometheus специальные лейблы Kubernetes-объектов. Позволяет улучшить Prometheus-правила, путём добавления порога срабатывания для алертов.
 Использование метрик, экспортируемых данным модулем, позволяет, например, заменить "магические" константы в правилах.
 
 До:


### PR DESCRIPTION
## Description 
Fix doc extended monitoring label (fetching the threshold passes over the label, change in the annotation dock to the label)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs 
type: fix 
summary: Fix doc extended monitoring 
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
