### PR TITLE
[runtime-audit-engine] Support 3.8 python webhook

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/webhook/webhook.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/webhook/webhook.py
@@ -4,6 +4,7 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
 import subprocess
+import typing
 from os import remove
 
 from deckhouse import hook
@@ -24,16 +25,15 @@ def main(ctx: hook.Context):
         ctx.output.validations.error(str(e))
 
 
-def validate(request: dict) -> str | None:
+def validate(request: dict) -> typing.Union[str,  None]:
     uid = request.get("uid", "uid")
     spec = request.get("object", {}).get("spec", {})
-    match request["operation"]:
-        case "CREATE":
-            return validate_falco_rules(uid, spec)
-        case "UPDATE":
-            return validate_falco_rules(uid, spec)
-        case _:
-            raise Exception(f"Unknown operation {request.operation}")
+    if request["operation"] == "CREATE":
+        return validate_falco_rules(uid, spec)
+    elif request["operation"] == "UPDATE":
+        return validate_falco_rules(uid, spec)
+    else:
+        raise Exception(f"Unknown operation {request.operation}")
 
 
 def validate_falco_rules(uid: str, spec: dict):

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/requirements.txt
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/requirements.txt
@@ -2,4 +2,4 @@ dictdiffer==0.9.0
 dotmap==1.3.30
 PyYAML==6.0
 stringcase==1.2.0
-deckhouse==0.4.4
+deckhouse==0.4.7


### PR DESCRIPTION
## Description
Do webhook code compatibility with python 3.8

## Why do we need it, and what problem does it solve?
For CSE compatibility OS contains only 3.8 python. We do not have build python 3.10 itself.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
## Manual testing
![image](https://github.com/deckhouse/deckhouse/assets/30695496/73ba23e6-94b4-4b32-a644-eea9cf6df2f2)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: chore
summary: Support 3.8 python webhook 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
