### PR TITLE
[global] Fix endpoints cleanup

### DIFF
--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -180,6 +180,17 @@ func cleanupOldEndpoints(input *go_hook.HookInput, dc dependency.Container) erro
 		return err
 	}
 
+	if len(list.Items) > 0 {
+		// remove selector from deckhouse service to prevent endpointslices creation
+		patch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"selector": nil,
+			},
+		}
+
+		input.PatchCollector.MergePatch(patch, "v1", "Service", d8Namespace, d8Name)
+	}
+
 	for _, es := range list.Items {
 		input.PatchCollector.Delete("discovery.k8s.io/v1", "EndpointSlice", d8Namespace, es.Name)
 	}

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -181,7 +181,7 @@ func cleanupOldEndpoints(input *go_hook.HookInput, dc dependency.Container) erro
 	}
 
 	for _, es := range list.Items {
-		input.PatchCollector.Delete(es.APIVersion, es.Kind, es.Namespace, es.Name)
+		input.PatchCollector.Delete("discovery.k8s.io/v1", "EndpointSlice", d8Namespace, es.Name)
 	}
 
 	return nil

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -164,7 +164,7 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput, dc dependency.Containe
 	input.PatchCollector.Create(ep, object_patch.UpdateIfExists())
 	input.PatchCollector.Create(es, object_patch.UpdateIfExists())
 
-	// TODO: remove this part after Deckhouse release 1.55
+	// TODO: remove this part after Deckhouse release 1.56
 	// we have to remove old endpointslices here also, to prevent block on cm/deckhouse check
 	return cleanupOldEndpoints(input, dc)
 }

--- a/global-hooks/create_endpoints.go
+++ b/global-hooks/create_endpoints.go
@@ -161,12 +161,17 @@ func generateDeckhouseEndpoints(input *go_hook.HookInput, dc dependency.Containe
 		},
 	}
 
+	// TODO: remove this part after Deckhouse release 1.56
+	// we have to remove old endpointslices here also, to prevent block on cm/deckhouse check
+	err := cleanupOldEndpoints(input, dc)
+	if err != nil {
+		return err
+	}
+
 	input.PatchCollector.Create(ep, object_patch.UpdateIfExists())
 	input.PatchCollector.Create(es, object_patch.UpdateIfExists())
 
-	// TODO: remove this part after Deckhouse release 1.56
-	// we have to remove old endpointslices here also, to prevent block on cm/deckhouse check
-	return cleanupOldEndpoints(input, dc)
+	return nil
 }
 
 func cleanupOldEndpoints(input *go_hook.HookInput, dc dependency.Container) error {


### PR DESCRIPTION
## Description
Endpoints cleanup generate an error:
```
Delete object //d8-system/deckhouse-mfqfl: apiVersion '', kind '' is not supported by cluster
```

## Why do we need it, and what problem does it solve?
Objects, listed from cluster don't have apiVersion and Kind inside (don't know why). We have to set in constantly

## Why do we need it in the patch release (if we do)?
Deckhouse can break on endpointslice deletion

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: fix
summary: Fix orphaned endpointslice deletion.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
