### PR TITLE
[dhctl] Add information about deckhouse pod is ready and deckhouse cluster created successfully

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -378,7 +378,7 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 			return nil
 		})
 
-		log.Success("Deckhouse cluster was created successfully!")
+		log.Success("Deckhouse cluster was created successfully!\n")
 
 		if metaConfig.ClusterType == config.CloudClusterType {
 			_ = log.Process("common", "Kubernetes Master Node addresses for SSH", func() error {

--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -378,6 +378,8 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 			return nil
 		})
 
+		log.Success("Deckhouse cluster was created successfully!")
+
 		if metaConfig.ClusterType == config.CloudClusterType {
 			_ = log.Process("common", "Kubernetes Master Node addresses for SSH", func() error {
 				for nodeName, address := range masterAddressesForSSH {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -388,8 +388,7 @@ func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode stri
 				}
 
 				if ok {
-
-					log.Success("Deckhouse pod is Ready!")
+					log.Success("Deckhouse pod is Ready!\n")
 					return nil
 				}
 

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -388,7 +388,8 @@ func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode stri
 				}
 
 				if ok {
-					log.InfoLn("Deckhouse pod is Ready!")
+
+					log.Success("Deckhouse pod is Ready!")
 					return nil
 				}
 


### PR DESCRIPTION
## Description

Add information about deckhouse pod is ready and deckhouse cluster created successfully

## Why do we need it, and what problem does it solve?
1. Sometimes deckhouse controller show unnecessary errors, but controller  will be ready.
We should mark the moment when the fetus becomes ready. For better user experiences.

2. Also we do not show that cluster is bootstrapped. This is especially noticeable on static clusters.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Manual testing
![image](https://github.com/deckhouse/deckhouse/assets/30695496/9ddbb698-5563-4e2c-a760-e0a403a8096d)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add information about deckhouse pod is ready and deckhouse cluster created successfully
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
