### PR TITLE
[cloud-provider-openstack] fix ignoreVolumeMicroversion parameter appliance for k8s>1.24

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -233,34 +233,9 @@ subnet-id = "my-subnet-id"
 floating-network-id = "my-floating-network-id"
 enable-ingress-hostname = true
 [BlockStorage]
-rescan-on-resize = true`
-		if k8sVer == "1.23" {
-			ccmExpectedConfig = `
-[Global]
-auth-url = "http://my.cloud.lalla/123/"
-domain-name = "mydomain"
-tenant-name = "mytenantname"
-username = "myuser"
-password = "myPaSs"
-region = "myreg"
-ca-file = /etc/config/ca.crt
-[Networking]
-public-network-name = "myextnetname"
-public-network-name = "myextnetname2"
-internal-network-name = "myintnetname"
-internal-network-name = "myintnetname2"
-ipv6-support-disabled = true
-[LoadBalancer]
-create-monitor = "true"
-monitor-delay = "2s"
-monitor-timeout = "1s"
-subnet-id = "my-subnet-id"
-floating-network-id = "my-floating-network-id"
-enable-ingress-hostname = true
-[BlockStorage]
 ignore-volume-microversion = false
 rescan-on-resize = true`
-		}
+
 		ccmConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(string(ccmConfig)).To(Equal(ccmExpectedConfig))
@@ -379,49 +354,11 @@ storageclass.kubernetes.io/is-default-class: "true"
 			ccmSecret := f.KubernetesResource("Secret", "d8-cloud-provider-openstack", "cloud-controller-manager")
 			ccmConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())
 			Expect(err).ShouldNot(HaveOccurred())
-			if s == "" {
-				Expect(ccmConfig).ToNot(ContainSubstring("ignore-volume-microversion = "))
-				return
-			}
 			sExp := fmt.Sprintf("ignore-volume-microversion = %s", s)
 			Expect(ccmConfig).To(ContainSubstring(sExp))
 		}
 
-		Context("with 1.23 or 1.24 kube version", func() {
-			Context("ignoreVolumeMicroversion disabled", func() {
-				BeforeEach(func() {
-					f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.24", "1.24"))
-					f.ValuesSet("global.modulesImages", GetModulesImages())
-					f.ValuesSetFromYaml("cloudProviderOpenstack", moduleValues)
-					f.ValuesSetFromYaml("cloudProviderOpenstack.ignoreVolumeMicroversion", "false")
-					f.HelmRender()
-				})
-
-				It("Should render 'ignore-volume-microversion = false' in ccm config", func() {
-					Expect(f.RenderError).ShouldNot(HaveOccurred())
-
-					assertConfigSecretIgnoreMicroVer(f, "false")
-				})
-			})
-
-			Context("ignoreVolumeMicroversion enabled", func() {
-				BeforeEach(func() {
-					f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.23", "1.23"))
-					f.ValuesSet("global.modulesImages", GetModulesImages())
-					f.ValuesSetFromYaml("cloudProviderOpenstack", moduleValues)
-					f.ValuesSetFromYaml("cloudProviderOpenstack.ignoreVolumeMicroversion", "true")
-					f.HelmRender()
-				})
-
-				It("Should render 'ignore-volume-microversion = true' in ccm config", func() {
-					Expect(f.RenderError).ShouldNot(HaveOccurred())
-
-					assertConfigSecretIgnoreMicroVer(f, "true")
-				})
-			})
-		})
-
-		Context("another kube version", func() {
+		Context("all kube versions", func() {
 			Context("ignoreVolumeMicroversion disabled", func() {
 				BeforeEach(func() {
 					f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.25", "1.25"))
@@ -434,7 +371,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 				It("Should not render 'ignore-volume-microversion' in ccm config", func() {
 					Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-					assertConfigSecretIgnoreMicroVer(f, "")
+					assertConfigSecretIgnoreMicroVer(f, "false")
 				})
 			})
 
@@ -450,7 +387,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 				It("Should render 'ignore-volume-microversion = true' in ccm config", func() {
 					Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-					assertConfigSecretIgnoreMicroVer(f, "")
+					assertConfigSecretIgnoreMicroVer(f, "true")
 				})
 			})
 		})

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -41,9 +41,7 @@ floating-network-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.fl
   {{- end }}
 enable-ingress-hostname = true
 [BlockStorage]
-  {{- if or (semverCompare "1.23" .Values.global.discovery.kubernetesVersion) (semverCompare "1.24" .Values.global.discovery.kubernetesVersion) }}
 ignore-volume-microversion = {{ .Values.cloudProviderOpenstack.ignoreVolumeMicroversion }}
-  {{- end }}
 rescan-on-resize = true
 {{- end }}
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR fix error in openstack cloud-controller-manager config.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When the k8s cluster version > 1.24, the `ignore-volume-microversion` option does not appear in the cloud-controller-manager configuration regardless of the option value in the module configuration. This leads to problems with PV creating in some openstack clouds.

```
root@dev-master-0:~# kubectl -n d8-cloud-provider-openstack get secret cloud-controller-manager -o json | jq -r '.data."cloud-config"' | base64 -d

[Global]
...
[BlockStorage]
rescan-on-resize = true
```
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
```
root@dev-master-0:~# kubectl -n d8-cloud-provider-openstack get secret cloud-controller-manager -o json | jq -r '.data."cloud-config"' | base64 -d

[Global]
...
[BlockStorage]
ignore-volume-microversion = false
rescan-on-resize = true

```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Fix `ignoreVolumeMicroversion` parameter appliance for Kubernetes version > 1.24.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
