### PR TITLE
[chrony] Sync time on Nodes with control plane.

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
@@ -62,7 +62,7 @@ nodeSelector:
 {{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "without-storage-problems") }} */ -}}
 {{- define "helm_lib_tolerations" }}
   {{- $context := index . 0 }}  {{- /* Template context with .Values, .Chart, etc */ -}}
-  {{- $strategy := index . 1 | include "helm_lib_internal_check_tolerations_strategy" }} {{- /* base strategy, one of "frontend" "monitoring" "system" any-node" "wildcard" "only-masters" */ -}}
+  {{- $strategy := index . 1 | include "helm_lib_internal_check_tolerations_strategy" }} {{- /* base strategy, one of "frontend" "monitoring" "system" any-node" "wildcard" */ -}}
   {{- $additionalStrategies := tuple }} {{- /* list of additional strategies. To add strategy list it with prefix "with-", to remove strategy list it with prefix "without-". */ -}}
   {{- if eq $strategy "custom" }}
     {{ if lt (len .) 3 }}
@@ -107,10 +107,6 @@ tolerations:
     {{- /* System: Nodes for system components: prometheus, dns, cert-manager */ -}}
     {{- else if eq $strategy "system" }}
       {{- include "_helm_lib_system_tolerations" $context }}
-
-    {{- /* Only master nodes */ -}}
-    {{- else if eq $strategy "master" }}
-      {{- include "_helm_lib_master_tolerations" $context }}
     {{- end }}
 
     {{- /* Additional strategies */ -}}
@@ -139,7 +135,7 @@ tolerations:
 {{- /* Verify base strategy. */ -}}
 {{- /* Fails if strategy not in allowed list */ -}}
 {{- define "helm_lib_internal_check_tolerations_strategy" -}}
-  {{ if not (has . (list "custom" "frontend" "monitoring" "system" "any-node" "wildcard" "master")) }}
+  {{ if not (has . (list "custom" "frontend" "monitoring" "system" "any-node" "wildcard" )) }}
     {{- fail (printf "unknown strategy \"%v\"" .) }}
   {{- end }}
   {{- . -}}
@@ -205,14 +201,6 @@ tolerations:
 - key: dedicated.deckhouse.io
   operator: Equal
   value: "system"
-{{- end }}
-
-{{- /* Base strategy that tolerates nodes with "node-role.kubernetes.io/control-plane: NoSchedule" taints. */ -}}
-{{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "master") }} */ -}}
-{{- define "_helm_lib_master_tolerations" }}
-- key: node-role.kubernetes.io/control-plane
-  operator: "Exists"
-  effect: "NoSchedule"
 {{- end }}
 
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
@@ -62,7 +62,7 @@ nodeSelector:
 {{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "without-storage-problems") }} */ -}}
 {{- define "helm_lib_tolerations" }}
   {{- $context := index . 0 }}  {{- /* Template context with .Values, .Chart, etc */ -}}
-  {{- $strategy := index . 1 | include "helm_lib_internal_check_tolerations_strategy" }} {{- /* base strategy, one of "frontend" "monitoring" "system" any-node" "wildcard" */ -}}
+  {{- $strategy := index . 1 | include "helm_lib_internal_check_tolerations_strategy" }} {{- /* base strategy, one of "frontend" "monitoring" "system" any-node" "wildcard" "only-masters" */ -}}
   {{- $additionalStrategies := tuple }} {{- /* list of additional strategies. To add strategy list it with prefix "with-", to remove strategy list it with prefix "without-". */ -}}
   {{- if eq $strategy "custom" }}
     {{ if lt (len .) 3 }}
@@ -107,6 +107,10 @@ tolerations:
     {{- /* System: Nodes for system components: prometheus, dns, cert-manager */ -}}
     {{- else if eq $strategy "system" }}
       {{- include "_helm_lib_system_tolerations" $context }}
+
+    {{- /* Only master nodes */ -}}
+    {{- else if eq $strategy "master" }}
+      {{- include "_helm_lib_master_tolerations" $context }}
     {{- end }}
 
     {{- /* Additional strategies */ -}}
