### PR TITLE
[getting started] Remove a protocol prefix from the imagesRepo

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/getting-started-setup.js.liquid
+++ b/docs/site/_includes/getting_started/global/partials/getting-started-setup.js.liquid
@@ -33,7 +33,8 @@ function restoreData() {
 }
 
 $(document).ready(function () {
-  let publicDomainTemplatePattern = /^(%s([-a-z0-9]*[a-z0-9])?|[a-z0-9]([-a-z0-9]*)?%s([-a-z0-9]*)?[a-z0-9]|[a-z0-9]([-a-z0-9]*)?%s)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+  const publicDomainTemplatePattern = /^(%s([-a-z0-9]*[a-z0-9])?|[a-z0-9]([-a-z0-9]*)?%s([-a-z0-9]*)?[a-z0-9]|[a-z0-9]([-a-z0-9]*)?%s)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+  const httpPrefixPattern = /^(http|https):\/\//i;
   $('#clusterdomain').change(function () {
     if (!$(this).val().match(publicDomainTemplatePattern)) {
       $(this).addClass('invalid');
@@ -63,7 +64,11 @@ $(document).ready(function () {
   });
   // registry
   $('#registryImagesRepo').change(function () {
-    sessionStorage.setItem('dhctl-registry-images-repo', $(this).val());
+    const val = $(this).val().replace(httpPrefixPattern, '');
+    if (!($(this).val() === val)) {
+      $(this).val(val);
+    };
+    sessionStorage.setItem('dhctl-registry-images-repo', val);
   });
   $('#registryDockerCfg').change(function () {
     sessionStorage.setItem('dhctl-registry-docker-cfg', $(this).val());

--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -93,7 +93,7 @@
 
   <div class="form__row">
     <label class="label" title="Specify the path prefix for Deckhouse container images">
-      The path prefix for Deckhouse container images (e.g., <code>registry.deckhouse.io/deckhouse/ce</code> for CE).
+      The path prefix for Deckhouse container images (e.g., <code>registry.deckhouse.io/deckhouse/ce</code> for Deckhouse CE).
     </label>
     <input
       class="textfield"

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -93,7 +93,7 @@
 
   <div class="form__row">
     <label class="label" title="Укажите префикс имени образов контейнеров Deckhouse">
-      Префикс имени образов контейнеров Deckhouse (например, для публичных образов Deckhouse редакции CE — <code>registry.deckhouse.io/deckhouse/ce</code>)
+      Префикс имени образов контейнеров Deckhouse (например, для публичных образов Deckhouse CE — <code>registry.deckhouse.io/deckhouse/ce</code>).
     </label>
     <input
       class="textfield"


### PR DESCRIPTION
## Description

Remove a protocol prefix from the imagesRepo in the Getting started for the private environment.

## Why do we need it in the patch release (if we do)?

We need it to get rid of one of the common mistakes.

## Changelog entries
```changes
section: docs
type: chore
summary: The Getting started updates.
impact_level: low
```
