### PR TITLE
[control-plane-manager] Properly detect home directory path for kubeconfig symlinking

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/kubeconfig.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/kubeconfig.go
@@ -143,7 +143,13 @@ func loadKubeconfig(path string) (*configv1.Config, error) {
 }
 
 func updateRootKubeconfig() error {
-	path := "/root/.kube/config"
+	var path string
+	if homeDir, hasHomeDir := os.LookupEnv("HOME"); hasHomeDir && homeDir != "/" {
+		path = filepath.Join(homeDir, ".kube", "config")
+	} else {
+		path = "/root/.kube/config"
+	}
+
 	originalPath := filepath.Join(kubernetesConfigPath, "admin.conf")
 	log.Infof("update root user kubeconfig (%s)", path)
 	if _, err := os.Stat(path); err == nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`$HOME` is now used instead of hardcoded `/root` path in `updateRootKubeconfig` phase if it contains usable path

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
https://github.com/deckhouse/deckhouse/issues/5482

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Path for kubeconfig symlink is now constructed using $HOME variable instead of /root if possible.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
