### PR TITLE
[log-shipper] Suppress metrics timestamp

### DIFF
--- a/modules/460-log-shipper/hooks/testdata/__default-config.json
+++ b/modules/460-log-shipper/hooks/testdata/__default-config.json
@@ -23,7 +23,8 @@
       "inputs": [
         "internal_metrics"
       ],
-      "address": "127.0.0.1:9090"
+      "address": "127.0.0.1:9090",
+      "suppress_timestamp": true
     }
   }
 }

--- a/modules/460-log-shipper/templates/configmap.yaml
+++ b/modules/460-log-shipper/templates/configmap.yaml
@@ -31,7 +31,8 @@ data:
           "inputs": [
             "internal_metrics"
           ],
-          "address": "127.0.0.1:9090"
+          "address": "127.0.0.1:9090",
+          "suppress_timestamp": true
         }
       }
     }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Toggle the option to suppress timestamps in the vector config

## Why do we need it in the patch release (if we do)?
Metrics exposed by vector look like this
```
vector_uptime_seconds{host="log-shipper-agent-5hjmn"} 513828 1694687172697
```
Because of the last timestamp values, Prometheus can throw errors like the following
```
ts=2023-09-14T13:28:39.352Z caller=scrape.go:1690 level=warn component="scrape manager" scrape_pool=podMonitor/d8-monitoring/log-shipper-agent/0 target=https://10.111.23.184:9254/metrics msg="Error on ingesting out-of-order samples" num_dropped=8
```

However, a timestamp is not a necessity. For our use case, it is ok to let Prometheus handle timestamps on its own. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: feat
summary: Suppress metrics timestamp to avoid out-of-order ingestion error
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
