### PR TITLE
[go_lib] Change generate password hook

### DIFF
--- a/go_lib/hooks/generate_password/hook.go
+++ b/go_lib/hooks/generate_password/hook.go
@@ -45,8 +45,7 @@ func NewBasicAuthPlainHook(settings HookSettings) *Hook {
 			Namespace: settings.Namespace,
 			Name:      settings.SecretName,
 		},
-		ValuesKey:                  valuesKey,
-		keepPasswordOnExternalAuth: settings.KeepPasswordOnExternalAuth,
+		ValuesKey: valuesKey,
 	}
 }
 
@@ -54,10 +53,6 @@ type HookSettings struct {
 	ModuleName string
 	Namespace  string
 	SecretName string
-
-	// by default, basic-auth password will be removed if externalAuth is set
-	// you can change this behavior by this flag
-	KeepPasswordOnExternalAuth bool
 }
 
 // RegisterHook returns func to register common hook that generates

--- a/go_lib/hooks/generate_password/hook_test.go
+++ b/go_lib/hooks/generate_password/hook_test.go
@@ -82,7 +82,7 @@ func TestRestoreGeneratedPassword(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewBasicAuthPlainHook("testMod", "default", "auth")
+			h := NewBasicAuthPlainHook(HookSettings{ModuleName: "testMod", Namespace: "default", SecretName: "auth"})
 			pass, err := h.restoreGeneratedPasswordFromSnapshot(tt.snapshot)
 			if tt.expectErr == expectError {
 				require.NotNil(t, err, "input '%s' should not success", tt.snapshot)

--- a/modules/110-istio/hooks/generate_password.go
+++ b/modules/110-istio/hooks/generate_password.go
@@ -26,4 +26,12 @@ const (
 	authSecretName  = "kiali-basic-auth"
 )
 
-var _ = generate_password.RegisterHook(moduleValuesKey, authSecretNS, authSecretName)
+var (
+	generatePasswordSettings = generate_password.HookSettings{
+		ModuleName: moduleValuesKey,
+		Namespace:  authSecretNS,
+		SecretName: authSecretName,
+	}
+)
+
+var _ = generate_password.RegisterHook(generatePasswordSettings)

--- a/modules/110-istio/hooks/generate_password_test.go
+++ b/modules/110-istio/hooks/generate_password_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("Modules :: istio :: hooks :: generate_password ", func() {
 	var (
-		hook = generate_password.NewBasicAuthPlainHook(moduleValuesKey, authSecretNS, authSecretName)
+		hook = generate_password.NewBasicAuthPlainHook(generatePasswordSettings)
 
 		testPassword    = generate_password.GeneratePassword()
 		testPasswordB64 = base64.StdEncoding.EncodeToString([]byte(

--- a/modules/300-prometheus/hooks/generate_password.go
+++ b/modules/300-prometheus/hooks/generate_password.go
@@ -28,10 +28,9 @@ const (
 
 var (
 	generatePasswordSettings = generate_password.HookSettings{
-		ModuleName:                 moduleValuesKey,
-		Namespace:                  authSecretNS,
-		SecretName:                 authSecretName,
-		KeepPasswordOnExternalAuth: true,
+		ModuleName: moduleValuesKey,
+		Namespace:  authSecretNS,
+		SecretName: authSecretName,
 	}
 )
 

--- a/modules/300-prometheus/hooks/generate_password.go
+++ b/modules/300-prometheus/hooks/generate_password.go
@@ -26,4 +26,13 @@ const (
 	authSecretName  = "basic-auth"
 )
 
-var _ = generate_password.RegisterHook(moduleValuesKey, authSecretNS, authSecretName)
+var (
+	generatePasswordSettings = generate_password.HookSettings{
+		ModuleName:                 moduleValuesKey,
+		Namespace:                  authSecretNS,
+		SecretName:                 authSecretName,
+		KeepPasswordOnExternalAuth: true,
+	}
+)
+
+var _ = generate_password.RegisterHook(generatePasswordSettings)

--- a/modules/300-prometheus/hooks/generate_password_test.go
+++ b/modules/300-prometheus/hooks/generate_password_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Modules :: prometheus :: hooks :: generate_password ", func() {
 	var (
-		hook = generate_password.NewBasicAuthPlainHook(moduleValuesKey, authSecretNS, authSecretName)
+		hook = generate_password.NewBasicAuthPlainHook(generatePasswordSettings)
 
 		testPassword    = generate_password.GeneratePassword()
 		testPasswordB64 = base64.StdEncoding.EncodeToString([]byte(
@@ -65,15 +65,15 @@ data:
 
 	Context("giving external auth configuration", func() {
 		BeforeEach(func() {
-			f.KubeStateSet("")
+			f.KubeStateSet(authSecretManifest)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSetFromYaml(hook.ExternalAuthKey(), []byte(`{"authURL": "test"}`))
-			f.ValuesSet(hook.PasswordInternalKey(), []byte(`password`))
 			f.RunHook()
 		})
-		It("should clean password from values", func() {
+		It("should keep password from values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeFalse(), "should delete internal value")
+			Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeTrue(), "should delete internal value")
+			Expect(f.ValuesGet(hook.PasswordInternalKey()).String()).Should(Equal(testPassword))
 		})
 	})
 
@@ -101,15 +101,15 @@ data:
 			})
 		})
 
-		Context("giving external auth configuration", func() {
+		Context("giving external auth configuration without previous basic-auth", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 				f.ValuesSetFromYaml(hook.ExternalAuthKey(), []byte(`{"authURL": "test"}`))
 				f.RunHook()
 			})
-			It("should clean password from values", func() {
+			It("should generate basic-auth password", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeFalse(), "should delete internal value")
+				Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeTrue(), "should generate a new password")
 			})
 		})
 

--- a/modules/300-prometheus/hooks/generate_password_test.go
+++ b/modules/300-prometheus/hooks/generate_password_test.go
@@ -70,10 +70,9 @@ data:
 			f.ValuesSetFromYaml(hook.ExternalAuthKey(), []byte(`{"authURL": "test"}`))
 			f.RunHook()
 		})
-		It("should keep password from values", func() {
+		It("should delete password from values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeTrue(), "should delete internal value")
-			Expect(f.ValuesGet(hook.PasswordInternalKey()).String()).Should(Equal(testPassword))
+			Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeFalse(), "should delete internal value")
 		})
 	})
 
@@ -100,18 +99,5 @@ data:
 				Expect(pass).ShouldNot(BeEmpty())
 			})
 		})
