### PR TITLE
[prometheus] fix issue with add custom grafana plugins

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -39,7 +39,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 64535
   runAsGroup: 64535
-  fsGroup: 64535
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . }} */ -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -39,6 +39,7 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 64535
   runAsGroup: 64535
+  fsGroup: 64535
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . }} */ -}}

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -170,8 +170,7 @@ COPY --from=grafana-statusmap /grafana-statusmap/dist/ ${GF_PATHS_PLUGINS}/flant
 COPY ./grafana_home_dashboard.json /usr/share/grafana/public/dashboards/grafana_home_dashboard.json
 COPY ./web/ /usr/share/grafana/public/img/
 
-RUN mkdir -p /etc/grafana/plugins && \
-    chown -R 64535:64535 /usr/share/grafana && \
+RUN chown -R 64535:64535 /usr/share/grafana && \
     chown -R 64535:64535 /etc/grafana && \
     chown -R 64535:64535 /var/lib/grafana && \
     chown -R 64535:64535 /var/log/grafana

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -77,7 +77,7 @@ FROM $BASE_GOLANG_17_BUSTER as go-builder
 ARG GRAFANA_VERSION
 ENV GRAFANA_VERSION=${GRAFANA_VERSION}
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install git gcc musl glibc-source build-essential
+    apt-get -y --no-install-recommends install git gcc musl musl-tools
 COPY --from=src-files /usr/src/app /usr/src/app
 WORKDIR /usr/src/app/
 
@@ -86,6 +86,7 @@ ENV GOPROXY=${GOPROXY} \
     CGO_ENABLED=1 \
     GOOS=linux \
     GOARCH=amd64
+    CC=/usr/bin/musl-gcc
 
 RUN make gen-go
 RUN go build -ldflags -w -ldflags "-linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-server ./pkg/cmd/grafana-server

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -89,8 +89,8 @@ ENV GOPROXY=${GOPROXY} \
     CC=/usr/bin/musl-gcc
 
 RUN make gen-go
-RUN go build -ldflags -w -ldflags "-linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-server ./pkg/cmd/grafana-server
-RUN go build -ldflags -w -ldflags "-linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-cli ./pkg/cmd/grafana-cli
+RUN go build -ldflags -w -ldflags "-X main.version=${GRAFANA_VERSION} -linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-server ./pkg/cmd/grafana-server
+RUN go build -ldflags -w -ldflags "-X main.version=${GRAFANA_VERSION} -linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-cli ./pkg/cmd/grafana-cli
 
 FROM $BASE_GOLANG_20_ALPINE as entrypoint
 

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -170,7 +170,8 @@ COPY --from=grafana-statusmap /grafana-statusmap/dist/ ${GF_PATHS_PLUGINS}/flant
 COPY ./grafana_home_dashboard.json /usr/share/grafana/public/dashboards/grafana_home_dashboard.json
 COPY ./web/ /usr/share/grafana/public/img/
 
-RUN chown -R 64535:64535 /usr/share/grafana && \
+RUN mkdir -p /etc/grafana/plugins && \
+    chown -R 64535:64535 /usr/share/grafana && \
     chown -R 64535:64535 /etc/grafana && \
     chown -R 64535:64535 /var/lib/grafana && \
     chown -R 64535:64535 /var/log/grafana

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -85,7 +85,7 @@ ARG GOPROXY
 ENV GOPROXY=${GOPROXY} \
     CGO_ENABLED=1 \
     GOOS=linux \
-    GOARCH=amd64
+    GOARCH=amd64 \
     CC=/usr/bin/musl-gcc
 
 RUN make gen-go

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -77,7 +77,7 @@ FROM $BASE_GOLANG_17_BUSTER as go-builder
 ARG GRAFANA_VERSION
 ENV GRAFANA_VERSION=${GRAFANA_VERSION}
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install git gcc musl
+    apt-get -y --no-install-recommends install git gcc musl glibc-source build-essential
 COPY --from=src-files /usr/src/app /usr/src/app
 WORKDIR /usr/src/app/
 
@@ -89,7 +89,7 @@ ENV GOPROXY=${GOPROXY} \
 
 RUN make gen-go
 RUN go build -ldflags -w -ldflags "-linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-server ./pkg/cmd/grafana-server
-RUN go run build.go build-cli
+RUN go build -ldflags -w -ldflags "-linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana-cli ./pkg/cmd/grafana-cli
 
 FROM $BASE_GOLANG_20_ALPINE as entrypoint
 

