### PR TITLE
[loki] fix permissions for existing files

### DIFF
--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -36,6 +36,21 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - chown -vfR 64535:64535 /loki/
+        image: {{ include "helm_lib_module_image" (list . "loki") }}
+        imagePullPolicy: IfNotPresent
+        name: fix-permissions
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /loki
+          name: storage
+          subPath: loki
       containers:
       - name: loki
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         - sh
         - -c
         - chown -vfR 64535:64535 /loki/
-        image: {{ include "helm_lib_module_image" (list . "loki") }}
+        image: {{ include "helm_lib_module_image" (list . "alpine") }}
         imagePullPolicy: IfNotPresent
         name: fix-permissions
         securityContext:

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
           name: storage
           subPath: loki
         resources:
-          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+          {{ include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
       containers:
       - name: loki
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         - sh
         - -c
         - chown -vfR 64535:64535 /loki/
-        image: {{ include "helm_lib_module_image" (list . "alpine") }}
+        image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
         imagePullPolicy: IfNotPresent
         name: fix-permissions
         securityContext:

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -52,7 +52,8 @@ spec:
           name: storage
           subPath: loki
         resources:
-          {{ include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+          requests:
+            {{ include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
       containers:
       - name: loki
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -51,6 +51,8 @@ spec:
         - mountPath: /loki
           name: storage
           subPath: loki
+        resources:
+          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
       containers:
       - name: loki
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}


### PR DESCRIPTION
## Description
Fixed permissions for existing files after changing GID and UID.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Loki can't start
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: loki
type: fix
summary: Fixed permissions for existing files after changing GID and UID.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
