### PR TITLE
[deckhouse] Set ready and converging status for module configs

### DIFF
--- a/go_lib/deckhouse-config/status.go
+++ b/go_lib/deckhouse-config/status.go
@@ -24,6 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/deckhouse-config/conversion"
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	d8v1alpha1 "github.com/deckhouse/deckhouse/modules/002-deckhouse/hooks/pkg/apis/v1alpha1"
+	"github.com/flant/addon-operator/pkg/module_manager"
 )
 
 type Status struct {
@@ -45,22 +46,17 @@ func NewModuleInfo(mm ModuleManager, possibleNames set.Set) *StatusReporter {
 	}
 }
 
-func (s *StatusReporter) ForConfig(cfg *d8v1alpha1.ModuleConfig, bundleName string, externalModulesToRepo map[string]string) Status {
+func (s *StatusReporter) ForConfig(cfg *d8v1alpha1.ModuleConfig, bundleName string, modulesToSource map[string]string) Status {
 	// Special case: unknown module name.
-	repo, isExternal := externalModulesToRepo[cfg.GetName()]
+	moduleType, fromSource := modulesToSource[cfg.GetName()]
 
-	if !s.possibleNames.Has(cfg.GetName()) && !isExternal {
+	if !s.possibleNames.Has(cfg.GetName()) && !fromSource {
 		return Status{
 			State:   "N/A",
 			Version: "",
 			Status:  "Ignored: unknown module name",
 			Type:    "N/A",
 		}
-	}
-
-	moduleType := "Embedded"
-	if isExternal {
-		moduleType = fmt.Sprintf("External: %s", repo)
 	}
 
 	chain := conversion.Registry().Chain(cfg.GetName())
@@ -120,12 +116,28 @@ func (s *StatusReporter) ForConfig(cfg *d8v1alpha1.ModuleConfig, bundleName stri
 	stateMsg := "Disabled"
 	if s.moduleManager.IsModuleEnabled(cfg.GetName()) {
 		stateMsg = "Enabled"
+
 		lastHookErr := mod.State.GetLastHookErr()
 		if lastHookErr != nil {
 			statusMsgs = append(statusMsgs, fmt.Sprintf("HookError: %v", lastHookErr))
 		}
 		if mod.State.LastModuleErr != nil {
 			statusMsgs = append(statusMsgs, fmt.Sprintf("ModuleError: %v", mod.State.LastModuleErr))
+		}
+
+		if len(statusMsgs) == 0 { // no errors were added
+			// Best effort alarm!
+			//
+			// Actually, this condition is not correct because the `CanRunHelm` status appears right before the first run.
+			// The right approach is to check the queue for the module run task.
+			// However, there are too many addon-operator internals involved.
+			// We should consider moving these statuses to the `Module` resource,
+			// which is directly controlled by addon-operator.
+			if mod.State.Phase == module_manager.CanRunHelm {
+				statusMsgs = append(statusMsgs, "Ready")
+			} else {
+				statusMsgs = append(statusMsgs, "Converging: module is waiting for the first run")
+			}
 		}
 	} else {
 		// Special case: no enabled flag in ModuleConfig, module disabled by bundle.

--- a/go_lib/deckhouse-config/status.go
+++ b/go_lib/deckhouse-config/status.go
@@ -21,10 +21,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/flant/addon-operator/pkg/module_manager"
+
 	"github.com/deckhouse/deckhouse/go_lib/deckhouse-config/conversion"
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	d8v1alpha1 "github.com/deckhouse/deckhouse/modules/002-deckhouse/hooks/pkg/apis/v1alpha1"
-	"github.com/flant/addon-operator/pkg/module_manager"
 )
 
 type Status struct {
@@ -128,7 +129,7 @@ func (s *StatusReporter) ForConfig(cfg *d8v1alpha1.ModuleConfig, bundleName stri
 		if len(statusMsgs) == 0 { // no errors were added
 			// Best effort alarm!
 			//
-			// Actually, this condition is not correct because the `CanRunHelm` status appears right before the first run.
+			// Actually, this condition is not correct because the `CanRunHelm` status appears right before the first run.c
 			// The right approach is to check the queue for the module run task.
 			// However, there are too many addon-operator internals involved.
 			// We should consider moving these statuses to the `Module` resource,

--- a/modules/002-deckhouse/crds/doc-ru-module.yaml
+++ b/modules/002-deckhouse/crds/doc-ru-module.yaml
@@ -16,4 +16,4 @@ spec:
                 state:
                   description: 'Состояние модуля (включен или выключен).'
                 source:
-                  description: 'Адрес репозитория для внешнего модуля, либо `Embedded` — для внутреннего.'
+                  description: 'Имя ModuleSource если модуль скачан из него (иначе пусто)'

--- a/modules/002-deckhouse/crds/module.yaml
+++ b/modules/002-deckhouse/crds/module.yaml
@@ -39,7 +39,7 @@ spec:
                     - Disabled
                 source:
                   type: string
-                  description: 'Source repository address for an external module, or `Embedded` — for internal.'
+                  description: 'ModuleSource name of the module if provided by one (otherwise empty).'
       additionalPrinterColumns:
         - name: weight
           jsonPath: .properties.weight
@@ -52,4 +52,4 @@ spec:
         - name: source
           jsonPath: .properties.source
           type: string
-          description: 'Source repository address for an external module, or Embedded — for internal.'
+          description: 'ModuleSource name of the module if provided by one (otherwise empty).'

--- a/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
+++ b/modules/002-deckhouse/hooks/pkg/apis/v1alpha1/module.go
@@ -80,18 +80,9 @@ func (m *Module) SetTags(tags []string) {
 }
 
 func (m *Module) SetSource(source string) {
-	if source == "" {
-		source = "Embedded"
-	}
-	m.Labels["type"] = "embedded"
-
-	if source != "Embedded" {
-		source = "External: " + source
-		m.Labels["type"] = "external"
-	}
-
 	m.Properties.Source = source
 }
+
 func (m *Module) SetEnabledState(enabled bool) {
 	if enabled {
 		m.Properties.State = "Enabled"

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -124,7 +124,7 @@ func applyModuleRelease(input *go_hook.HookInput) error {
 		if pred.currentReleaseIndex == len(pred.releases)-1 {
 			// latest release deployed
 			deployedRelease := pred.releases[pred.currentReleaseIndex]
-			deckhouse_config.Service().AddExternalModuleName(deployedRelease.ModuleName, deployedRelease.ModuleSource)
+			deckhouse_config.Service().AddModuleNameToSource(deployedRelease.ModuleName, deployedRelease.ModuleSource)
 
 			// check symlink exists on FS, relative symlink
 			modulePath := generateModulePath(module, deployedRelease.Version.String())

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -58,15 +58,11 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: echoserver
-  labels:
-    type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: hellow
-  labels:
-    type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease
@@ -117,8 +113,6 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: testmodule
-  labels:
-    type: "external"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ExternalModuleRelease


### PR DESCRIPTION
## Description
* Set status for modules in their normal state
* Migrate the source field from `Embedded / External: %s` to `<empty>/%s`.

## Why do we need it, and what problem does it solve?
It is not clear wether a module is ready or not.

Best effort alarm!

Actually, the condition for a module stage is not correct because the `CanRunHelm` status appears right before the first run.
The right approach is to check the queue for the module run task. However, there are too many addon-operator internals involved. We should consider moving these statuses to the `Module` resource, which is directly controlled by addon-operator.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature 
summary: Set ready and converging status for module configs.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
