### PR TITLE
[candi] Fixed CSI mount cleaner

### DIFF
--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -42,7 +42,7 @@ exit 0
 # not in pipeline to avoid capturing mount's non-zero exit code in the if expression
 mount_output="$(mount)"
 
-if grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/' <<< "$mount_output"; then
+if ! grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/' <<< "$mount_output"; then
   echo 'No mounts of form "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/" present. No-op...'
   disable_systemd_units
   exit 0


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed missing negation from https://github.com/deckhouse/deckhouse/pull/5548/files#diff-13ff18bfb1e6b6302d0f5d327557b20bab73b8b29570c517cdcec53369d2ca04L42

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes forgotten negation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The previous fix does not work and CSI mount cleaner won't work correctly on Kubernetes 1.25 (which is default now).

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

I've created a test mount:
```
/dev/vdb on /tmp/test/var/lib/kubelet/plugins/kubernetes.io/csi/pv/test type ext4 (rw,relatime,discard)
```

All systemd units got successfully enabled:
```
root@klimentyev-master-0:~# systemctl cat old-csi-mount-cleaner.timer
# /etc/systemd/system/old-csi-mount-cleaner.timer
[Unit]
Description=Old CSI mount cleaner timer

[Timer]
OnBootSec=2min
OnUnitActiveSec=2min

[Install]
WantedBy=multi-user.target
root@klimentyev-master-0:~# systemctl cat old-csi-mount-cleaner.service
# /etc/systemd/system/old-csi-mount-cleaner.service
[Unit]
Description=Old CSI mount cleaner service

[Service]
EnvironmentFile=/etc/environment
ExecStart=/var/lib/bashible/old-csi-mount-cleaner.sh

[Install]
WantedBy=multi-user.target
root@klimentyev-master-0:~# systemctl status old-csi-mount-cleaner.service
○ old-csi-mount-cleaner.service - Old CSI mount cleaner service
     Loaded: loaded (/etc/systemd/system/old-csi-mount-cleaner.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Tue 2023-08-29 10:17:11 UTC; 1min 26s ago
TriggeredBy: ● old-csi-mount-cleaner.timer
    Process: 342326 ExecStart=/var/lib/bashible/old-csi-mount-cleaner.sh (code=exited, status=0/SUCCESS)
   Main PID: 342326 (code=exited, status=0/SUCCESS)
        CPU: 41ms

Aug 29 10:17:11 klimentyev-master-0 systemd[1]: Started Old CSI mount cleaner service.
Aug 29 10:17:11 klimentyev-master-0 systemd[1]: old-csi-mount-cleaner.service: Deactivated successfully.
root@klimentyev-master-0:~# systemctl status old-csi-mount-cleaner.timer
● old-csi-mount-cleaner.timer - Old CSI mount cleaner timer
     Loaded: loaded (/etc/systemd/system/old-csi-mount-cleaner.timer; enabled; vendor preset: enabled)
     Active: active (waiting) since Tue 2023-08-29 10:17:10 UTC; 1min 43s ago
    Trigger: Tue 2023-08-29 10:19:11 UTC; 17s left
   Triggers: ● old-csi-mount-cleaner.service

Aug 29 10:17:10 klimentyev-master-0 systemd[1]: Stopping Old CSI mount cleaner timer...
Aug 29 10:17:10 klimentyev-master-0 systemd[1]: Started Old CSI mount cleaner timer.
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed CSI mount cleaner.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
