### PR TITLE
[candi] Clean /tmp after bootstrap

### DIFF
--- a/candi/bashible/common-steps/cluster-bootstrap/098_cleanup_after_cluster_bootstrap.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/098_cleanup_after_cluster_bootstrap.sh.tpl
@@ -19,4 +19,3 @@ rm -f /tmp/bootstrap.sh
 rm -rf /tmp/candi-bundle*
 rm -f /tmp/bundle*.tar
 rm -f /tmp/kubeadm-config*
-rm -f /tmp/kubernetes-api-proxy.pid

--- a/candi/bashible/common-steps/cluster-bootstrap/098_cleanup_after_cluster_bootstrap.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/098_cleanup_after_cluster_bootstrap.sh.tpl
@@ -14,3 +14,9 @@
 
 rm -rf /var/lib/bashible/kubeadm
 bb-rp-remove kubeadm
+
+rm -f /tmp/bootstrap.sh
+rm -rf /tmp/candi-bundle*
+rm -f /tmp/bundle*.tar
+rm -f /tmp/kubeadm-config*
+rm -f /tmp/kubernetes-api-proxy.pid


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Candi's `098_cleanup.sh` will now also clean `/tmp` from remnants of the bootstrap bundle.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

See [#5597](https://github.com/deckhouse/deckhouse/issues/5597#issuecomment-1695348015), point №2

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: `/tmp` is now cleared before node is rebooted after bootstrap.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
