### PR TITLE
[distroless] move csi binaries to distroless

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -31,7 +31,7 @@ k8s:
     csi:
       openstack: v1.23.1
       provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
-      attacher: v4.2.0@sha256:34cf9b32736c6624fc9787fb149ea6e0fbeb45415707ac2f6440ac960f1116e6
+      attacher: v4.2.0
       resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
       registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
       snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
@@ -51,7 +51,7 @@ k8s:
     csi:
       openstack: v1.24.2
       provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
-      attacher: v4.2.0@sha256:34cf9b32736c6624fc9787fb149ea6e0fbeb45415707ac2f6440ac960f1116e6
+      attacher: v4.2.0
       resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
       registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
       snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
@@ -71,7 +71,7 @@ k8s:
     csi:
       openstack: v1.25.3
       provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
-      attacher: v4.2.0@sha256:34cf9b32736c6624fc9787fb149ea6e0fbeb45415707ac2f6440ac960f1116e6
+      attacher: v4.2.0
       resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
       registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
       snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
@@ -91,7 +91,7 @@ k8s:
     csi:
       openstack: v1.26.1
       provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
-      attacher: v4.2.0@sha256:34cf9b32736c6624fc9787fb149ea6e0fbeb45415707ac2f6440ac960f1116e6
+      attacher: v4.2.0
       resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
       registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
       snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
@@ -111,7 +111,7 @@ k8s:
     csi:
       openstack: v1.27.1
       provisioner: v3.5.0@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
-      attacher: v4.3.0@sha256:4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af
+      attacher: v4.3.0
       resizer: v1.8.0@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
       registrar: v2.8.0@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1
       snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -30,12 +30,12 @@ k8s:
       gcp: 66064c62c6c23110c7a93faca5fba668018df732
     csi:
       openstack: v1.23.1
-      provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
+      provisioner: v3.4.1
       attacher: v4.2.0
-      resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
-      registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
-      snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
-      livenessprobe: v2.9.0@sha256:2b10b24dafdc3ba94a03fc94d9df9941ca9d6a9207b927f5dfd21d59fbe05ba0
+      resizer: v1.7.0
+      registrar: v2.7.0
+      snapshotter: v6.2.1
+      livenessprobe: v2.9.0
   '1.24':
     status: available
     patch: 17
@@ -50,12 +50,12 @@ k8s:
       gcp: eda9a5a3dd73ef923df7b16cf067af1b0ccbb929
     csi:
       openstack: v1.24.2
-      provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
+      provisioner: v3.4.1
       attacher: v4.2.0
-      resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
-      registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
-      snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
-      livenessprobe: v2.9.0@sha256:2b10b24dafdc3ba94a03fc94d9df9941ca9d6a9207b927f5dfd21d59fbe05ba0
+      resizer: v1.7.0
+      registrar: v2.7.0
+      snapshotter: v6.2.1
+      livenessprobe: v2.9.0
   '1.25':
     status: available
     patch: 13
@@ -70,12 +70,12 @@ k8s:
       gcp: ccm/v25.3.0
     csi:
       openstack: v1.25.3
-      provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
+      provisioner: v3.4.1
       attacher: v4.2.0
-      resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
-      registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
-      snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
-      livenessprobe: v2.9.0@sha256:2b10b24dafdc3ba94a03fc94d9df9941ca9d6a9207b927f5dfd21d59fbe05ba0
+      resizer: v1.7.0
+      registrar: v2.7.0
+      snapshotter: v6.2.1
+      livenessprobe: v2.9.0
   '1.26':
     status: available
     patch: 8
@@ -90,12 +90,12 @@ k8s:
       gcp: ccm/v26.0.4
     csi:
       openstack: v1.26.1
-      provisioner: v3.4.1@sha256:893e37a388e7a7463d6c3523311b28cfbc5ae536dbef35430eed272cdc6850dc
+      provisioner: v3.4.1
       attacher: v4.2.0
-      resizer: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
-      registrar: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
-      snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
-      livenessprobe: v2.9.0@sha256:2b10b24dafdc3ba94a03fc94d9df9941ca9d6a9207b927f5dfd21d59fbe05ba0
+      resizer: v1.7.0
+      registrar: v2.7.0
+      snapshotter: v6.2.1
+      livenessprobe: v2.9.0
   '1.27':
     status: preview
     patch: 5
@@ -110,9 +110,9 @@ k8s:
       gcp: ccm/v27.1.0
     csi:
       openstack: v1.27.1
-      provisioner: v3.5.0@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
+      provisioner: v3.5.0
       attacher: v4.3.0
