### PR TITLE
[deckhouse]  Handle Endpoints and orphan EndpointSlices

### DIFF
--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -17,7 +17,11 @@ limitations under the License.
 package hooks
 
 import (
+	"context"
 	"os"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -32,24 +36,84 @@ import (
 // But Deckhouse itself has ValidationWebhooks that should be executed even when pod is not ready.
 // Endpoints created via service do not go to ready state in this case and we cannot use validation.
 
+const (
+	d8Namespace = "d8-system"
+	d8Name      = "deckhouse"
+)
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnStartup: &go_hook.OrderedConfig{Order: 1},
-}, generateDeckhouseEndpoints)
+}, dependency.WithExternalDependencies(generateDeckhouseEndpoints))
 
-func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
+func generateDeckhouseEndpoints(input *go_hook.HookInput, dc dependency.Container) error {
+	client, err := dc.GetK8sClient()
+	if err != nil {
+		return err
+	}
+	err = cleanupOldEndpointSlices(client)
+	if err != nil {
+		return err
+	}
+
+	ep := &v1.Endpoints{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Endpoints",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      d8Name,
+			Namespace: d8Namespace,
+			Labels: map[string]string{
+				"app":                        d8Name,
+				"module":                     d8Name,
+				"heritage":                   d8Name,
+				"kubernetes.io/service-name": d8Name,
+			},
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP:       os.Getenv("ADDON_OPERATOR_LISTEN_ADDRESS"),
+						Hostname: os.Getenv("DECKHOUSE_NODE_NAME"),
+						NodeName: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
+						TargetRef: &v1.ObjectReference{
+							Kind:       "Pod",
+							Namespace:  d8Namespace,
+							Name:       os.Getenv("DECKHOUSE_POD"),
+							APIVersion: "v1",
+						},
+					},
+				},
+				Ports: []v1.EndpointPort{
+					{
+						Name:     "self",
+						Port:     9650,
+						Protocol: v1.ProtocolTCP,
+					},
+					{
+						Name:     "webhook",
+						Port:     9651,
+						Protocol: v1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
 	es := &discv1.EndpointSlice{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "EndpointSlice",
 			APIVersion: "discovery.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "deckhouse",
-			Namespace: "d8-system",
+			Name:      d8Name,
+			Namespace: d8Namespace,
 			Labels: map[string]string{
-				"app":                        "deckhouse",
-				"module":                     "deckhouse",
-				"heritage":                   "deckhouse",
-				"kubernetes.io/service-name": "deckhouse",
+				"app":                        d8Name,
+				"module":                     d8Name,
+				"heritage":                   d8Name,
+				"kubernetes.io/service-name": d8Name,
 			},
 		},
 		AddressType: "IPv4",
@@ -64,7 +128,7 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 				Hostname: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
-					Namespace: "d8-system",
+					Namespace: d8Namespace,
 					Name:      os.Getenv("DECKHOUSE_POD"),
 				},
 				NodeName: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
@@ -84,7 +148,26 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 		},
 	}
 
+	input.PatchCollector.Create(ep, object_patch.UpdateIfExists())
 	input.PatchCollector.Create(es, object_patch.UpdateIfExists())
