### PR TITLE
[ingress-controller] fix controller preStop probe

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -349,6 +349,15 @@ updates:
   open-pull-requests-limit: 0
 
 - package-ecosystem: "gomod"
+  directory: "/modules/402-ingress-nginx/images/kube-rbac-proxy/src"
+  labels:
+  - "type/dependencies"
+  - "status/ok-to-test"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 0
+
+- package-ecosystem: "gomod"
   directory: "/modules/402-ingress-nginx/images/protobuf-exporter"
   labels:
   - "type/dependencies"

--- a/modules/402-ingress-nginx/images/kube-rbac-proxy/src/controller-probe.go
+++ b/modules/402-ingress-nginx/images/kube-rbac-proxy/src/controller-probe.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/modules/402-ingress-nginx/images/kube-rbac-proxy/src/controller-probe.go
+++ b/modules/402-ingress-nginx/images/kube-rbac-proxy/src/controller-probe.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+	var server string
+	flag.StringVar(&server, "server", "127.0.0.1:10254", "server address:port to check open tcp port")
+	flag.Parse()
+
+	for {
+		_, err := net.DialTimeout("tcp", server, time.Second*1)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(0)
+		}
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/modules/402-ingress-nginx/images/kube-rbac-proxy/src/go.mod
+++ b/modules/402-ingress-nginx/images/kube-rbac-proxy/src/go.mod
@@ -1,3 +1,3 @@
 module probe-controller
 
-go 1.19
+go 1.20

--- a/modules/402-ingress-nginx/images/kube-rbac-proxy/src/go.mod
+++ b/modules/402-ingress-nginx/images/kube-rbac-proxy/src/go.mod
@@ -1,0 +1,3 @@
+module probe-controller
+
+go 1.19

--- a/modules/402-ingress-nginx/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/kube-rbac-proxy/werf.inc.yaml
@@ -1,0 +1,35 @@
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- artifact: common/kube-rbac-proxy-artifact
+  add: /kube-rbac-proxy
+  to: /kube-rbac-proxy
+  before: setup
+- artifact: {{ .ModuleName }}/controller-probe-artifact
+  add: /controller-probe
+  to: /controller-probe
+  before: setup
+docker:
+  ENTRYPOINT: ["/kube-rbac-proxy", "--tls-cipher-suites", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"]
+  EXPOSE: "8080"
+---
+artifact: {{ .ModuleName }}/controller-probe-artifact
+from: {{ .Images.BASE_GOLANG_20_ALPINE }}
+git:
+- add: /{{ $.ModulePath }}modules/402-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
+  to: /src
+  stageDependencies:
+    install:
+    - '**/*'
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  beforeInstall:
+  install:
+  - cd /src
+  - export GOPROXY={{ .GOPROXY }} GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  - go build -o /controller-probe controller-probe.go
+  - chown 64535:64535 /controller-probe
+  - chmod 0755 /controller-probe

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -286,7 +286,7 @@ spec:
           - mountPath: /var/files
             name: telemetry-config-file
       - name: kube-rbac-proxy
-        image: {{ include "helm_lib_module_common_image" (list $context "kubeRbacProxy") }}
+        image: {{ include "helm_lib_module_image" (list $context "kubeRbacProxy") }}
         args:
         - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):10354"
         - "--v=2"
@@ -326,9 +326,9 @@ spec:
           preStop:
             exec:
               command:
-              - /bin/sh
-              - -c
-              - while [ $(nc 127.0.0.1 10254 -z; echo $?) -eq 0 ];do sleep 1; done
+              - /controller-probe
+              - -server
+              - 127.0.0.1:10254
         ports:
         - containerPort: 10354
           name: https-metrics

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -208,6 +208,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"controller16":          "imageHash-ingressNginx-controller16",
 		"kruise":                "imageHash-ingressNginx-kruise",
 		"kruiseStateMetrics":    "imageHash-ingressNginx-kruiseStateMetrics",
+		"kubeRbacProxy":         "imageHash-ingressNginx-kubeRbacProxy",
 		"nginxExporter":         "imageHash-ingressNginx-nginxExporter",
 		"protobufExporter":      "imageHash-ingressNginx-protobufExporter",
 		"proxyFailover":         "imageHash-ingressNginx-proxyFailover",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Rewrite preStop probe to go.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After moving build to distroless, preStop probe does not work due to shell absense in kube-rbac-proxy pod. We create static Go probe to solve this problem.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-controller
type: fix
summary: Fix controller preStop probe.
impact: Ingress controller will restart.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
