### PR TITLE
[cloud-provider-yandex] Add storage class for new disk type network-ssd-io-m3

### DIFF
--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -10,7 +10,7 @@ title: "Cloud provider — Yandex Cloud: configuration"
 
 The module automatically creates StorageClasses covering all available disks in Yandex:
 
-| Type | StorageClass Name |
+| Type | StorageClass Name | Comment |
 ``
 |---|---|
 | network-hdd | network-hdd | |

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -13,7 +13,7 @@ The module automatically creates StorageClasses covering all available disks in 
 | Type | StorageClass Name |
 ``
 |---|---|
-| network-hdd | network-hdd | |'
+| network-hdd | network-hdd | |
 | network-ssd | network-ssd | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ The module automatically creates StorageClasses covering all available disks in 
 | network-ssd | network-ssd | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
-| network-ssd-io-m3         | etwork-ssd-io-m3 | Disk size must be a multiple of 93 GB. |
+| network-ssd-io-m3         | network-ssd-io-m3 | Disk size must be a multiple of 93 GB. |
 
 You can filter out the unnecessary StorageClasses via the [exclude](#parameters-storageclass-exclude) parameter.
 

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -16,7 +16,6 @@ The module automatically creates StorageClasses covering all available disks in 
 | network-hdd | network-hdd | |
 | network-ssd | network-ssd | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
-| network-ssd-nonreplicated | network-ssd-nonreplicated | |
 | network-ssd-io-m3         | network-ssd-io-m3 | Disk size must be a multiple of 93 GB. |
 
 You can filter out the unnecessary StorageClasses via the [exclude](#parameters-storageclass-exclude) parameter.

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -11,10 +11,13 @@ title: "Cloud provider — Yandex Cloud: configuration"
 The module automatically creates StorageClasses covering all available disks in Yandex:
 
 | Type | StorageClass Name |
+``
 |---|---|
-| network-hdd | network-hdd |
-| network-ssd | network-ssd |
-| network-ssd-nonreplicated | network-ssd-nonreplicated |
+| network-hdd | network-hdd | |'
+| network-ssd | network-ssd | |
+| network-ssd-nonreplicated | network-ssd-nonreplicated | |
+| network-ssd-nonreplicated | network-ssd-nonreplicated | |
+| network-ssd-io-m3         | etwork-ssd-io-m3 | Disk size must be a multiple of 93 GB. |
 
 You can filter out the unnecessary StorageClasses via the [exclude](#parameters-storageclass-exclude) parameter.
 

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
@@ -15,8 +15,7 @@ title: "Cloud provider — Yandex Cloud: настройки"
 | network-hdd | network-hdd | |'
 | network-ssd | network-ssd | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
-| network-ssd-nonreplicated | network-ssd-nonreplicated | |
-| network-ssd-io-m3         | etwork-ssd-io-m3 | Размер дисков должен быть кратен 93 ГБ |
+| network-ssd-io-m3         | network-ssd-io-m3 | Размер дисков должен быть кратен 93 ГБ |
 
 Вы можете отфильтровать ненужные StorageClass'ы с помощью параметра [exclude](#parameters-storageclass-exclude).
 

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
@@ -16,7 +16,7 @@ title: "Cloud provider — Yandex Cloud: настройки"
 | network-ssd | network-ssd | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
 | network-ssd-nonreplicated | network-ssd-nonreplicated | |
-| network-ssd-io-m3         | etwork-ssd-io-m3 | Размер дисков должен быть кратен 93 ГБ |                
+| network-ssd-io-m3         | etwork-ssd-io-m3 | Размер дисков должен быть кратен 93 ГБ |
 
 Вы можете отфильтровать ненужные StorageClass'ы с помощью параметра [exclude](#parameters-storageclass-exclude).
 

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
@@ -10,7 +10,7 @@ title: "Cloud provider — Yandex Cloud: настройки"
 
 Модуль автоматически создаёт StorageClass'ы, покрывающие все варианты дисков в Yandex:
 ``
-| Тип | Имя StorageClass | Комментарии
+| Тип | Имя StorageClass | Комментарии |
 |---|---|
 | network-hdd | network-hdd | |'
 | network-ssd | network-ssd | |

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
@@ -9,12 +9,14 @@ title: "Cloud provider — Yandex Cloud: настройки"
 ## Storage
 
 Модуль автоматически создаёт StorageClass'ы, покрывающие все варианты дисков в Yandex:
-
-| Тип | Имя StorageClass |
+``
+| Тип | Имя StorageClass | Комментарии
 |---|---|
-| network-hdd | network-hdd |
-| network-ssd | network-ssd |
-| network-ssd-nonreplicated | network-ssd-nonreplicated |
+| network-hdd | network-hdd | |'
+| network-ssd | network-ssd | |
+| network-ssd-nonreplicated | network-ssd-nonreplicated | |
+| network-ssd-nonreplicated | network-ssd-nonreplicated | |
+| network-ssd-io-m3         | etwork-ssd-io-m3 | Размер дисков должен быть кратен 93 ГБ |                
 
 Вы можете отфильтровать ненужные StorageClass'ы с помощью параметра [exclude](#parameters-storageclass-exclude).
 

--- a/modules/030-cloud-provider-yandex/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-yandex/hooks/storage_classes.go
@@ -33,6 +33,10 @@ var storageClassesConfig = []storage_class.StorageClass{
 		Name: "network-ssd-nonreplicated",
 		Type: "network-ssd-nonreplicated",
 	},
+	&storage_class.SimpleStorageClass{
+		Name: "network-ssd-io-m3",
+		Type: "network-ssd-io-m3",
+	},
 }
 
 var _ = storage_class.RegisterHook("cloudProviderYandex", storageClassesConfig)

--- a/modules/030-cloud-provider-yandex/hooks/storage_classes_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/storage_classes_test.go
@@ -55,6 +55,10 @@ cloudProviderYandex:
   {
 	"name": "network-ssd-nonreplicated",
 	"type": "network-ssd-nonreplicated"
+  },
+  {
+	"name": "network-ssd-io-m3",
+	"type": "network-ssd-io-m3"
   }
 ]
 `))


### PR DESCRIPTION
## Description
Yandex cloud presented new disk type `network-ssd-io-m3`. See more information [here](https://cloud.yandex.com/en-ru/docs/compute/concepts/disk)
In this pr we add storage class for new disk type.

## Why do we need it, and what problem does it solve?
Deckhouse should support all disk types for cloud.

## Manual testing 
Before update we have 3 storage classes
![image](https://github.com/deckhouse/deckhouse/assets/30695496/0ec2ce36-47bf-495b-9cce-ae38d83ebbdf)

Storage class edded and deckhouse reaady
![image](https://github.com/deckhouse/deckhouse/assets/30695496/bb8d699e-69bd-4140-a39c-49ec8385ad5e)


PVC created successfully
![image](https://github.com/deckhouse/deckhouse/assets/30695496/b38a1d96-42c9-40a0-a379-d3973d43f0fa)


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Add storage class for new disk type network-ssd-io-m3
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
