### PR TITLE
[monitoring] Fixing the etcd version in the home dashboard

### DIFF
--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -649,7 +649,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max by (cluster_version) (etcd_cluster_version{job=\"kube-etcd3\"})",
+          "expr": "max by (server_version) (etcd_server_version{job=\"kube-etcd3\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{ version }}",


### PR DESCRIPTION
## Description
Fixing the etcd version in the home grafana dashboard.

## Why do we need it, and what problem does it solve?
The `etcd_cluster_version` metric disappeared, so we will use the `etcd_server_version`.
Also, the new `etcd_server_version` metric has a patch version, but `etcd_cluster_version` doesn't.

## Why do we need it in the patch release (if we do)?
All the dashboards has empty etcd plate in dashboard. It is weird.

## What is the expected result?
The etcd version is showed in home dashboards.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: The etcd version in the home dashboard is fixed.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
