### PR TITLE
[dhctl][deckhouse-controller] Static build

### DIFF
--- a/deckhouse-controller/go-build.sh
+++ b/deckhouse-controller/go-build.sh
@@ -23,7 +23,7 @@ addonOpVer=$(go list -m all | grep addon-operator | cut -d' ' -f 2-)
 # Can be removed when Go 1.16 will be in use.
 export GO111MODULE=on
 
-GOOS=linux \
+CGO_ENABLED=0 GOOS=linux \
     go build \
      -ldflags="-s -w -extldflags '-static' -X 'main.DeckhouseVersion=$deckhouseVer' -X 'main.AddonOperatorVersion=$addonOpVer' -X 'main.ShellOperatorVersion=$shellOpVer'" \
      -o ./deckhouse-controller \

--- a/deckhouse-controller/go-build.sh
+++ b/deckhouse-controller/go-build.sh
@@ -25,6 +25,6 @@ export GO111MODULE=on
 
 GOOS=linux \
     go build \
-     -ldflags="-s -w -X 'main.DeckhouseVersion=$deckhouseVer' -X 'main.AddonOperatorVersion=$addonOpVer' -X 'main.ShellOperatorVersion=$shellOpVer'" \
+     -ldflags="-s -w -extldflags '-static' -X 'main.DeckhouseVersion=$deckhouseVer' -X 'main.AddonOperatorVersion=$addonOpVer' -X 'main.ShellOperatorVersion=$shellOpVer'" \
      -o ./deckhouse-controller \
      ./cmd/deckhouse-controller

--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -51,7 +51,7 @@ bin/gofumpt:
 	@chmod +x "./bin/gofumpt"
 
 build:
-	GOOS="$(OS)" GOARCH="$(GOARCH)" go build -ldflags="-s -w" -o $(DHCTL_BIN_NAME) ./cmd/dhctl
+	GOOS="$(OS)" GOARCH="$(GOARCH)" go build -ldflags='-s -w -extldflags "-static"' -o $(DHCTL_BIN_NAME) ./cmd/dhctl
 
 build-test:
 	GOOS="linux" GOARCH="$(GOARCH)" go build -ldflags="-s -w" -o "bin/dhctl-linux-amd64-test" ./cmd/dhctl

--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -51,7 +51,7 @@ bin/gofumpt:
 	@chmod +x "./bin/gofumpt"
 
 build:
-	GOOS="$(OS)" GOARCH="$(GOARCH)" go build -ldflags='-s -w -extldflags "-static"' -o $(DHCTL_BIN_NAME) ./cmd/dhctl
+	CGO_ENABLED=0 GOOS="$(OS)" GOARCH="$(GOARCH)" go build -ldflags='-s -w -extldflags "-static"' -o $(DHCTL_BIN_NAME) ./cmd/dhctl
 
 build-test:
 	GOOS="linux" GOARCH="$(GOARCH)" go build -ldflags="-s -w" -o "bin/dhctl-linux-amd64-test" ./cmd/dhctl


### PR DESCRIPTION
## Description
Build deckhouse-controller and dhctl as static binary.

## Why do we need it, and what problem does it solve?
It is more portable between os'es. It needs for CSE version

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manually testing
`dhctl terraform check` and `dhctl converge` is working.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Static build
impact_level: default
---
section: dhctl
type: feature
summary: Static build
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
