### PR TITLE
[cloud-provider-yandex] Fix calculate disks limit in csi driver

### DIFF
--- a/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/Dockerfile
+++ b/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_ALPINE
-FROM registry.deckhouse.io/yandex-csi-driver/yandex-csi-driver:v0.9.12@sha256:5aba630c3e7c8b7acfbfb1f8ded22f5dabd803dcdef34a21ecc04144fcec0630 as artifact
+FROM registry.deckhouse.io/yandex-csi-driver/yandex-csi-driver:v0.10.0@sha256:5bbefd73169b25bb17723515569fea8ed4423c9e4ba87f8d348afa4f323567fc as artifact
 
 FROM $BASE_ALPINE
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Updated yandex-csi-driver. In the new version, the calculation of the limit of disks per node has been fixed.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In the new version of yandex-csi-driver, the calculation of the limit of disks per node has been fixed.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manual test results

<details>

```
root@destroymeafter31aug-master-0:~# kubectl get po -o wide
NAME     READY   STATUS    RESTARTS   AGE     IP            NODE                                              NOMINATED NODE   READINESS GATES
asd-0    1/1     Running   0          50m     10.111.0.12   destroymeafter31aug-master-0                      <none>           <none>
asd-1    1/1     Running   0          12m     10.111.0.13   destroymeafter31aug-master-0                      <none>           <none>
asd-2    1/1     Running   0          12m     10.111.0.14   destroymeafter31aug-master-0                      <none>           <none>
asd-3    1/1     Running   0          11m     10.111.0.15   destroymeafter31aug-master-0                      <none>           <none>
asd-4    1/1     Running   0          11m     10.111.0.16   destroymeafter31aug-master-0                      <none>           <none>
asd-5    1/1     Running   0          10m     10.111.0.17   destroymeafter31aug-master-0                      <none>           <none>
asd-6    0/1     Pending   0          9m57s   <none>        <none>                                            <none>           <none>
test-0   1/1     Running   0          6m28s   10.111.1.12   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-1   1/1     Running   0          5m48s   10.111.1.13   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-2   1/1     Running   0          5m29s   10.111.1.14   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-3   1/1     Running   0          5m5s    10.111.1.15   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-4   1/1     Running   0          4m43s   10.111.1.16   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-5   1/1     Running   0          4m18s   10.111.1.17   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-6   1/1     Running   0          3m56s   10.111.1.18   destroymeafter31aug-worker-ef91da1e-59578-bvq2c   <none>           <none>
test-7   0/1     Pending   0          3m32s   <none>        <none>                                            <none>           <none>
root@destroymeafter31aug-master-0:~# kubectl get pvc
NAME          STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-asd-0    Bound     pvc-d7314791-c32a-4b14-81fc-13487317477f   10Gi       RWO            network-hdd    50m
data-asd-1    Bound     pvc-54c523f8-df34-43ca-8c2b-ebc942831f89   10Gi       RWO            network-hdd    12m
data-asd-2    Bound     pvc-7f11598e-dcb4-4b82-96eb-07c93e3d303f   10Gi       RWO            network-hdd    12m
data-asd-3    Bound     pvc-f1f3ce9a-50f7-4c5e-993b-1a0539b0da32   10Gi       RWO            network-hdd    11m
data-asd-4    Bound     pvc-ca36d44d-0937-42a6-9223-783ac9a30432   10Gi       RWO            network-hdd    11m
data-asd-5    Bound     pvc-9aa55042-02b8-4e15-81b5-5c1eeeb3dcfc   10Gi       RWO            network-hdd    11m
data-asd-6    Pending                                                                        network-hdd    10m
data-test-0   Bound     pvc-4df26dd5-ba21-409d-859b-ed0a4a3d95ba   10Gi       RWO            network-hdd    6m32s
data-test-1   Bound     pvc-7e342a7e-8442-476d-9e59-8eb8ea0e6645   10Gi       RWO            network-hdd    5m52s
data-test-2   Bound     pvc-9df12468-f0a4-41e4-9569-4b2d2bc5ec07   10Gi       RWO            network-hdd    5m33s
data-test-3   Bound     pvc-30f44a05-1069-400d-8b3f-e4a8a27bd917   10Gi       RWO            network-hdd    5m9s
data-test-4   Bound     pvc-51dabedc-170b-415a-b3c8-a0c3a56ed91d   10Gi       RWO            network-hdd    4m47s
data-test-5   Bound     pvc-b51dc7ed-366e-4cf6-b662-663d80c66cc9   10Gi       RWO            network-hdd    4m22s
data-test-6   Bound     pvc-dd8387cb-3136-487f-8365-6b7274882caf   10Gi       RWO            network-hdd    4m
data-test-7   Pending
```
![image](https://github.com/deckhouse/deckhouse/assets/32643620/dcf0b2c5-8264-4ef2-8614-9899d7646ad0)

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Updated yandex-csi-driver. In the new version, the calculation of the limit of disks per node has been fixed.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
