### PR TITLE
[global] Fix hostname for endpointslices

### DIFF
--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -43,7 +43,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, generateDeckhouseEndpoints)
 
 func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
-	// hostname = os.Getenv("HOSTNAME")
+	// hostname := os.Getenv("HOSTNAME")
 	// At this moment we don't use Hostname because of 2 reasons:
 	// 1. According to the endpoint controller, it should be set only when:
 	//		len(pod.Spec.Hostname) > 0 && pod.Spec.Subdomain == svc.Name && svc.Namespace == pod.Namespace

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -63,7 +63,7 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 				Addresses: []v1.EndpointAddress{
 					{
 						IP:       os.Getenv("ADDON_OPERATOR_LISTEN_ADDRESS"),
-						Hostname: os.Getenv("DECKHOUSE_NODE_NAME"),
+						Hostname: os.Getenv("HOSTNAME"),
 						NodeName: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
 						TargetRef: &v1.ObjectReference{
 							Kind:       "Pod",
@@ -118,7 +118,7 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 					Serving:     pointer.Bool(true),
 					Terminating: pointer.Bool(false),
 				},
-				Hostname: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
+				Hostname: pointer.String(os.Getenv("HOSTNAME")),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: d8Namespace,

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -44,7 +44,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 	hostname := ""
-	//hostname = os.Getenv("HOSTNAME")
+	// hostname = os.Getenv("HOSTNAME")
 	// At this moment we don't use Hostname because of 2 reasons:
 	// 1. According to the endpoint controller, it should be set only when:
 	//		len(pod.Spec.Hostname) > 0 && pod.Spec.Subdomain == svc.Name && svc.Namespace == pod.Namespace

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -43,7 +43,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, generateDeckhouseEndpoints)
 
 func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
-	hostname := ""
 	// hostname = os.Getenv("HOSTNAME")
 	// At this moment we don't use Hostname because of 2 reasons:
 	// 1. According to the endpoint controller, it should be set only when:
@@ -79,7 +78,6 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 				Addresses: []v1.EndpointAddress{
 					{
 						IP:       address,
-						Hostname: hostname,
 						NodeName: pointer.String(nodeName),
 						TargetRef: &v1.ObjectReference{
 							Kind:       "Pod",
@@ -134,7 +132,6 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 					Serving:     pointer.Bool(true),
 					Terminating: pointer.Bool(false),
 				},
-				Hostname: pointer.String(hostname),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: d8Namespace,

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -43,6 +43,22 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, generateDeckhouseEndpoints)
 
 func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
+	hostname := ""
+	//hostname = os.Getenv("HOSTNAME")
+	// At this moment we don't use Hostname because of 2 reasons:
+	// 1. According to the endpoint controller, it should be set only when:
+	//		len(pod.Spec.Hostname) > 0 && pod.Spec.Subdomain == svc.Name && svc.Namespace == pod.Namespace
+	//    https://github.com/kubernetes/kubernetes/blob/v1.27.5/pkg/controller/util/endpoint/controller_utils.go#L116
+	//
+	// 2. Deckhouse is a singleton now. Probably we will need it, when we will make a HA mode
+	// 		Pay attention!! That hostname could be like 'ip-10-0-3-207.eu-central-1.compute.internal' on the EKS installations for example,
+	// 		so it wouldn't validate via RFC1123 DNS Subdomain.
+	//		We have to lowercase the value and cut it until the first dot or something like that
+
+	nodeName := os.Getenv("DECKHOUSE_NODE_NAME")
+	podName := os.Getenv("DECKHOUSE_POD")
+	address := os.Getenv("ADDON_OPERATOR_LISTEN_ADDRESS")
+
 	ep := &v1.Endpoints{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Endpoints",
@@ -62,13 +78,13 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 			{
 				Addresses: []v1.EndpointAddress{
 					{
-						IP:       os.Getenv("ADDON_OPERATOR_LISTEN_ADDRESS"),
-						Hostname: os.Getenv("HOSTNAME"),
-						NodeName: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
+						IP:       address,
+						Hostname: hostname,
+						NodeName: pointer.String(nodeName),
 						TargetRef: &v1.ObjectReference{
 							Kind:       "Pod",
 							Namespace:  d8Namespace,
-							Name:       os.Getenv("DECKHOUSE_POD"),
+							Name:       podName,
 							APIVersion: "v1",
 						},
 					},
@@ -112,19 +128,19 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 		AddressType: "IPv4",
 		Endpoints: []discv1.Endpoint{
 			{
-				Addresses: []string{os.Getenv("ADDON_OPERATOR_LISTEN_ADDRESS")},
+				Addresses: []string{address},
 				Conditions: discv1.EndpointConditions{
 					Ready:       pointer.Bool(true),
 					Serving:     pointer.Bool(true),
 					Terminating: pointer.Bool(false),
 				},
-				Hostname: pointer.String(os.Getenv("HOSTNAME")),
+				Hostname: pointer.String(hostname),
 				TargetRef: &v1.ObjectReference{
 					Kind:      "Pod",
 					Namespace: d8Namespace,
-					Name:      os.Getenv("DECKHOUSE_POD"),
+					Name:      podName,
 				},
-				NodeName: pointer.String(os.Getenv("DECKHOUSE_NODE_NAME")),
+				NodeName: pointer.String(nodeName),
 				Zone:     nil,
 				Hints:    nil,
 			},

--- a/global-hooks/create_endpoints_test.go
+++ b/global-hooks/create_endpoints_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Global hooks :: create_endpoints ", func() {
 		BeforeEach(func() {
 			os.Setenv("ADDON_OPERATOR_LISTEN_ADDRESS", "192.168.1.1")
 			os.Setenv("DECKHOUSE_NODE_NAME", "test-node")
+			os.Setenv("HOSTNAME", "test-master-1")
 			os.Setenv("DECKHOUSE_POD", "deckhouse-test-1")
 			f.KubeStateSet("")
 			generateEndpoints()
@@ -47,6 +48,7 @@ var _ = Describe("Global hooks :: create_endpoints ", func() {
 			ep := f.KubernetesResource("Endpoints", "d8-system", "deckhouse")
 			Expect(ep.Field("subsets.0.addresses.0.ip").String()).To(Equal("192.168.1.1"))
 			Expect(ep.Field("subsets.0.addresses.0.nodeName").String()).To(Equal("test-node"))
+			Expect(ep.Field("subsets.0.addresses.0.hostname").String()).To(Equal("test-master-1"))
 			Expect(ep.Field("subsets.0.addresses.0.targetRef.name").String()).To(Equal("deckhouse-test-1"))
 			Expect(len(ep.Field("subsets.0.ports").Array())).To(Equal(3))
 		})
@@ -56,6 +58,7 @@ var _ = Describe("Global hooks :: create_endpoints ", func() {
 
 			Expect(eps.Field("endpoints.0.addresses.0").String()).To(Equal("192.168.1.1"))
 			Expect(eps.Field("endpoints.0.nodeName").String()).To(Equal("test-node"))
+			Expect(eps.Field("endpoints.0.hostname").String()).To(Equal("test-master-1"))
 			Expect(eps.Field("endpoints.0.targetRef.name").String()).To(Equal("deckhouse-test-1"))
 			Expect(len(eps.Field("ports").Array())).To(Equal(3))
 		})

--- a/global-hooks/create_endpoints_test.go
+++ b/global-hooks/create_endpoints_test.go
@@ -35,7 +35,6 @@ var _ = Describe("Global hooks :: create_endpoints ", func() {
 		BeforeEach(func() {
 			os.Setenv("ADDON_OPERATOR_LISTEN_ADDRESS", "192.168.1.1")
 			os.Setenv("DECKHOUSE_NODE_NAME", "test-node")
-			os.Setenv("HOSTNAME", "test-master-1")
 			os.Setenv("DECKHOUSE_POD", "deckhouse-test-1")
 			f.KubeStateSet("")
 			generateEndpoints()
@@ -48,7 +47,6 @@ var _ = Describe("Global hooks :: create_endpoints ", func() {
 			ep := f.KubernetesResource("Endpoints", "d8-system", "deckhouse")
 			Expect(ep.Field("subsets.0.addresses.0.ip").String()).To(Equal("192.168.1.1"))
 			Expect(ep.Field("subsets.0.addresses.0.nodeName").String()).To(Equal("test-node"))
-			Expect(ep.Field("subsets.0.addresses.0.hostname").String()).To(Equal("test-master-1"))
 			Expect(ep.Field("subsets.0.addresses.0.targetRef.name").String()).To(Equal("deckhouse-test-1"))
 			Expect(len(ep.Field("subsets.0.ports").Array())).To(Equal(3))
 		})
@@ -58,7 +56,6 @@ var _ = Describe("Global hooks :: create_endpoints ", func() {
 
 			Expect(eps.Field("endpoints.0.addresses.0").String()).To(Equal("192.168.1.1"))
 			Expect(eps.Field("endpoints.0.nodeName").String()).To(Equal("test-node"))
-			Expect(eps.Field("endpoints.0.hostname").String()).To(Equal("test-master-1"))
 			Expect(eps.Field("endpoints.0.targetRef.name").String()).To(Equal("deckhouse-test-1"))
 			Expect(len(eps.Field("ports").Array())).To(Equal(3))
 		})


### PR DESCRIPTION
## Description
Remove hostname from endpoints

## Why do we need it, and what problem does it solve?
Hostname is not needed for single-instance installations but generates some problems and errors in the managed clusters, like EKS

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: fix
summary: Remove hostname from the deckhouse endpoints/endpointslices to avoid managed cluster problems.
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
