### PR TITLE
[dhctl] Fix restarting bootstrap process 

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -179,9 +179,8 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 				// deckhouse create manifests: create resource: admission webhook "validate-cm.deckhouse-config-webhook.deckhouse.io" denied the request:
 				// changing ConfigMap/deckhouse is not allowed for kubernetes-admin. Use ModuleConfig resources to configure Deckhouse.
 				// after restart bootstrap
-				cm := manifest.(*apiv1.ConfigMap)
 				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-					Get(context.TODO(), cm.GetName(), metav1.GetOptions{})
+					Get(context.TODO(), "deckhouse-generated-config-do-not-edit", metav1.GetOptions{})
 				if k8serror.IsNotFound(err) {
 					_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
 						Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})


### PR DESCRIPTION
## Description
In CreateDeckhouseManifests method we search `ConfigMap "Deckhouse"` by a new name.

## Why do we need it, and what problem does it solve?
We need that to prevent an error of editing `ConfigMap "Deckhouse"` while we try to create `ConfigMap "Deckhouse"` after cluster's restart.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
After cluster restart we will not have an error that `ConfigMap "Deckhouse"` is cannot be edited.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix restarting bootstrap process
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
