### PR TITLE
[log-shipper] Fix CRD schema bugs

### DIFF
--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -635,7 +635,7 @@ spec:
                       - pattern: '^\{\{\ [a-zA-Z0-9\\\-][a-zA-Z0-9\[\]_\\\-\.]+\ \}\}$'
                 buffer:
                   type: object
-                  oneOF:
+                  oneOf:
                     - properties:
                         disk: {}
                         type:

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -645,6 +645,8 @@ spec:
                         - disk
                         - type
                         - whenFull
+                      not:
+                        required: [memory]
                     - properties:
                         memory: {}
                         type:
@@ -654,6 +656,8 @@ spec:
                         - memory
                         - type
                         - whenFull
+                      not:
+                        required: [disk]
                   description: Buffer parameters.
                   required: ["type"]
                   properties:

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -655,6 +655,7 @@ spec:
                         - type
                         - whenFull
                   description: Buffer parameters.
+                  required: ["type"]
                   properties:
                     type:
                       type: string

--- a/modules/460-log-shipper/crds/cluster-logging-config.yaml
+++ b/modules/460-log-shipper/crds/cluster-logging-config.yaml
@@ -152,10 +152,19 @@ spec:
                               - staging
                             ```
                           items:
+                            oneOf:
+                              - properties:
+                                  operator:
+                                    enum: [Exists, DoesNotExist]
+                                required: [key, operator]
+                                not:
+                                  required: [values]
+                              - properties:
+                                  operator:
+                                    enum: [In, NotIn]
+                                required: [key, operator, values]
                             type: object
-                            required:
-                              - key
-                              - operator
+                            required: ["operator"]
                             properties:
                               key:
                                 type: string

--- a/modules/460-log-shipper/crds/pod-logging-config.yaml
+++ b/modules/460-log-shipper/crds/pod-logging-config.yaml
@@ -62,10 +62,19 @@ spec:
                           - staging
                         ```
                       items:
+                        oneOf:
+                          - properties:
+                              operator:
+                                enum: [Exists, DoesNotExist]
+                            required: [key, operator]
+                            not:
+                              required: [values]
+                          - properties:
+                              operator:
+                                enum: [In, NotIn]
+                            required: [key, operator, values]
                         type: object
-                        required:
-                          - key
-                          - operator
+                        required: ["operator"]
                         properties:
                           key:
                             type: string
@@ -266,8 +275,8 @@ spec:
                       type: object
                       description: Multiline parser custom regex rules.
                       oneOf:
-                        - required: [regex]
-                        - required: [notRegex]
+                        - required: [startsWhen]
+                        - required: [endsWhen]
                       properties:
                         startsWhen:
                           type: object


### PR DESCRIPTION
## Description
Fix various reported bugs

## Why do we need it, and what problem does it solve?
- Fixes https://github.com/deckhouse/deckhouse/issues/5516
- Fixes https://github.com/deckhouse/deckhouse/issues/5382
- Make the type field mandatory for the buffer settings

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Fix validation for the buffer ClusterLogDestination schema.
---
section: log-shipper
type: fix
summary: Add stricter validation for label selectors. Prevents the deckhouse pods from panicking.
---
section: log-shipper
type: fix
summary: Fix custom multiline parser validation for PodLoggingConfig (previously, it was not possible to use the Custom type due to a validation bug).
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
