### PR TITLE
Revert "[linstor] update controller version to 1.24.1, update drbd ve…

### DIFF
--- a/modules/007-registrypackages/images/drbd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/drbd/werf.inc.yaml
@@ -1,10 +1,11 @@
-{{- $version := "9.2.5" }}
+{{- $version := "9.2.4" }}
+{{- $image_version := $version | replace "." "-" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
     add: /
     to: /
     includePaths:
@@ -18,7 +19,7 @@ docker:
     version: all
     drbd: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ $.Images.BASE_ALPINE }}
 
 git:

--- a/modules/041-linstor/hack/update.sh
+++ b/modules/041-linstor/hack/update.sh
@@ -61,6 +61,6 @@ echo "Applying changes:"
 (set -x; sed -e "$sed_regex" -i $targets)
 if [ -n "$drbd_version" ]; then
   (set -x; sed -e "/^      drbdVersion:/,/default:/{/^\([[:space:]]*default: \).*/s//\1\"${drbd_version}\"/}" -i openapi/values.yaml)
-  (set -x; sed 's/$version[[:space:]]*:=[[:space:]]*"[0-9]\+\.[0-9]\+\.[0-9]\+"/$version := "'$drbd_version'"/' -i ../../modules/007-registrypackages/images/drbd/werf.inc.yaml)
-  (set -x; sed 's/drbd[0-9]\+/drbd'$drbd_version_undotted'/' -i ../../modules/041-linstor/templates/nodegroupconfiguration-drbd-install-*-like.yaml)
+  (set -x; sed 's/$version[[:space:]]+:=[[:space:]]+"[0-9]\+\.[0-9]\+\.[0-9]\+"/$version := "'$drbd_version'"/' -i modules/007-registrypackages/images/drbd/werf.inc.yaml)
+  (set -x; sed 's/drbd[0-9]\+/drbd'$drbd_version_undotted'/' -i modules/041-linstor/templates/nodegroupconfiguration-drbd-install-*-like.yaml)
 fi

--- a/modules/041-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/041-linstor/images/drbd-driver-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_UBUNTU
 
 FROM $BASE_UBUNTU as builder
 ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
-ARG DRBD_VERSION=9.2.5
+ARG DRBD_VERSION=9.2.4
 
 RUN apt-get update \
  && apt-get install -y make git \

--- a/modules/041-linstor/images/drbd-reactor/Dockerfile
+++ b/modules/041-linstor/images/drbd-reactor/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_UBUNTU
 FROM $BASE_UBUNTU as utils-builder
 
 ARG UTILS_GITREPO=https://github.com/LINBIT/drbd-utils
-ARG UTILS_VERSION=9.25.0
+ARG UTILS_VERSION=9.24.0
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \

--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -4,19 +4,13 @@ ARG BASE_GOLANG_19_BULLSEYE
 FROM $BASE_UBUNTU as linstor-builder
 
 ARG LINSTOR_GITREPO=https://github.com/LINBIT/linstor-server
-ARG LINSTOR_VERSION=1.24.1
+ARG LINSTOR_VERSION=1.23.0
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
- && apt-get -y install build-essential debhelper git wget zip default-jdk-headless python3-all \
+ && apt-get -y install build-essential debhelper git default-jdk-headless gradle python3-all \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-# We are using Gradle version 6.9.3 because building Linstor Controller with version 7+ completes unsuccesfully.
-RUN mkdir /opt/gradle && cd /opt/gradle \
- && wget -q https://services.gradle.org/distributions/gradle-6.9.3-bin.zip \
- && unzip gradle-6.9.3-bin.zip \
- && ln -s /opt/gradle/gradle-6.9.3/bin/gradle /usr/local/bin/gradle
 
 RUN git clone ${LINSTOR_GITREPO} /linstor-server
 WORKDIR /linstor-server
@@ -36,9 +30,9 @@ RUN dpkg-buildpackage -us -uc
 FROM $BASE_UBUNTU as client-builder
 
 ARG API_GITREPO=https://github.com/LINBIT/linstor-api-py
