### PR TITLE
[dhctl] Check if registry can be reached through proxy

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -22,6 +22,7 @@ var (
 	PreflightSkipAvailabilityPorts     = false
 	PreflightSkipResolvingLocalhost    = false
 	PreflightSkipDeckhouseVersionCheck = false
+	PreflightSkipRegistryThroughProxy  = false
 )
 
 func DefinePreflight(cmd *kingpin.CmdClause) {
@@ -40,4 +41,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag("preflight-skip-deckhouse-version-check", "Skip verifying deckhouse version").
 		Envar(configEnvName("PREFLIGHT_SKIP_INCOMPATIBLE_VERSION_CHECK")).
 		BoolVar(&PreflightSkipDeckhouseVersionCheck)
+	cmd.Flag("preflight-skip-registry-through-proxy", "Skip verifying deckhouse version").
+		Envar(configEnvName("PREFLIGHT_SKIP_REGISTRY_THROUGH_PROXY")).
+		BoolVar(&PreflightSkipRegistryThroughProxy)
 }

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -616,7 +616,7 @@ func (m *MetaConfig) EnrichProxyData() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	p.NoProxy = append(p.NoProxy, "127.0.0.1", "169.254.169.254", string(clusterDomain), string(podSubnetCIDR), string(serviceSubnetCIDR))
+	p.NoProxy = append(p.NoProxy, "127.0.0.1", "169.254.169.254", clusterDomain, podSubnetCIDR, serviceSubnetCIDR)
 
 	ret := make(map[string]interface{})
 	if p.HttpProxy != "" {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -238,7 +238,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	deckhouseInstallConfig.KubeadmBootstrap = true
 	deckhouseInstallConfig.MasterNodeSelector = true
 
-	preflightCheck := preflight.NewPreflightCheck(sshClient, deckhouseInstallConfig)
+	preflightCheck := preflight.NewPreflightCheck(sshClient, deckhouseInstallConfig, metaConfig)
 
 	bootstrapState := NewBootstrapState(stateCache)
 

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -50,8 +50,8 @@ func (pc *PreflightCheck) StaticCheck() error {
 		type preflightCheckFunc func() error
 		checks := []preflightCheckFunc{
 			pc.CheckDhctlVersionObsolescence,
-			pc.CheckRegistryAccessThroughProxy,
 			pc.CheckSSHTunel,
+			pc.CheckRegistryAccessThroughProxy,
 			pc.CheckAvailabilityPorts,
 			pc.CheckLocalhostDomain,
 		}

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -1,0 +1,159 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/utils/strings/slices"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/frontend"
+)
+
+var (
+	ErrBadProxyConfig      = errors.New("bad proxy config")
+	ErrRegistryUnreachable = errors.New("could not reach registry over proxy")
+)
+
+const ProxyTunnelPort = "22323"
+
+func (pc *PreflightCheck) CheckRegistryAccessThroughProxy() error {
+	log.DebugLn("Checking if registry is accessible through proxy")
+
+	proxyUrl, noProxyAddresses, err := getProxyFromMetaConfig(pc.metaConfig)
+	if err != nil {
+		return fmt.Errorf("get proxy config: %w", err)
+	}
+	if proxyUrl == nil {
+		log.DebugLn("No proxy is configured, skipping check")
+		return nil
+	}
+	if slices.Contains(noProxyAddresses, pc.metaConfig.Registry.Address) {
+		log.DebugLn("Proxy address found in proxy.noProxy list, skipping check")
+		return nil
+	}
+
+	tun, err := setupSSHTunnelToProxyAddr(pc.sshClient, proxyUrl)
+	if err != nil {
+		return fmt.Errorf("setup tunnel to proxy: %w", err)
+	}
+	defer tun.Stop()
+
+	registryURL := &url.URL{Scheme: pc.metaConfig.Registry.Scheme, Host: pc.metaConfig.Registry.Address, Path: "/v2"}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("prepare request: %w", err)
+	}
+
+	httpCl := buildHTTPClientWithLocalhostProxy(proxyUrl)
+	resp, err := httpCl.Do(req)
+	if err != nil {
+		return fmt.Errorf("call container registry api: %w", err)
+	}
+
+	if err = checkResponseIsFromDockerRegistry(resp); err != nil {
+		return err
+	}
+
+	log.InfoLn("Checked registry access through proxy successfully")
+	return nil
+}
+
+func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {
+	localhostProxy := proxyUrl
+	localhostProxy.Host = net.JoinHostPort("localhost", ProxyTunnelPort)
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:             http.ProxyURL(localhostProxy),
+			DisableKeepAlives: true,
+		},
+	}
+}
+
+func getProxyFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, []string, error) {
+	proxyConfig, err := metaConfig.EnrichProxyData()
+	switch {
+	case err != nil:
+		return nil, nil, err
+	case proxyConfig == nil:
+		return nil, nil, nil
+	}
+
+	var proxyAddrClause any
+	if proxyAddr, hasHTTPSProxy := proxyConfig["httpsProxy"]; hasHTTPSProxy {
+		proxyAddrClause = proxyAddr
+	} else if proxyAddr, hasHTTPProxy := proxyConfig["httpProxy"]; hasHTTPProxy {
+		proxyAddrClause = proxyAddr
+	} else {
+		return nil, nil, fmt.Errorf("%w: no proxy address was given", ErrBadProxyConfig)
+	}
+
+	noProxyClause, hasNoProxy := proxyConfig["noProxy"]
+	var noProxyAddresses []string
+	if hasNoProxy {
+		addrs, isStringSlice := noProxyClause.([]string)
+		if !isStringSlice {
+			return nil, nil, fmt.Errorf("proxy.noProxy is not a set of addresses")
+		}
+		noProxyAddresses = addrs
+	}
+
+	proxyAddr, proxyAddrIsString := proxyAddrClause.(string)
+	if !proxyAddrIsString {
+		return nil, nil, fmt.Errorf(`%w: malformed proxy address: "%v"`, ErrBadProxyConfig, proxyAddr)
+	}
+
+	proxyUrl, err := url.Parse(proxyAddr)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`%w: %w`, ErrBadProxyConfig, err)
+	}
+
+	return proxyUrl, noProxyAddresses, nil
+}
+
+func checkResponseIsFromDockerRegistry(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
+		return fmt.Errorf("%w: got %d status code", ErrRegistryUnreachable, resp.StatusCode)
+	}
+
+	// https://docs.docker.com/registry/spec/api/#api-version-check
+	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
+		return fmt.Errorf("%w: expected Docker-Distribution-API-Version=registry/2.0 header", ErrRegistryUnreachable)
+	}
+
+	return nil
+}
+
+func setupSSHTunnelToProxyAddr(sshCl *ssh.Client, proxyUrl *url.URL) (*frontend.Tunnel, error) {
+	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), proxyUrl.Port()}, ":")
+	tun := sshCl.Tunnel("L", tunnel)
+	err := tun.Up()
+	if err != nil {
+		return nil, err
+	}
+	return tun, nil
+}

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -57,7 +57,9 @@ func (pc *PreflightCheck) CheckRegistryAccessThroughProxy() error {
 
 	tun, err := setupSSHTunnelToProxyAddr(pc.sshClient, proxyUrl)
 	if err != nil {
-		return fmt.Errorf("setup tunnel to proxy: %w", err)
+		return fmt.Errorf(`Cannot setup tunnel to control-plane host: %w.
+Please check connectivity to control-plane host or
+check that sshd config 'AllowTcpForwarding' set to 'yes' on control-plane node`, err)
 	}
 	defer tun.Stop()
 
@@ -72,7 +74,8 @@ func (pc *PreflightCheck) CheckRegistryAccessThroughProxy() error {
 	httpCl := buildHTTPClientWithLocalhostProxy(proxyUrl)
 	resp, err := httpCl.Do(req)
 	if err != nil {
-		return fmt.Errorf("call container registry api: %w", err)
+		return fmt.Errorf(`Container registry api connectivity check was failed with error: %w.
+Please chech connectivity from control-plane node to proxy an from proxy to container registry.`, err)
 	}
 
 	if err = checkResponseIsFromDockerRegistry(resp); err != nil {

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -51,7 +51,7 @@ func (pc *PreflightCheck) CheckRegistryAccessThroughProxy() error {
 		return nil
 	}
 	if slices.Contains(noProxyAddresses, pc.metaConfig.Registry.Address) {
-		log.DebugLn("Proxy address found in proxy.noProxy list, skipping check")
+		log.DebugLn("Registry address found in proxy.noProxy list, skipping check")
 		return nil
 	}
 

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/utils/strings/slices"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
@@ -40,6 +41,11 @@ var (
 const ProxyTunnelPort = "22323"
 
 func (pc *PreflightCheck) CheckRegistryAccessThroughProxy() error {
+	if app.PreflightSkipRegistryThroughProxy {
+		log.InfoLn("Checking if registry is accessible through proxy was skipped")
+		return nil
+	}
+
 	log.DebugLn("Checking if registry is accessible through proxy")
 
 	proxyUrl, noProxyAddresses, err := getProxyFromMetaConfig(pc.metaConfig)

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -1,0 +1,140 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestCheckRegistryAccessThroughProxy(t *testing.T) {
+	tests := map[string]func(*testing.T){
+		"getProxyFromMetaConfig_NoProxy":    getProxyFromMetaConfigSuccessNoProxy,
+		"getProxyFromMetaConfig_HTTPSProxy": getProxyFromMetaConfigSuccessHTTPSProxy,
+		"getProxyFromMetaConfig_HTTPProxy":  getProxyFromMetaConfigSuccessHTTPProxy,
+
+		"checkResponse_Success_OK":           checkResponseSuccess_OKResponse,
+		"checkResponse_Success_Unauthorized": checkResponseSuccess_UnauthorizedResponse,
+		"checkResponse_NoAPIVersionHeader":   checkResponse_NoAPIVersionHeader,
+		"checkResponse_WrongResponseStatus":  checkResponse_WrongStatus,
+	}
+
+	for testCase, testFunc := range tests {
+		t.Run(testCase, testFunc)
+	}
+}
+
+func getProxyFromMetaConfigSuccessHTTPSProxy(t *testing.T) {
+	s := require.New(t)
+
+	metaConfig := &config.MetaConfig{
+		Registry: config.RegistryData{
+			Address: "registry.deckhouse.io",
+			Scheme:  "https",
+		},
+		ClusterConfig: map[string]json.RawMessage{
+			"clusterDomain":     []byte(`"cluster.local"`),
+			"podSubnetCIDR":     []byte(`"10.0.0.0/8"`),
+			"serviceSubnetCIDR": []byte(`"11.0.0.0/8"`),
+			"proxy": []byte(
+				`{
+                   "httpsProxy": "https://login:pass@proxy.me",
+                   "httpProxy":  "http://login:pass@proxy.me"
+                 }`),
+		},
+	}
+
+	proxyURL, noProxyList, err := getProxyFromMetaConfig(metaConfig)
+	s.NoError(err)
+	s.Equal("https://login:pass@proxy.me", proxyURL.String())
+	s.ElementsMatch(noProxyList, []string{"127.0.0.1", "169.254.169.254", "cluster.local", "10.0.0.0/8", "11.0.0.0/8"})
+}
+
+func getProxyFromMetaConfigSuccessHTTPProxy(t *testing.T) {
+	s := require.New(t)
+
+	metaConfig := &config.MetaConfig{
+		Registry: config.RegistryData{
+			Address: "registry.deckhouse.io",
+			Scheme:  "https",
+		},
+		ClusterConfig: map[string]json.RawMessage{
+			"clusterDomain":     []byte(`"cluster.local"`),
+			"podSubnetCIDR":     []byte(`"10.0.0.0/8"`),
+			"serviceSubnetCIDR": []byte(`"11.0.0.0/8"`),
+			"proxy": []byte(
+				`{
+                   "httpProxy":  "http://login:pass@proxy.me"
+                 }`),
+		},
+	}
+
+	proxyURL, noProxyList, err := getProxyFromMetaConfig(metaConfig)
+	s.NoError(err)
+	s.Equal("http://login:pass@proxy.me", proxyURL.String())
+	s.ElementsMatch(noProxyList, []string{"127.0.0.1", "169.254.169.254", "cluster.local", "10.0.0.0/8", "11.0.0.0/8"})
+}
+
+func getProxyFromMetaConfigSuccessNoProxy(t *testing.T) {
+	s := require.New(t)
+
+	metaConfig := &config.MetaConfig{
+		Registry: config.RegistryData{
+			Address: "registry.deckhouse.io",
+			Scheme:  "https",
+		},
+		ClusterConfig: map[string]json.RawMessage{
+			"clusterDomain":     []byte(`"cluster.local"`),
+			"podSubnetCIDR":     []byte(`"10.0.0.0/8"`),
+			"serviceSubnetCIDR": []byte(`"11.0.0.0/8"`),
+		},
+	}
+
+	proxyURL, noProxyList, err := getProxyFromMetaConfig(metaConfig)
+	s.NoError(err)
+	s.Nil(proxyURL)
+	s.Nil(noProxyList)
+}
+
+func checkResponseSuccess_OKResponse(t *testing.T) {
+	s := require.New(t)
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+	resp.Header.Set("Docker-Distribution-API-Version", "registry/2.0")
+	s.Nil(checkResponseIsFromDockerRegistry(resp))
+}
+
+func checkResponseSuccess_UnauthorizedResponse(t *testing.T) {
+	s := require.New(t)
+	resp := &http.Response{StatusCode: http.StatusUnauthorized, Header: http.Header{}}
+	resp.Header.Set("Docker-Distribution-API-Version", "registry/2.0")
+	s.Nil(checkResponseIsFromDockerRegistry(resp))
+}
+
+func checkResponse_NoAPIVersionHeader(t *testing.T) {
+	s := require.New(t)
+	resp := &http.Response{StatusCode: http.StatusUnauthorized, Header: http.Header{}}
+	s.ErrorIs(checkResponseIsFromDockerRegistry(resp), ErrRegistryUnreachable)
+}
+
+func checkResponse_WrongStatus(t *testing.T) {
+	s := require.New(t)
+	resp := &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{}}
+	s.ErrorIs(checkResponseIsFromDockerRegistry(resp), ErrRegistryUnreachable)
+}

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -15,6 +15,7 @@
 package preflight
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -43,8 +44,9 @@ func (pc *PreflightCheck) CheckSSHTunel() error {
 	tun := pc.sshClient.Tunnel("L", builder.String())
 	err := tun.Up()
 	if err != nil {
-		log.ErrorLn("Checking ssh tunnel fail")
-		return err
+		return fmt.Errorf(`Cannot setup tunnel to control-plane host: %w.
+Please check connectivity to control-plane host or
+check that sshd config 'AllowTcpForwarding' set to 'yes' on control-plane node.`, err)
 	}
 
 	log.InfoLn("Checking ssh tunnel success")

--- a/dhctl/pkg/preflight/suite_test.go
+++ b/dhctl/pkg/preflight/suite_test.go
@@ -30,7 +30,7 @@ type PreflightChecksTestSuite struct {
 }
 
 func (s *PreflightChecksTestSuite) SetupSuite() {
-	s.checker = NewPreflightCheck(nil, &deckhouse.Config{})
+	s.checker = NewPreflightCheck(nil, nil, nil)
 }
 
 func (s *PreflightChecksTestSuite) SetupTest() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a preflight check that tries to reach registry api using a proxy if one is given and registry address is not blacklisted for proxying.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Dhctl will check if container registry can be reached with provided HTTP\HTTPS proxy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
