### PR TITLE
[external-module-manager] Deckhouse module source

### DIFF
--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_deckhouse_secret.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_deckhouse_secret.go
@@ -37,7 +37,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion:        "v1",
 			Kind:              "Secret",
 			NamespaceSelector: &types.NamespaceSelector{NameSelector: &types.NameSelector{MatchNames: []string{"d8-system"}}},
-			NameSelector:      &types.NameSelector{MatchNames: []string{"d8-deckhouse-flant-integration"}},
+			NameSelector:      &types.NameSelector{MatchNames: []string{"deckhouse-discovery"}},
 			FilterFunc:        ApplyPricingDeckhouseSecretFilter,
 		},
 	},

--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_deckhouse_secret_test.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_deckhouse_secret_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Flant integration :: hooks :: envs_from_deckhouse_secret ", func() {
 	f := HookExecutionConfigInit(`{"flantIntegration":{"internal":{}}}`, `{}`)
 
-	Context("Without d8-deckhouse-flant-integration secret", func() {
+	Context("Without deckhouse-discovery secret", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(``, 0))
 			f.RunHook()
@@ -27,7 +27,7 @@ var _ = Describe("Flant integration :: hooks :: envs_from_deckhouse_secret ", fu
 		})
 	})
 
-	Context("With d8-deckhouse-flant-integration secret", func() {
+	Context("With deckhouse-discovery secret", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
 apiVersion: v1
@@ -38,7 +38,7 @@ kind: Secret
 metadata:
   labels:
     heritage: deckhouse
-  name: d8-deckhouse-flant-integration
+  name: deckhouse-discovery
   namespace: d8-system
 type: Opaque
 `, 0))

--- a/modules/002-deckhouse/templates/registration.yaml
+++ b/modules/002-deckhouse/templates/registration.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: d8-deckhouse-flant-integration
+  name: deckhouse-discovery
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: Opaque

--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -1,0 +1,138 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"github.com/iancoleman/strcase"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
+)
+
+type deckhouseSecret struct {
+	Bundle         string
+	ReleaseChannel string
+}
+
+func filterDeckhouseSecret(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &corev1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert kubernetes secret to secret: %v", err)
+	}
+
+	return deckhouseSecret{
+		Bundle:         string(secret.Data["bundle"]),
+		ReleaseChannel: string(secret.Data["releaseChannel"]),
+	}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// ensure crds hook has order 5, for creating a module source we should use greater number
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 6},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "sources",
+			ApiVersion:                   "deckhouse.io/v1alpha1",
+			Kind:                         "ModuleSource",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"deckhouse"},
+			},
+			FilterFunc: filterSource,
+		},
+		{
+			Name:       "deckhouse-secret",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{"d8-system"}},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"deckhouse-discovery"},
+			},
+			FilterFunc: filterDeckhouseSecret,
+		},
+	},
+}, createDeckhouseModuleSource)
+
+func createDeckhouseModuleSource(input *go_hook.HookInput) error {
+	if input.Values.Get("global.modulesImages.registry.address").String() != "registry.deckhouse.io" {
+		// For now, modules are only stored in the base deckhouse registry,
+		// for other registries deploying this resource by default will only cause an error.
+		return nil
+	}
+
+	if input.Values.Get("global.modulesImages.registry.path").String() == "/deckhouse/ce" {
+		// For CE, there are no modules for now, but will be some in the future!
+		return nil
+	}
+
+	newms := v1alpha1.ModuleSource{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ModuleSource",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "deckhouse",
+			Labels: map[string]string{
+				"heritage": "deckhouse",
+			},
+		},
+		Spec: v1alpha1.ModuleSourceSpec{
+			Registry: v1alpha1.ModuleSourceSpecRegistry{
+				Repo:      input.Values.Get("global.modulesImages.registry.base").String() + "/modules",
+				DockerCFG: input.Values.Get("global.modulesImages.registry.dockercfg").String(),
+			},
+		},
+	}
+
+	ca := input.Values.Get("global.modulesImages.registry.CA").String()
+	if ca != "" {
+		newms.Spec.Registry.CA = ca
+	}
+
+	if len(input.Snapshots["deckhouse-secret"]) > 0 {
+		ds := input.Snapshots["deckhouse-secret"][0].(deckhouseSecret)
+		newms.Spec.ReleaseChannel = strcase.ToKebab(ds.ReleaseChannel)
+	}
+
+	if len(input.Snapshots["sources"]) > 0 {
+		ms := input.Snapshots["sources"][0].(v1alpha1.ModuleSource)
+
+		// Keep some options that users configured manually to prevent overriding
+		// In the future, instead, it is possible to use the server-side apply instead of subscribing to the object.
+		newms.Spec.ReleaseChannel = ms.Spec.ReleaseChannel
+	}
+
+	o, err := sdk.ToUnstructured(&newms)
+	if err != nil {
+		return err
+	}
+
+	input.PatchCollector.Create(o, object_patch.UpdateIfExists())
+
+	return nil
+}

--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source_test.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source_test.go
@@ -1,0 +1,172 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: external module manager :: hooks :: create deckhouse module source ::", func() {
+	initValues := `
+global:
+  modulesImages:
+    registry:
+      address: registry.deckhouse.io
+      base: registry.deckhouse.io/deckhouse/fe
+      dockercfg: "PGI2ND4K"
+`
+
+	f := HookExecutionConfigInit(initValues, `{}`)
+
+	var msResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "modulesources"}
+	f.RegisterCRD(msResource.Group, msResource.Version, "ModuleSource", false)
+
+	const (
+		discoverySecret = `
+---
+apiVersion: v1
+data:
+  bundle: RGVmYXVsdA==
+  releaseChannel: QWxwaGE=
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: deckhouse-discovery
+  namespace: d8-system
+type: Opaque
+`
+	)
+
+	Context("Without deckhouse-discovery secret", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should deploy the module source", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(ms.Exists()).To(BeTrue())
+			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
+			Expect(ms.Field("spec.registry.CA").String()).To(Equal(""))
+			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
+			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
+		})
+	})
+
+	Context("With deckhouse-discovery secret", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(discoverySecret))
+			f.RunHook()
+		})
+
+		It("Should deploy the module source", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(ms.Exists()).To(BeTrue())
+			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
+			Expect(ms.Field("spec.registry.CA").String()).To(Equal(""))
+			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
+			Expect(ms.Field("spec.releaseChannel").String()).To(Equal("alpha"))
+		})
+	})
+
+	Context("With different registry than registry.deckhouse.io", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.modulesImages.registry.address", "registry.my-company.com")
+			f.BindingContexts.Set(f.KubeStateSet(discoverySecret))
+			f.RunHook()
+		})
+
+		It("Should not deploy the module source", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(ms.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("With CE", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.modulesImages.registry.path", "/deckhouse/ce")
+			f.BindingContexts.Set(f.KubeStateSet(discoverySecret))
+			f.RunHook()
+		})
+
+		It("Should not deploy the module source", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(ms.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("With CA", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.modulesImages.registry.CA", "--- BEGIN ...")
+			f.BindingContexts.Set(f.KubeStateSet(discoverySecret))
+			f.RunHook()
+		})
+
+		It("Should deploy the module source with CA", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
+			Expect(ms.Field("spec.registry.ca").String()).To(Equal("--- BEGIN ..."))
+			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
+			Expect(ms.Field("spec.releaseChannel").String()).To(Equal("alpha"))
+		})
+	})
+
+	Context("With existed resource", func() {
+		existedModuleSource := `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  labels:
+    heritage: deckhouse
+  name: deckhouse
+spec:
+  releaseChannel: test
+  registry:
+    repo: xxx
+    dockerCfg: yyy
+`
+
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(discoverySecret + existedModuleSource))
+			f.RunHook()
+		})
+
+		It("Should update the module source", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
+			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
+			Expect(ms.Field("spec.releaseChannel").String()).To(Equal("test"))
+		})
+	})
+
+})

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -76,30 +76,30 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, dependency.WithExternalDependencies(handleSource))
 
 func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	var ex v1alpha1.ModuleSource
+	var ms v1alpha1.ModuleSource
 
-	err := sdk.FromUnstructured(obj, &ex)
+	err := sdk.FromUnstructured(obj, &ms)
 	if err != nil {
 		return nil, err
 	}
 
 	// remove unused fields
-	newex := v1alpha1.ModuleSource{
-		TypeMeta: ex.TypeMeta,
+	newms := v1alpha1.ModuleSource{
+		TypeMeta: ms.TypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ex.Name,
+			Name: ms.Name,
 		},
-		Spec: ex.Spec,
+		Spec: ms.Spec,
 		Status: v1alpha1.ModuleSourceStatus{
-			ModuleErrors: ex.Status.ModuleErrors,
+			ModuleErrors: ms.Status.ModuleErrors,
 		},
 	}
 
-	if newex.Spec.ReleaseChannel == "" {
-		newex.Spec.ReleaseChannel = defaultReleaseChannel
+	if newms.Spec.ReleaseChannel == "" {
+		newms.Spec.ReleaseChannel = defaultReleaseChannel
 	}
 
-	return newex, nil
+	return newms, nil
 }
 
 func handleSource(input *go_hook.HookInput, dc dependency.Container) error {

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -37,12 +37,14 @@ type ModuleSource struct {
 }
 
 type ModuleSourceSpec struct {
-	Registry struct {
-		Repo      string `json:"repo"`
-		DockerCFG string `json:"dockerCfg"`
-		CA        string `json:"ca"`
-	} `json:"registry"`
-	ReleaseChannel string `json:"releaseChannel"`
+	Registry       ModuleSourceSpecRegistry `json:"registry"`
+	ReleaseChannel string                   `json:"releaseChannel"`
+}
+
+type ModuleSourceSpecRegistry struct {
+	Repo      string `json:"repo"`
+	DockerCFG string `json:"dockerCfg"`
+	CA        string `json:"ca"`
 }
 
 type ModuleSourceStatus struct {


### PR DESCRIPTION
## Description
For Deckhouse EE and FE deploy a module source for modules distributed for Deckhouse.

## Why do we need it, and what problem does it solve?
There are modules developed by the Deckhouse team separately from the main Deckhouse repository.

By deploying the default module source, it will be more convenient to see other modules that can be deployed and enable them.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: feature
summary: |
  Deploy the `deckhouse` modules source. It will make it possible to enable modules developed by the Deckhouse team but distributed separately.
  
  The most awaited module that can be enabled now is the `deckhouse-admin` module - a convenient web-interface to administer deckhouse clusters.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
