### PR TITLE
[operator-prometheus] leave basic-auth password in place if externalAuth is enabled

### DIFF
--- a/go_lib/hooks/generate_password/hook.go
+++ b/go_lib/hooks/generate_password/hook.go
@@ -105,14 +105,7 @@ func (h *Hook) Filter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 // It generates new password if there is no password in the configuration
 // and no Secret found.
 func (h *Hook) Handle(input *go_hook.HookInput) error {
-	externalAuthKey := h.ExternalAuthKey()
 	passwordInternalKey := h.PasswordInternalKey()
-
-	// Clear password from internal values if an external authentication is enabled.
-	if input.Values.Exists(externalAuthKey) {
-		input.Values.Remove(passwordInternalKey)
-		return nil
-	}
 
 	// Try to restore generated password from the Secret, or generate a new one.
 	pass, err := h.restoreGeneratedPasswordFromSnapshot(input.Snapshots[secretBindingName])

--- a/modules/300-prometheus/hooks/generate_password_test.go
+++ b/modules/300-prometheus/hooks/generate_password_test.go
@@ -71,9 +71,9 @@ data:
 			f.ValuesSet(hook.PasswordInternalKey(), []byte(`password`))
 			f.RunHook()
 		})
-		It("should clean password from values", func() {
+		It("shouldn't clean password from values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeFalse(), "should delete internal value")
+			Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeTrue(), "shouldn't delete internal value")
 		})
 	})
 
@@ -107,9 +107,9 @@ data:
 				f.ValuesSetFromYaml(hook.ExternalAuthKey(), []byte(`{"authURL": "test"}`))
 				f.RunHook()
 			})
-			It("should clean password from values", func() {
+			It("shouldn't clean password from values", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeFalse(), "should delete internal value")
+				Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeTrue(), "shouldn't delete internal value")
 			})
 		})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
