### PR TITLE
[runtime-audit-engine] add read-only root for falco container

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falco/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falco/Dockerfile
@@ -1,1 +1,0 @@
-FROM falcosecurity/falco:0.35.1-slim@sha256:99478d303b189ea933d50a45c422f91abae167e9e52485f3d12bcc3f5a34cd69

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -5,7 +5,7 @@ from: {{ $.Images.BASE_UBUNTU }}
 shell:
   beforeInstall:
     - apt-get update
-    - apt-get install tar gzip curl
+    - apt-get install tar gzip curl -y
     - curl -sfL https://download.falco.org/packages/bin/x86_64/falco-{{ $falcoVersion }}-x86_64.tar.gz --output /tmp/falco.tar.gz
     - tar -zxvf /tmp/falco.tar.gz --strip-components 1 --directory /
     - rm -f /tmp/falco.tar.gz

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,5 +1,17 @@
-image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromArtifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+{{- $falcoVersion := "0.35.1" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: falcosecurity/falco:0.35.1-slim@sha256:99478d303b189ea933d50a45c422f91abae167e9e52485f3d12bcc3f5a34cd69
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+from: {{ $.Images.BASE_UBUNTU }}
+shell:
+  beforeInstall:
+    - apt-get update
+    - apt-get install tar gzip curl
+    - curl -sfL https://download.falco.org/packages/bin/x86_64/falco-{{ $falcoVersion }}-x86_64.tar.gz --output /tmp/falco.tar.gz
+    - tar -zxvf /tmp/falco.tar.gz --strip-components 1 --directory /
+    - rm -f /tmp/falco.tar.gz
+  install:
+    - "sed -i 's/time_format_iso_8601: false/time_format_iso_8601: true/' /etc/falco/falco.yaml"
+    - rm -df /lib/modules
+    - ln -s $HOST_ROOT/lib/modules /lib/modules
+docker:
+  CMD: ["/usr/bin/falco"]

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,0 +1,2 @@
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+from: falcosecurity/falco:0.35.1-slim@sha256:99478d303b189ea933d50a45c422f91abae167e9e52485f3d12bcc3f5a34cd69

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,2 +1,5 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
+fromImage: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: falcosecurity/falco:0.35.1-slim@sha256:99478d303b189ea933d50a45c422f91abae167e9e52485f3d12bcc3f5a34cd69

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+fromArtifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: falcosecurity/falco:0.35.1-slim@sha256:99478d303b189ea933d50a45c422f91abae167e9e52485f3d12bcc3f5a34cd69

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -84,7 +84,7 @@ spec:
       - name: falco
         # TODO(nabokihms): Fix 'Error response from daemon: invalid CapAdd: unknown capability: "CAP_BPF"'
         # Migrate to capabilities: "BPF" "SYS_RESOURCE" "PERFMON" "SYS_PTRACE"
-        {{- include "helm_lib_module_container_security_context_privileged" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "falco") }}
         args:
         - /usr/bin/falco


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add read-only root for falco container
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Read-only container fs is needed for security purposes.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: security
type: fix
summary: add read-only root for falco container
impact: runtime-audit-engine pods should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