-ARG API_VERSION=1.19.0
+ARG API_VERSION=1.18.0
 ARG CLIENT_GITREPO=https://github.com/LINBIT/linstor-client
-ARG CLIENT_VERSION=1.19.0
+ARG CLIENT_VERSION=1.18.0
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
@@ -85,7 +79,7 @@ RUN git clone ${K8S_AWAIT_ELECTION_GITREPO} /usr/local/go/k8s-await-election/ \
 FROM $BASE_UBUNTU as utils-builder
 
 ARG UTILS_GITREPO=https://github.com/LINBIT/drbd-utils
-ARG UTILS_VERSION=9.25.0
+ARG UTILS_VERSION=9.24.0
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
@@ -127,7 +121,7 @@ RUN dpkg-buildpackage -us -uc
 
 FROM $BASE_UBUNTU
 ARG PIRAEUS_GITREPO=https://github.com/piraeusdatastore/piraeus
-ARG PIRAEUS_COMMIT_REF=01411fc6fe7f329fb91a64ba67d882c24dfcb3c6
+ARG PIRAEUS_COMMIT_REF=4fce0345892e4cefa906cbb09b8a9bb87ef956f3
 
 COPY --from=linstor-builder /linstor-common_*.deb /linstor-controller_*.deb /linstor-satellite_*.deb /packages/
 COPY --from=client-builder /python-linstor_*.deb /linstor-client_*.deb /packages/

--- a/modules/041-linstor/images/piraeus-ha-controller/Dockerfile
+++ b/modules/041-linstor/images/piraeus-ha-controller/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_GOLANG_19_BULLSEYE
 FROM $BASE_UBUNTU as utils-builder
 
 ARG UTILS_GITREPO=https://github.com/LINBIT/drbd-utils
-ARG UTILS_VERSION=9.25.0
+ARG UTILS_VERSION=9.24.0
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \

--- a/modules/041-linstor/images/piraeus-operator/Dockerfile
+++ b/modules/041-linstor/images/piraeus-operator/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_GOLANG_19_BULLSEYE
 
 FROM $BASE_GOLANG_19_BULLSEYE as builder
 ARG PIRAEUS_OPERATOR_GITREPO=https://github.com/piraeusdatastore/piraeus-operator
-ARG PIRAEUS_OPERATOR_VERSION=1.10.6
+ARG PIRAEUS_OPERATOR_VERSION=1.10.5
 
 # Copy patches
 COPY ./patches /patches

--- a/modules/041-linstor/images/piraeus-operator/patches/020-linux-kbuild.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/020-linux-kbuild.patch
@@ -1,27 +1,27 @@
 diff --git a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
-index 8fa5257..077d676 100644
+index 2c93547..f9f163a 100644
 --- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
 +++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
-@@ -1261,12 +1261,17 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
+@@ -1260,12 +1260,18 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
  		MountPath: kubeSpec.ModulesDir,
  	},
  	)
--
 +	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 +		Name:      kubeSpec.UsrLibDirName,
 +		MountPath: kubeSpec.UsrLibDirMountPath,
 +	},
 +	)
+ 
  	ds.Spec.Template.Spec.InitContainers = []corev1.Container{
  		{
  			Name:            "kernel-module-injector",
  			Image:           satelliteSet.Spec.KernelModuleInjectionImage,
  			ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
 +			Command:         []string{"/bin/bash", "-c", "find /host/usr/lib -maxdepth 1 -mindepth 1 -exec ln -vs {} /usr/lib \\; 2>/dev/null; exec /entry.sh"},
- 			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
- 				SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
- 			Env:          env,
-@@ -1296,6 +1301,16 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
+ 			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
+ 			Env:             env,
+ 			VolumeMounts:    volumeMounts,
+@@ -1294,6 +1300,15 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
  				},
  			},
  		})
@@ -34,12 +34,11 @@ index 8fa5257..077d676 100644
 +				},
 +			},
 +		})
