### PR TITLE
[runtime-audit-engine] move falcosidekick to distroless

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache make git bash && \
     git clone --branch 2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
     make falcosidekick && \
     chown -R 64535:64535 /src/falcosidekick && \
-    chmod 0700 /src/falcosidekick
+    chmod 0755 /src/falcosidekick
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /src/falcosidekick /falcosidekick

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -4,10 +4,13 @@ ARG BASE_DISTROLESS
 
 FROM $BASE_GOLANG_18_ALPINE as artifact
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
-
 ARG SOURCE_REPO
-ENV SOURCE_REPO=${SOURCE_REPO}
+
+ENV GOPROXY=${GOPROXY} \
+    SOURCE_REPO=${SOURCE_REPO} \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 WORKDIR /src
 RUN apk add --no-cache make git bash && \
@@ -19,4 +22,3 @@ RUN apk add --no-cache make git bash && \
 FROM $BASE_DISTROLESS
 COPY --from=artifact /src/falcosidekick /falcosidekick
 ENTRYPOINT [ "/falcosidekick" ]
-

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -10,7 +10,7 @@ ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 
 WORKDIR /src
-RUN apk add --no-cache make git && \
+RUN apk add --no-cache make git bash && \
     git clone --branch 2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
     make falcodisekick && \
     chown -R 64535:64535 /src/falcosidekick && \

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -12,7 +12,7 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 WORKDIR /src
 RUN apk add --no-cache make git bash && \
     git clone --branch 2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
-    make falcodisekick && \
+    make falcosidekick && \
     chown -R 64535:64535 /src/falcosidekick && \
     chmod 0700 /src/falcosidekick
 

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -11,7 +11,7 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 
 WORKDIR /src
 RUN apk add --no-cache make git && \
-    git clone --branch v2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
+    git clone --branch 2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
     make falcodisekick && \
     chown -R 64535:64535 /src/falcosidekick && \
     chmod 0700 /src/falcosidekick

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -1,6 +1,22 @@
 # Based on https://github.com/falcosecurity/falcosidekick/blob/41d530807f1a0294c0276e4cb42af68c8b26a659/Dockerfile
-ARG BASE_ALPINE
-FROM $BASE_ALPINE
-COPY --from=falcosecurity/falcosidekick:2.26.0-amd64@sha256:e13135c2cb2f01457dcf4ebca941c78898ad80c33c94a95e9b94033693411a31 /app /app
-WORKDIR /app
-ENTRYPOINT ["./falcosidekick"]
+ARG BASE_GOLANG_18_ALPINE
+ARG BASE_DISTROLESS
+
+FROM $BASE_GOLANG_18_ALPINE as artifact
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
+ARG SOURCE_REPO
+ENV SOURCE_REPO=${SOURCE_REPO}
+
+WORKDIR /src
+RUN apk add --no-cache make git && \
+    git clone --branch v2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
+    make falcodisekick && \
+    chown -R 64535:64535 /src/falcosidekick && \
+    chmod 0700 /src/falcosidekick
+
+FROM $BASE_DISTROLESS
+COPY --from=artifact /src/falcosidekick /falcosidekick
+ENTRYPOINT [ "/falcosidekick" ]
+

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: {{ $.Chart.Name }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -80,6 +80,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
+
       - name: falco
         # TODO(nabokihms): Fix 'Error response from daemon: invalid CapAdd: unknown capability: "CAP_BPF"'
         # Migrate to capabilities: "BPF" "SYS_RESOURCE" "PERFMON" "SYS_PTRACE"

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -76,11 +76,10 @@ spec:
       serviceAccountName: {{ $.Chart.Name }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-
       - name: falco
         # TODO(nabokihms): Fix 'Error response from daemon: invalid CapAdd: unknown capability: "CAP_BPF"'
         # Migrate to capabilities: "BPF" "SYS_RESOURCE" "PERFMON" "SYS_PTRACE"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Move faclosidekick container to the distroless image.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR is a part of https://github.com/deckhouse/deckhouse/issues/2797
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audt-engine
type: chore
summary: move falcosidekick to distroless
impact: runtime-audit-engine pod will be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
