### PR TITLE
[user-authn] [Docks] Added descriptions for crowd groups

### DIFF
--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -103,6 +103,8 @@ To do this, go to `Applications` -> `Add application`.
 
 Paste the generated `Application Name` and `Password` into the [DexProvider](cr.html#dexprovider) custom resource.
 
+CROWD groups, specified in lowcase format for custom resource DexProvider.
+
 ### Bitbucket Cloud
 
 ```yaml

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -103,7 +103,7 @@ To do this, go to `Applications` -> `Add application`.
 
 Paste the generated `Application Name` and `Password` into the [DexProvider](cr.html#dexprovider) custom resource.
 
-CROWD groups, specified in lowcase format for custom resource DexProvider.
+CROWD groups are specified in the lowercase format for the custom resource `DexProvider`.
 
 ### Bitbucket Cloud
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -103,7 +103,7 @@ spec:
 
 Полученные `Application Name` и `Password` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 
-Группы CROWD, указываются в lowercase формате для custom resource DexProvider.
+Группы CROWD указываются в lowercase-формате для custom resource `DexProvider`.
 
 ### Bitbucket Cloud
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -103,6 +103,8 @@ spec:
 
 Полученные `Application Name` и `Password` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 
+Группы CROWD, указываются в lowercase формате для custom resource DexProvider.
+
 ### Bitbucket Cloud
 
 ```yaml


### PR DESCRIPTION
## Description
Added descriptions for crowd groups in DexProviders custom resource

## Why do we need it, and what problem does it solve?
Groups from CROWD are passed to Dex in lowcase format and matched with what is described in DexProvider.
For example, your CROWD group is MyGroup, it is passed to Dex as mygmoup, and if you write MyGroup in DexProvider they will not be equal.
It is important to write it the way groups are passed to Dex

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: user-authn
type: Documentation updates.
impact_level: low
```
