### PR TITLE
Added more command checks in CheckDHCTLDependencies method

### DIFF
--- a/candi/bashible/docs/README.md
+++ b/candi/bashible/docs/README.md
@@ -14,6 +14,7 @@ Bashible consists of small bash scripts, that are called `steps`.
   * Use the same code for different purposes: installation, daily routine, vm image creation
 
 * Step files, and the bashible entrypoint are located in the `/var/lib/bashible` directory.
+  * Also, there is a bashible entrypoint for EE version in the `./ee/candi/bashible` directory. 
 
 * Bashible is periodically executing on a Node by systemd unit timer.  
 

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -190,7 +190,8 @@ const dependencyCmd = "type"
 
 func CheckDHCTLDependencies(sshClient *ssh.Client) error {
 	return log.Process("bootstrap", "Check DHCTL Dependencies", func() error {
-		var dependencyArgs = []string{"sudo", "rm", "tar"}
+		dependencyArgs := []string{"sudo", "rm", "tar", "mount", "awk", "grep", "cut", "sed", "shopt",
+			"mkdir", "cp", "join"}
 
 		for _, args := range dependencyArgs {
 			output, err := sshClient.Command(dependencyCmd, args).CombinedOutput()


### PR DESCRIPTION
## Description
Added more command checks in CheckDHCTLDependencies method to prevent unexpected fails in bootstrap.sh script.

## Why do we need it, and what problem does it solve?
Fix https://github.com/deckhouse/deckhouse/issues/5066. It solves the problem of unexpected bootstrap.sh failure, if some of shell-commands are missing.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
If some of shell-commands using in bootstrap.sh isn't installed, we'll get an error of a missing shell-command.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: bashible
type: fix
summary: client will get an error of missing shell-command in bootstrap.sh 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
