### PR TITLE
[registrypackages] Update containerd to 1.6.24

### DIFF
--- a/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
@@ -23,5 +23,5 @@ post-install() {
 {{- end }}
 }
 
-bb-rp-install "containerd:{{- index $.images.registrypackages "containerd1620" }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}" "toml-merge:{{ .images.registrypackages.tomlMerge01 }}"
+bb-rp-install "containerd:{{- index $.images.registrypackages "containerd1624" }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}" "toml-merge:{{ .images.registrypackages.tomlMerge01 }}"
 {{- end }}

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $containerd_version := "1.6.20" }}
+{{- $containerd_version := "1.6.24" }}
 {{- $image_version := $containerd_version | replace "." "-" }}
 {{- $runc_version := "1.1.6" }}
 ---

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,6 +1,6 @@
 {{- $containerd_version := "1.6.24" }}
 {{- $image_version := $containerd_version | replace "." "-" }}
-{{- $runc_version := "1.1.6" }}
+{{- $runc_version := "1.1.9" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -337,7 +337,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"pushgateway": "imageHash-prometheusPushgateway-pushgateway",
 	},
 	"registrypackages": map[string]interface{}{
-		"containerd1620":   "imageHash-registrypackages-containerd1620",
+		"containerd1624":   "imageHash-registrypackages-containerd1624",
 		"crictl123":        "imageHash-registrypackages-crictl123",
 		"crictl124":        "imageHash-registrypackages-crictl124",
 		"crictl125":        "imageHash-registrypackages-crictl125",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Update containerd to 1.6.24
Update [runc](https://github.com/containerd/containerd/blob/v1.6.24/script/setup/runc-version) to 1.1.9


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Info

<details><summary>before</summary>

```shell
root@dev-master-0:~# kubectl get po -o wide -A
NAMESPACE                    NAME                                                                   READY   STATUS    RESTARTS       AGE     IP             NODE                                              NOMINATED NODE   READINESS GATES
d8-admission-policy-engine   gatekeeper-audit-f6f894c77-8n2vd                                       3/3     Running   0              23h     10.111.1.146   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-admission-policy-engine   gatekeeper-controller-manager-76497d74bf-lfmvz                         2/2     Running   0              23h     10.111.1.145   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cert-manager              cert-manager-fbc8894f5-qsh8d                                           2/2     Running   4 (23h ago)    23h     10.111.1.148   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cert-manager              webhook-66bb549f65-lh8t6                                               1/1     Running   0              23h     10.111.0.31    dev-master-0                      <none>           <none>
d8-chrony                    chrony-9ls9f                                                           1/1     Running   0              12h     10.111.4.3     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-chrony                    chrony-bhkkk                                                           1/1     Running   0              12h     10.111.0.40    dev-master-0                      <none>           <none>
d8-chrony                    chrony-master-69659d697c-xlrsj                                         1/1     Running   0              12h     10.111.0.39    dev-master-0                      <none>           <none>
d8-chrony                    chrony-n2cmb                                                           1/1     Running   0              12h     10.111.3.3     dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-chrony                    chrony-zzbf7                                                           1/1     Running   0              12h     10.111.1.175   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cloud-instance-manager    bashible-apiserver-c54cf74dc-w7lhv                                     1/1     Running   3 (12h ago)    12h     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-instance-manager    early-oom-6hf72                                                        2/2     Running   0              8d      10.111.0.27    dev-master-0                      <none>           <none>
d8-cloud-instance-manager    early-oom-8q8t5                                                        2/2     Running   0              18h     10.111.4.2     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-cloud-instance-manager    early-oom-btgrt                                                        2/2     Running   0              8d      10.111.1.127   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cloud-instance-manager    early-oom-pzfdm                                                        2/2     Running   0              18h     10.111.3.2     dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-cloud-instance-manager    machine-controller-manager-7db6966b59-np8ct                            2/2     Running   4 (12h ago)    8d      10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     cloud-controller-manager-7989c4596f-97rpz                              1/1     Running   11 (12h ago)   11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     csi-controller-6677c96944-w2k8k                                        5/5     Running   5 (12h ago)    12h     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     csi-node-2l4n4                                                         2/2     Running   0              49m     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     csi-node-9w2hr                                                         2/2     Running   0              49m     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cloud-provider-yandex     csi-node-cvkfm                                                         2/2     Running   0              49m     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-cloud-provider-yandex     csi-node-vmsmv                                                         2/2     Running   0              49m     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-cni-simple-bridge         simple-bridge-5mrfv                                                    1/1     Running   0              11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cni-simple-bridge         simple-bridge-98sgv                                                    1/1     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-cni-simple-bridge         simple-bridge-9vbgf                                                    1/1     Running   1 (18h ago)    18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-cni-simple-bridge         simple-bridge-brww7                                                    1/1     Running   2 (18h ago)    18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-dashboard                 dashboard-8fd5fd554-8fgls                                              1/1     Running   0              11d     10.111.1.13    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-dashboard                 dashboard-dex-authenticator-856c6c6d6c-dkckz                           2/2     Running   1 (23h ago)    23h     10.111.1.149   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-dashboard                 metrics-scraper-8699dbf6db-p26vc                                       1/1     Running   0              11d     10.111.1.14    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-ingress-nginx             controller-main-zvdqv                                                  3/3     Running   0              11d     10.111.0.12    dev-master-0                      <none>           <none>
d8-ingress-nginx             kruise-controller-manager-784544ccc-66l7m                              3/3     Running   9 (12h ago)    11d     10.111.0.11    dev-master-0                      <none>           <none>
d8-monitoring                alerts-receiver-fbdc8657-hxnl2                                         1/1     Running   0              8d      10.111.1.121   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                control-plane-proxy-pfl4m                                              1/1     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                ebpf-exporter-2rjdn                                                    2/2     Running   0              7d13h   10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                ebpf-exporter-97nzn                                                    2/2     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-monitoring                ebpf-exporter-kjnmn                                                    2/2     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-monitoring                ebpf-exporter-rts9q                                                    2/2     Running   0              7d13h   10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                extended-monitoring-exporter-74ff7cfb66-mdvwz                          2/2     Running   0              11d     10.111.1.28    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                grafana-dex-authenticator-d59795f4d-ctf5t                              2/2     Running   1 (23h ago)    23h     10.111.1.153   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                grafana-f986c555f-st2gv                                                4/4     Running   0              23h     10.111.1.155   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                image-availability-exporter-6f4d845bfb-bmvfj                           2/2     Running   0              8d      10.111.1.123   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                kube-state-metrics-5776fb699c-7668g                                    2/2     Running   0              8d      10.111.1.124   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                monitoring-ping-7jlhj                                                  1/1     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-monitoring                monitoring-ping-8xl6c                                                  1/1     Running   0              11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                monitoring-ping-crnj8                                                  1/1     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-monitoring                monitoring-ping-xzgfd                                                  1/1     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                node-exporter-4dj7q                                                    3/3     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-monitoring                node-exporter-4ncc5                                                    3/3     Running   3 (23h ago)    11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                node-exporter-b5zft                                                    3/3     Running   3 (23h ago)    11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                node-exporter-cgvdd                                                    3/3     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-monitoring                prometheus-longterm-0                                                  3/3     Running   0              12h     10.111.1.172   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                prometheus-main-0                                                      3/3     Running   0              12h     10.111.1.173   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                prometheus-metrics-adapter-5d89b55fdb-dhmf9                            2/2     Running   0              8d      10.111.0.26    dev-master-0                      <none>           <none>
d8-monitoring                trickster-59d6666c77-jv4mb                                             2/2     Running   0              8d      10.111.1.120   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-operator-prometheus       prometheus-operator-658cd94754-bxl2k                                   2/2     Running   0              12h     10.111.1.169   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-pod-reloader              pod-reloader-dd467d876-qp8hk                                           2/2     Running   0              11d     10.111.1.8     dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    admin-backend-8577544575-h68cg                                         2/2     Running   0              11d     10.111.1.19    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    admin-dex-authenticator-75475d9569-282dx                               2/2     Running   1 (23h ago)    23h     10.111.1.150   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    admin-frontend-68b495dc79-xg4qq                                        1/1     Running   0              14h     10.111.1.167   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    deckhouse-5684b5f966-qljnz                                             2/2     Running   0              12h     10.146.0.18    dev-master-0                      <none>           <none>
d8-system                    documentation-d96f576f-k2z7q                                           1/1     Running   0              12h     10.111.1.174   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    documentation-dex-authenticator-68c8dbb9d8-5n74n                       2/2     Running   1 (23h ago)    23h     10.111.1.152   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    terraform-auto-converger-66dfff486f-skbx8                              2/2     Running   0              12h     10.111.0.38    dev-master-0                      <none>           <none>
d8-system                    terraform-state-exporter-578cdc465f-l72ws                              2/2     Running   0              12h     10.111.1.168   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    webhook-handler-8bb878bcd-d8ngr                                        1/1     Running   0              12h     10.111.0.37    dev-master-0                      <none>           <none>
d8-user-authn                dex-68d6cd698b-5k6pb                                                   2/2     Running   0              23h     10.111.1.151   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-user-authz                user-authz-webhook-xwb82                                               1/1     Running   0              8d      10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  d8-control-plane-manager-7wm4f                                         6/6     Running   0              12h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  d8-kube-dns-5bcb595f78-5ckr2                                           2/2     Running   0              7d18h   10.111.0.28    dev-master-0                      <none>           <none>
kube-system                  d8-kube-dns-5bcb595f78-ptb7p                                           2/2     Running   0              11d     10.111.0.22    dev-master-0                      <none>           <none>
kube-system                  d8-kube-proxy-fjvcl                                                    2/2     Running   0              8d      10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  d8-kube-proxy-lk2lq                                                    2/2     Running   0              8d      10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  d8-kube-proxy-ndm4b                                                    2/2     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
kube-system                  d8-kube-proxy-wd258                                                    2/2     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
kube-system                  etcd-dev-master-0                                      1/1     Running   0              23h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kube-apiserver-dev-master-0                            2/2     Running   0              12h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kube-controller-manager-dev-master-0                   1/1     Running   7 (12h ago)    11d     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kube-scheduler-dev-master-0                            1/1     Running   3 (12h ago)    23h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kubernetes-api-proxy-dev-master-0                      2/2     Running   1 (23h ago)    23h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-l5q57     2/2     Running   2 (18h ago)    18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
kube-system                  kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-xk2hj     2/2     Running   2 (18h ago)    18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
kube-system                  kubernetes-api-proxy-dev-worker-79d06ec4-5c6b6-5kp6w   2/2     Running   1 (23h ago)    23h     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  node-local-dns-4x7z8                                                   3/3     Running   0              11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  node-local-dns-9h5ks                                                   3/3     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
kube-system                  node-local-dns-9t2t7                                                   3/3     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
kube-system                  node-local-dns-s5txd                                                   3/3     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  vpa-admission-controller-bb854bc77-95vf7                               1/1     Running   0              11d     10.111.0.19    dev-master-0                      <none>           <none>
kube-system                  vpa-recommender-755844869f-nfmcx                                       1/1     Running   0              11d     10.111.1.26    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  vpa-updater-7467f6db65-7dgfn                                           1/1     Running   0              11d     10.111.1.27    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
```

</details>

<details><summary>after</summary>

```shell
root@dev-master-0:~# kubectl get po -o wide -A
NAMESPACE                    NAME                                                                   READY   STATUS    RESTARTS       AGE     IP             NODE                                              NOMINATED NODE   READINESS GATES
d8-admission-policy-engine   gatekeeper-audit-f6f894c77-8n2vd                                       3/3     Running   0              23h     10.111.1.146   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-admission-policy-engine   gatekeeper-controller-manager-76497d74bf-lfmvz                         2/2     Running   0              23h     10.111.1.145   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cert-manager              cert-manager-fbc8894f5-qsh8d                                           2/2     Running   4 (23h ago)    23h     10.111.1.148   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cert-manager              webhook-66bb549f65-lh8t6                                               1/1     Running   0              23h     10.111.0.31    dev-master-0                      <none>           <none>
d8-chrony                    chrony-9ls9f                                                           1/1     Running   0              12h     10.111.4.3     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-chrony                    chrony-bhkkk                                                           1/1     Running   0              12h     10.111.0.40    dev-master-0                      <none>           <none>
d8-chrony                    chrony-master-69659d697c-xlrsj                                         1/1     Running   0              12h     10.111.0.39    dev-master-0                      <none>           <none>
d8-chrony                    chrony-n2cmb                                                           1/1     Running   0              12h     10.111.3.3     dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-chrony                    chrony-zzbf7                                                           1/1     Running   0              12h     10.111.1.175   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cloud-instance-manager    bashible-apiserver-d776cdcb9-dqrgj                                     1/1     Running   0              2m51s   10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-instance-manager    early-oom-6hf72                                                        2/2     Running   0              8d      10.111.0.27    dev-master-0                      <none>           <none>
d8-cloud-instance-manager    early-oom-8q8t5                                                        2/2     Running   0              18h     10.111.4.2     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-cloud-instance-manager    early-oom-btgrt                                                        2/2     Running   0              8d      10.111.1.127   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cloud-instance-manager    early-oom-pzfdm                                                        2/2     Running   0              18h     10.111.3.2     dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-cloud-instance-manager    machine-controller-manager-7db6966b59-np8ct                            2/2     Running   4 (12h ago)    8d      10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     cloud-controller-manager-7989c4596f-97rpz                              1/1     Running   11 (12h ago)   11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     csi-controller-6677c96944-w2k8k                                        5/5     Running   5 (12h ago)    12h     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     csi-node-2l4n4                                                         2/2     Running   0              53m     10.146.0.18    dev-master-0                      <none>           <none>
d8-cloud-provider-yandex     csi-node-9w2hr                                                         2/2     Running   0              53m     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cloud-provider-yandex     csi-node-cvkfm                                                         2/2     Running   0              53m     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-cloud-provider-yandex     csi-node-vmsmv                                                         2/2     Running   0              53m     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-cni-simple-bridge         simple-bridge-5mrfv                                                    1/1     Running   0              11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-cni-simple-bridge         simple-bridge-98sgv                                                    1/1     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-cni-simple-bridge         simple-bridge-9vbgf                                                    1/1     Running   1 (18h ago)    18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-cni-simple-bridge         simple-bridge-brww7                                                    1/1     Running   2 (18h ago)    18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-dashboard                 dashboard-8fd5fd554-8fgls                                              1/1     Running   0              11d     10.111.1.13    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-dashboard                 dashboard-dex-authenticator-856c6c6d6c-dkckz                           2/2     Running   1 (23h ago)    23h     10.111.1.149   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-dashboard                 metrics-scraper-8699dbf6db-p26vc                                       1/1     Running   0              11d     10.111.1.14    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-ingress-nginx             controller-main-zvdqv                                                  3/3     Running   0              11d     10.111.0.12    dev-master-0                      <none>           <none>
d8-ingress-nginx             kruise-controller-manager-784544ccc-66l7m                              3/3     Running   9 (12h ago)    11d     10.111.0.11    dev-master-0                      <none>           <none>
d8-monitoring                alerts-receiver-fbdc8657-hxnl2                                         1/1     Running   0              8d      10.111.1.121   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                control-plane-proxy-pfl4m                                              1/1     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                ebpf-exporter-2rjdn                                                    2/2     Running   0              7d13h   10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                ebpf-exporter-97nzn                                                    2/2     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-monitoring                ebpf-exporter-kjnmn                                                    2/2     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-monitoring                ebpf-exporter-rts9q                                                    2/2     Running   0              7d13h   10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                extended-monitoring-exporter-74ff7cfb66-mdvwz                          2/2     Running   0              11d     10.111.1.28    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                grafana-dex-authenticator-d59795f4d-ctf5t                              2/2     Running   1 (23h ago)    23h     10.111.1.153   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                grafana-f986c555f-st2gv                                                4/4     Running   0              23h     10.111.1.155   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                image-availability-exporter-6f4d845bfb-bmvfj                           2/2     Running   0              8d      10.111.1.123   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                kube-state-metrics-5776fb699c-7668g                                    2/2     Running   0              8d      10.111.1.124   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                monitoring-ping-7jlhj                                                  1/1     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-monitoring                monitoring-ping-8xl6c                                                  1/1     Running   0              11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                monitoring-ping-crnj8                                                  1/1     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-monitoring                monitoring-ping-xzgfd                                                  1/1     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                node-exporter-4dj7q                                                    3/3     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
d8-monitoring                node-exporter-4ncc5                                                    3/3     Running   3 (23h ago)    11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                node-exporter-b5zft                                                    3/3     Running   3 (23h ago)    11d     10.146.0.18    dev-master-0                      <none>           <none>
d8-monitoring                node-exporter-cgvdd                                                    3/3     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
d8-monitoring                prometheus-longterm-0                                                  3/3     Running   0              12h     10.111.1.172   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                prometheus-main-0                                                      3/3     Running   0              12h     10.111.1.173   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-monitoring                prometheus-metrics-adapter-5d89b55fdb-dhmf9                            2/2     Running   0              8d      10.111.0.26    dev-master-0                      <none>           <none>
d8-monitoring                trickster-59d6666c77-jv4mb                                             2/2     Running   0              8d      10.111.1.120   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-operator-prometheus       prometheus-operator-658cd94754-bxl2k                                   2/2     Running   0              12h     10.111.1.169   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-pod-reloader              pod-reloader-dd467d876-qp8hk                                           2/2     Running   0              11d     10.111.1.8     dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    admin-backend-8577544575-h68cg                                         2/2     Running   0              11d     10.111.1.19    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    admin-dex-authenticator-75475d9569-282dx                               2/2     Running   1 (23h ago)    23h     10.111.1.150   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    admin-frontend-68b495dc79-xg4qq                                        1/1     Running   0              14h     10.111.1.167   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    deckhouse-6db664689d-bzt7b                                             2/2     Running   0              3m51s   10.146.0.18    dev-master-0                      <none>           <none>
d8-system                    documentation-85d69dcf4c-mmd7r                                         1/1     Running   0              101s    10.111.1.177   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    documentation-dex-authenticator-68c8dbb9d8-5n74n                       2/2     Running   1 (23h ago)    23h     10.111.1.152   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    terraform-auto-converger-7d7f67dfc4-7v2zx                              2/2     Running   0              2m48s   10.111.0.41    dev-master-0                      <none>           <none>
d8-system                    terraform-state-exporter-5767fc8d78-ms8q6                              2/2     Running   0              2m49s   10.111.1.176   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-system                    webhook-handler-8bb878bcd-d8ngr                                        1/1     Running   0              12h     10.111.0.37    dev-master-0                      <none>           <none>
d8-user-authn                dex-68d6cd698b-5k6pb                                                   2/2     Running   0              23h     10.111.1.151   dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
d8-user-authz                user-authz-webhook-xwb82                                               1/1     Running   0              8d      10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  d8-control-plane-manager-7wm4f                                         6/6     Running   0              12h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  d8-kube-dns-5bcb595f78-5ckr2                                           2/2     Running   0              7d18h   10.111.0.28    dev-master-0                      <none>           <none>
kube-system                  d8-kube-dns-5bcb595f78-ptb7p                                           2/2     Running   0              11d     10.111.0.22    dev-master-0                      <none>           <none>
kube-system                  d8-kube-proxy-fjvcl                                                    2/2     Running   0              8d      10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  d8-kube-proxy-lk2lq                                                    2/2     Running   0              8d      10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  d8-kube-proxy-ndm4b                                                    2/2     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
kube-system                  d8-kube-proxy-wd258                                                    2/2     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
kube-system                  etcd-dev-master-0                                      1/1     Running   0              23h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kube-apiserver-dev-master-0                            2/2     Running   0              12h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kube-controller-manager-dev-master-0                   1/1     Running   7 (12h ago)    11d     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kube-scheduler-dev-master-0                            1/1     Running   3 (12h ago)    23h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kubernetes-api-proxy-dev-master-0                      2/2     Running   1 (23h ago)    23h     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-l5q57     2/2     Running   2 (18h ago)    18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
kube-system                  kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-xk2hj     2/2     Running   2 (18h ago)    18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
kube-system                  kubernetes-api-proxy-dev-worker-79d06ec4-5c6b6-5kp6w   2/2     Running   1 (23h ago)    23h     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  node-local-dns-4x7z8                                                   3/3     Running   0              11d     10.146.0.31    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  node-local-dns-9h5ks                                                   3/3     Running   0              18h     10.146.0.15    dev-test-79d06ec4-5c8b7-l5q57     <none>           <none>
kube-system                  node-local-dns-9t2t7                                                   3/3     Running   0              18h     10.146.0.8     dev-test-79d06ec4-5c8b7-xk2hj     <none>           <none>
kube-system                  node-local-dns-s5txd                                                   3/3     Running   0              11d     10.146.0.18    dev-master-0                      <none>           <none>
kube-system                  vpa-admission-controller-bb854bc77-95vf7                               1/1     Running   0              11d     10.111.0.19    dev-master-0                      <none>           <none>
kube-system                  vpa-recommender-755844869f-nfmcx                                       1/1     Running   0              11d     10.111.1.26    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
kube-system                  vpa-updater-7467f6db65-7dgfn                                           1/1     Running   0              11d     10.111.1.27    dev-worker-79d06ec4-5c6b6-5kp6w   <none>           <none>
```

</details>

<details>

![image](https://github.com/deckhouse/deckhouse/assets/32643620/80afe9a0-670f-44f8-9365-c6a68c6b9dae)


```shell
root@dev-test-79d06ec4-5c8b7-l5q57:~# containerd --version
containerd github.com/containerd/containerd v1.6.24 61f9fd88f79f081d64d6fa3bb1a0dc71ec870523
root@dev-test-79d06ec4-5c8b7-l5q57:~# crictl ps
CONTAINER           IMAGE               CREATED             STATE               NAME                                   ATTEMPT             POD ID              POD
2b45cfd69f67d       1ad08b5ae175f       56 minutes ago      Running             node                                   0                   b422b92757737       csi-node-vmsmv
19c1752aa45da       fd40a848bc560       56 minutes ago      Running             node-driver-registrar                  0                   b422b92757737       csi-node-vmsmv
0590c30c7f6da       1fee2e060d7b3       13 hours ago        Running             chrony                                 0                   e6c15533c4101       chrony-n2cmb
247be020316c4       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   7ccdf74ea5179       node-exporter-cgvdd
38f96304a13bd       cb18dd4ee4a04       18 hours ago        Running             kubelet-eviction-thresholds-exporter   0                   7ccdf74ea5179       node-exporter-cgvdd
47091d436fdb0       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   ff6f7e7be60ba       node-local-dns-9h5ks
092c42a8b2fad       900e11bd4a16c       18 hours ago        Running             iptables-loop                          0                   ff6f7e7be60ba       node-local-dns-9h5ks
c5af2d14d20fa       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   b59020e36208a       early-oom-pzfdm
63ca2a64d160b       79246d5220d44       18 hours ago        Running             psi-monitor                            0                   b59020e36208a       early-oom-pzfdm
253a359e89d02       6647778ede9c9       18 hours ago        Running             node-exporter                          0                   7ccdf74ea5179       node-exporter-cgvdd
ac0e815048b20       67670a4e8e809       18 hours ago        Running             coredns                                0                   ff6f7e7be60ba       node-local-dns-9h5ks
f3a3c05a39aa1       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   57a730d016f8d       ebpf-exporter-97nzn
888dd5c8393e7       c90436ed5324f       18 hours ago        Running             ebpf-exporter                          0                   57a730d016f8d       ebpf-exporter-97nzn
8b2db51824249       2628e6d0613d7       18 hours ago        Running             monitoring-ping                        0                   8ec4d0523ca2e       monitoring-ping-7jlhj
5b9425188d1ea       9a5f88d7332c5       18 hours ago        Running             simple-bridge                          2                   6ca6b8bee30f6       simple-bridge-brww7
019acf3cea92d       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   7b934626f0034       d8-kube-proxy-wd258
2769ee77c71b8       a8e732efb95fe       18 hours ago        Running             kube-proxy                             0                   7b934626f0034       d8-kube-proxy-wd258
f2973a536b2d5       2f56f65b586dd       18 hours ago        Running             kubernetes-api-proxy-reloader          1                   108aa33fdb1cd       kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-l5q57
ef6c24283d9c1       2f56f65b586dd       18 hours ago        Running             kubernetes-api-proxy                   1                   108aa33fdb1cd       kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-l5q57
root@dev-test-79d06ec4-5c8b7-l5q57:~# systemctl restart containerd-deckhouse.service 
root@dev-test-79d06ec4-5c8b7-l5q57:~# crictl ps
CONTAINER           IMAGE               CREATED             STATE               NAME                                   ATTEMPT             POD ID              POD
2b45cfd69f67d       1ad08b5ae175f       57 minutes ago      Running             node                                   0                   b422b92757737       csi-node-vmsmv
19c1752aa45da       fd40a848bc560       57 minutes ago      Running             node-driver-registrar                  0                   b422b92757737       csi-node-vmsmv
0590c30c7f6da       1fee2e060d7b3       13 hours ago        Running             chrony                                 0                   e6c15533c4101       chrony-n2cmb
247be020316c4       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   7ccdf74ea5179       node-exporter-cgvdd
38f96304a13bd       cb18dd4ee4a04       18 hours ago        Running             kubelet-eviction-thresholds-exporter   0                   7ccdf74ea5179       node-exporter-cgvdd
47091d436fdb0       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   ff6f7e7be60ba       node-local-dns-9h5ks
092c42a8b2fad       900e11bd4a16c       18 hours ago        Running             iptables-loop                          0                   ff6f7e7be60ba       node-local-dns-9h5ks
c5af2d14d20fa       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   b59020e36208a       early-oom-pzfdm
63ca2a64d160b       79246d5220d44       18 hours ago        Running             psi-monitor                            0                   b59020e36208a       early-oom-pzfdm
253a359e89d02       6647778ede9c9       18 hours ago        Running             node-exporter                          0                   7ccdf74ea5179       node-exporter-cgvdd
ac0e815048b20       67670a4e8e809       18 hours ago        Running             coredns                                0                   ff6f7e7be60ba       node-local-dns-9h5ks
f3a3c05a39aa1       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   57a730d016f8d       ebpf-exporter-97nzn
888dd5c8393e7       c90436ed5324f       18 hours ago        Running             ebpf-exporter                          0                   57a730d016f8d       ebpf-exporter-97nzn
8b2db51824249       2628e6d0613d7       18 hours ago        Running             monitoring-ping                        0                   8ec4d0523ca2e       monitoring-ping-7jlhj
5b9425188d1ea       9a5f88d7332c5       18 hours ago        Running             simple-bridge                          2                   6ca6b8bee30f6       simple-bridge-brww7
019acf3cea92d       3279662f05f54       18 hours ago        Running             kube-rbac-proxy                        0                   7b934626f0034       d8-kube-proxy-wd258
2769ee77c71b8       a8e732efb95fe       18 hours ago        Running             kube-proxy                             0                   7b934626f0034       d8-kube-proxy-wd258
f2973a536b2d5       2f56f65b586dd       18 hours ago        Running             kubernetes-api-proxy-reloader          1                   108aa33fdb1cd       kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-l5q57
ef6c24283d9c1       2f56f65b586dd       18 hours ago        Running             kubernetes-api-proxy                   1                   108aa33fdb1cd       kubernetes-api-proxy-dev-test-79d06ec4-5c8b7-l5q57
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: Update containerd to 1.6.24
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