-      resizer: v1.8.0@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
-      registrar: v2.8.0@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1
-      snapshotter: v6.2.1@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
-      livenessprobe: v2.10.0@sha256:4dc0b87ccd69f9865b89234d8555d3a614ab0a16ed94a3016ffd27f8106132ce
+      resizer: v1.8.0
+      registrar: v2.8.0
+      snapshotter: v6.2.1
+      livenessprobe: v2.10.0

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.7.0
-digest: sha256:bb67e4e525dc4c2066575fb8350decc559dda41e651ec88470e1258da870056b
-generated: "2023-08-10T15:01:18.262686304+03:00"
+  version: 1.8.0
+digest: sha256:f5a98932e4ffc046f42102efc890e545e027649c98f635237a582b760a430bae
+generated: "2023-09-20T09:35:57.31878+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.7.0"
+    version: "1.8.0"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.7.0
+version: 1.8.0

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -175,7 +175,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple $context "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple $context "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $context "any-node" "with-uninitialized") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: csi
       containers:
       - name: provisioner

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -20,11 +20,10 @@ from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 shell:
   beforeInstall:
     - apk add --no-cache make bash git patch rsync gcc musl-dev
-    - git clone --depth 1 --branch {{ $value.csi.attacher }} https://{{ $.SOURCE_REPO }}/deckhouse/3p/kubernetes-csi/external-attacher.git /src
+    - git clone --depth 1 --branch {{ $value.csi.attacher }} {{ $.SOURCE_REPO }}/deckhouse/3p/kubernetes-csi/external-attacher.git /src
   install:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
-    - mkdir /src
     - cd /src
     - make build
     - cp bin/csi-attacher /csi-attacher

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -19,7 +19,7 @@ artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace ".
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 shell:
   beforeInstall:
-    - apk add --no-cache add make bash git patch rsync gcc musl-dev
+    - apk add --no-cache make bash git patch rsync gcc musl-dev
     - git clone --depth 1 --branch {{ $value.csi.attacher }} https://{{ $.SOURCE_REPO }}/deckhouse/3p/kubernetes-csi/external-attacher.git /src
   install:
     - export GO_VERSION=${GOLANG_VERSION}

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -7,8 +7,8 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-    add: /
-    to: /
+    add: /csi-attacher
+    to: /csi-attacher
     includePaths:
       - csi-attacher
     before: setup
@@ -16,6 +16,19 @@ docker:
   ENTRYPOINT: ["/csi-attacher"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: registry.k8s.io/sig-storage/csi-attacher:{{ $value.csi.attacher }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+shell:
+  beforeInstall:
+    - apk add --no-cache add make bash git patch rsync gcc musl-dev
+    - git clone --depth 1 --branch {{ $value.csi.attacher }} https://{{ $.SOURCE_REPO }}/deckhouse/3p/kubernetes-csi/external-attacher.git /src
+  install:
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
+    - mkdir /src
+    - cd /src
+    - make build
+    - cp bin/csi-attacher /csi-attacher
+    - chown 64535:64535 /csi-attacher
+    - chmod 0755 /csi-attacher
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if $value.csi.attacher }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-attacher

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -20,7 +20,7 @@ from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 shell:
   beforeInstall:
     - apk add --no-cache make bash git patch rsync gcc musl-dev
-    - git clone --depth 1 --branch {{ $value.csi.attacher }} {{ $.SOURCE_REPO }}/deckhouse/3p/kubernetes-csi/external-attacher.git /src
+    - git clone --depth 1 --branch {{ $value.csi.attacher }} {{ $.SOURCE_REPO }}/kubernetes-csi/external-attacher.git /src
   install:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if $value.csi.provisioner }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-provisioner

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -7,8 +7,8 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-    add: /
-    to: /
+    add: /csi-provisioner
+    to: /csi-provisioner
     includePaths:
       - csi-provisioner
     before: setup
