### PR TITLE
Fix that proxy settings moved to clusterConfiguration

### DIFF
--- a/ee/modules/600-flant-integration/templates/pricing/config.yaml
+++ b/ee/modules/600-flant-integration/templates/pricing/config.yaml
@@ -47,13 +47,13 @@ prometheus:
         action: labeldrop
     remote_write:
     - url: {{ .Values.flantIntegration.metrics.url }}
-  {{- if .Values.global.modules.proxy }}
+  {{- if .Values.global.clusterConfiguration.proxy }}
     {{- $proxy := "" }}
-    {{- if .Values.global.modules.proxy.httpProxy }}
-      {{- $proxy = .Values.global.modules.proxy.httpProxy }}
+    {{- if .Values.global.clusterConfiguration.proxy.httpProxy }}
+      {{- $proxy = .Values.global.clusterConfiguration.proxy.httpProxy }}
     {{- end }}
-    {{- if .Values.global.modules.proxy.httpsProxy }}
-      {{- $proxy = .Values.global.modules.proxy.httpsProxy }}
+    {{- if .Values.global.clusterConfiguration.proxy.httpsProxy }}
+      {{- $proxy = .Values.global.clusterConfiguration.proxy.httpsProxy }}
     {{- end }}
     {{- if $proxy }}
       proxy_url: {{ $proxy }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Proxy settings were moved to clusterConfiguration. Fix issue in 600-flant-integration with usage Values.global.modules instead

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: modules
type: fix 
summary: fix config take values from clusterConfiguration instead global module
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
