### PR TITLE
[docs] Fix typos in user-authz module examples and ya/instance_class documentation

### DIFF
--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -80,8 +80,8 @@ spec:
                 diskSizeGB:
                   description: |
                     Yandex Compute Instance disk size in gibibytes.
-                  example: 20
-                  x-doc-default: 50
+                  example: 50
+                  x-doc-default: 20
                   type: integer
                 assignPublicIPAddress:
                   description: |

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -28,7 +28,7 @@ spec:
       matchExpressions:
       - key: stage
         operator: In
-        vaules:
+        values:
         - test
         - review
       matchLabels:

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -28,7 +28,7 @@ spec:
       matchExpressions:
       - key: stage
         operator: In
-        vaules:
+        values:
         - test
         - review
       matchLabels:


### PR DESCRIPTION
## Description
Fix typos in user-authz module examples, and yandex cloud provider/instance_class documentation (fix based on https://github.com/deckhouse/deckhouse/blob/main/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf#L52 )
```changes
section: docs
type: chore
summary: Fix typos in user-authz module examples and ya/instance_class documentation.
impact_level: low
```