--- a/modules/300-prometheus/images/grafana/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana/entrypoint/main.go
@@ -161,14 +161,16 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 	for _, plugin := range strings.Split(gfInstallPlugins, ",") {
 
 		if strings.Contains(plugin, ";") {
-			bit := strings.Split(plugin, ";")
+			part := strings.Split(plugin, ";")
 			cmd := exec.Command(
 				"grafana-cli",
-				fmt.Sprintf("--pluginUrl %s", bit[0]),
-				fmt.Sprintf("--pluginsDir %s", gfPathsPlugins),
+				"--pluginUrl",
+				part[0],
+				"--pluginsDir",
+				gfPathsPlugins,
 				"plugins",
 				"install",
-				bit[1],
+				part[1],
 			)
 
 			if stdout, err := cmd.CombinedOutput(); err != nil {
@@ -178,7 +180,8 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 		}
 		cmd := exec.Command(
 			"grafana-cli",
-			fmt.Sprintf("--pluginsDir %s", gfPathsPlugins),
+			"--pluginsDir",
+			gfPathsPlugins,
 			"plugins",
 			"install",
 			plugin,

--- a/modules/300-prometheus/images/grafana/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana/entrypoint/main.go
@@ -172,7 +172,7 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 			)
 
 			if stdout, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%v | %v", stdout, err)
+				return fmt.Errorf("%v | %v", string(stdout), err)
 			}
 			continue
 		}
@@ -184,7 +184,7 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 			plugin,
 		)
 		if stdout, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("%v | %v", stdout, err)
+			return fmt.Errorf("%v | %v", string(stdout), err)
 		}
 	}
 	return nil

--- a/modules/300-prometheus/images/grafana/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana/entrypoint/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	err = installPlugins(gfInstallPlugins, gfPathsPlugins)
 	if err != nil {
-		log.Fatalf("convert env: %v", err)
+		log.Fatalf("install plugins: %v", err)
 	}
 
 	grafanaArgs := []string{
@@ -154,14 +154,6 @@ func convertEnv() error {
 }
 
 func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
-	fmt.Println("DEBUG_gfPathsPlugins: ", gfPathsPlugins)
-	fmt.Println("DEBUG_gfInstallPlugins: ", gfInstallPlugins)
-	fileInfo, _ := os.Lstat("/usr/share/grafana/bin/grafana-cli")
-	fmt.Println("Name : ", fileInfo.Name())
-	fmt.Println("Size : ", fileInfo.Size())
-	fmt.Println("Mode/permission : ", fileInfo.Mode())
-	fmt.Println("Sys : ", fileInfo.Sys())
-
 	if gfInstallPlugins == "" {
 		return nil
 	}
@@ -178,8 +170,9 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 				"install",
 				bit[1],
 			)
-			if err := cmd.Run(); err != nil {
-				return err
+
+			if stdout, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("%v | %v", stdout, err)
 			}
 			continue
 		}
@@ -190,8 +183,8 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 			"install",
 			plugin,
 		)
-		if err := cmd.Run(); err != nil {
-			return err
+		if stdout, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%v | %v", stdout, err)
 		}
 	}
 	return nil

--- a/modules/300-prometheus/images/grafana/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana/entrypoint/main.go
@@ -147,11 +147,14 @@ func convertEnv() error {
 }
 
 func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
