### PR TITLE
[prometheus] Change description and formula for oldest metrics panel

### DIFF
--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -1213,7 +1213,7 @@
       "type": "table"
     },
     {
-      "description": "Difference between the last timestamp in the Prometheus tsdb and the current time. It shows how far in the past users can see.",
+      "description": "Difference between the oldest timestamp in the Prometheus tsdb and the current time. It shows how far in the past Prometheus instance collect the stats.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1320,7 +1320,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (service) (time() - prometheus_tsdb_lowest_timestamp_seconds) / 60 / 60 / 24",
+          "expr": "max by (service) (time() - prometheus_tsdb_lowest_timestamp_seconds{service=~\"prometheus|prometheus-longterm\", namespace=\"d8-monitoring\"}) / 60 / 60 / 24",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1328,7 +1328,7 @@
           "refId": "A"
         }
       ],
-      "title": "Metrics Interval",
+      "title": "Oldest metrics in Prometheus",
       "transformations": [
         {
           "id": "filterFieldsByName",


### PR DESCRIPTION
## Description
* clarify the title and description for the panel that shows the difference between the oldest metric timestamp and the current time
* limit the query to a specific namespace 
 
## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/5691

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Clarify description and formula for the oldest metrics panel on the starting page of Grafana
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
