### PR TITLE
[monitoring-kubernetes] Remove allValue regexp from Capacity Planning

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/capacity-planning/capacity-planning.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/capacity-planning/capacity-planning.json
@@ -2358,7 +2358,7 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
+        "allValue": "",
         "current": {
           "selected": true,
           "text": [
@@ -2393,7 +2393,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": "",
         "current": {
           "selected": true,
           "text": [


### PR DESCRIPTION
## Description
Removes `".*"` regexp from `allValue` for nodes and namespaces.

## Why do we need it, and what problem does it solve?
This allows automatic filtering out namespaces not present on a node/nodes, when not all nodes are selected.


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Improve filtering in the Capacity Planning dashboard.
impact_level: low
```
