### PR TITLE
[doc]  Add a list of directories used by Deckhouse

### DIFF
--- a/docs/documentation/_data/deckhouse-used-directories.yml
+++ b/docs/documentation/_data/deckhouse-used-directories.yml
@@ -8,72 +8,72 @@ directories:
   - path: /mnt/kubernetes-data
     node: master
     description:
-      en: Exists only in cloud installations, when a separate disk is used for etcd database.
-      ru: Существует только в кластерах развернутых в облаке, когда используется отдельный диск для базы данных etcd.
+      en: exists only in cloud installations, when a separate disk is used for etcd database.
+      ru: существует только в кластерах развернутых в облаке, когда используется отдельный диск для базы данных etcd.
   - path: /var/lib/etcd
     node: master
     description:
       en: etcd database.
-      ru: База данных etcd.
+      ru: база данных etcd.
   - path: /var/lib/deckhouse/
     node: master
     description:
-      en: Files of Deckhouse modules, which dynamically loads from a registry.
-      ru: Файлы модулей Deckhouse, динамически загружаемых из хранилища образов.
+      en: files of Deckhouse modules, which dynamically loads from a registry.
+      ru: файлы модулей Deckhouse, динамически загружаемых из хранилища образов.
   - path: /var/lib/upmeter
     node: master
     module: upmeter
     description:
-      en: The upmeter module database.
-      ru: База данных модуля upmeter.
+      en: the upmeter module database.
+      ru: база данных модуля upmeter.
   - path: /etc/kubernetes
     node: any
     description:
-      en: Static pods manifests, PKI certificate files.
-      ru: Манифесты статических подов, файлы сертификатов PKI.
+      en: manifests of static pods, PKI certificate files.
+      ru: манифесты статических подов, файлы сертификатов PKI.
   - path: /var/lib/bashible
     node: any
     description:
-      en: Node configuration files.
-      ru: Файлы настройки узла.
+      en: node configuration files.
+      ru: файлы настройки узла.
   - path: /var/lib/containerd
     node: any
     description:
-      en: Files of container images and containers running on the node.
-      ru: Файлы образов контейнеров и контейнеров, запущенных на узле.
+      en: files of container images and containers running on the node.
+      ru: файлы образов контейнеров и контейнеров, запущенных на узле.
   - path: /mnt/vector-data
     node: any
     module: log-shipper
     description:
-      en: Checkpoints of sent logs.
-      ru: Служебные данные статуса отправленных журналов.
+      en: checkpoints of sent logs.
+      ru: служебные данные статуса отправленных журналов.
   - path: /var/log/containers
     node: any
     description:
-      en: Logs of containers (when using `containerd`).
-      ru: Журналы контейнеров (при использовании `containerd`).
+      en: logs of containers (when using `containerd`).
+      ru: журналы контейнеров (при использовании `containerd`).
   - path: /var/lib/kubelet/
     node: any
     description:
       en: "`kubelet` configuration files."
-      ru: Файлы настройки `kubelet`.
+      ru: файлы настройки `kubelet`.
   - path: /opt/cni/bin/
     node: any
     description:
       en: CNI plugin executables.
-      ru: Исполняемые файлы модуля CNI.
+      ru: исполняемые файлы модуля CNI.
   - path: /opt/deckhouse/bin/
     node: any
     description:
-      en: Executable files required for Deckhouse to work.
-      ru: Исполняемые файлы, необходимые для работы Deckhouse.
+      en: executable files required for Deckhouse to work.
+      ru: исполняемые файлы, необходимые для работы Deckhouse.
   - path: /var/log/pods/
     node: any
     description:
-      en: Logs of all pod containers that are running on this cluster node.
-      ru: Журналы всех контейнеров подов, запущенных на узле.
+      en: logs of all pod containers that are running on this cluster node.
+      ru: журналы всех контейнеров подов, запущенных на узле.
   - path: /etc/cni/
     node: any
     description:
       en: CNI plugin configuration files.
-      ru: Файлы настройки модуля CNI.
+      ru: файлы настройки модуля CNI.