+	fmt.Println("DEBUG_gfPathsPlugins: ", gfPathsPlugins)
+	fmt.Println("DEBUG_gfInstallPlugins: ", gfInstallPlugins)
 	if gfInstallPlugins == "" {
 		return nil
 	}
 
 	for _, plugin := range strings.Split(gfInstallPlugins, ",") {
+
 		if strings.Contains(plugin, ";") {
 			bit := strings.Split(plugin, ";")
 			cmd := exec.Command(

--- a/modules/300-prometheus/images/grafana/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana/entrypoint/main.go
@@ -149,6 +149,12 @@ func convertEnv() error {
 func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 	fmt.Println("DEBUG_gfPathsPlugins: ", gfPathsPlugins)
 	fmt.Println("DEBUG_gfInstallPlugins: ", gfInstallPlugins)
+	fileInfo, _ := os.Lstat("/usr/share/grafana/bin/grafana-cli")
+	fmt.Println("Name : ", fileInfo.Name())
+	fmt.Println("Size : ", fileInfo.Size())
+	fmt.Println("Mode/permission : ", fileInfo.Mode())
+	fmt.Println("Sys : ", fileInfo.Sys())
+
 	if gfInstallPlugins == "" {
 		return nil
 	}

--- a/modules/300-prometheus/images/grafana/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana/entrypoint/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	_, err := os.Stat(gfPathsPlugins)
 	if os.IsNotExist(err) {
-		err := os.MkdirAll(gfPathsPlugins, 0600)
+		err := os.MkdirAll(gfPathsPlugins, 0660)
 		if err != nil {
 			log.Fatalf("create plugins folder: %v", err)
 		}
@@ -48,6 +48,11 @@ func main() {
 	}
 
 	if bundledPluginsPath != "" && gfInstallPlugins != "" && gfPathsPlugins != bundledPluginsPath {
+		fstatDest, err := os.Stat(gfPathsPlugins)
+		if err != nil {
+			log.Fatalf("file info error: path: %s err: %v", gfPathsPlugins, err)
+		}
+
 		_, err = os.Stat(bundledPluginsPath)
 		if err == nil {
 			opt := cp.Options{
@@ -57,6 +62,8 @@ func main() {
 					}
 					return err
 				},
+				// add permissions from destination folder
+				PermissionControl: cp.AddPermission(fstatDest.Mode()),
 			}
 			err := cp.Copy(bundledPluginsPath, gfPathsPlugins, opt)
 			if err != nil {

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -127,7 +127,7 @@ spec:
   externalUrl: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}/prometheus/longterm/
 {{- end }}
   {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
-    fsGroup: 2000
+    fsGroup: 64535
   serviceAccountName: prometheus
   podMetadata:
     labels:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -257,7 +257,7 @@ spec:
   externalUrl: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}/prometheus/
 {{- end }}
   {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
-
+    fsGroup: 64535
   {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 2 }}
   {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 2 }}
   {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 2 }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -257,7 +257,6 @@ spec:
   externalUrl: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}/prometheus/
 {{- end }}
   {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
-    fsGroup: 2000
   {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 2 }}
   {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 2 }}
   {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 2 }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -257,6 +257,7 @@ spec:
   externalUrl: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}/prometheus/
 {{- end }}
   {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
+
   {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 2 }}
   {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 2 }}
   {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 2 }}


### PR DESCRIPTION
## Description
Static build grafana-cli for distroless. Fix issue with add custom grafana plugins.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We can run grafana-cli in distroless images. 
Fixed issue with add custom grafana plugins to the grafana.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Because clients can't add custom plugins to the grafana.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
We can add custom plugins to the grafana.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Additional info
```shell
2023/09/14 15:18:00 copy plugins: chmod /etc/grafana/plugins: operation not permitted

2023/09/14 20:40:24 convert env: fork/exec /usr/share/grafana/bin/grafana-cli: no such file or directory

$ ldd grafana-cli 
        linux-vdso.so.1 (0x00007ffd3cb93000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f7d772ec000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f7d772e7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7d77000000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f7d77312000)
```

```shell
root@08f37fc1fe62:/usr/src/app# export LDFLAGS="-extldflags -static -linkmode external"
root@08f37fc1fe62:/usr/src/app# go run build.go -build-tags netgo build-cli 
Version: 8.5.13, Linux Version: 8.5.13, Package Iteration: 1694731986
rm -r dist
rm -r tmp
rm -r /go/pkg/linux_amd64/github.com/grafana
building grafana-cli ./pkg/cmd/grafana-cli
rm -r ./bin/linux-amd64/grafana-cli
rm -r ./bin/linux-amd64/grafana-cli.md5
go build -ldflags -w -X main.version=8.5.13 -X main.commit=fix_heatmap,feat_extra_vars -X main.buildstamp=1663666086 -X main.buildBranch=HEAD -extldflags "-extldflags -static -linkmode external" -tags netgo -o ./bin/linux-amd64/grafana-cli ./pkg/cmd/grafana-cli
# github.com/grafana/grafana/pkg/cmd/grafana-cli
/usr/local/go/pkg/tool/linux_amd64/link: running musl-gcc failed: exit status 1
cc: error: external: No such file or directory

exit status 2
exit status 1
```

