### PR TITLE
[cloud-provider-aws] Explicitly provide tags to root_block_device

### DIFF
--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -73,6 +73,7 @@ resource "aws_instance" "master" {
   root_block_device {
     volume_size = var.root_volume_size
     volume_type = var.root_volume_type
+    tags        = var.tags
   }
 
   tags = merge(var.tags, {

--- a/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
@@ -49,6 +49,7 @@ resource "aws_instance" "node" {
   root_block_device {
     volume_size = var.root_volume_size
     volume_type = var.root_volume_type
+    tags        = var.tags
   }
 
   tags = merge(var.tags, {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Explicitly specified tags from `AWSClusterConfiguration` for `root_block_device` in `master-node` and `static-node` terraform configurations

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes #5120 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: "AWS node's root_block_device is now marked with tags from AWSClusterConfiguration"
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
