### PR TITLE
[candi] Rename vendored containerd.service into containerd-deckhouse.service

### DIFF
--- a/candi/bashible/common-steps/node-group/002_add_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_add_system_proxy.sh.tpl
@@ -29,8 +29,8 @@ DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY}" "http_proxy=${HTTP_PROXY}" "HTTPS_
 EOF
 
   {{- if eq .cri "Containerd" }}
-mkdir -p /etc/systemd/system/containerd.service.d/
-bb-sync-file /etc/systemd/system/containerd.service.d/proxy-environment.conf - << EOF
+mkdir -p /etc/systemd/system/containerd-deckhouse.service.d/
+bb-sync-file /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf - << EOF
 [Service]
 Environment="HTTP_PROXY=${HTTP_PROXY}" "http_proxy=${HTTP_PROXY}" "HTTPS_PROXY=${HTTPS_PROXY}" "https_proxy=${HTTPS_PROXY}" "NO_PROXY=${NO_PROXY}" "no_proxy=${NO_PROXY}"
 EOF
@@ -50,8 +50,8 @@ if [ -f /etc/systemd/system.conf.d/proxy-default-environment.conf ]; then
   _reload_systemd
 fi
 
-if [ -f /etc/systemd/system/containerd.service.d/proxy-environment.conf ]; then
-  rm -f /etc/systemd/system/containerd.service.d/proxy-environment.conf
+if [ -f /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf ]; then
+  rm -f /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf
   _reload_systemd
 fi
 

--- a/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
@@ -17,7 +17,7 @@
 bb-event-on 'bb-package-installed' 'post-install'
 post-install() {
   systemctl daemon-reload
-  systemctl enable containerd.service
+  systemctl enable containerd-deckhouse.service
 {{ if ne .runType "ImageBuilding" -}}
   bb-flag-set containerd-need-restart
 {{- end }}

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -15,7 +15,7 @@
 {{- if eq .cri "Containerd" }}
 _on_containerd_config_changed() {
   {{ if ne .runType "ImageBuilding" -}}
-  systemctl restart containerd.service
+  systemctl restart containerd-deckhouse.service
   {{- end }}
 }
 

--- a/modules/007-registrypackages/images/containerd/scripts/install
+++ b/modules/007-registrypackages/images/containerd/scripts/install
@@ -33,6 +33,11 @@ EOF
 
 cp -f containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2 ctr runc /opt/deckhouse/bin
 
-cp -f containerd.service /lib/systemd/system
+cp -f containerd.service /lib/systemd/system/containerd-deckhouse.service
 systemctl daemon-reload
-systemctl enable containerd.service
+
+if [[ -f /etc/systemd/system/containerd.service ]] || [[ -f /usr/lib/systemd/system/containerd.service ]]; then
+  systemctl disable --now containerd.service &> /dev/null
+fi
+
+systemctl enable containerd-deckhouse.service

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -157,7 +157,7 @@ This is only needed if you have to move a static node from one cluster to anothe
    systemctl stop kubernetes-api-proxy.service kubernetes-api-proxy-configurator.service kubernetes-api-proxy-configurator.timer
    systemctl stop bashible.service bashible.timer
    systemctl stop kubelet.service
-   systemctl stop containerd
+   systemctl stop containerd-deckhouse
    systemctl list-units --full --all | grep -q docker.service && systemctl stop docker
    kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}')
    ```
@@ -208,7 +208,7 @@ This is only needed if you have to move a static node from one cluster to anothe
 1. Start CRI:
 
    ```shell
-   systemctl start containerd
+   systemctl start containerd-deckhouse
    systemctl list-units --full --all | grep -q docker.service && systemctl start docker
    ```
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -157,7 +157,7 @@ kubectl label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
    systemctl stop kubernetes-api-proxy.service kubernetes-api-proxy-configurator.service kubernetes-api-proxy-configurator.timer
    systemctl stop bashible.service bashible.timer
    systemctl stop kubelet.service
-   systemctl stop containerd
+   systemctl stop containerd-deckhouse
    systemctl list-units --full --all | grep -q docker.service && systemctl stop docker
    kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}')
    ```