-
-		Context("giving external auth configuration without previous basic-auth", func() {
-			BeforeEach(func() {
-				f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-				f.ValuesSetFromYaml(hook.ExternalAuthKey(), []byte(`{"authURL": "test"}`))
-				f.RunHook()
-			})
-			It("should generate basic-auth password", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet(hook.PasswordInternalKey()).Exists()).Should(BeTrue(), "should generate a new password")
-			})
-		})
-
 	})
 })

--- a/modules/300-prometheus/templates/alertmanager/internal/ingress.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     web.deckhouse.io/export-name: "alertmanager/{{ .name }}"
     {{- end }}
     web.deckhouse.io/export-icon: "/public/img/alertmanager.ico"
-    {{- if $.Values.global.enabledModules | has "user-authn" }}
+    {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.prometheus.auth.externalAuthentication }}
     nginx.ingress.kubernetes.io/auth-signin: {{ include "helm_lib_module_uri_scheme" $ }}://$host/dex-authenticator/sign_in
     nginx.ingress.kubernetes.io/auth-url: https://grafana-dex-authenticator.d8-monitoring.svc.{{ $.Values.global.discovery.clusterDomain }}/dex-authenticator/auth
     {{- else }}

--- a/modules/300-prometheus/templates/alertmanager/internal/ingress.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     web.deckhouse.io/export-name: "alertmanager/{{ .name }}"
     {{- end }}
     web.deckhouse.io/export-icon: "/public/img/alertmanager.ico"
-    {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.prometheus.auth.externalAuthentication }}
+    {{- if and (ne (include "helm_lib_module_https_mode" $) "Disabled") $.Values.prometheus.auth.externalAuthentication }}
     nginx.ingress.kubernetes.io/auth-signin: {{ include "helm_lib_module_uri_scheme" $ }}://$host/dex-authenticator/sign_in
     nginx.ingress.kubernetes.io/auth-url: https://grafana-dex-authenticator.d8-monitoring.svc.{{ $.Values.global.discovery.clusterDomain }}/dex-authenticator/auth
     {{- else }}

--- a/modules/500-cilium-hubble/hooks/generate_password.go
+++ b/modules/500-cilium-hubble/hooks/generate_password.go
@@ -26,4 +26,12 @@ const (
 	authSecretName  = "hubble-basic-auth"
 )
 
-var _ = generate_password.RegisterHook(moduleValuesKey, authSecretNS, authSecretName)
+var (
+	generatePasswordSettings = generate_password.HookSettings{
+		ModuleName: moduleValuesKey,
+		Namespace:  authSecretNS,
+		SecretName: authSecretName,
+	}
+)
+
+var _ = generate_password.RegisterHook(generatePasswordSettings)