@@ -135,7 +139,7 @@ tolerations:
 {{- /* Verify base strategy. */ -}}
 {{- /* Fails if strategy not in allowed list */ -}}
 {{- define "helm_lib_internal_check_tolerations_strategy" -}}
-  {{ if not (has . (list "custom" "frontend" "monitoring" "system" "any-node" "wildcard" )) }}
+  {{ if not (has . (list "custom" "frontend" "monitoring" "system" "any-node" "wildcard" "master")) }}
     {{- fail (printf "unknown strategy \"%v\"" .) }}
   {{- end }}
   {{- . -}}
@@ -201,6 +205,14 @@ tolerations:
 - key: dedicated.deckhouse.io
   operator: Equal
   value: "system"
+{{- end }}
+
+{{- /* Base strategy that tolerates nodes with "node-role.kubernetes.io/control-plane: NoSchedule" taints. */ -}}
+{{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "master") }} */ -}}
+{{- define "_helm_lib_master_tolerations" }}
+- key: node-role.kubernetes.io/control-plane
+  operator: "Exists"
+  effect: "NoSchedule"
 {{- end }}
 
 

--- a/modules/470-chrony/enabled
+++ b/modules/470-chrony/enabled
@@ -17,7 +17,6 @@
 source /deckhouse/shell_lib.sh
 
 function __main__() {
-  enabled::disable_module_if_cluster_is_not_bootstraped
   echo "true" > $MODULE_ENABLED_RESULT
 }
 

--- a/modules/470-chrony/images/chrony/start.sh
+++ b/modules/470-chrony/images/chrony/start.sh
@@ -19,48 +19,35 @@ if ss -nlup | grep -q "127.0.0.1:123"; then
   exit 1
 fi
 
-if ss -nlup | grep -q "127.0.0.1:323"; then
-  echo "Chrony port on node is used"
-  exit 1
-fi
-
 touch /var/run/chrony/chrony.drift
 chown chrony:chrony -R /var/run/chrony
 chmod 700 /var/run/chrony
 
 cat << "EOF" > /var/run/chrony/chrony.conf
 user chrony
-cmdallow 127/8
+cmdport 0
 driftfile /var/run/chrony/chrony.drift
 makestep 1.0 -1
 rtcsync
 bindaddress 0.0.0.0
 EOF
 
-case $NTP_ROLE in
-  server)
-    echo "allow" >> /var/run/chrony/chrony.conf
+case ${NTP_ROLE} in
+  "source")
+    echo "allow ${POD_SUBNET}" >> /var/run/chrony/chrony.conf
+    echo "deny 127/8" >> /var/run/chrony/chrony.conf
     echo "local stratum 5" >> /var/run/chrony/chrony.conf
-
-    if [ -z "${NTP_SERVERS}" ]; then
-      echo "NTP_SERVERS env must be set"
-      exit 1
-    fi
-
-    for NTP_SERVER in ${NTP_SERVERS}; do
-      echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
-    done
-    ;;
-
-  client)
+  ;;
+  "sink")
     echo "pool ${CHRONY_MASTERS_SERVICE} iburst" >> /var/run/chrony/chrony.conf
-    ;;
-
-  *)
-    echo "unknown \$NTP_ROLE: $NTP_ROLE"
-    exit 1
-    ;;
+    echo "port 0" >> /var/run/chrony/chrony.conf
+    echo "local stratum 10" >> /var/run/chrony/chrony.conf
+  ;;
 esac
+
+for NTP_SERVER in ${NTP_SERVERS}; do
+  echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
+done
 
 # remove stale pidfile
 rm -f /run/chrony/chronyd.pid

--- a/modules/470-chrony/images/chrony/start.sh
+++ b/modules/470-chrony/images/chrony/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2021 Flant JSC
+# Copyright 2023 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "${NTP_SERVERS}" ]; then
-  echo "NTP_SERVERS env must be set"
+if ss -nlup | grep -q "127.0.0.1:123"; then
+  echo "NTP port on node is used"
   exit 1
 fi
 
