### PR TITLE
[cluster-autoscaler] fix liveness probe

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -42,7 +42,7 @@ import:
     add: /src/cluster-autoscaler/cluster-autoscaler
     to: /cluster-autoscaler
     before: setup
-  - artifact: 007-registrypackages/d8-curl-artifact-{{ $curlVersion | replace "." "-" }}
+  - artifact: registrypackages/d8-curl-artifact-{{ $curlVersion | replace "." "-" }}
     add: /d8-curl
     to: /curl
     before: setup

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -1,4 +1,5 @@
-{{- range $key, $value := .CandiVersionMap.k8s }}
+{{- $curlVersion := "8.2.1" }}
+  {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- if $value.clusterAutoscalerPatch }}
 ---
@@ -40,6 +41,10 @@ import:
   - artifact: {{ $.ModuleName }}/distroless-{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /src/cluster-autoscaler/cluster-autoscaler
     to: /cluster-autoscaler
+    before: setup
+  - artifact: 007-registrypackages/d8-curl-artifact-{{ $curlVersion | replace "." "-" }}
+    add: /d8-curl
+    to: /curl
     before: setup
 docker:
   ENV:

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -1,5 +1,4 @@
-{{- $curlVersion := "8.2.1" }}
-  {{- range $key, $value := .CandiVersionMap.k8s }}
+{{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- if $value.clusterAutoscalerPatch }}
 ---

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -42,10 +42,6 @@ import:
     add: /src/cluster-autoscaler/cluster-autoscaler
     to: /cluster-autoscaler
     before: setup
-  - artifact: registrypackages/d8-curl-artifact-{{ $curlVersion | replace "." "-" }}
-    add: /d8-curl
-    to: /curl
-    before: setup
 docker:
   ENV:
     container: docker

--- a/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
@@ -115,11 +115,10 @@ spec:
         - name: CONTROL_NAMESPACE
           value: d8-cloud-instance-manager
         livenessProbe:
-          exec:
-            command:
-            - /curl
-            - -f
-            - http://127.0.0.1:8085/health-check
+          httpGet:
+            path: /health-check
+            port: 8443
+            scheme: HTTPS
           failureThreshold: 6
           periodSeconds: 5
           successThreshold: 1
@@ -144,6 +143,8 @@ spec:
           value: "0.0.0.0"
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
+            excludePaths:
+            - /health-check
             upstreams:
             - upstream: http://127.0.0.1:8085/metrics
               path: /metrics

--- a/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
@@ -140,14 +140,16 @@ spec:
         - "--livez-path=/livez"
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:
             - /health-check
             upstreams:
-            - upstream: http://127.0.0.1:8085/metrics
-              path: /metrics
+            - upstream: http://127.0.0.1:8085/
+              path: /
               authorization:
                 resourceAttributes:
                   namespace: d8-cloud-instance-manager

--- a/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
@@ -117,9 +117,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - sh
-            - -c
-            - wget -T 3 -q -O /dev/null http://127.0.0.1:8085/health-check
+            - curl
+            - -f
+            - http://127.0.0.1:8085/health-check
           failureThreshold: 6
           periodSeconds: 5
           successThreshold: 1

--- a/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
@@ -117,7 +117,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - curl
+            - /curl
             - -f
             - http://127.0.0.1:8085/health-check
           failureThreshold: 6


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix liveness probe thru kube-rbac-proxy.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After moving to distroless cluster-autoscaler liveness probe does not work due to absent wget binary.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix `cluster-autoscaler` liveness probe.
impact_level: default
```
