### PR TITLE
[global] Fix global hooks order

### DIFF
--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -37,6 +37,7 @@ const (
 	d8Name      = "deckhouse"
 )
 
+// should run before all hooks
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnStartup: &go_hook.OrderedConfig{Order: 1},
 }, generateDeckhouseEndpoints)

--- a/global-hooks/deckhouse-config/ensure_crd.go
+++ b/global-hooks/deckhouse-config/ensure_crd.go
@@ -26,7 +26,7 @@ import (
 
 const moduleConfigCRDPath = "/deckhouse/modules/002-deckhouse/crds/module-config.yaml"
 
-// Use order:1 to run before all global hooks.
+// Use order:2 to run before all global hooks but after EndpointSlice creation.
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnStartup: &go_hook.OrderedConfig{Order: 1},
+	OnStartup: &go_hook.OrderedConfig{Order: 2},
 }, dependency.WithExternalDependencies(ensure_crds.EnsureCRDsHandler(moduleConfigCRDPath)))

--- a/global-hooks/deckhouse-config/startup_sync.go
+++ b/global-hooks/deckhouse-config/startup_sync.go
@@ -42,9 +42,9 @@ resources and a managed ConfigMap/deckhouse-generated-config-do-not-edit object
 instead of one untyped and unmanaged ConfigMap/deckhouse object.
 */
 
-// Use order:1 to run before all global hooks.
+// Use order:2 to run before all global hooks but after EndpointSlice creation.
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnStartup: &go_hook.OrderedConfig{Order: 1},
+	OnStartup: &go_hook.OrderedConfig{Order: 2},
 }, dependency.WithExternalDependencies(migrateOrSyncModuleConfigs))
 
 // migrateOrSyncModuleConfigs runs on deckhouse-controller startup


### PR DESCRIPTION
## Description
Fix global hooks order

## Why do we need it, and what problem does it solve?
Endpoints should be created before all other hooks

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: fix 
summary: Fix global hooks order
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