-if ss -nlup | grep -q "127.0.0.1:123"; then
-  echo "NTP port on node is used"
+if ss -nlup | grep -q "127.0.0.1:323"; then
+  echo "Chrony port on node is used"
   exit 1
 fi
 
@@ -28,18 +28,39 @@ touch /var/run/chrony/chrony.drift
 chown chrony:chrony -R /var/run/chrony
 chmod 700 /var/run/chrony
 
-cat << EOF > /var/run/chrony/chrony.conf
+cat << "EOF" > /var/run/chrony/chrony.conf
 user chrony
 cmdallow 127/8
-allow 127/8
-bindaddress 127.0.0.1
 driftfile /var/run/chrony/chrony.drift
 makestep 1.0 -1
 rtcsync
+bindaddress 0.0.0.0
 EOF
-for NTP_SERVER in ${NTP_SERVERS}; do
-  echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
-done
+
+case $NTP_ROLE in
+  server)
+    echo "allow" >> /var/run/chrony/chrony.conf
+    echo "local stratum 5" >> /var/run/chrony/chrony.conf
+
+    if [ -z "${NTP_SERVERS}" ]; then
+      echo "NTP_SERVERS env must be set"
+      exit 1
+    fi
+
+    for NTP_SERVER in ${NTP_SERVERS}; do
+      echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
+    done
+    ;;
+
+  client)
+    echo "pool ${CHRONY_MASTERS_SERVICE} iburst" >> /var/run/chrony/chrony.conf
+    ;;
+
+  *)
+    echo "unknown \$NTP_ROLE: $NTP_ROLE"
+    exit 1
+    ;;
+esac
 
 # remove stale pidfile
 rm -f /run/chrony/chronyd.pid

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -10,12 +10,34 @@ kind: VerticalPodAutoscaler
 metadata:
   name: chrony
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "tier" "node" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: DaemonSet
     name: chrony
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "chrony"
+      minAllowed:
+        {{- include "chrony_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: 25m
+        memory: 50Mi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: chrony-master
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "tier" "node" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: DaemonSet
+    name: chrony-master
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -33,44 +55,41 @@ kind: DaemonSet
 metadata:
   name: chrony
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "deckhouse.io/chrony-location" "worker")) | nindent 2 }}
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
       app: chrony
+      deckhouse.io/chrony-location: worker
   template:
     metadata:
       labels:
-        tier: node
         app: chrony
+        deckhouse.io/chrony-location: worker
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       containers:
       - name: chrony
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "CHOWN" "DAC_OVERRIDE" "FOWNER" "FSETID" "KILL" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "NET_RAW" "SYS_CHROOT" "MKNOD" "AUDIT_WRITE" "SETFCAP")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "chrony") }}
         env:
-{{ $ntpServers := list }}
-{{- range $value := .Values.chrony.ntpServers }}
-  {{- if regexMatch "(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$" $value }}
-    {{ $ntpServers = append $ntpServers $value }}
-  {{ else }}
-    {{ $ntpServers = append $ntpServers (printf "%s." ($value | trimSuffix ".")) }}
-  {{- end }}
-{{ end }}
-        - name: NTP_SERVERS
-          value: {{ join " " $ntpServers | quote }}
+        - name: NTP_ROLE
+          value: "client"
+        - name: CHRONY_MASTERS_SERVICE
+          value: {{ printf "chrony-masters.d8-%s.svc.%s" .Chart.Name .Values.global.clusterConfiguration.clusterDomain | quote }}
         ports:
         - name: ntp
           containerPort: 123
+          protocol: UDP
+        - name: chrony
+          containerPort: 323
           protocol: UDP
         livenessProbe:
           exec:
@@ -104,3 +123,106 @@ spec:
           path: /etc/timezone
       - name: chrony
         emptyDir: {}