--- a/docs/documentation/_data/deckhouse-used-directories.yml
+++ b/docs/documentation/_data/deckhouse-used-directories.yml
@@ -1,0 +1,79 @@
+directories:
+#  - path: <directory path>
+#    module: <module name>
+#    node: [any|master|worker]
+#    description:
+#      en:
+#      ru:
+  - path: /mnt/kubernetes-data
+    node: master
+    description:
+      en: Exists only in cloud installations, when a separate disk is used for etcd database.
+      ru: Существует только в кластерах развернутых в облаке, когда используется отдельный диск для базы данных etcd.
+  - path: /var/lib/etcd
+    node: master
+    description:
+      en: etcd database.
+      ru: База данных etcd.
+  - path: /var/lib/deckhouse/
+    node: master
+    description:
+      en: Files of Deckhouse modules, which dynamically loads from a registry.
+      ru: Файлы модулей Deckhouse, динамически загружаемых из хранилища образов.
+  - path: /var/lib/upmeter
+    node: master
+    module: upmeter
+    description:
+      en: The upmeter module database.
+      ru: База данных модуля upmeter.
+  - path: /etc/kubernetes
+    node: any
+    description:
+      en: Static pods manifests, PKI certificate files.
+      ru: Манифесты статических подов, файлы сертификатов PKI.
+  - path: /var/lib/bashible
+    node: any
+    description:
+      en: Node configuration files.
+      ru: Файлы настройки узла.
+  - path: /var/lib/containerd
+    node: any
+    description:
+      en: Files of container images and containers running on the node.
+      ru: Файлы образов контейнеров и контейнеров, запущенных на узле.
+  - path: /mnt/vector-data
+    node: any
+    module: log-shipper
+    description:
+      en: Checkpoints of sent logs.
+      ru: Служебные данные статуса отправленных журналов.
+  - path: /var/log/containers
+    node: any
+    description:
+      en: Logs of containers (when using `containerd`).
+      ru: Журналы контейнеров (при использовании `containerd`).
+  - path: /var/lib/kubelet/
+    node: any
+    description:
+      en: "`kubelet` configuration files."
+      ru: Файлы настройки `kubelet`.
+  - path: /opt/cni/bin/
+    node: any
+    description:
+      en: CNI plugin executables.
+      ru: Исполняемые файлы модуля CNI.
+  - path: /opt/deckhouse/bin/
+    node: any
+    description:
+      en: Executable files required for Deckhouse to work.
+      ru: Исполняемые файлы, необходимые для работы Deckhouse.
+  - path: /var/log/pods/
+    node: any
+    description:
+      en: Logs of all pod containers that are running on this cluster node.
+      ru: Журналы всех контейнеров подов, запущенных на узле.
+  - path: /etc/cni/
+    node: any
+    description:
+      en: CNI plugin configuration files.
+      ru: Файлы настройки модуля CNI.

--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -43,6 +43,10 @@ entries:
             en: Revision comparison
             ru: Сравнение редакций
           url: /revision-comparison.html
+        - title:
+            en: Security software settings
+            ru: Настройка ПО безопасности
+          url: /security_software_setup.html
         - title: FAQ
           url: /deckhouse-faq.html
         - title:

