### PR TITLE
[external-module-manager] Fix modules migration hook

### DIFF
--- a/deckhouse-controller/files/kubectl_wrapper.sh
+++ b/deckhouse-controller/files/kubectl_wrapper.sh
@@ -20,7 +20,7 @@ if [ -s /tmp/kubectl_version ]; then
  kubernetes_version="$(cat /tmp/kubectl_version)"
 else
  # Workaround for running kubectl before global hook global-hooks/discovery/kubernetes_version running
- kubernetes_version="$(/usr/local/bin/kubectl-1.22 version -o json | jq -r '.serverVersion.gitVersion | ltrimstr("v")')"
+ kubernetes_version="$(/usr/local/bin/kubectl-1.26 version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion | ltrimstr("v")')"
 fi
 
 case "$kubernetes_version" in

--- a/global-hooks/migrate/migrate_modules.go
+++ b/global-hooks/migrate/migrate_modules.go
@@ -48,6 +48,8 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 		return fmt.Errorf("cannot init Kubernetes client: %v", err)
 	}
 
+	fmt.Println("1 ASDSAD")
+
 	modulesMigrationCM := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -61,10 +63,12 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 
 	_, err = kubeCl.CoreV1().ConfigMaps(modulesMigrationCM.Namespace).Get(context.TODO(), modulesMigrationCM.Name, metav1.GetOptions{})
 	if err == nil {
+		fmt.Println("2 SKIP")
 		input.LogEntry.Info("Modules migration configmap exists, skipping the migration")
 		return nil
 	}
 	if !errors.IsNotFound(err) {
+		fmt.Println("3 ERR", err)
 		return err
 	}
 
@@ -80,15 +84,20 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 	moduleSources, err := kubeCl.Dynamic().Resource(emsGVR).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
+			fmt.Println("4 ERR", err)
 			return err
 		}
+		fmt.Println("5 ERR", err)
 
 		input.LogEntry.Info("ExternalModuleSource resource is not in the cluster")
 		skipMigrationCount++
 	}
 
+	fmt.Println("6")
+
 	moduleReleases, err := kubeCl.Dynamic().Resource(emrGVR).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
+		fmt.Println("7 ERR", err)
 		if !errors.IsNotFound(err) {
 			return err
 		}
@@ -98,12 +107,15 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 	}
 
 	if skipMigrationCount == 2 { // both resources are absent
+		fmt.Println("8 HERE", err)
 		input.LogEntry.Info("Skipping modules migration")
 		return nil
 	}
 
 	ensureRes := ensure_crds.EnsureCRDs("/deckhouse/modules/005-external-module-manager/crds/module-*.yaml", input, dc)
+	fmt.Println("9  ENSURE", ensureRes)
 	if err := ensureRes.ErrorOrNil(); err != nil {
+		fmt.Println("10  ENSUYRE", err)
 		return err
 	}
 
@@ -112,6 +124,7 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 
 		_, err := kubeCl.Dynamic().Resource(msGVR).Create(context.TODO(), &ms, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
+			fmt.Println("11 xxx", err)
 			return err
 		}
 	}
@@ -121,26 +134,35 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 
 		_, err := kubeCl.Dynamic().Resource(mrGVR).Create(context.TODO(), &mr, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
+			fmt.Println("12 xxx", err)
 			return err
 		}
 	}
 
+	fmt.Println("13")
+
 	err = kubeCl.Dynamic().Resource(emsGVR).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 	if err != nil {
+		fmt.Println("14", err)
 		input.LogEntry.Info("cannot delete external module sources", err)
 		return nil
 	}
 
 	err = kubeCl.Dynamic().Resource(emrGVR).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 	if err != nil {
+		fmt.Println("15", err)
 		input.LogEntry.Info("cannot delete external module releases", err)
 		return nil
 	}
 
+	fmt.Println("16")
+
 	_, err = kubeCl.CoreV1().ConfigMaps(modulesMigrationCM.Namespace).Create(context.TODO(), modulesMigrationCM, metav1.CreateOptions{})
 	if err != nil {
+		fmt.Println("17", err)
 		return err
 	}
+	fmt.Println("18")
 	return nil
 }
 

--- a/global-hooks/migrate/migrate_modules_crds.go
+++ b/global-hooks/migrate/migrate_modules_crds.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/hooks/ensure_crds"
+)
+
+/* Migration: Delete after Deckhouse release 1.53
+This migration is implemented as a global hook because it must happen
+before the rolling update of the validating webhook from the 002-deckhouse module.
+Otherwise, the webhook will prevent any interactions with ExternalModule* resources.
+*/
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(createModuleCRD))
+
+func createModuleCRD(input *go_hook.HookInput, dc dependency.Container) error {
+	ensureRes := ensure_crds.EnsureCRDs("/deckhouse/modules/005-external-module-manager/crds/module-*.yaml", input, dc)
+	if err := ensureRes.ErrorOrNil(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -43,8 +43,7 @@ spec:
                     repo:
                       type: string
                       description: URL of the container registry.
-                      x-examples:
-                        - registry.deckhouse.io/deckhouse/external-modules
+                      example: 'registry.deckhouse.io/deckhouse/external-modules'
                     dockerCfg:
                       type: string
                       description: Container registry access token in Base64.

--- a/modules/005-external-module-manager/crds/module-source.yaml
+++ b/modules/005-external-module-manager/crds/module-source.yaml
@@ -44,8 +44,7 @@ spec:
                     repo:
                       type: string
                       description: URL of the container registry.
-                      x-examples:
-                        - registry.example.io/deckhouse/modules
+                      example: 'registry.example.io/deckhouse/modules'
                     dockerCfg:
                       type: string
                       description: Container registry access token in Base64.


### PR DESCRIPTION
## Description
Create CRD before modules migration

## Why do we need it, and what problem does it solve?
EnsureCRDs works via PatchCollector and applies changes only in the end of the script. So, we don't have new CRD when creating the Modules.

## Why do we need it in the patch release (if we do)?
1.51 is broken atm. It will fail if you have existed resources in the cluster

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: fix 
summary: Fix modules migration webhook.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
