### PR TITLE
[delivery] Fix customCertificate

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/ee/modules/450-network-gateway/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/500-operator-trivy/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/502-delivery/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/modules/502-delivery/hooks/https"
 	_ "github.com/deckhouse/deckhouse/ee/modules/502-delivery/hooks/werf_sources"
 	_ "github.com/deckhouse/deckhouse/ee/modules/600-flant-integration/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/600-flant-integration/hooks/madison"

--- a/ee/modules/502-delivery/hooks/https/copy_custom_certificate.go
+++ b/ee/modules/502-delivery/hooks/https/copy_custom_certificate.go
@@ -1,17 +1,6 @@
 /*
-Copyright 2021 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/modules/502-delivery/hooks/https/copy_custom_certificate.go
+++ b/ee/modules/502-delivery/hooks/https/copy_custom_certificate.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/hooks/copy_custom_certificate"
+)
+
+var _ = copy_custom_certificate.RegisterHook("delivery")

--- a/ee/modules/502-delivery/openapi/values.yaml
+++ b/ee/modules/502-delivery/openapi/values.yaml
@@ -7,6 +7,15 @@ properties:
     type: object
     default: {}
     properties:
+      customCertificateData:
+        type: object
+        properties:
+          tls.crt:
+            type: string
+          tls.key:
+            type: string
+          ca.crt:
+            type: string
       argocdImageUpdater:
         type: object
         default:

--- a/ee/modules/502-delivery/template_tests/copy_custom_certificate_test.go
+++ b/ee/modules/502-delivery/template_tests/copy_custom_certificate_test.go
@@ -1,17 +1,6 @@
 /*
-Copyright 2021 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package template_tests

--- a/ee/modules/502-delivery/template_tests/copy_custom_certificate_test.go
+++ b/ee/modules/502-delivery/template_tests/copy_custom_certificate_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: delivery :: helm template :: custom-certificate", func() {
+	const globalValues = `
+enabledModules: ["vertical-pod-autoscaler-crd", "delivery"]
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%s.example.com"
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+`
+	const customCertificatePresent = `
+https:
+  mode: CustomCertificate
+internal:
+  customCertificateData:
+    tls.crt: CRTCRTCRT
+    tls.key: KEYKEYKEY
+  auth: {}
+# defaults from config-values.yaml
+auth: {}
+accessLevel: User
+`
+	f := SetupHelmConfig(``)
+
+	Context("Default", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("delivery", customCertificatePresent)
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for default cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			createdSecret := f.KubernetesResource("Secret", "d8-delivery", "ingress-tls-argocd-customcertificate")
+			Expect(createdSecret.Exists()).To(BeTrue())
+			Expect(createdSecret.Field("data").String()).To(Equal(`{"tls.crt":"CRTCRTCRT","tls.key":"KEYKEYKEY"}`))
+		})
+
+	})
+
+})

--- a/ee/modules/502-delivery/templates/argocd/argocd-cm-configmap.yaml
+++ b/ee/modules/502-delivery/templates/argocd/argocd-cm-configmap.yaml
@@ -13,4 +13,5 @@ data:
     issuer: https://{{ include "helm_lib_module_public_domain" (list . "dex") }}/
     clientID: dex-client-argocd@d8-{{ .Chart.Name }}
     clientSecret: $dex-client-argocd:clientSecret
+  oidc.tls.insecure.skip.verify: "true"
   {{- end }}


### PR DESCRIPTION
## Description
Add CustomCertificate hook for delivery module.

## Why do we need it, and what problem does it solve?
Fix https://github.com/deckhouse/deckhouse/issues/5238. Delivery module fails when using CustomCertificate https mode.

## Why do we need it in the patch release (if we do)?
This affects our customers.

## What is the expected result?
Delivery module work with CustomCertificate https mode.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: delivery
type: fix
summary: Fix delivery module work in customCertificate https mode.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