-+
  	}
  
  	return ds
 diff --git a/pkg/k8s/spec/const.go b/pkg/k8s/spec/const.go
-index 1fb8051..9ad09fb 100644
+index fe89064..a9d186e 100644
 --- a/pkg/k8s/spec/const.go
 +++ b/pkg/k8s/spec/const.go
 @@ -40,6 +40,9 @@ const (

--- a/modules/041-linstor/images/piraeus-operator/patches/030-add-selinux-support.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/030-add-selinux-support.patch
@@ -1,0 +1,41 @@
+diff --git a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+index f9f163a..44b013b 100644
+--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
++++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+@@ -960,7 +960,8 @@ func newSatelliteDaemonSet(satelliteSet *piraeusv1.LinstorSatelliteSet, satellit
+ 							}, // Run linstor-satellite.
+ 							Env:             satelliteSet.Spec.AdditionalEnv,
+ 							ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
+-							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
++							SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
++								SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
+ 							Ports: []corev1.ContainerPort{
+ 								{
+ 									HostPort:      satelliteSet.Spec.SslConfig.Port(),
+@@ -1272,10 +1273,11 @@ func daemonSetWithDRBDKernelModuleInjection(ds *apps.DaemonSet, satelliteSet *pi
+ 			Image:           satelliteSet.Spec.KernelModuleInjectionImage,
+ 			ImagePullPolicy: satelliteSet.Spec.ImagePullPolicy,
+ 			Command:         []string{"/bin/bash", "-c", "find /host/usr/lib -maxdepth 1 -mindepth 1 -exec ln -vs {} /usr/lib \\; 2>/dev/null; exec /entry.sh"},
+-			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged},
+-			Env:             env,
+-			VolumeMounts:    volumeMounts,
+-			Resources:       satelliteSet.Spec.KernelModuleInjectionResources,
++			SecurityContext: &corev1.SecurityContext{Privileged: &kubeSpec.Privileged,
++				SELinuxOptions: &corev1.SELinuxOptions{Level: kubeSpec.Level, Type: kubeSpec.Type}},
++			Env:          env,
++			VolumeMounts: volumeMounts,
++			Resources:    satelliteSet.Spec.KernelModuleInjectionResources,
+ 		},
+ 	}
+ 
+diff --git a/pkg/k8s/spec/const.go b/pkg/k8s/spec/const.go
+index df4ad27..9ad09fb 100644
+--- a/pkg/k8s/spec/const.go
++++ b/pkg/k8s/spec/const.go
+@@ -110,4 +110,6 @@ var (
+ // are addressible.
+ var (
+ 	Privileged = true
++	Level      = "s0"
++	Type       = "spc_t"
+ )

--- a/modules/041-linstor/images/piraeus-operator/patches/050-bump-k8s-api-versions-and-client.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/050-bump-k8s-api-versions-and-client.patch
@@ -1,0 +1,140 @@
+diff --git a/go.mod b/go.mod
+index 098ea42..0cddd19 100644
+--- a/go.mod
++++ b/go.mod
+@@ -9,9 +9,9 @@ require (
+ 	github.com/linbit/k8s-await-election v0.3.1
+ 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
+ 	gopkg.in/ini.v1 v1.67.0
+-	k8s.io/api v0.26.1
+-	k8s.io/apimachinery v0.26.1
+-	k8s.io/client-go v0.26.1
++	k8s.io/api v0.26.7
++	k8s.io/apimachinery v0.26.7
++	k8s.io/client-go v0.26.7
+ 	sigs.k8s.io/controller-runtime v0.14.4
+ 	sigs.k8s.io/yaml v1.3.0
+ )
+@@ -54,11 +54,11 @@ require (
+ 	go.uber.org/atomic v1.10.0 // indirect
+ 	go.uber.org/multierr v1.9.0 // indirect
+ 	go.uber.org/zap v1.24.0 // indirect
+-	golang.org/x/net v0.7.0 // indirect
++	golang.org/x/net v0.8.0 // indirect
+ 	golang.org/x/oauth2 v0.5.0 // indirect
+-	golang.org/x/sys v0.5.0 // indirect
+-	golang.org/x/term v0.5.0 // indirect
+-	golang.org/x/text v0.7.0 // indirect
++	golang.org/x/sys v0.6.0 // indirect
++	golang.org/x/term v0.6.0 // indirect
++	golang.org/x/text v0.8.0 // indirect
+ 	golang.org/x/time v0.3.0 // indirect
+ 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+ 	google.golang.org/appengine v1.6.7 // indirect
+diff --git a/go.sum b/go.sum
+index 50baebe..d5ae72b 100644
+--- a/go.sum
++++ b/go.sum
+@@ -38,6 +38,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
+ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
++github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
++github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+@@ -90,6 +92,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
+ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
+ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
++github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+ github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+@@ -185,12 +188,14 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
+ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
++github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
++github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+@@ -221,6 +226,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
+ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
++github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+@@ -363,6 +369,8 @@ golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qx
+ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+ golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
+ golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
++golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
++golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -411,11 +419,15 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
++golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
+ golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
++golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
++golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -425,6 +437,8 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
++golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
++golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+@@ -536,6 +550,7 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
+ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+ google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
++gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+@@ -572,14 +587,20 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
+ k8s.io/api v0.22.0/go.mod h1:0AoXXqst47OI/L0oGKq9DG61dvGRPXs7X4/B7KyjBCU=
+ k8s.io/api v0.26.1 h1:f+SWYiPd/GsiWwVRz+NbFyCgvv75Pk9NK6dlkZgpCRQ=
+ k8s.io/api v0.26.1/go.mod h1:xd/GBNgR0f707+ATNyPmQ1oyKSgndzXij81FzWGsejg=
++k8s.io/api v0.26.7 h1:Lf4iEBEJb5OFNmawtBfSZV/UNi9riSJ0t1qdhyZqI40=
++k8s.io/api v0.26.7/go.mod h1:Vk9bMadzA49UHPmHB//lX7VRCQSXGoVwfLd3Sc1SSXI=
+ k8s.io/apiextensions-apiserver v0.26.1 h1:cB8h1SRk6e/+i3NOrQgSFij1B2S0Y0wDoNl66bn8RMI=
+ k8s.io/apiextensions-apiserver v0.26.1/go.mod h1:AptjOSXDGuE0JICx/Em15PaoO7buLwTs0dGleIHixSM=
+ k8s.io/apimachinery v0.22.0/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
+ k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
+ k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
++k8s.io/apimachinery v0.26.7 h1:590jSBwaSHCAFCqltaEogY/zybFlhGsnLteLpuF2wig=
++k8s.io/apimachinery v0.26.7/go.mod h1:qYzLkrQ9lhrZRh0jNKo2cfvf/R1/kQONnSiyB7NUJU0=
+ k8s.io/client-go v0.22.0/go.mod h1:GUjIuXR5PiEv/RVK5OODUsm6eZk7wtSWZSaSJbpFdGg=
+ k8s.io/client-go v0.26.1 h1:87CXzYJnAMGaa/IDDfRdhTzxk/wzGZ+/HUQpqgVSZXU=
+ k8s.io/client-go v0.26.1/go.mod h1:IWNSglg+rQ3OcvDkhY6+QLeasV4OYHDjdqeWkDQZwGE=
++k8s.io/client-go v0.26.7 h1:hyU9aKHlwVOykgyxzGYkrDSLCc4+mimZVyUJjPyUn1E=
++k8s.io/client-go v0.26.7/go.mod h1:okYjy0jtq6sdeztALDvCh24tg4opOQS1XNvsJlERDAo=
+ k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
+ k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/modules/041-linstor/images/piraeus-operator/patches/README.md
+++ b/modules/041-linstor/images/piraeus-operator/patches/README.md
@@ -13,8 +13,22 @@ This patch passes through `/usr/lib` directory into kernel-module-injector and s
 
 - Upstream: https://github.com/piraeusdatastore/piraeus-operator/pull/475
 
+### Add SELinux params for enforced mode
+
+This is proposition from upstream, made for set satellite usable in enforced SELinux mode. 
+
+- Upstream: https://github.com/piraeusdatastore/piraeus-operator/pull/477
+
+
 ### Add metrics port
 
 Add the securedMetricsPort parameter to the linstorcontrollers.piraeus.linbit.com crd. If this parameter is set, then port for scraping metrics will be added to linstor-controller service and K8S_AWAIT_ELECTION_SERVICE_PORTS_JSON env var of the linstor-controller deployment. This is required when using service monitor to monitor the linstor controller in HA mode.
 
 - Upstream: https://github.com/piraeusdatastore/piraeus-operator/pull/495
+
+
+### Bump k8s api versions and client for piraeus operator
+
+Bump k8s api versions and client for piraeus operator.
+
+- Upstream: https://github.com/piraeusdatastore/piraeus-operator/pull/504

--- a/modules/041-linstor/images/spaas/Dockerfile
+++ b/modules/041-linstor/images/spaas/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_GOLANG_19_BULLSEYE as builder
 ARG SPAAS_GITREPO=https://github.com/LINBIT/saas
 ARG SPAAS_COMMIT_REF=7bef2e7976a455550bce2533487c635f20390ccf
 ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
-ARG DRBD_VERSION=9.2.5
+ARG DRBD_VERSION=9.2.4
 
 RUN git clone ${SPAAS_GITREPO} /usr/local/go/spaas \
  && cd /usr/local/go/spaas \

--- a/modules/041-linstor/openapi/values.yaml
+++ b/modules/041-linstor/openapi/values.yaml
@@ -14,7 +14,7 @@ properties:
     properties:
       drbdVersion:
         type: string
-        default: "9.2.5"
+        default: "9.2.4"
       masterPassphrase:
         type: string
       httpsClientCert:

--- a/modules/041-linstor/templates/linstor-controller/rbac-for-us.yaml
+++ b/modules/041-linstor/templates/linstor-controller/rbac-for-us.yaml
@@ -80,7 +80,6 @@ rules:
       - list
       - create
       - delete
-      - deletecollection
       - update
       - patch
 ---

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -24,17 +24,17 @@ spec:
 
     kubeconfig="/etc/kubernetes/kubelet.conf"
 
-    kernel_version_in_use="$(uname -r)"
+    version_in_use="$(uname -r)"
 
     {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
-    is_linstor_data_node=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname -s)" -o json | jq -c '.metadata.labels | contains({{ .Values.linstor.dataNodes.nodeSelector | toJson }})')
+    need_drbd=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname -s)" -o json | jq -c '.metadata.labels | contains({{ .Values.linstor.dataNodes.nodeSelector | toJson }})')
     {{- else }}
-    is_linstor_data_node="true"
+    need_drbd="true"
     {{- end }}
 
-    bb-log-info "we need drbd on node: "$is_linstor_data_node
+    bb-log-info "we need drbd on node: "$need_drbd
 
-    if [ $is_linstor_data_node == "false" ]; then
+    if [ $need_drbd == "false" ]; then
       if [ -e "/proc/drbd" ]; then
         sed -i 's/^drbd$//' /etc/modules
         rmmod drbd_transport_rdma || true
@@ -49,7 +49,7 @@ spec:
     # So further we check, if we need new kernel version. It is altlinux feature.
     apt-get -y install kernel-headers-modules-std-def
 
-    if [ ! -e "/lib/modules/$kernel_version_in_use/build" ]; then
+    if [ ! -e "/lib/modules/$version_in_use/build" ]; then
       update-kernel -y
       bb-flag-set reboot
       exit 0
@@ -80,7 +80,7 @@ spec:
       fi
     fi
 
-    bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
+    bb-rp-install "drbd924:{{ .Values.global.modulesImages.digests.registrypackages.drbd924 }}"
     apt-get -y install make gcc bind-utils patch
 
     attempt=0
@@ -116,11 +116,10 @@ spec:
     bb-log-info "SPAAS service is accessible, starting DRBD building"
 
     cd /opt/deckhouse/drbd
-    make clean || true
     make
     make install
     cd drbd
-    cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
+    cp *.ko /lib/modules/$version_in_use/kernel/drivers/
     echo 'drbd' | tee -a /etc/modules
     depmod
     modprobe drbd

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -24,17 +24,17 @@ spec:
 
     kubeconfig="/etc/kubernetes/kubelet.conf"
 
-    kernel_version_in_use="$(uname -r)"
+    version_in_use="$(uname -r)"
 
     {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
-    is_linstor_data_node=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname -s)" -o json | jq -c '.metadata.labels | contains({{ .Values.linstor.dataNodes.nodeSelector | toJson }})')
+    need_drbd=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname -s)" -o json | jq -c '.metadata.labels | contains({{ .Values.linstor.dataNodes.nodeSelector | toJson }})')
     {{- else }}
-    is_linstor_data_node="true"
+    need_drbd="true"
     {{- end }}
 
-    bb-log-info "we need drbd on node: "$is_linstor_data_node
+    bb-log-info "we need drbd on node: "$need_drbd
 
-    if [ $is_linstor_data_node == "false" ]; then
+    if [ $need_drbd == "false" ]; then
       if [ -e "/proc/drbd" ]; then
         sed -i 's/^drbd$//' /etc/modules
         rmmod drbd_transport_rdma || true
@@ -51,11 +51,11 @@ spec:
     #   kernel-modules-core   --> kernel-devel
     #   kernel-lt             --> kernel-lt-devel
     #   kernel-lt-core        --> kernel-lt-devel
-    package_name="$(rpm -qf --qf "%{NAME}" "/lib/modules/${kernel_version_in_use}" | sed 's/\(-modules-core\)\?$//g; s/\(-core\)\?$/-devel/g')"
-    bb-yum-install "${package_name}-${kernel_version_in_use}"
+    package_name="$(rpm -qf --qf "%{NAME}" "/lib/modules/${version_in_use}" | sed 's/\(-modules-core\)\?$//g; s/\(-core\)\?$/-devel/g')"
+    bb-yum-install "${package_name}-${version_in_use}"
 
     # Remove unused kernel-headers
-    packages_to_remove="$(rpm -q "$package_name" | grep -Ev "^${package_name}-${kernel_version_in_use}$" || true)"
+    packages_to_remove="$(rpm -q "$package_name" | grep -Ev "^${package_name}-${version_in_use}$" || true)"
     if [ -n "$packages_to_remove" ]; then
       bb-yum-remove $packages_to_remove
     fi
@@ -85,7 +85,7 @@ spec:
       fi
     fi
 
-    bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
+    bb-rp-install "drbd924:{{ .Values.global.modulesImages.digests.registrypackages.drbd924 }}"
     bb-yum-install make gcc bind-utils patch
 
     attempt=0
@@ -121,11 +121,10 @@ spec:
     bb-log-info "SPAAS service is accessible, starting DRBD building"
 
     cd /opt/deckhouse/drbd
-    make clean || true
     make
     make install
     cd drbd
-    cp *.ko /lib/modules/${kernel_version_in_use}/kernel/drivers/
+    cp *.ko /lib/modules/$version_in_use/kernel/drivers/
     echo 'drbd' | tee -a /etc/modules
     depmod
     modprobe drbd

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -24,17 +24,17 @@ spec:
 
     kubeconfig="/etc/kubernetes/kubelet.conf"
 
-    kernel_version_in_use="$(uname -r)"
+    version_in_use="$(uname -r)"
 
     {{- if dig "dataNodes" "nodeSelector" false .Values.linstor }}
-    is_linstor_data_node=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname -s)" -o json | jq -c '.metadata.labels | contains({{ .Values.linstor.dataNodes.nodeSelector | toJson }})')
+    need_drbd=$(bb-kubectl --kubeconfig $kubeconfig  get node "$(hostname -s)" -o json | jq -c '.metadata.labels | contains({{ .Values.linstor.dataNodes.nodeSelector | toJson }})')
     {{- else }}