--- a/modules/500-cilium-hubble/hooks/generate_password_test.go
+++ b/modules/500-cilium-hubble/hooks/generate_password_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Modules :: cilium-hubble :: hooks :: generate_password", func() {
 	var (
-		hook = generate_password.NewBasicAuthPlainHook(moduleValuesKey, authSecretNS, authSecretName)
+		hook = generate_password.NewBasicAuthPlainHook(generatePasswordSettings)
 
 		testPassword    = generate_password.GeneratePassword()
 		testPasswordB64 = base64.StdEncoding.EncodeToString([]byte(

--- a/modules/500-dashboard/hooks/generate_password.go
+++ b/modules/500-dashboard/hooks/generate_password.go
@@ -26,4 +26,12 @@ const (
 	authSecretName  = "basic-auth"
 )
 
-var _ = generate_password.RegisterHook(moduleValuesKey, authSecretNS, authSecretName)
+var (
+	generatePasswordSettings = generate_password.HookSettings{
+		ModuleName: moduleValuesKey,
+		Namespace:  authSecretNS,
+		SecretName: authSecretName,
+	}
+)
+
+var _ = generate_password.RegisterHook(generatePasswordSettings)

--- a/modules/500-dashboard/hooks/generate_password_test.go
+++ b/modules/500-dashboard/hooks/generate_password_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Modules :: dashboard :: hooks :: generate_password", func() {
 	var (
-		hook = generate_password.NewBasicAuthPlainHook(moduleValuesKey, authSecretNS, authSecretName)
+		hook = generate_password.NewBasicAuthPlainHook(generatePasswordSettings)
 
 		testPassword    = generate_password.GeneratePassword()
 		testPasswordB64 = base64.StdEncoding.EncodeToString([]byte(

--- a/modules/500-openvpn/hooks/generate_password.go
+++ b/modules/500-openvpn/hooks/generate_password.go
@@ -26,4 +26,12 @@ const (
 	authSecretName  = "basic-auth"
 )
 
-var _ = generate_password.RegisterHook(moduleValuesKey, authSecretNS, authSecretName)
+var (
+	generatePasswordSettings = generate_password.HookSettings{
+		ModuleName: moduleValuesKey,
+		Namespace:  authSecretNS,
+		SecretName: authSecretName,
+	}
+)
+
+var _ = generate_password.RegisterHook(generatePasswordSettings)

--- a/modules/500-openvpn/hooks/generate_password_test.go
+++ b/modules/500-openvpn/hooks/generate_password_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Modules :: openvpn :: hooks :: generate_password ", func() {
 	var (
-		hook = generate_password.NewBasicAuthPlainHook(moduleValuesKey, authSecretNS, authSecretName)
+		hook = generate_password.NewBasicAuthPlainHook(generatePasswordSettings)
 
 		testPassword    = generate_password.GeneratePassword()
 		testPasswordB64 = base64.StdEncoding.EncodeToString([]byte(

--- a/modules/810-documentation/hooks/generate_password.go
+++ b/modules/810-documentation/hooks/generate_password.go
@@ -26,4 +26,12 @@ const (
 	authSecretName  = "documentation-basic-auth"
 )
 
-var _ = generate_password.RegisterHook(moduleValuesKey, authSecretNS, authSecretName)
+var (
+	generatePasswordSettings = generate_password.HookSettings{
+		ModuleName: moduleValuesKey,
+		Namespace:  authSecretNS,
+		SecretName: authSecretName,
+	}
+)
+
+var _ = generate_password.RegisterHook(generatePasswordSettings)

--- a/modules/810-documentation/hooks/generate_password_test.go
+++ b/modules/810-documentation/hooks/generate_password_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Modules :: documentation :: hooks :: generate_password", func() {
 	var (
-		hook = generate_password.NewBasicAuthPlainHook(moduleValuesKey, authSecretNS, authSecretName)
+		hook = generate_password.NewBasicAuthPlainHook(generatePasswordSettings)
 
 		testPassword    = generate_password.GeneratePassword()
 		testPasswordB64 = base64.StdEncoding.EncodeToString([]byte(


### PR DESCRIPTION
## Description
We need a flag to control basic-auth password deletion if external authentication is enabled

## Why do we need it, and what problem does it solve?
Prometheus alertmanager always use basic-auth event is external auth is set.
We want to keep this password forever

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Alertmanager should have the `nil` password even the external auth is set

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: go_lib
type:  chore
summary: Add ability to keep basic-auth password via the flag
impact_level: low
```

```changes
section: prometheus
type:  fix
summary: Keep basic-auth password for alertmanager event is external authentication is set.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
