### PR TITLE
[linstor] fixes in SPAAS usage

### DIFF
--- a/modules/007-registrypackages/images/drbd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/drbd/werf.inc.yaml
@@ -35,3 +35,4 @@ shell:
     - chmod +x /install
     - chmod +x /uninstall
     - echo 'GIT-hash:123456' > /drbd/drbd/.drbd_git_revision
+    - sed -e "s/\<curl\>/d8-curl -k/g" -i /drbd/drbd/drbd-kernel-compat/gen_compat_patch.sh

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -98,7 +98,7 @@ spec:
 
     bb-log-info "Cluster DNS responded, got SPAAS service IP"
 
-    SPAAS_URL="https://${SPAAS_IP}:2020"
+    export SPAAS_URL="https://${SPAAS_IP}:2020"
 
     attempt=0
     until [[ "$(d8-curl -ks -w '%{http_code}' -o /dev/null $SPAAS_URL'/api/v1/hello')" == "200" ]]

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -103,7 +103,7 @@ spec:
 
     bb-log-info "Cluster DNS responded, got SPAAS service IP"
 
-    SPAAS_URL="https://${SPAAS_IP}:2020"
+    export SPAAS_URL="https://${SPAAS_IP}:2020"
 
     attempt=0
     until [[ "$(d8-curl -ks -w '%{http_code}' -o /dev/null $SPAAS_URL'/api/v1/hello')" == "200" ]]

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -100,7 +100,7 @@ spec:
 
     bb-log-info "Cluster DNS responded, got SPAAS service IP"
 
-    SPAAS_URL="https://${SPAAS_IP}:2020"
+    export SPAAS_URL="https://${SPAAS_IP}:2020"
 
     attempt=0
     until [[ "$(d8-curl -ks -w '%{http_code}' -o /dev/null $SPAAS_URL'/api/v1/hello')" == "200" ]]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We are currently using an external SPAAS service instead of a cluster in any case.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It is necessary to use an internal SPAAS service to save traffic especially in closed environments.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This affects our customers.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Using an internal SPAAS service when building DRBD.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Using an internal SPAAS service instead of the external one when building DRBD.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
