### PR TITLE
[Docks] fix misstakes "yam" to "yum"

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -702,7 +702,7 @@ spec:
 
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
     curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
-    yam install -y nvidia-container-toolkit nvidia-driver
+    yum install -y nvidia-container-toolkit nvidia-driver
   nodeGroups:
   - gpu
   weight: 30

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -705,7 +705,7 @@ spec:
 
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
     curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
-    yam install -y nvidia-container-toolkit nvidia-driver
+    yum install -y nvidia-container-toolkit nvidia-driver
   nodeGroups:
   - gpu
   weight: 30


### PR DESCRIPTION
## Description
Fix misstakes docks 040-node-manager install-cuda.sh for Centos

## Why do we need it, and what problem does it solve?
it fix nodegroupconfiguration install-cuda.sh

## What is the expected result?
install-cuda.sh will work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: node-manager
type: fix 
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