```shell
root@08f37fc1fe62:/usr/src/app# export CGO_ENABLED=0
root@08f37fc1fe62:/usr/src/app# go run build.go -build-tags netgo build-cli 
Version: 8.5.13, Linux Version: 8.5.13, Package Iteration: 1694732045
rm -r dist
rm -r tmp
rm -r /go/pkg/linux_amd64/github.com/grafana
building grafana-cli ./pkg/cmd/grafana-cli
rm -r ./bin/linux-amd64/grafana-cli
rm -r ./bin/linux-amd64/grafana-cli.md5
go build -ldflags -w -X main.version=8.5.13 -X main.commit=fix_heatmap,feat_extra_vars -X main.buildstamp=1663666086 -X main.buildBranch=HEAD -extldflags "-extldflags -static -linkmode external" -tags netgo -o ./bin/linux-amd64/grafana-cli ./pkg/cmd/grafana-cli
# github.com/grafana/grafana/pkg/services/sqlstore/migrator
pkg/services/sqlstore/migrator/sqlite_dialect.go:127:16: undefined: sqlite3.Error
pkg/services/sqlstore/migrator/sqlite_dialect.go:138:16: undefined: sqlite3.Error
pkg/services/sqlstore/migrator/sqlite_dialect.go:146:33: undefined: sqlite3.ErrConstraintUnique
exit status 2
exit status 1
```

<details><summary>Dockerfile</summary>

```shell
ARG BASE_ALPINE="alpine"
ARG BASE_NODE_16_ALPINE="node:16.15"
ARG BASE_GOLANG_17_BUSTER="golang:1.17-buster"
ARG BASE_GOLANG_20_ALPINE="golang:1.20-buster"
ARG BASE_UBUNTU="ubuntu:22.04"
ARG BASE_DISTROLESS="ubuntu:22.04"
ARG GRAFANA_VERSION="8.5.13"
ARG STATUSMAP_VERSION="0.5.1"
ARG BUNDLED_PLUGINS="petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel"

# This Dockerfile is based on Dockerfile from https://github.com/grafana/grafana/blob/v8.5.2/Dockerfile
# Changes:
# - Source files are not available in the current directory.
#   Archive is downloaded and patched using an intermediate image.
# - Install bundled plugins in final stage.

# ===================================================
# Step 1. Download sources and apply patches.
# It will fail fast on problems with future versions.
FROM $BASE_ALPINE as src-files
WORKDIR /usr/src/app
RUN apk add --no-cache patch git

ARG SOURCE_REPO="https://github.com"
ENV SOURCE_REPO=${SOURCE_REPO}

ARG GRAFANA_VERSION

RUN git clone --depth 1 --branch v${GRAFANA_VERSION} ${SOURCE_REPO}/grafana/grafana.git .
# Extra '__interval_*' vars for prometheus datasource.
COPY ./patches/feat_prometheus_extra_vars.patch .
RUN patch -p1 < ./feat_prometheus_extra_vars.patch
# Fix heatmap render: constant bucket widths for fast-forward datasource.
COPY ./patches/fix_heatmap_thin_bars_on_ff.patch .
RUN patch -p1 < ./fix_heatmap_thin_bars_on_ff.patch
# Set more useful version than 'dev'. There are tabs in patch, so -l is used.
COPY patches/build_go.patch .
RUN patch -p1 -l < ./build_go.patch
# Patch to copy bundled plugins at start from ro directory to rw.
COPY ./patches/run_sh.patch .
RUN patch -p1 < ./run_sh.patch


FROM $BASE_GOLANG_17_BUSTER as go-builder
ARG GRAFANA_VERSION
ENV GRAFANA_VERSION=${GRAFANA_VERSION}
RUN apt-get update && \
    apt-get -y --no-install-recommends install git gcc musl
COPY --from=src-files /usr/src/app /usr/src/app
WORKDIR /usr/src/app/

ARG GOPROXY
ENV GOPROXY=${GOPROXY} \
    CGO_ENABLED=1 \
    GOOS=linux \
    GOARCH=amd64

RUN make gen-go
RUN go build -ldflags -w -ldflags "-linkmode external -extldflags '-static'" -tags netgo -o ./bin/linux-amd64/grafana-server ./pkg/cmd/grafana-server
RUN export LDFLAGS="-extldflags -static -linkmode external" && \
    export CGO_ENABLED=0 && \
    go run build.go -build-tags netgo build-cli
```

</details>

## Test results
![image](https://github.com/deckhouse/deckhouse/assets/32643620/348959ad-7a1d-4a7a-8344-bf8d2dbd8d23)

```shell
# kubectl -n d8-monitoring logs grafana-6cfcfb8b5b-g7pl5 grafana | grep Listen
logger=http.server t=2023-09-17T18:17:23.9+0000 lvl=info msg="HTTP Server Listen" address=127.0.0.1:3000 protocol=http subUrl= socket=
```

```shell
# kubectl get mc prometheus -o yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: prometheus
spec:
  enabled: true
  settings:
    grafana:
      customPlugins:
      - redis-datasource
  version: 2
```


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: fixed issue with add custom grafana plugins
impact_level: default
---
section: prometheus
type: chore
summary: move grafana to distroless
impact_level: default

```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