+---
+{{ $ntpServers := list }}
+{{- range $value := .Values.chrony.ntpServers }}
+  {{- if regexMatch "(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$" $value }}
+    {{ $ntpServers = append $ntpServers $value }}
+  {{ else }}
+    {{ $ntpServers = append $ntpServers (printf "%s." ($value | trimSuffix ".")) }}
+  {{- end }}
+{{ end }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chrony-master
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "deckhouse.io/chrony-location" "master")) | nindent 2 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: chrony
+      deckhouse.io/chrony-location: master
+  template:
+    metadata:
+      labels:
+        app: chrony
+        deckhouse.io/chrony-location: master
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      imagePullSecrets:
+        - name: deckhouse-registry
+      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "master") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
+      containers:
+        - name: chrony
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "CHOWN" "DAC_OVERRIDE" "FOWNER" "FSETID" "KILL" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "NET_RAW" "SYS_CHROOT" "MKNOD" "AUDIT_WRITE" "SETFCAP")) | nindent 10 }}
+          image: {{ include "helm_lib_module_image" (list . "chrony") }}
+          env:
+            - name: NTP_SERVERS
+              value: {{ join " " $ntpServers | quote }}
+            - name: NTP_ROLE
+              value: "server"
+          ports:
+            - name: ntp
+              containerPort: 123
+              protocol: UDP
+            - name: chrony
+              containerPort: 323
+              protocol: UDP
+          livenessProbe:
+            exec:
+              command:
+                - chronyc
+                - tracking
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 15
+          volumeMounts:
+            - name: tz-config
+              mountPath: /etc/localtime
+              readOnly: true
+            - name: tzdata-config
+              mountPath: /etc/timezone
+              readOnly: true
+            - name: chrony
+              mountPath: /run/chrony
+          resources:
+            requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 14 }}
+  {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            {{- include "chrony_resources" . | nindent 12 }}
+  {{- end }}
+      volumes:
+        - name: tz-config
+          hostPath:
+            path: /etc/localtime
+        - name: tzdata-config
+          hostPath:
+            path: /etc/timezone
+        - name: chrony
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chrony-masters
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
+spec:
+  clusterIP: None
+  selector:
+    app: chrony
+    deckhouse.io/chrony-location: master
+  ports:
+    - protocol: UDP
+      port: 123
+      name: ntp
+    - protocol: UDP
+      port: 323
+      name: chrony

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
       dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       containers:

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -3,6 +3,15 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{ $ntpServers := list }}
+{{- range $value := .Values.chrony.ntpServers }}
+  {{- if regexMatch "(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$" $value }}
+    {{ $ntpServers = append $ntpServers $value }}
+  {{ else }}
+    {{ $ntpServers = append $ntpServers (printf "%s." ($value | trimSuffix ".")) }}
+  {{- end }}
+{{ end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -10,34 +19,12 @@ kind: VerticalPodAutoscaler
 metadata:
   name: chrony
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "tier" "node" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: DaemonSet
     name: chrony
-  updatePolicy:
-    updateMode: "Auto"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "chrony"
-      minAllowed:
-        {{- include "chrony_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 25m
-        memory: 50Mi
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: chrony-master
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "tier" "node" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: DaemonSet
-    name: chrony-master
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -55,41 +42,39 @@ kind: DaemonSet
 metadata:
   name: chrony
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "deckhouse.io/chrony-location" "worker")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
       app: chrony
-      deckhouse.io/chrony-location: worker
   template:
     metadata:
       labels:
+        tier: node
         app: chrony
-        deckhouse.io/chrony-location: worker
     spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       containers:
       - name: chrony
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "CHOWN" "DAC_OVERRIDE" "FOWNER" "FSETID" "KILL" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "NET_RAW" "SYS_CHROOT" "MKNOD" "AUDIT_WRITE" "SETFCAP")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "chrony") }}
         env:
-        - name: NTP_ROLE
-          value: "client"
-        - name: CHRONY_MASTERS_SERVICE
-          value: {{ printf "chrony-masters.d8-%s.svc.%s" .Chart.Name .Values.global.clusterConfiguration.clusterDomain | quote }}
+          - name: NTP_ROLE
+            value: sink
+          - name: NTP_SERVERS
+            value: {{ join " " $ntpServers | quote }}
+          - name: CHRONY_MASTERS_SERVICE
+            value: {{ printf "chrony-masters.d8-%s.svc.%s" .Chart.Name .Values.global.clusterConfiguration.clusterDomain | quote }}
         ports:
         - name: ntp
           containerPort: 123
-          protocol: UDP
-        - name: chrony
-          containerPort: 323
           protocol: UDP
         livenessProbe:
           exec:
@@ -123,106 +108,3 @@ spec:
           path: /etc/timezone
       - name: chrony
         emptyDir: {}
----
-{{ $ntpServers := list }}
-{{- range $value := .Values.chrony.ntpServers }}
-  {{- if regexMatch "(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$" $value }}
-    {{ $ntpServers = append $ntpServers $value }}
-  {{ else }}
-    {{ $ntpServers = append $ntpServers (printf "%s." ($value | trimSuffix ".")) }}
-  {{- end }}
-{{ end }}
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: chrony-master
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony" "deckhouse.io/chrony-location" "master")) | nindent 2 }}
-spec:
-  updateStrategy:
-    type: RollingUpdate
-  selector:
-    matchLabels:
-      app: chrony
-      deckhouse.io/chrony-location: master
-  template:
-    metadata:
-      labels:
-        app: chrony
-        deckhouse.io/chrony-location: master
-    spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      imagePullSecrets:
-        - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      containers:
-        - name: chrony
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "CHOWN" "DAC_OVERRIDE" "FOWNER" "FSETID" "KILL" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "NET_RAW" "SYS_CHROOT" "MKNOD" "AUDIT_WRITE" "SETFCAP")) | nindent 10 }}
-          image: {{ include "helm_lib_module_image" (list . "chrony") }}
-          env:
-            - name: NTP_SERVERS
-              value: {{ join " " $ntpServers | quote }}
-            - name: NTP_ROLE
-              value: "server"
-          ports:
-            - name: ntp
-              containerPort: 123
-              protocol: UDP
-            - name: chrony
-              containerPort: 323
-              protocol: UDP
-          livenessProbe:
-            exec:
-              command:
-                - chronyc
-                - tracking
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 15
-          volumeMounts:
-            - name: tz-config
-              mountPath: /etc/localtime
-              readOnly: true
-            - name: tzdata-config
-              mountPath: /etc/timezone
-              readOnly: true
-            - name: chrony
-              mountPath: /run/chrony
-          resources:
-            requests:
-            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 14 }}
-  {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "chrony_resources" . | nindent 12 }}
-  {{- end }}
-      volumes:
-        - name: tz-config
-          hostPath:
-            path: /etc/localtime
-        - name: tzdata-config
-          hostPath:
-            path: /etc/timezone
-        - name: chrony
-          emptyDir: {}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: chrony-masters
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
-spec:
-  clusterIP: None
-  selector:
-    app: chrony
-    deckhouse.io/chrony-location: master
-  ports:
-    - protocol: UDP
-      port: 123
-      name: ntp
-    - protocol: UDP
-      port: 323
-      name: chrony

--- a/modules/470-chrony/templates/deployment.yaml
+++ b/modules/470-chrony/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         app: chrony-master
     spec:
-      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "chrony-master")) | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}