@@ -208,7 +208,7 @@ kubectl label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
 1. Запустите обратно CRI:
 
    ```shell
-   systemctl start containerd
+   systemctl start containerd-deckhouse
    systemctl list-units --full --all | grep -q docker.service && systemctl start docker
    ```
 

--- a/tools/astra_integrity_check/main.go
+++ b/tools/astra_integrity_check/main.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var gostsumsPath *string
+
+const resultXMLPath = "/tmp/astra-int-check-report.xml"
+
+func main() {
+	if os.Geteuid() != 0 {
+		log.Fatalln("This program should be run with root priviliges")
+	}
+
+	setupFlags()
+	ensureAstraIntCheckInstalled()
+	ensureGostsums()
+
+	if err := runChecks(); err != nil {
+		log.Fatalln("astra-int-check:", err)
+	}
+
+	results, err := parseResult()
+	if err != nil {
+		log.Fatalln("parsing results:", err)
+	}
+	defer func() {
+		_ = os.Remove(resultXMLPath)
+	}()
+
+	if results.Failed != 0 || results.NotFound != 0 {
+		log.Printf("TEST FAILED\n\n%v", results)
+		os.Exit(1)
+	}
+
+	log.Println("TEST PASSED")
+	os.Exit(0)
+}
+
+func setupFlags() {
+	gostsumsPath = flag.String("g", "/tmp/gostsums.txt", "Path to file with gost checksums")
+	flag.Parse()
+}
+
+func runChecks() error {
+	forcedFilter := []string{
+		`/boot/*`,
+		`/lib/*`,
+		`/usr/bin/*`,
+		`/lib/security/*`,
+		`/etc/init.d/*`,
+	}
+	ignoreFilter := []string{
+		`/etc/*`,
+		`/var/*`,
+		`/tmp/*`,
+		`/proc/*`,
+		`/sys/*`,
+		`/usr/share/pam-configs/*`,
+		`/usr/lib/libreoffice/share/registry/main.xcd`,
+		`/usr/lib/libreoffice/share/config/soffice.cfg/modules/*`,
+		`/bin/setupcon`,
+		`/usr/lib/firefox/browser/defaults/preferences/vendor-firefox.js`,
+		`/usr/share/icons/hicolor/index.theme`,
+		`/usr/share/icons/hicolor/*/apps/gimp.png`,
+		`/usr/sbin/plymouth-set-default-theme`,
+		`/usr/sbin/plymouth/debian-logo.png`,
+		`/usr/share/vim/vim81/doc/help.txt`,
+		`/usr/share/vim/vim81/doc/tags`,
+		`/usr/lib/mime/packages/vlc`,
+		`/lib/udev/rules.d/91-group-floppy.rules`,
+		`/usr/share/knotifications5/astra-event-watcher.notifyrc`,
+	}
+
+	checkCmd := exec.Command(
+		"/usr/bin/astra-int-check",
+		"--gost", *gostsumsPath,
+		"--xml", resultXMLPath,
+		"--force-filters", strings.Join(forcedFilter, ","),
+		"--ignore-filters", strings.Join(ignoreFilter, ","),
+	)
+
+	if err := checkCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/astra_integrity_check/pre_run.go
+++ b/tools/astra_integrity_check/pre_run.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func ensureAstraIntCheckInstalled() {
+	_, err := os.Lstat("/usr/bin/astra-int-check")
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		log.Println("astra-int-check was not found on the system, trying to install")
+		if err := installAstraIntChecker(); err != nil {
+			log.Fatalln("astra-int-check installation failed:", err)
+		}
+	case err != nil:
+		log.Fatalln(fmt.Errorf("os.Lstat: %w", err))
+	}
+}
+
+func installAstraIntChecker() error {
+	aptUpdateCmd := exec.Command("apt-get", "update")
+	aptUpdateCmd.Env = append(aptUpdateCmd.Env, "DEBIAN_FRONTEND=noninteractive")
+
+	aptCmd := exec.Command("apt-get", "install", "-y", "astra-int-check")
+	aptCmd.Env = append(aptCmd.Env, "DEBIAN_FRONTEND=noninteractive")
+
+	if err := aptUpdateCmd.Run(); err != nil {
+		return fmt.Errorf("apt-get update: %w", err)
+	}
+	if err := aptCmd.Run(); err != nil {
+		return fmt.Errorf("apt-get install: %w", err)
+	}
+	return nil
+}
+
+func ensureGostsums() {
+	gostsumsFilePath := filepath.Clean(*gostsumsPath)
+	stat, err := os.Lstat(gostsumsFilePath)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		log.Fatalf("%v: %s", err, gostsumsFilePath)
+	case err != nil:
+		log.Fatalln(fmt.Errorf("os.Lstat: %w", err))
+	case stat.IsDir():
+		log.Fatalln("gostsums path points to a directory")
+	case !stat.Mode().IsRegular():
+		log.Fatalln("gostsums path should point to a regular file")
+	}
+
+	gostsumsPath = &gostsumsFilePath
+}

