### PR TITLE
[docs][operator-trivy] Add OpenAPI spec to the documentation and mino…

### DIFF
--- a/ee/modules/500-operator-trivy/docs/CONFIGURATION.md
+++ b/ee/modules/500-operator-trivy/docs/CONFIGURATION.md
@@ -1,7 +1,6 @@
 ---
 title: "The operator-trivy module: configuration"
+description: Settings of the operator-trivy Deckhouse module.
 ---
 
-{% include module-bundle.liquid %}
-
-The module does not have any mandatory parameters.
+<!-- SCHEMA -->

--- a/ee/modules/500-operator-trivy/docs/CONFIGURATION_RU.md
+++ b/ee/modules/500-operator-trivy/docs/CONFIGURATION_RU.md
@@ -1,7 +1,6 @@
 ---
 title: "Модуль operator-trivy: настройки"
+description: Настройки модуля operator-trivy Deckhouse.
 ---
 
-{% include module-bundle.liquid %}
-
-У модуля нет обязательных настроек.
+<!-- SCHEMA -->

--- a/ee/modules/500-operator-trivy/docs/FAQ.md
+++ b/ee/modules/500-operator-trivy/docs/FAQ.md
@@ -1,5 +1,6 @@
 ---
 title: "The operator-trivy module: FAQ"
+description: How to view resources that have not passed CIS compliance checks in the operator-trivy Deckhouse module.
 ---
 {% raw %}
 

--- a/ee/modules/500-operator-trivy/docs/FAQ_RU.md
+++ b/ee/modules/500-operator-trivy/docs/FAQ_RU.md
@@ -1,5 +1,6 @@
 ---
 title: "Модуль operator-trivy: FAQ"
+description: Как в модуле operator-trivy Deckhouse посмотреть ресурсы, которые не прошли CIS compliance проверки.
 ---
 {% raw %}
 
@@ -10,7 +11,7 @@ kubectl get clustercompliancereports.aquasecurity.github.io cis -ojson |
   jq '.status.detailReport.results | map(select(.checks | map(.success) | all | not))'
 ```
 
-## Как посмотреть ресуры, которые не прошли конкретную CIS compliance-проверку?
+## Как посмотреть ресурсы, которые не прошли конкретную CIS compliance-проверку?
 
 По `id`:
 

--- a/ee/modules/500-operator-trivy/docs/README.md
+++ b/ee/modules/500-operator-trivy/docs/README.md
@@ -1,5 +1,6 @@
 ---
 title: "The operator-trivy module"
+description: operator-trivy is a Deckhouse module for periodic scanning for vulnerabilities in a Kubernetes cluster.
 ---
 
 The module allows you to run periodic vulnerability scans. The module uses the [Trivy](https://github.com/aquasecurity/trivy) project. 

--- a/ee/modules/500-operator-trivy/docs/README_RU.md
+++ b/ee/modules/500-operator-trivy/docs/README_RU.md
@@ -1,5 +1,6 @@
 ---
 title: "Модуль operator-trivy"
+description: operator-trivy — модуль Deckhouse для периодического сканирования на уязвимости в кластере Kubernetes. 
 ---
 
 Модуль позволяет запускать периодическое сканирование на уязвимости. Базируется на проекте [Trivy](https://github.com/aquasecurity/trivy).

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -3,7 +3,7 @@ properties:
   tolerations:
     type: array
     description: |
-      Operator and scan jobs tolerations.
+      Optional `tolerations` for trivy operator and scan jobs.
 
       The same as `spec.tolerations` for the Kubernetes pod.
 
@@ -36,7 +36,7 @@ properties:
     x-examples:
       - disktype: ssd
     description: |
-      Operator and scan jobs nodeSelector.
+      Optional `nodeSelector` for trivy operator and scan jobs.
 
       The same as `spec.nodeSelector` for the Kubernetes pod.
 

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -2,15 +2,15 @@ type: object
 properties:
   tolerations:
     description: |
-      tolerations для Scan Jobs и trivy operator.
+      Опциональные tolerations для компонентов trivy operator и заданий сканирования (Jobs).
 
       Структура, аналогичная `spec.tolerations` Kubernetes pod.
 
       Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
   nodeSelector:
     description: |
-      tolerations для Scan Jobs и trivy operator.
+      Опциональный селектор для компонентов trivy operator и заданий сканирования (Jobs).
 
-        Структура, аналогичная `spec.nodeSelector` Kubernetes pod.
+      Структура, аналогичная `spec.nodeSelector` Kubernetes pod.
 
-        Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+      Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).


### PR DESCRIPTION
## Description
Add OpenAPI spec to the documentation. Other minor documentation updates.

## Why do we need it in the patch release (if we do)?

Not needed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: operator-trivy
type: chore
summary: Add OpenAPI spec to the documentation. Other minor documentation updates.
impact_level: low
```
