### PR TITLE
[cloud-provider-aws] Reduce cloud-init data size

### DIFF
--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -163,8 +163,6 @@ bb-rp-install() {
 
   shopt -s failglob
 }
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 export PATH="/opt/deckhouse/bin:$PATH"
 export LANG=C
 {{- if .proxy }}

--- a/candi/bashible/bundles/debian/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/debian/bootstrap.sh.tpl
@@ -15,8 +15,6 @@
 */}}
 #!/bin/bash
 export LANG=C
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}
 export HTTP_PROXY={{ .proxy.httpProxy | quote }}

--- a/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
@@ -1,5 +1,17 @@
 {{- /*
-
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 */}}
 #!/bin/bash
 export LANG=C

--- a/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
@@ -1,17 +1,5 @@
 {{- /*
-# Copyright 2021 Flant JSC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 */}}
 #!/bin/bash
 export LANG=C

--- a/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/bootstrap.sh.tpl
@@ -3,8 +3,6 @@
 */}}
 #!/bin/bash
 export LANG=C
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}
 export HTTP_PROXY={{ .proxy.httpProxy | quote }}

--- a/ee/candi/bashible/bundles/alteros/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/alteros/bootstrap.sh.tpl
@@ -3,8 +3,6 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
 #!/bin/bash
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 export LANG=C
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}

--- a/ee/candi/bashible/bundles/altlinux/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/altlinux/bootstrap.sh.tpl
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 export LANG=C
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}

--- a/ee/candi/bashible/bundles/astra/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/bootstrap.sh.tpl
@@ -2,8 +2,6 @@
 # Copyright 2022 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 #!/bin/bash
 export LANG=C
 {{- if .proxy }}

--- a/ee/candi/bashible/bundles/redos/bootstrap.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/bootstrap.sh.tpl
@@ -3,8 +3,6 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 */}}
 #!/bin/bash
-mkdir -p /opt/deckhouse/tmp
-export TMPDIR=/opt/deckhouse/tmp
 export LANG=C
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
@@ -101,8 +101,8 @@ function detect_bundle() {
   {{- tpl ($context.Files.Get "candi/bashible/detect_bundle.sh") $context | nindent 2 }}
 }
 
-mkdir -p /opt/deckhouse/tmp
 export TMPDIR=/opt/deckhouse/tmp
+mkdir -p "$TMPDIR"
 
   {{- range $bundle := $context.allowedBundles }}
 function basic_bootstrap_{{ $bundle }} {

--- a/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
@@ -101,6 +101,9 @@ function detect_bundle() {
   {{- tpl ($context.Files.Get "candi/bashible/detect_bundle.sh") $context | nindent 2 }}
 }
 
+mkdir -p /opt/deckhouse/tmp
+export TMPDIR=/opt/deckhouse/tmp
+
   {{- range $bundle := $context.allowedBundles }}
 function basic_bootstrap_{{ $bundle }} {
   {{- tpl ($context.Files.Get (printf "candi/bashible/bundles/%s/bootstrap.sh.tpl" $bundle)) $context | nindent 2 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The size of the cloud-init data has been reduced because we're limited to 16384 bytes

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: The size of the cloud-init data has been reduced
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
