### PR TITLE
[candi] Use /opt/deckhouse/tmp instead of /tmp during bootstrap

### DIFF
--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -84,6 +84,8 @@ bb-rp-install() {
       continue
     fi
 
+    trap "rm -rf ${BB_RP_INSTALLED_PACKAGES_STORE}/${PACKAGE}" ERR
+
     local DIGESTS=""
     DIGESTS="$(bb-rp-get-digests "${DIGEST}")"
 
@@ -122,6 +124,7 @@ bb-rp-install() {
     rm -rf "${TMPDIR}"
 
     bb-event-fire "bb-package-installed" "${PACKAGE}"
+    trap - ERR
   done
 }
 

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -150,6 +150,7 @@ function main() {
   export CONFIGURATION_CHECKSUM="{{ .configurationChecksum | default "" }}"
   export FIRST_BASHIBLE_RUN="no"
   export NODE_GROUP="{{ .nodeGroup.name }}"
+  export TMPDIR="/opt/deckhouse/tmp"
 {{- if .registry }}
   export REGISTRY_ADDRESS="{{ .registry.address }}"
   export SCHEME="{{ .registry.scheme }}"

--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -163,6 +163,8 @@ bb-rp-install() {
 
   shopt -s failglob
 }
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 export PATH="/opt/deckhouse/bin:$PATH"
 export LANG=C
 {{- if .proxy }}

--- a/candi/bashible/bundles/debian/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/debian/bootstrap.sh.tpl
@@ -15,6 +15,8 @@
 */}}
 #!/bin/bash
 export LANG=C
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}
 export HTTP_PROXY={{ .proxy.httpProxy | quote }}

--- a/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
@@ -15,6 +15,8 @@
 */}}
 #!/bin/bash
 export LANG=C
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}
 export HTTP_PROXY={{ .proxy.httpProxy | quote }}

--- a/candi/bashible/common-steps/cluster-bootstrap/060_bootstrap_kubernetes_pki.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/060_bootstrap_kubernetes_pki.sh.tpl
@@ -17,7 +17,7 @@
 export MY_IP="$(</var/lib/bashible/discovered-node-ip)"
 
 function subst_config() {
-    tmpfile=$(mktemp /tmp/kubeadm-config.XXXXXX)
+    tmpfile=$(mktemp /opt/deckhouse/tmp/kubeadm-config.XXXXXX)
     envsubst < "$1" > "$tmpfile"
     mv "$tmpfile" "$1"
 }

