### PR TITLE
[prometheus] Fix permissions for existing files

### DIFF
--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -65,7 +65,7 @@ spec:
   - command:
     - sh
     - -c
-    - if [ "$(ls -1 /prometheus-db | wc -l)" -gt 0 ]; then chown -vR 64535:64535 /prometheus-db/*; fi
+    - chown -vfR 64535:64535 /prometheus-db/
     image: {{ include "helm_lib_module_image" (list . "prometheus") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -61,6 +61,21 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
+  initContainers:
+  - command:
+    - sh
+    - -c
+    - chown -R 64535:64535 /prometheus-db/*
+    image: {{ include "helm_lib_module_image" (list . "prometheus") }}
+    imagePullPolicy: IfNotPresent
+    name: fix-permissions
+    securityContext:
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /prometheus-db
+      name: prometheus-longterm-db
+      subPath: prometheus-db
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -65,7 +65,7 @@ spec:
   - command:
     - sh
     - -c
-    - chown -R 64535:64535 /prometheus-db/*
+    - chown -vR 64535:64535 /prometheus-db/*
     image: {{ include "helm_lib_module_image" (list . "prometheus") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -65,7 +65,7 @@ spec:
   - command:
     - sh
     - -c
-    - chown -vR 64535:64535 /prometheus-db/*
+    - if [ "$(ls -1 /prometheus-db | wc -l)" -gt 0 ]; then chown -vR 64535:64535 /prometheus-db/*; fi
     image: {{ include "helm_lib_module_image" (list . "prometheus") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -69,7 +69,7 @@ spec:
   - command:
     - sh
     - -c
-    - if [ "$(ls -1 /prometheus-db | wc -l)" -gt 0 ]; then chown -vR 64535:64535 /prometheus-db/*; fi
+    - chown -vfR 64535:64535 /prometheus-db/
     image: {{ include "helm_lib_module_image" (list . "prometheus") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -65,6 +65,21 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
+  initContainers:
+  - command:
+    - sh
+    - -c
+    - chown -R 64535:64535 /prometheus-db/*
+    image: {{ include "helm_lib_module_image" (list . "prometheus") }}
+    imagePullPolicy: IfNotPresent
+    name: fix-permissions
+    securityContext:
+      runAsNonRoot: false
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /prometheus-db
+      name: prometheus-main-db
+      subPath: prometheus-db
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -69,7 +69,7 @@ spec:
   - command:
     - sh
     - -c
-    - chown -vR 64535:64535 /prometheus-db/*
+    - if [ "$(ls -1 /prometheus-db | wc -l)" -gt 0 ]; then chown -vR 64535:64535 /prometheus-db/*; fi
     image: {{ include "helm_lib_module_image" (list . "prometheus") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -69,7 +69,7 @@ spec:
   - command:
     - sh
     - -c
-    - chown -R 64535:64535 /prometheus-db/*
+    - chown -vR 64535:64535 /prometheus-db/*
     image: {{ include "helm_lib_module_image" (list . "prometheus") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed permissions for existing files after changing GID and UID.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Prometheus can't start

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Test results

<details>

```shell
# kubectl -n d8-monitoring logs prometheus-main-0 fix-permissions  -f
changed ownership of '/prometheus-db/01HAAYRKFEESRWBYSNZDG445S8/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAAYRKFEESRWBYSNZDG445S8/index' to 64535:64535
changed ownership of '/prometheus-db/01HAAYRKFEESRWBYSNZDG445S8/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAAYRKFEESRWBYSNZDG445S8/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAAYRKFEESRWBYSNZDG445S8/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAAYRKFEESRWBYSNZDG445S8' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PN8J7238BFGPER3SYFTP/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PN8J7238BFGPER3SYFTP/index' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PN8J7238BFGPER3SYFTP/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PN8J7238BFGPER3SYFTP/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PN8J7238BFGPER3SYFTP/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PN8J7238BFGPER3SYFTP' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PSD3GR5EE31Q0PA2YQHG/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PSD3GR5EE31Q0PA2YQHG/index' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PSD3GR5EE31Q0PA2YQHG/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PSD3GR5EE31Q0PA2YQHG/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PSD3GR5EE31Q0PA2YQHG/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAJ8PSD3GR5EE31Q0PA2YQHG' to 64535:64535
changed ownership of '/prometheus-db/01HAK3P143KSNP0D6EXVB4Y7NJ/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAK3P143KSNP0D6EXVB4Y7NJ/index' to 64535:64535
changed ownership of '/prometheus-db/01HAK3P143KSNP0D6EXVB4Y7NJ/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAK3P143KSNP0D6EXVB4Y7NJ/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAK3P143KSNP0D6EXVB4Y7NJ/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAK3P143KSNP0D6EXVB4Y7NJ' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHRC2MJDBSBD4X1ZX5N5Y/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHRC2MJDBSBD4X1ZX5N5Y/index' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHRC2MJDBSBD4X1ZX5N5Y/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHRC2MJDBSBD4X1ZX5N5Y/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHRC2MJDBSBD4X1ZX5N5Y/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHRC2MJDBSBD4X1ZX5N5Y' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHWKEJ847D2Y4R7WBCHFY/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHWKEJ847D2Y4R7WBCHFY/index' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHWKEJ847D2Y4R7WBCHFY/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHWKEJ847D2Y4R7WBCHFY/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHWKEJ847D2Y4R7WBCHFY/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAKAHWKEJ847D2Y4R7WBCHFY' to 64535:64535
changed ownership of '/prometheus-db/01HAKHDFMM6MTKTYG7BFCSVCKK/meta.json' to 64535:64535
changed ownership of '/prometheus-db/01HAKHDFMM6MTKTYG7BFCSVCKK/index' to 64535:64535
changed ownership of '/prometheus-db/01HAKHDFMM6MTKTYG7BFCSVCKK/tombstones' to 64535:64535
changed ownership of '/prometheus-db/01HAKHDFMM6MTKTYG7BFCSVCKK/chunks/000001' to 64535:64535
changed ownership of '/prometheus-db/01HAKHDFMM6MTKTYG7BFCSVCKK/chunks' to 64535:64535
changed ownership of '/prometheus-db/01HAKHDFMM6MTKTYG7BFCSVCKK' to 64535:64535
changed ownership of '/prometheus-db/chunk_snapshot.000049.0009437184/00000000' to 64535:64535
changed ownership of '/prometheus-db/chunk_snapshot.000049.0009437184' to 64535:64535
changed ownership of '/prometheus-db/chunks_head/000010' to 64535:64535
changed ownership of '/prometheus-db/chunks_head/000011' to 64535:64535
changed ownership of '/prometheus-db/chunks_head/000009' to 64535:64535
changed ownership of '/prometheus-db/chunks_head/000008' to 64535:64535
changed ownership of '/prometheus-db/chunks_head' to 64535:64535
changed ownership of '/prometheus-db/permissions-fixed-flag' to 64535:64535
changed ownership of '/prometheus-db/queries.active' to 64535:64535
changed ownership of '/prometheus-db/wal/00000049' to 64535:64535
changed ownership of '/prometheus-db/wal/00000048' to 64535:64535
changed ownership of '/prometheus-db/wal/00000047' to 64535:64535
changed ownership of '/prometheus-db/wal/00000046' to 64535:64535
changed ownership of '/prometheus-db/wal/checkpoint.00000044/00000000' to 64535:64535
changed ownership of '/prometheus-db/wal/checkpoint.00000044' to 64535:64535
changed ownership of '/prometheus-db/wal/00000045' to 64535:64535
changed ownership of '/prometheus-db/wal' to 64535:64535
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fixed permissions for existing files after changing GID and UID.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
