### PR TITLE
[dhctl] Add registryDockerCfg validation

### DIFF
--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -239,6 +239,28 @@ func TestPrepareRegistry(t *testing.T) {
 			require.Equal(t, cfg.Registry, expectedData)
 		})
 	})
+
+	t.Run("Validate registryDockerCfg", func(t *testing.T) {
+		t.Run("Expect successful validation", func(t *testing.T) {
+			creds := "{\"auths\": { \"registry.deckhouse.io\": {}}}"
+			dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
+
+			err := validateRegistryDockerCfg(dockerCfg)
+			require.NoError(t, err)
+		})
+
+		t.Run("Expect failed validation", func(t *testing.T) {
+			host := "some-bad-host:1434/deckhouse"
+			creds := fmt.Sprintf("{\"auths\": { \"%s\": {}}}", host)
+			dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
+
+			err := validateRegistryDockerCfg(dockerCfg)
+			require.EqualErrorf(t,
+				err,
+				fmt.Sprintf("invalid registryDockerCfg. Your auths host \"%s\" should be similar to \"your.private.registry.example.com\"", host),
+				err.Error())
+		})
+	})
 }
 
 func TestParseRegistryData(t *testing.T) {

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -242,23 +242,53 @@ func TestPrepareRegistry(t *testing.T) {
 
 	t.Run("Validate registryDockerCfg", func(t *testing.T) {
 		t.Run("Expect successful validation", func(t *testing.T) {
-			creds := "{\"auths\": { \"registry.deckhouse.io\": {}}}"
-			dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
+			creds := []string{
+				`{"auths": { "registry.deckhouse.io": {}}}`,
+				`{"auths": { "regi-stry.deckhouse.io": {}}}`,
+				`{"auths": { "registry.io": {}}}`,
+				`{"auths": { "1.io": {}}}`,
+				`{"auths": { "1.s.io": {}}}`,
+				`{"auths": { "regi.stry:5000": {}}}`,
+				`{"auths": { "1.2.3": {}}}`,
+				`{"auths": { "1.2:5000": {}}}`,
+				`{"auths": { "reg.dec.io1": {}}}`,
+				`{"auths": { "one.two.three.four.five.six.whatever": {}}}`,
+				`{"auths": { "1.2.3.4.5.6.0": {}}}`,
+				``,
+			}
 
-			err := validateRegistryDockerCfg(dockerCfg)
-			require.NoError(t, err)
+			for _, cred := range creds {
+				dockerCfg := base64.StdEncoding.EncodeToString([]byte(cred))
+
+				err := validateRegistryDockerCfg(dockerCfg)
+				require.NoError(t, err)
+			}
 		})
 
 		t.Run("Expect failed validation", func(t *testing.T) {
-			host := "some-bad-host:1434/deckhouse"
-			creds := fmt.Sprintf("{\"auths\": { \"%s\": {}}}", host)
-			dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
+			hosts := []string{
+				"some-bad-host:1434/deckhouse",
+				"some-bad/deckhouse",
+				".some-bad/deckhouse",
+				"-some.bad",
+				"somebad.",
+				"some--ba",
+				"some..ba",
+				"14214.ba1::1554",
+				"some.bad:host",
+				"some-bad:host1",
+			}
 
-			err := validateRegistryDockerCfg(dockerCfg)
-			require.EqualErrorf(t,
-				err,
-				fmt.Sprintf("invalid registryDockerCfg. Your auths host \"%s\" should be similar to \"your.private.registry.example.com\"", host),
-				err.Error())
+			for _, host := range hosts {
+				creds := fmt.Sprintf("{\"auths\": { \"%s\": {}}}", host)
+				dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
+
+				err := validateRegistryDockerCfg(dockerCfg)
+				require.EqualErrorf(t,
+					err,
+					fmt.Sprintf("invalid registryDockerCfg. Your auths host \"%s\" should be similar to \"your.private.registry.example.com\"", host),
+					err.Error())
+			}
 		})
 	})
 }


### PR DESCRIPTION
## Description
Added registryDockerCfg validation in MetaConfig.Prepare() 

## Why do we need it, and what problem does it solve?
Fix for https://github.com/deckhouse/deckhouse/issues/3814. 
In some cases we could have unexpected blank or invalid value at REGISTRY_AUTH in bootstrap.sh script. It is caused of incorrect "auths" field's value in docker credentials, which is got from registryDockerCfg field in InitConfiguration manifest. To prevent this issue the validation was added. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
InitConfiguration with invalid registryDockerCfg will fail dhctl bootstrap.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add registryDockerCfg validation
impact_level:  default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
