### PR TITLE
[external-module-manager] Fix panic if there are no resources for migration

### DIFF
--- a/global-hooks/migrate/migrate_modules.go
+++ b/global-hooks/migrate/migrate_modules.go
@@ -101,21 +101,25 @@ func modulesCRMigrate(input *go_hook.HookInput, dc dependency.Container) error {
 		return nil
 	}
 
-	for _, ms := range moduleSources.Items {
-		sanitizeUnstructured("ModuleSource", &ms)
+	if moduleSources != nil {
+		for _, ms := range moduleSources.Items {
+			sanitizeUnstructured("ModuleSource", &ms)
 
-		_, err := kubeCl.Dynamic().Resource(msGVR).Create(context.TODO(), &ms, metav1.CreateOptions{})
-		if err != nil && !errors.IsAlreadyExists(err) {
-			return err
+			_, err := kubeCl.Dynamic().Resource(msGVR).Create(context.TODO(), &ms, metav1.CreateOptions{})
+			if err != nil && !errors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 	}
 
-	for _, mr := range moduleReleases.Items {
-		sanitizeUnstructured("ModuleRelease", &mr)
+	if moduleReleases != nil {
+		for _, mr := range moduleReleases.Items {
+			sanitizeUnstructured("ModuleRelease", &mr)
 
-		_, err := kubeCl.Dynamic().Resource(mrGVR).Create(context.TODO(), &mr, metav1.CreateOptions{})
-		if err != nil && !errors.IsAlreadyExists(err) {
-			return err
+			_, err := kubeCl.Dynamic().Resource(mrGVR).Create(context.TODO(), &mr, metav1.CreateOptions{})
+			if err != nil && !errors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Add the check to prevent nil pointer dereference 

## Why do we need it, and what problem does it solve?
```
{"binding":"onStartup","event.type":"OperatorStartup","hook":"migrate/migrate_modules.go","hook.type":"global","level":"info","msg":"ExternalModuleSource resource is not in the cluster","output":"gohook","queue":"main","task.id":"12c91450-3aa8-4a61-bc8b-5c7f92091004","time":"2023-09-10T17:17:38Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x354932a]

goroutine 8 [running]:
github.com/deckhouse/deckhouse/global-hooks/migrate.modulesCRMigrate(0xc000e323c0, {0x4623bf0?, 0xc000206660?})
	/deckhouse/global-hooks/migrate/migrate_modules.go:104 +0x66a
github.com/deckhouse/deckhouse/global-hooks/migrate.init.func3(0x3be9601?)
	/deckhouse/go_lib/dependency/dependency.go:200 +0x2b
github.com/flant/addon-operator/sdk.(*commonGoHook).Run(0xc000162c40?, 0xc0014c01f0?)
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Add the check to prevent nil pointer dereference to the modules migration hook.
impact_level: low

```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
