### PR TITLE
[global] Remove old deckhouse endpointslices on start

### DIFF
--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -17,7 +17,10 @@ limitations under the License.
 package hooks
 
 import (
+	"context"
 	"os"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -40,9 +43,9 @@ const (
 // should run before all hooks
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnStartup: &go_hook.OrderedConfig{Order: 1},
-}, generateDeckhouseEndpoints)
+}, dependency.WithExternalDependencies(generateDeckhouseEndpoints))
 
-func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
+func generateDeckhouseEndpoints(input *go_hook.HookInput, dc dependency.Container) error {
 	// hostname := os.Getenv("HOSTNAME")
 	// At this moment we don't use Hostname because of 2 reasons:
 	// 1. According to the endpoint controller, it should be set only when:
@@ -160,6 +163,26 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput) error {
 
 	input.PatchCollector.Create(ep, object_patch.UpdateIfExists())
 	input.PatchCollector.Create(es, object_patch.UpdateIfExists())
+
+	// TODO: remove this part after Deckhouse release 1.55
+	// we have to remove old endpointslices here also, to prevent block on cm/deckhouse check
+	return cleanupOldEndpoints(input, dc)
+}
+
+func cleanupOldEndpoints(input *go_hook.HookInput, dc dependency.Container) error {
+	client, err := dc.GetK8sClient()
+	if err != nil {
+		return err
+	}
+
+	list, err := client.DiscoveryV1().EndpointSlices(d8Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=deckhouse,heritage=deckhouse,endpointslice.kubernetes.io/managed-by=endpointslice-controller.k8s.io"})
+	if err != nil {
+		return err
+	}
+
+	for _, es := range list.Items {
+		input.PatchCollector.Delete(es.APIVersion, es.Kind, es.Namespace, es.Name)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description
Remove deckhouse automatically created endpointslices

## Why do we need it, and what problem does it solve?
We have a hook in 002-deckhouse module, which remove these endpointslices but old endpointslice could block validating webhook on startup. So, we have to remove it on startup, and then check one more time in the deckhouse module, because it could be created with the service again

## Why do we need it in the patch release (if we do)?
In some cases release could block on validating deckhouse cm during the startup

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: fix 
summary: Clean old deckhouse endpointslices on startup.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