+
+	return nil
+}
+
+// we have to clean old EndpointSlices, otherwise in a multi-master cluster it can lead to the Request Timeout error
+func cleanupOldEndpointSlices(client k8s.Client) error {
+	list, err := client.DiscoveryV1().EndpointSlices(d8Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=deckhouse,heritage=deckhouse,endpointslice.kubernetes.io/managed-by=endpointslice-controller.k8s.io"})
+	if err != nil {
+		return err
+	}
+
+	policy := metav1.DeletePropagationBackground
+	for _, item := range list.Items {
+		err = client.DiscoveryV1().EndpointSlices(d8Namespace).Delete(context.Background(), item.Name, metav1.DeleteOptions{PropagationPolicy: &policy})
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/global-hooks/create_endpoints_test.go
+++ b/global-hooks/create_endpoints_test.go
@@ -1,0 +1,155 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Global hooks :: create_endpoints ", func() {
+	f := HookExecutionConfigInit(`{"global": {}}`, `{}`)
+
+	Context("Cluster with old Endpoint and EndpointSlices", func() {
+		BeforeEach(func() {
+			os.Setenv("ADDON_OPERATOR_LISTEN_ADDRESS", "192.168.1.1")
+			os.Setenv("DECKHOUSE_NODE_NAME", "test-node")
+			os.Setenv("DECKHOUSE_POD", "deckhouse-test-1")
+			f.KubeStateSet("")
+			generateEndpoints()
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Should overwrite Endpoint", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ep := f.KubernetesResource("Endpoints", "d8-system", "deckhouse")
+			Expect(ep.Field("subsets.0.addresses.0.ip").String()).To(Equal("192.168.1.1"))
+			Expect(ep.Field("subsets.0.addresses.0.nodeName").String()).To(Equal("test-node"))
+			Expect(ep.Field("subsets.0.addresses.0.targetRef.name").String()).To(Equal("deckhouse-test-1"))
+			Expect(len(ep.Field("subsets.0.ports").Array())).To(Equal(2))
+		})
+
+		It("Should create EndpointSlice", func() {
+			eps := f.KubernetesResource("EndpointSlice", "d8-system", "deckhouse")
+
+			Expect(eps.Field("endpoints.0.addresses.0").String()).To(Equal("192.168.1.1"))
+			Expect(eps.Field("endpoints.0.nodeName").String()).To(Equal("test-node"))
+			Expect(eps.Field("endpoints.0.targetRef.name").String()).To(Equal("deckhouse-test-1"))
+			Expect(len(eps.Field("ports").Array())).To(Equal(2))
+		})
+
+		It("Should delete old EndpointSlices", func() {
+			list, err := dependency.TestDC.MustGetK8sClient().DiscoveryV1().EndpointSlices("d8-system").List(context.Background(), metav1.ListOptions{LabelSelector: "app=deckhouse,heritage=deckhouse,endpointslice.kubernetes.io/managed-by=endpointslice-controller.k8s.io"})
+			Expect(err).To(BeNil())
+			Expect(len(list.Items)).To(Equal(0))
+		})
+	})
+})
+
+func generateEndpoints() {
+	epsYaml := `
+---
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 10.241.0.32
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: main-master-2
+  targetRef:
+    kind: Pod
+    name: deckhouse-6cb4c7bcfd-jf265
+    namespace: d8-system
+    resourceVersion: "2238272329"
+    uid: fac9948d-d350-420d-8075-78b9e1fa66c8
+  zone: ru-central1-a
+kind: EndpointSlice
+metadata:
+  labels:
+    app: deckhouse
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    heritage: deckhouse
+    kubernetes.io/service-name: deckhouse
+    module: deckhouse
+  name: deckhouse-6hs6p
+  namespace: d8-system
+  ownerReferences:
+  - apiVersion: v1
+    controller: true
+    kind: Service
+    name: deckhouse
+ports:
+- name: self
+  port: 9650
+  protocol: TCP
+- name: webhook
+  port: 9651
+  protocol: TCP
+`
+
+	epYaml := `
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    app: deckhouse
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    module: deckhouse
+  name: deckhouse
+  namespace: d8-system
+subsets:
+- addresses:
+  - ip: 10.241.0.32
+    nodeName: main-master-2
+    targetRef:
+      kind: Pod
+      name: deckhouse-6cb4c7bcfd-jf265
+      namespace: d8-system
+      resourceVersion: "2238272329"
+      uid: fac9948d-d350-420d-8075-78b9e1fa66c8
+  ports:
+  - name: self
+    port: 9650
+    protocol: TCP
+  - name: webhook
+    port: 9651
+    protocol: TCP
+`
+	var eps v1.EndpointSlice
+	_ = yaml.Unmarshal([]byte(epsYaml), &eps)
+	_, _ = dependency.TestDC.MustGetK8sClient().DiscoveryV1().EndpointSlices("d8-system").Create(context.TODO(), &eps, metav1.CreateOptions{})
+
+	var ep corev1.Endpoints
+	_ = yaml.Unmarshal([]byte(epYaml), &ep)
+	_, _ = dependency.TestDC.MustGetK8sClient().CoreV1().Endpoints("d8-system").Create(context.TODO(), &ep, metav1.CreateOptions{})
+}

--- a/modules/002-deckhouse/hooks/clean_endpoint_slices.go
+++ b/modules/002-deckhouse/hooks/clean_endpoint_slices.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+// this hook clean orphan EndpointSlices from the previous version of the `deckhouse` Service
+// TODO: remove after the release 1.55
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:       "/modules/deckhouse/sync-configs",
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "endpointslices",
+			ApiVersion:                   "discovery.k8s.io/v1",
+			Kind:                         "EndpointSlice",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":                                    "deckhouse",
+					"heritage":                               "deckhouse",
+					"endpointslice.kubernetes.io/managed-by": "endpointslice-controller.k8s.io",
+				},
+			},
+			FilterFunc: filterEndpointSlices,
+		},
+	},
+}, deleteOrphanEndpoints)
+
+func filterEndpointSlices(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func deleteOrphanEndpoints(input *go_hook.HookInput) error {
+	snap := input.Snapshots["endpointslices"]
+
+	for _, sn := range snap {
+		endpointSliceName := sn.(string)
+		input.PatchCollector.Delete("discovery.k8s.io/v1", "EndpointSlice", "d8-system", endpointSliceName, object_patch.InBackground())
+	}
+
+	return nil
+}

--- a/modules/002-deckhouse/hooks/clean_endpoint_slices_test.go
+++ b/modules/002-deckhouse/hooks/clean_endpoint_slices_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: deckhouse :: hooks :: cleanup endpoint slices ::", func() {
+	f := HookExecutionConfigInit(`{"deckhouse":{}}`, `{}`)
+
+	Context("Have a few orphan EndpointSlices", func() {
+		BeforeEach(func() {
+			state := `
+---
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 10.241.0.32
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: test-master-1
+  targetRef:
+    kind: Pod
+    name: deckhouse-6cb4c7bcfd-jf265
+    namespace: d8-system
+kind: EndpointSlice
+metadata:
+  labels:
+    app: deckhouse
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    heritage: deckhouse
+    kubernetes.io/service-name: deckhouse
+    module: deckhouse
+  name: deckhouse-6hs6p
+  namespace: d8-system
+  ownerReferences:
+  - apiVersion: v1
+    controller: true
+    kind: Service
+    name: deckhouse
+ports:
+- name: self
+  port: 9650
+  protocol: TCP
+- name: webhook
+  port: 9651
+  protocol: TCP
+---
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 10.240.0.30
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: test-master-2
+  targetRef:
+    kind: Pod
+    name: deckhouse-6cb4c7bcfd-jf266
+    namespace: d8-system
+kind: EndpointSlice
+metadata:
+  labels:
+    app: deckhouse
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    heritage: deckhouse
+    kubernetes.io/service-name: deckhouse
+    module: deckhouse
+  name: deckhouse-6hs6d
+  namespace: d8-system
+  ownerReferences:
+  - apiVersion: v1
+    controller: true
+    kind: Service
+    name: deckhouse
+ports:
+- name: self
+  port: 9650
+  protocol: TCP
+- name: webhook
+  port: 9651
+  protocol: TCP
+---
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 192.168.199.39
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  hostname: test-master-0
+  nodeName: test-master-0
+  targetRef:
+    kind: Pod
+    name: deckhouse-c6974f69-68tlp
+    namespace: d8-system
+kind: EndpointSlice
+metadata:
+  labels:
+    app: deckhouse
+    heritage: deckhouse
+    kubernetes.io/service-name: deckhouse
+    module: deckhouse
+  name: deckhouse
+  namespace: d8-system
+ports:
+- name: self
+  port: 9650
+  protocol: TCP
+- name: webhook
+  port: 9651
+  protocol: TCP
+`
+			f.KubeStateSet(state)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+		It("Should delete orphan EndpointSlices", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("EndpointSlice", "d8-system", "deckhouse-6hs6p").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("EndpointSlice", "d8-system", "deckhouse-6hs6d").Exists()).To(BeFalse())
+
+			// new EndpointSlice should be kept
+			Expect(f.KubernetesResource("EndpointSlice", "d8-system", "deckhouse").Exists()).To(BeTrue())
+		})
+	})
+
+})


### PR DESCRIPTION
## Description
Handle orphan Endpoint and EndpointSlices

## Why do we need it, and what problem does it solve?
In a multi-master cluster old, orphan Endpoints and EndpointSlices could cause the request timeout error to a validation webhook.
We will rewrite the Endpoint and delete orphan EndpointSlices

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Handle orphan deckhouse Endpoints and EndpointSlices
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