-    is_linstor_data_node="true"
+    need_drbd="true"
     {{- end }}
 
-    bb-log-info "we need drbd on node: "$is_linstor_data_node
+    bb-log-info "we need drbd on node: "$need_drbd
 
-    if [ $is_linstor_data_node == "false" ]; then
+    if [ $need_drbd == "false" ]; then
       if [ -e "/proc/drbd" ]; then
         sed -i 's/^drbd$//' /etc/modules
         rmmod drbd_transport_rdma || true
@@ -46,12 +46,12 @@ spec:
 
     # DRBD requires the kernel sources to be installed.
     # Install actual kernel headers
-    bb-apt-install "linux-headers-${kernel_version_in_use}"
+    bb-apt-install "linux-headers-${version_in_use}"
 
     # Remove unused kernel-headers
-    kernel_version_pattern="$(echo "$kernel_version_in_use" | sed -r 's/([0-9\.-]+)-([^0-9]+)$/^linux-headers-(\1|\1-\2)$/')"
+    version_in_use_pattern="$(echo "$version_in_use" | sed -r 's/([0-9\.-]+)-([^0-9]+)$/^linux-headers-(\1|\1-\2)$/')"
     packages_to_remove="$(
-      dpkg-query -S '/lib/modules/*/build' | awk -F: '{print $1}' | grep -Ev "$kernel_version_pattern" || true
+      dpkg-query -S '/lib/modules/*/build' | awk -F: '{print $1}' | grep -Ev "$version_in_use_pattern" || true
     )"
     if [ -n "$packages_to_remove" ]; then
       bb-apt-remove $packages_to_remove