--- a/modules/470-chrony/templates/deployment.yaml
+++ b/modules/470-chrony/templates/deployment.yaml
@@ -1,0 +1,122 @@
+{{- define "chrony_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
+{{ $ntpServers := list }}
+{{- range $value := .Values.chrony.ntpServers }}
+  {{- if regexMatch "(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$" $value }}
+    {{ $ntpServers = append $ntpServers $value }}
+  {{ else }}
+    {{ $ntpServers = append $ntpServers (printf "%s." ($value | trimSuffix ".")) }}
+  {{- end }}
+{{ end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chrony-master
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-master")) | nindent 2 }}
+spec:
+  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: chrony-master
+  template:
+    metadata:
+      labels:
+        app: chrony-master
+    spec:
+      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "chrony-master")) | nindent 6 }}
+      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: deckhouse-registry
+      containers:
+        - image: {{ include "helm_lib_module_image" (list . "chrony") }}
+          name: chrony-server
+          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "CHOWN" "DAC_OVERRIDE" "FOWNER" "FSETID" "KILL" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "NET_RAW" "SYS_CHROOT" "MKNOD" "AUDIT_WRITE" "SETFCAP")) | nindent 10 }}
+          ports:
+            - name: ntp
+              containerPort: 123
+              protocol: UDP
+          livenessProbe:
+            exec:
+              command:
+                - chronyc
+                - tracking
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 15
+          volumeMounts:
+            - name: tz-config
+              mountPath: /etc/localtime
+              readOnly: true
+            - name: tzdata-config
+              mountPath: /etc/timezone
+              readOnly: true
+            - name: chrony-server
+              mountPath: /run/chrony
+          resources:
+            requests:
+              {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
+    {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+              {{- include "chrony_resources" . | nindent 14 }}
+    {{- end }}
+          env:
+            - name: NTP_ROLE
+              value: source
+            - name: NTP_SERVERS
+              value: {{ join " " $ntpServers | quote }}
+            - name: POD_SUBNET
+              value: {{ .Values.global.clusterConfiguration.podSubnetCIDR | quote }}
+      volumes:
+        - name: tz-config
+          hostPath:
+            path: /etc/localtime
+        - name: tzdata-config
+          hostPath:
+            path: /etc/timezone
+        - name: chrony-server
+          emptyDir: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chrony-master
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-master")) | nindent 2 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: chrony-master
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: chrony-master
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-master" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: chrony-master
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "chrony-server"
+        minAllowed:
+        {{- include "chrony_resources" . | nindent 10 }}
+        maxAllowed:
+          cpu: 20m
+          memory: 70Mi
+{{- end }}

--- a/modules/470-chrony/templates/service.yaml
+++ b/modules/470-chrony/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: chrony-masters
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony")) | nindent 2 }}
+spec:
+  clusterIP: None
+  selector:
+    app: chrony-master
+  ports:
+    - protocol: UDP
+      port: 123
+      name: ntp

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -81,8 +81,8 @@ func skipObjectContainerIfNeeded(o *storage.StoreObject, c *v1.Container) bool {
 		o.Unstructured.GetName() == "chrony" && c.Name == "chrony" {
 		return true
 	}
-	if o.Unstructured.GetKind() == "DaemonSet" && o.Unstructured.GetNamespace() == "d8-chrony" &&
-		o.Unstructured.GetName() == "chrony-master" && c.Name == "chrony" {
+	if o.Unstructured.GetKind() == "Deployment" && o.Unstructured.GetNamespace() == "d8-chrony" &&
+		o.Unstructured.GetName() == "chrony-master" && c.Name == "chrony-server" {
 		return true
 	}
 

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -81,6 +81,10 @@ func skipObjectContainerIfNeeded(o *storage.StoreObject, c *v1.Container) bool {
 		o.Unstructured.GetName() == "chrony" && c.Name == "chrony" {
 		return true
 	}
+	if o.Unstructured.GetKind() == "DaemonSet" && o.Unstructured.GetNamespace() == "d8-chrony" &&
+		o.Unstructured.GetName() == "chrony-master" && c.Name == "chrony" {
+		return true
+	}
 
 	return false
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`470-chrony` is now deployed to all nodes at once, but master nodes are configured run 2 chrony processes at once, one acts as an intermediate NTP server, pulling clock from some other NTP service if possible, other works as regular chrony NTP client. 

Chrony clients are configured to use master nodes as their primary NTP clock source (`stratum 5`) via a headless service acting as an NTP pool, and fall back to NTP servers from module config in case something bad happens with masters.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
See #2949

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony
type: feature
summary: Master nodes act as NTP servers for cluster.
impact_level: default
```