--- a/tools/astra_integrity_check/result_xml.go
+++ b/tools/astra_integrity_check/result_xml.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+)
+
+type File struct {
+	XMLName xml.Name `xml:"file"`
+	Name    string   `xml:"filename,attr"`
+	Sum     string   `xml:"gostsumorig,attr"`
+}
+
+type FilesList struct {
+	Files []File
+}
+
+type TestResult struct {
+	Passed        int       `xml:"-"`
+	Failed        int       `xml:"-"`
+	NotFound      int       `xml:"-"`
+	OKFiles       FilesList `xml:"intOKFiles"`
+	FailedFiles   FilesList `xml:"intFailedFiles"`
+	NotFoundFiles FilesList `xml:"notFoundFiles"`
+}
+
+func (t *TestResult) String() string {
+	return fmt.Sprintf("Passed: %d\nFailed: %d\nNot found: %d\n", t.Passed, t.Failed, t.NotFound)
+}
+
+func parseResult() (*TestResult, error) {
+	resultBin, err := os.ReadFile(resultXMLPath)
+	if err != nil {
+		return nil, fmt.Errorf("os.ReadFile: %w", err)
+	}
+
+	result := &TestResult{}
+	if err := xml.Unmarshal(resultBin, result); err != nil {
+		return nil, fmt.Errorf("xml.Unmarshal: %w", err)
+	}
+	result.Passed = len(result.OKFiles.Files)
+	result.Failed = len(result.FailedFiles.Files)
+	result.NotFound = len(result.NotFoundFiles.Files)
+
+	return result, nil
+}

--- a/tools/astra_integrity_check/run_test.sh
+++ b/tools/astra_integrity_check/run_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage example
+# SSH should be up and accessible on the host
+#
+# ASTRA_KEY=~/.ssh/astra ASTRA_USER=astra ASTRA_HOST=1.2.3.4 ASTRA_SUMS=~/Downloads/gostsums.txt ./run_test.sh
+#
+# gostsums.txt can be downloaded from Astra consumer portal and should match Astra Linux version you are about to test.
+
+
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o test_payload || exit 1
+
+scp -i ${ASTRA_KEY} ${ASTRA_SUMS} ${ASTRA_USER}@${ASTRA_HOST}:/tmp/gostsums.txt || exit 1
+scp -i ${ASTRA_KEY} ./test_payload ${ASTRA_USER}@${ASTRA_HOST}:/tmp/int-test-payload || exit 1
+rm -f ./test_payload
+
+ssh -i ${ASTRA_KEY} ${ASTRA_USER}@${ASTRA_HOST} "sudo /tmp/int-test-payload -g /tmp/gostsums.txt"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Systemd's `containerd.service` shipped with deckhouse is now installed and used as `containerd-deckhouse.service` to avoid corruption of `containerd` packages in OS repos.

Also, a new testing tool is implemented to validate Astra Linux SE security compliance.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This is necessary to comply with Astra Linux SE security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Containerd systemd unit that ships with Deckhouse renamed to `containerd-deckhouse.service`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