@@ -82,7 +82,7 @@ spec:
       fi
     fi
 
-    bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
+    bb-rp-install "drbd924:{{ .Values.global.modulesImages.digests.registrypackages.drbd924 }}"
     bb-apt-install make gcc bind9-host patch
 
     attempt=0
@@ -118,11 +118,10 @@ spec:
     bb-log-info "SPAAS service is accessible, starting DRBD building"
 
     cd /opt/deckhouse/drbd
-    make clean || true
     make
     make install
     cd drbd
-    cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
+    cp *.ko /lib/modules/$version_in_use/kernel/drivers/
     echo 'drbd' | tee -a /etc/modules
     depmod
     modprobe drbd

--- a/testing/cloud_layouts/Static/astra-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/astra-instance-bootstrap.sh
@@ -22,7 +22,7 @@ EOF
 chmod +x /usr/local/bin/is-instance-bootstrapped
 
 
-# This is temporarily commented out because DRBD doesn't currently compile on Astra with a hardened kernel.
+# This is temporarily commented out because DRBD version 9.2.4 doesn't currently compile on Astra with a hardened kernel.
 
 # if ! uname -a | grep -q hardened; then
 #   apt update && \

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -343,7 +343,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"crictl126":                 "imageHash-registrypackages-crictl126",
 		"crictl127":                 "imageHash-registrypackages-crictl127",
 		"d8Curl801":                 "imageHash-registrypackages-d8Curl801",
-		"drbd":                      "imageHash-registrypackages-drbd",
+		"drbd924":                   "imageHash-registrypackages-drbd924",
 		"inotifyToolsCentos73149":   "imageHash-registrypackages-inotifyToolsCentos73149",
 		"inotifyToolsCentos831419":  "imageHash-registrypackages-inotifyToolsCentos831419",
 		"inotifyToolsCentos9322101": "imageHash-registrypackages-inotifyToolsCentos9322101",


### PR DESCRIPTION
This reverts commit dcca00c1ef377acbe15a2bed9b5ee61223e46c09 (https://github.com/deckhouse/deckhouse/pull/5469).

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Our manual tests reveal some issues with the new version of Linstor and/or DRBD.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Revert the commit that updated the versions of Linstor and DRBD (revert https://github.com/deckhouse/deckhouse/pull/5469 ).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