--- a/docs/documentation/_includes/deckhouse-directories-csv.liquid
+++ b/docs/documentation/_includes/deckhouse-directories-csv.liquid
@@ -1,0 +1,12 @@
+{%- assign folders_sorted = site.data.deckhouse-used-directories.directories | sort: 'path'  %}
+{%- if page.lang == "ru" -%}
+Директория,Узел,Модуль,Описание
+{%- else -%}
+Folder path,Node,Module,Description
+{%- endif %}
+{% for folder in folders_sorted %}
+{{- folder.path -}}
+,{% if folder.node %}{{folder.node}}{% else %}{%- if page.lang == "ru" %}Любой{%- else %}Any{% endif %}{% endif -%}
+,{{ folder.module -}}
+,"{{ folder.description[page.lang] | replace: "`", "" }}"
+{% endfor -%}

--- a/docs/documentation/_includes/security_software_setup.liquid
+++ b/docs/documentation/_includes/security_software_setup.liquid
@@ -1,0 +1,5 @@
+{% for folder in site.data.deckhouse-used-directories.directories %}
+- `{{ folder.path }}` — 
+{%- if folder.module %}({% if page.lang == 'ru' %}модуль `{{ folder.module }}`{% else %}the `{{ folder.module }}` module {% endif %}) {% endif -%}
+{{ folder.description[page.lang]}}
+{% endfor %}

--- a/docs/documentation/_includes/security_software_setup.liquid
+++ b/docs/documentation/_includes/security_software_setup.liquid
@@ -1,5 +1,10 @@
 {% for folder in site.data.deckhouse-used-directories.directories %}
-- `{{ folder.path }}` — 
-{%- if folder.module %}({% if page.lang == 'ru' %}модуль `{{ folder.module }}`{% else %}the `{{ folder.module }}` module {% endif %}) {% endif -%}
-{{ folder.description[page.lang]}}
+- `{{ folder.path }}` (
+{%- if folder.node and folder.node != "any" %}{%- if page.lang == "ru" %}{{folder.node}}-узел{%- else %}{{folder.node}} node{% endif %}
+{%- else -%}{%- if page.lang == "ru" %}любой узел{%- else %}any node{% endif %}
+{%- endif -%}
+{%- if folder.module %}
+  {%- if page.lang == 'ru' %}, модуль `{{ folder.module }}`{% else %}, the `{{ folder.module }}` module{% endif %}
+{%- endif -%}
+) — {{ folder.description[page.lang]}}
 {% endfor %}

--- a/docs/documentation/pages/SECURITY_SOFTWARE_SETUP.md
+++ b/docs/documentation/pages/SECURITY_SOFTWARE_SETUP.md
@@ -1,0 +1,10 @@
+---
+title: Security software settings for working with Deckhouse
+permalink: en/security_software_setup.html
+---
+
+If security scanners (antivirus tools) scan nodes of the Kubernetes cluster, then it may be necessary to configure them to exclude false positives.
+
+Deckhouse uses the following directories when working ([download in csv...](deckhouse-directories.csv)):
+
+{% include security_software_setup.liquid %}

--- a/docs/documentation/pages/SECURITY_SOFTWARE_SETUP_RU.md
+++ b/docs/documentation/pages/SECURITY_SOFTWARE_SETUP_RU.md
@@ -1,0 +1,11 @@
+---
+title: Настройка ПО безопасности для работы с Deckhouse
+permalink: ru/security_software_setup.html
+lang: ru
+---
+
+Если узлы кластера Kubernetes анализируются сканерами безопасности (антивирусными средствами), то может потребоваться их настройка, для исключения ложноположительных срабатываний.
+
+Deckhouse использует следующие директории при работе ([скачать в csv...](deckhouse-directories.csv)):
+
+{% include security_software_setup.liquid %}

--- a/docs/documentation/pages/deckhouse-directories.csv
+++ b/docs/documentation/pages/deckhouse-directories.csv
@@ -1,0 +1,7 @@
+---
+permalink: en/deckhouse-directories.csv
+layout: none
+searchable: false
+sitemap_include: false
+---
+{%- include deckhouse-directories-csv.liquid -%}

--- a/docs/documentation/pages/deckhouse-directories_ru.csv
+++ b/docs/documentation/pages/deckhouse-directories_ru.csv
@@ -1,0 +1,8 @@
+---
+permalink: ru/deckhouse-directories.csv
+layout: none
+lang: ru
+searchable: false
+sitemap_include: false
+---
+{%- include deckhouse-directories-csv.liquid -%}


### PR DESCRIPTION
## Description
Add a list of directories used by Deckhouse. It is needed to properly configure the security software (antivirus scanners, etc.).

Closes: https://github.com/deckhouse/deckhouse/issues/5226

## Why do we need it, and what problem does it solve?
Some security software gives false positive events when scanning a node. Deckhouse security administrator needs a list of exceptions to tune security scanners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add a list of directories used by Deckhouse. It is needed to properly configure the security software.
impact_level: low
```