@@ -16,6 +16,18 @@ docker:
   ENTRYPOINT: ["/csi-provisioner"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: registry.k8s.io/sig-storage/csi-provisioner:{{ $value.csi.provisioner }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+shell:
+  beforeInstall:
+    - apk add --no-cache make bash git patch rsync gcc musl-dev
+    - git clone --depth 1 --branch {{ $value.csi.provisioner }} {{ $.SOURCE_REPO }}/kubernetes-csi/external-provisioner.git /src
+  install:
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
+    - cd /src
+    - make build
+    - cp bin/csi-provisioner /csi-provisioner
+    - chown 64535:64535 /csi-provisioner
+    - chmod 0755 /csi-provisioner
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if $value.csi.resizer }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-resizer

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -7,8 +7,8 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-    add: /
-    to: /
+    add: /csi-resizer
+    to: /csi-resizer
     includePaths:
       - csi-resizer
     before: setup
@@ -16,6 +16,18 @@ docker:
   ENTRYPOINT: ["/csi-resizer"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: registry.k8s.io/sig-storage/csi-resizer:{{ $value.csi.resizer }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+shell:
+  beforeInstall:
+    - apk add --no-cache make bash git patch rsync gcc musl-dev
+    - git clone --depth 1 --branch {{ $value.csi.resizer }} {{ $.SOURCE_REPO }}/kubernetes-csi/external-resizer.git /src
+  install:
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
+    - cd /src
+    - make build
+    - cp bin/csi-resizer /csi-resizer
+    - chown 64535:64535 /csi-resizer
+    - chmod 0755 /csi-resizer
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if $value.csi.snapshotter }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-snapshotter

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -29,8 +29,5 @@ shell:
     - cp bin/csi-snapshotter /csi-snapshotter
     - chown 64535:64535 /csi-snapshotter
     - chmod 0755 /csi-snapshotter
-
-
-from: registry.k8s.io/sig-storage/csi-snapshotter:{{ $value.csi.snapshotter }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -7,8 +7,8 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-    add: /
-    to: /
+    add: /csi-snapshotter
+    to: /csi-snapshotter
     includePaths:
       - csi-snapshotter
     before: setup
@@ -16,6 +16,21 @@ docker:
   ENTRYPOINT: ["/csi-snapshotter"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+shell:
+  beforeInstall:
+    - apk add --no-cache make bash git patch rsync gcc musl-dev
+    - git clone --depth 1 --branch {{ $value.csi.snapshotter }} {{ $.SOURCE_REPO }}/kubernetes-csi/external-snapshotter.git /src
+  install:
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
+    - cd /src
+    - make build
+    - cp bin/csi-snapshotter /csi-snapshotter
+    - chown 64535:64535 /csi-snapshotter
+    - chmod 0755 /csi-snapshotter
+
+
 from: registry.k8s.io/sig-storage/csi-snapshotter:{{ $value.csi.snapshotter }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if $value.csi.livenessprobe }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /livenessprobe

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -7,8 +7,8 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-    add: /
-    to: /
+    add: /livenessprobe
+    to: /livenessprobe
     includePaths:
       - livenessprobe
     before: setup
@@ -16,6 +16,18 @@ docker:
   ENTRYPOINT: ["/livenessprobe"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: registry.k8s.io/sig-storage/livenessprobe:{{ $value.csi.livenessprobe }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+shell:
+  beforeInstall:
+    - apk add --no-cache make bash git patch rsync gcc musl-dev
+    - git clone --depth 1 --branch {{ $value.csi.livenessprobe }} {{ $.SOURCE_REPO }}/kubernetes-csi/livenessprobe.git /src
+  install:
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
+    - cd /src
+    - make build
+    - cp bin/livenessprobe /livenessprobe
+    - chown 64535:64535 /livenessprobe
+    - chmod 0755 /livenessprobe
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -7,8 +7,8 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-    add: /
-    to: /
+    add: /csi-node-driver-registrar
+    to: /csi-node-driver-registrar
     includePaths:
       - csi-node-driver-registrar
     before: setup
@@ -16,6 +16,18 @@ docker:
   ENTRYPOINT: ["/csi-node-driver-registrar"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: registry.k8s.io/sig-storage/csi-node-driver-registrar:{{ $value.csi.registrar }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+shell:
+  beforeInstall:
+    - apk add --no-cache make bash git patch rsync gcc musl-dev
+    - git clone --depth 1 --branch {{ $value.csi.registrar }} {{ $.SOURCE_REPO }}/kubernetes-csi/node-driver-registrar.git /src
+  install:
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
+    - cd /src
+    - make build
+    - cp bin/csi-node-driver-registrar /csi-node-driver-registrar
+    - chown 64535:64535 /csi-node-driver-registrar
+    - chmod 0755 /csi-node-driver-registrar
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -4,7 +4,7 @@
   {{- if $value.csi.registrar }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-node-driver-registrar


### PR DESCRIPTION
## Description

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

csi binaries use distroless images and built from our repos instead of using prebuilt images from google.
- [x] csi-external-attacher
- [x] csi-external-provisioner
- [x] csi-external-resizer
- [x] csi-external-snapshotter
- [x] csi-livenessprobe 
- [x] csi-node-driver-registrar

## Why do we need it, and what problem does it solve?
This PR is a part of moving Deckhouse to distroless.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: move csi-external-attacher to distroless.
impact_level: default
---
section: candi
type: chore
summary: move csi-external-provisioner to distroless.
impact_level: default
---
section: candi
type: chore
summary: move csi-external-resizer to distroless.
impact_level: default
---
section: candi
type: chore
summary: move csi-external-snapshotter to distroless.
impact_level: default
---
section: candi
type: chore
summary: move csi-livenessprobe to distroless.
impact_level: default
---
section: candi
type: chore
summary: move csi-node-driver-registrar to distroless.
impact_level: default

```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