--- a/dhctl/pkg/app/app.go
+++ b/dhctl/pkg/app/app.go
@@ -27,6 +27,14 @@ import (
 const (
 	AppName     = "dhctl"
 	VersionFile = "/deckhouse/version"
+
+	// NodeDeckhouseDirectoryPath deckhouse operating directory path.
+	NodeDeckhouseDirectoryPath = "/opt/deckhouse"
+
+	// DeckhouseNodeTmpPath deckhouse directory for temporary files.
+	DeckhouseNodeTmpPath = NodeDeckhouseDirectoryPath + "/tmp"
+	// DeckhouseNodeBinPath deckhouse directory for binary files.
+	DeckhouseNodeBinPath = NodeDeckhouseDirectoryPath + "/bin"
 )
 
 var TmpDirName = filepath.Join(os.TempDir(), "dhctl")

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -55,6 +55,19 @@ func BootstrapMaster(sshClient *ssh.Client, bundleName, nodeIP string, metaConfi
 			return fmt.Errorf("prepare bootstrap: %v", err)
 		}
 
+		err := log.Process("bootstrap", "Create /opt/deckhouse{bin,tmp}", func() error {
+			if err := sshClient.Command("mkdir", "-p", "/opt/deckhouse/bin").Sudo().Run(); err != nil {
+				return fmt.Errorf("ssh: mkdir -p /opt/deckhouse/bin: %w", err)
+			}
+			if err := sshClient.Command("mkdir", "-p", "-m", "1777", "/opt/deckhouse/tmp").Sudo().Run(); err != nil {
+				return fmt.Errorf("ssh: mkdir -p -m 1777 /opt/deckhouse/tmp: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("cannot create /opt/deckhouse/ directories: %w", err)
+		}
+
 		for _, bootstrapScript := range []string{"bootstrap.sh", "bootstrap-networks.sh"} {
 			scriptPath := filepath.Join(controller.TmpDir, "bootstrap", bootstrapScript)
 			err := log.Process("default", bootstrapScript, func() error {

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -55,17 +55,17 @@ func BootstrapMaster(sshClient *ssh.Client, bundleName, nodeIP string, metaConfi
 			return fmt.Errorf("prepare bootstrap: %v", err)
 		}
 
-		err := log.Process("bootstrap", "Create /opt/deckhouse{bin,tmp}", func() error {
-			if err := sshClient.Command("mkdir", "-p", "/opt/deckhouse/bin").Sudo().Run(); err != nil {
-				return fmt.Errorf("ssh: mkdir -p /opt/deckhouse/bin: %w", err)
+		err := log.Process("bootstrap", fmt.Sprintf("Prepare %s", app.NodeDeckhouseDirectoryPath), func() error {
+			if err := sshClient.Command("mkdir", "-p", app.DeckhouseNodeBinPath).Sudo().Run(); err != nil {
+				return fmt.Errorf("ssh: mkdir -p %s: %w", app.DeckhouseNodeBinPath, err)
 			}
-			if err := sshClient.Command("mkdir", "-p", "-m", "1777", "/opt/deckhouse/tmp").Sudo().Run(); err != nil {
-				return fmt.Errorf("ssh: mkdir -p -m 1777 /opt/deckhouse/tmp: %w", err)
+			if err := sshClient.Command("mkdir", "-p", "-m", "1777", app.DeckhouseNodeTmpPath).Sudo().Run(); err != nil {
+				return fmt.Errorf("ssh: mkdir -p -m 1777 %s: %w", app.DeckhouseNodeTmpPath, err)
 			}
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("cannot create /opt/deckhouse/ directories: %w", err)
+			return fmt.Errorf("cannot create %s directories: %w", app.NodeDeckhouseDirectoryPath, err)
 		}
 
 		for _, bootstrapScript := range []string{"bootstrap.sh", "bootstrap-networks.sh"} {

--- a/dhctl/pkg/system/ssh/frontend/kube-proxy.go
+++ b/dhctl/pkg/system/ssh/frontend/kube-proxy.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )
@@ -142,7 +143,7 @@ func (k *KubeProxy) tryToRestartFully(startID int) {
 }
 
 func (k *KubeProxy) proxyCMD(startID int) *Command {
-	command := fmt.Sprintf("PATH=$PATH:/opt/deckhouse/bin/; kubectl proxy --port=%s --kubeconfig /etc/kubernetes/admin.conf", k.port)
+	command := fmt.Sprintf("PATH=$PATH:%s/; kubectl proxy --port=%s --kubeconfig /etc/kubernetes/admin.conf", app.DeckhouseNodeBinPath, k.port)
 
 	log.DebugF("[%d] Proxy command for start: %s\n", startID, command)
 

--- a/dhctl/pkg/system/ssh/frontend/upload-script.go
+++ b/dhctl/pkg/system/ssh/frontend/upload-script.go
@@ -78,7 +78,7 @@ func (u *UploadScript) Execute() (stdout []byte, err error) {
 
 	remotePath := "."
 	if u.sudo {
-		remotePath = "/tmp/" + scriptName
+		remotePath = "/opt/deckhouse/tmp/" + scriptName
 	}
 	err = NewFile(u.Session).Upload(u.ScriptPath, remotePath)
 	if err != nil {
@@ -88,7 +88,7 @@ func (u *UploadScript) Execute() (stdout []byte, err error) {
 	var cmd *Command
 	var scriptFullPath string
 	if u.sudo {
-		scriptFullPath = u.pathWithEnv("/tmp/" + scriptName)
+		scriptFullPath = u.pathWithEnv("/opt/deckhouse/tmp/" + scriptName)
 		cmd = NewCommand(u.Session, scriptFullPath, u.Args...).Sudo()
 	} else {
 		scriptFullPath = u.pathWithEnv("./" + scriptName)
@@ -142,15 +142,15 @@ func (u *UploadScript) ExecuteBundle(parentDir, bundleDir string) (stdout []byte
 
 	tomb.RegisterOnShutdown("Delete bashible bundle folder", func() { _ = os.Remove(bundleLocalFilepath) })
 
-	// upload to /tmp
-	err = NewFile(u.Session).Upload(bundleLocalFilepath, "/tmp")
+	// upload to /opt/deckhouse/tmp
+	err = NewFile(u.Session).Upload(bundleLocalFilepath, "/opt/deckhouse/tmp")
 	if err != nil {
 		return nil, fmt.Errorf("upload: %v", err)
 	}
 
 	// sudo:
-	// tar xpof /tmp/bundle.tar -C /var/lib && /var/lib/bashible/bashible.sh args...
-	tarCmdline := fmt.Sprintf("tar xpof /tmp/%s -C /var/lib && /var/lib/%s/%s %s", bundleName, bundleDir, u.ScriptPath, strings.Join(u.Args, " "))
+	// tar xpof /opt/deckhouse/tmp/bundle.tar -C /var/lib && /var/lib/bashible/bashible.sh args...
+	tarCmdline := fmt.Sprintf("tar xpof /opt/deckhouse/tmp/%s -C /var/lib && /var/lib/%s/%s %s", bundleName, bundleDir, u.ScriptPath, strings.Join(u.Args, " "))
 	bundleCmd := NewCommand(u.Session, tarCmdline).Sudo()
 
 	// Buffers to implement output handler logic

--- a/dhctl/pkg/system/ssh/frontend/upload-script.go
+++ b/dhctl/pkg/system/ssh/frontend/upload-script.go
@@ -78,7 +78,7 @@ func (u *UploadScript) Execute() (stdout []byte, err error) {
 
 	remotePath := "."
 	if u.sudo {
-		remotePath = "/opt/deckhouse/tmp/" + scriptName
+		remotePath = filepath.Join(app.DeckhouseNodeTmpPath, scriptName)
 	}
 	err = NewFile(u.Session).Upload(u.ScriptPath, remotePath)
 	if err != nil {
@@ -88,7 +88,7 @@ func (u *UploadScript) Execute() (stdout []byte, err error) {
 	var cmd *Command
 	var scriptFullPath string
 	if u.sudo {
-		scriptFullPath = u.pathWithEnv("/opt/deckhouse/tmp/" + scriptName)
+		scriptFullPath = u.pathWithEnv(filepath.Join(app.DeckhouseNodeTmpPath, scriptName))
 		cmd = NewCommand(u.Session, scriptFullPath, u.Args...).Sudo()
 	} else {
 		scriptFullPath = u.pathWithEnv("./" + scriptName)
@@ -142,15 +142,15 @@ func (u *UploadScript) ExecuteBundle(parentDir, bundleDir string) (stdout []byte
 
 	tomb.RegisterOnShutdown("Delete bashible bundle folder", func() { _ = os.Remove(bundleLocalFilepath) })
 
-	// upload to /opt/deckhouse/tmp
-	err = NewFile(u.Session).Upload(bundleLocalFilepath, "/opt/deckhouse/tmp")
+	// upload to node's deckhouse tmp directory
+	err = NewFile(u.Session).Upload(bundleLocalFilepath, app.DeckhouseNodeTmpPath)
 	if err != nil {
 		return nil, fmt.Errorf("upload: %v", err)
 	}
 
 	// sudo:
-	// tar xpof /opt/deckhouse/tmp/bundle.tar -C /var/lib && /var/lib/bashible/bashible.sh args...
-	tarCmdline := fmt.Sprintf("tar xpof /opt/deckhouse/tmp/%s -C /var/lib && /var/lib/%s/%s %s", bundleName, bundleDir, u.ScriptPath, strings.Join(u.Args, " "))
+	// tar xpof ${app.DeckhouseNodeTmpPath}/bundle.tar -C /var/lib && /var/lib/bashible/bashible.sh args...
+	tarCmdline := fmt.Sprintf("tar xpof %s/%s -C /var/lib && /var/lib/%s/%s %s", app.DeckhouseNodeTmpPath, bundleName, bundleDir, u.ScriptPath, strings.Join(u.Args, " "))
 	bundleCmd := NewCommand(u.Session, tarCmdline).Sudo()
 
 	// Buffers to implement output handler logic

--- a/ee/candi/bashible/bundles/alteros/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/alteros/bootstrap.sh.tpl
@@ -3,6 +3,8 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
 #!/bin/bash
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 export LANG=C
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}

--- a/ee/candi/bashible/bundles/altlinux/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/altlinux/bootstrap.sh.tpl
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 export LANG=C
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}

--- a/ee/candi/bashible/bundles/astra/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/bootstrap.sh.tpl
@@ -2,6 +2,8 @@
 # Copyright 2022 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 #!/bin/bash
 export LANG=C
 {{- if .proxy }}

--- a/ee/candi/bashible/bundles/redos/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/bootstrap.sh.tpl
@@ -3,6 +3,8 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
 #!/bin/bash
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
 export LANG=C
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Temporary files created by bashible steps during bootstrap will now be put into `/opt/deckhouse/tmp` instead of `/tmp`. `dhctl` will create this directory during master node bootstrap.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This solves points 1,3,4 and 5 of [#5597](https://github.com/deckhouse/deckhouse/issues/5597#issuecomment-1695348015)

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Point $TMPDIR to `/opt/deckhouse/tmp` during bashible bootstrap.
impact_level: default
```

```changes
section: dhctl
type: chore
summary: Render bootstrap bundle into `/opt/deckhouse/tmp`.
impact_level: default
```

```changes
section: candi
type: fix
summary: Delete registrypackage files if it failed to install before retrying installation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
