### PR TITLE
[dhctl] Bootstrap deckhouse with a version tag instead of release channel tag and refactor preflight checks messages

### DIFF
--- a/candi/bashible/preflight/check_localhost.sh
+++ b/candi/bashible/preflight/check_localhost.sh
@@ -15,6 +15,6 @@
 */}}
 
 if ! getent ahosts localhost; then
-  echo "FAIL localhost is unavailable"
+  echo "Localhost is unavailable. You should add record '127.0.0.1 localhost' to /etc/hosts file."
   exit 1
 fi

--- a/candi/bashible/preflight/check_ports.sh
+++ b/candi/bashible/preflight/check_ports.sh
@@ -57,7 +57,7 @@ do
     echo -n "Check port $port "
     check_port $port
     if [ $? -ne 0 ]; then
-        echo "FAIL"
+        echo "Cannot open port $port. Probably control-plane node protected with firewall rules or another software (like antivirus) does not allow to open port."
         has_error=true
         continue
     fi

--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/alessio/shellescape v1.4.1
 	github.com/fatih/color v1.9.0
 	github.com/flant/kube-client v0.25.0
@@ -41,7 +42,6 @@ require (
 require (
 	cloud.google.com/go v0.97.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -25,23 +25,31 @@ var (
 	PreflightSkipRegistryThroughProxy  = false
 )
 
+const (
+	SSHForwardArgName                = "preflight-skip-ssh-forward-check"
+	PortsAvailabilityArgName         = "preflight-skip-availability-ports-check"
+	ResolvingLocalhostArgName        = "preflight-skip-resolving-localhost-check"
+	DeckhouseVersionCheckArgName     = "preflight-skip-deckhouse-version-check"
+	RegistryThroughProxyCheckArgName = "preflight-skip-registry-through-proxy"
+)
+
 func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag("preflight-skip-all-checks", "Skip all preflight checks").
 		Envar(configEnvName("PREFLIGHT_SKIP_ALL_CHECKS")).
 		BoolVar(&PreflightSkipAll)
-	cmd.Flag("preflight-skip-ssh-forward-check", "Skip SSH forward preflight check").
+	cmd.Flag(SSHForwardArgName, "Skip SSH forward preflight check").
 		Envar(configEnvName("PREFLIGHT_SKIP_SSH_FORWARD_CHECK")).
 		BoolVar(&PreflightSkipSSHForword)
-	cmd.Flag("preflight-skip-availability-ports-check", "Skip availability ports preflight check").
+	cmd.Flag(PortsAvailabilityArgName, "Skip availability ports preflight check").
 		Envar(configEnvName("PREFLIGHT_SKIP_AVAILABILITY_PORTS_CHECK")).
 		BoolVar(&PreflightSkipAvailabilityPorts)
-	cmd.Flag("preflight-skip-resolving-localhost-check", "Skip resolving the localhost domain").
+	cmd.Flag(ResolvingLocalhostArgName, "Skip resolving the localhost domain").
 		Envar(configEnvName("PREFLIGHT_SKIP_RESOLVING_LOCALHOST_CHECK")).
 		BoolVar(&PreflightSkipResolvingLocalhost)
-	cmd.Flag("preflight-skip-deckhouse-version-check", "Skip verifying deckhouse version").
+	cmd.Flag(DeckhouseVersionCheckArgName, "Skip verifying deckhouse version").
 		Envar(configEnvName("PREFLIGHT_SKIP_INCOMPATIBLE_VERSION_CHECK")).
 		BoolVar(&PreflightSkipDeckhouseVersionCheck)
-	cmd.Flag("preflight-skip-registry-through-proxy", "Skip verifying deckhouse version").
+	cmd.Flag(RegistryThroughProxyCheckArgName, "Skip verifying deckhouse version").
 		Envar(configEnvName("PREFLIGHT_SKIP_REGISTRY_THROUGH_PROXY")).
 		BoolVar(&PreflightSkipRegistryThroughProxy)
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -38,7 +38,7 @@ const (
 )
 
 func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Deckhouse", 45, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Delete Deckhouse", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground
 		err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Delete(context.TODO(), deckhouseDeploymentName, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
 		if err != nil && !errors.IsNotFound(err) {
@@ -49,13 +49,13 @@ func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteStorageClasses(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete StorageClasses", 45, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Delete StorageClasses", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		return kubeCl.StorageV1().StorageClasses().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 	})
 }
 
 func DeletePods(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Pods", 45, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Delete Pods", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		pods, err := kubeCl.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -92,7 +92,7 @@ func DeletePods(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteServices(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Services", 45, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Delete Services", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		allServices, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -114,7 +114,7 @@ func DeleteServices(kubeCl *client.KubernetesClient) error {
 }
 
 func DeletePVC(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete PersistentVolumeClaims", 45, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Delete PersistentVolumeClaims", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		volumeClaims, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -176,7 +176,7 @@ func DeleteMachineDeployments(kubeCl *client.KubernetesClient) error {
 }
 
 func WaitForDeckhouseDeploymentDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).WithShowError(false).Run(func() error {
 		_, err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Get(context.TODO(), deckhouseDeploymentName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			log.InfoLn("Deckhouse Deployment and its dependents are removed")
@@ -214,7 +214,7 @@ func WaitForMachinesDeletion(kubeCl *client.KubernetesClient) error {
 }
 
 func WaitForServicesDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Services deletion", 45, 15*time.Second).Run(func() error {
+	return retry.NewLoop("Wait for Services deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
 		resources, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -241,7 +241,7 @@ func WaitForServicesDeletion(kubeCl *client.KubernetesClient) error {
 }
 
 func WaitForPVDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumes deletion", 45, 15*time.Second).Run(func() error {
+	return retry.NewLoop("Wait for PersistentVolumes deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
 		resources, err := kubeCl.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -275,7 +275,7 @@ func WaitForPVDeletion(kubeCl *client.KubernetesClient) error {
 }
 
 func WaitForPVCDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 45, 15*time.Second).Run(func() error {
+	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
 		resources, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -329,9 +329,10 @@ func checkMachinesAPI(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteMachinesIfResourcesExist(kubeCl *client.KubernetesClient) error {
-	err := retry.NewLoop("Get Kubernetes cluster resources for group/version", 5, 5*time.Second).Run(func() error {
-		return checkMachinesAPI(kubeCl)
-	})
+	err := retry.NewLoop("Get Kubernetes cluster resources for group/version", 5, 5*time.Second).WithShowError(false).
+		Run(func() error {
+			return checkMachinesAPI(kubeCl)
+		})
 	if err != nil {
 		log.WarnF("Can't get resources in group=machine.sapcloud.io, version=v1alpha1: %v\n", err)
 		if input.NewConfirmation().

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -194,7 +194,7 @@ func WaitForDeckhouseDeploymentDeletion(kubeCl *client.KubernetesClient) error {
 
 func WaitForMachinesDeletion(kubeCl *client.KubernetesClient) error {
 	resourceSchema := schema.GroupVersionResource{Group: "machine.sapcloud.io", Version: "v1alpha1", Resource: "machines"}
-	return retry.NewLoop("Wait for Machines deletion", 45, 15*time.Second).Run(func() error {
+	return retry.NewLoop("Wait for Machines deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
 		resources, err := kubeCl.Dynamic().Resource(resourceSchema).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -19,9 +19,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/iancoleman/strcase"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -59,17 +61,42 @@ type Config struct {
 	MasterNodeSelector bool
 }
 
-func (c *Config) GetImage() string {
+func (c *Config) GetImage(forceVersionTag bool) string {
 	registryNameTemplate := "%s%s:%s"
 	tag := c.DevBranch
 	if c.ReleaseChannel != "" {
 		tag = strcase.ToKebab(c.ReleaseChannel)
 	}
+	if forceVersionTag {
+		versionTag, foundValidTag := readVersionTagFromInstallerContainer()
+		if foundValidTag {
+			tag = versionTag
+		}
+	}
+
 	return fmt.Sprintf(registryNameTemplate, c.Registry.Address, c.Registry.Path, tag)
 }
 
 func (c *Config) IsRegistryAccessRequired() bool {
 	return c.Registry.DockerCfg != ""
+}
+
+func readVersionTagFromInstallerContainer() (string, bool) {
+	rawFile, err := os.ReadFile(app.VersionFile)
+	if err != nil {
+		log.WarnF(
+			"Could not read %s: %v\nWill fall back to installation from release channel or dev branch.",
+			app.VersionFile, err,
+		)
+		return "", false
+	}
+
+	tag := string(rawFile)
+	if _, err = semver.NewVersion(tag); err != nil {
+		return "", false
+	}
+
+	return tag, true
 }
 
 func prepareDeckhouseDeploymentForUpdate(kubeCl *client.KubernetesClient, cfg *Config, manifestForUpdate *appsv1.Deployment) (*appsv1.Deployment, error) {
@@ -407,7 +434,7 @@ func CreateDeckhouseDeployment(kubeCl *client.KubernetesClient, cfg *Config) err
 
 func deckhouseDeploymentParamsFromCfg(cfg *Config) manifests.DeckhouseDeploymentParams {
 	return manifests.DeckhouseDeploymentParams{
-		Registry:           cfg.GetImage(),
+		Registry:           cfg.GetImage(true),
 		LogLevel:           cfg.LogLevel,
 		Bundle:             cfg.Bundle,
 		IsSecureRegistry:   cfg.IsRegistryAccessRequired(),

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -238,7 +238,10 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	deckhouseInstallConfig.KubeadmBootstrap = true
 	deckhouseInstallConfig.MasterNodeSelector = true
 
-	preflightCheck := preflight.NewPreflightCheck(sshClient, deckhouseInstallConfig, metaConfig)
+	preflightChecker := preflight.NewChecker(sshClient, deckhouseInstallConfig, metaConfig)
+	if err := preflightChecker.Global(); err != nil {
+		return err
+	}
 
 	bootstrapState := NewBootstrapState(stateCache)
 
@@ -253,7 +256,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	var resourcesTemplateData map[string]interface{}
 
 	if metaConfig.ClusterType == config.CloudClusterType {
-		err = preflightCheck.CloudCheck()
+		err = preflightChecker.Cloud()
 		if err != nil {
 			return err
 		}
@@ -315,7 +318,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			return err
 		}
 	} else {
-		err = preflightCheck.StaticCheck()
+		err = preflightChecker.Static()
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/preflight/dhctl_obsolescence.go
+++ b/dhctl/pkg/preflight/dhctl_obsolescence.go
@@ -113,7 +113,6 @@ func (pc *Checker) CheckDhctlVersionObsolescence() error {
 		return fmt.Errorf(dhctlVersionMismatchError, ErrInstallerVersionMismatch)
 	}
 
-	log.InfoLn("Checked if dhctl version is compatible successfully")
 	return nil
 }
 

--- a/dhctl/pkg/preflight/dhctl_obsolescence.go
+++ b/dhctl/pkg/preflight/dhctl_obsolescence.go
@@ -34,7 +34,7 @@ import (
 )
 
 const dhctlVersionMismatchError = "" +
-	"There is a possibility that you will not be able to install latest versions of Deckhouse correctly with this image.\n" +
+	"%w\nThere is a possibility that you will not be able to install latest versions of Deckhouse correctly with this image.\n" +
 	`To fix this add "--pull=always" flag to your "docker run" cmdline`
 
 var (

--- a/dhctl/pkg/preflight/dhctl_obsolescence.go
+++ b/dhctl/pkg/preflight/dhctl_obsolescence.go
@@ -129,7 +129,7 @@ func (pc *Checker) fetchAndValidateDeckhouseImageHashFromReleaseChannel(ctx cont
 
 	versionTagRef, err := name.ParseReference(pc.installConfig.GetImage(true))
 	if err != nil {
-		return nil, fmt.Errorf("parse image refernce: %w", err)
+		return nil, fmt.Errorf("parse image reference: %w", err)
 	}
 
 	updateChanManifest, err := pc.imageDescriptorProvider.Descriptor(channelRef, remote.WithContext(ctx), remote.WithAuth(creds))

--- a/dhctl/pkg/preflight/dhctl_obsolescence_test.go
+++ b/dhctl/pkg/preflight/dhctl_obsolescence_test.go
@@ -24,7 +24,7 @@ import (
 func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolescence_Success_ReleaseChannel() {
 	t := s.Require()
 
-	image := s.checker.installConfig.GetImage()
+	image := s.checker.installConfig.GetImage(false)
 	ref, err := name.ParseReference(image)
 	t.NoError(err)
 
@@ -53,7 +53,7 @@ func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolesc
 	s.checker.installConfig.DevBranch = "pr1234"
 	s.checker.installConfig.ReleaseChannel = ""
 
-	image := s.checker.installConfig.GetImage()
+	image := s.checker.installConfig.GetImage(false)
 	ref, err := name.ParseReference(image)
 	t.NoError(err)
 
@@ -79,7 +79,7 @@ func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolesc
 func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolescence_VersionMismatch_ReleaseChannel() {
 	t := s.Require()
 
-	image := s.checker.installConfig.GetImage()
+	image := s.checker.installConfig.GetImage(false)
 	ref, err := name.ParseReference(image)
 	t.NoError(err)
 
@@ -108,7 +108,7 @@ func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolesc
 	s.checker.installConfig.DevBranch = "pr1234"
 	s.checker.installConfig.ReleaseChannel = ""
 
-	image := s.checker.installConfig.GetImage()
+	image := s.checker.installConfig.GetImage(false)
 	ref, err := name.ParseReference(image)
 	t.NoError(err)
 
@@ -136,7 +136,7 @@ func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolesc
 
 	app.PreflightSkipDeckhouseVersionCheck = true
 
-	image := s.checker.installConfig.GetImage()
+	image := s.checker.installConfig.GetImage(false)
 	ref, err := name.ParseReference(image)
 	t.NoError(err)
 
@@ -163,7 +163,7 @@ func (s *PreflightChecksTestSuite) Test_PreflightCheck_CheckDhctlVersionObsolesc
 	s.checker.installConfig.DevBranch = "pr1234"
 	s.checker.installConfig.ReleaseChannel = ""
 
-	image := s.checker.installConfig.GetImage()
+	image := s.checker.installConfig.GetImage(false)
 	ref, err := name.ParseReference(image)
 	t.NoError(err)
 

--- a/dhctl/pkg/preflight/domain.go
+++ b/dhctl/pkg/preflight/domain.go
@@ -24,7 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 )
 
-func (pc *PreflightCheck) CheckLocalhostDomain() error {
+func (pc *Checker) CheckLocalhostDomain() error {
 	if app.PreflightSkipResolvingLocalhost {
 		log.InfoLn("Resolving the localhost domain preflight check was skipped")
 		return nil

--- a/dhctl/pkg/preflight/domain.go
+++ b/dhctl/pkg/preflight/domain.go
@@ -48,6 +48,5 @@ func (pc *Checker) CheckLocalhostDomain() error {
 	}
 
 	log.DebugLn(string(out))
-	log.InfoLn("Checking resolving the localhost domain success")
 	return nil
 }

--- a/dhctl/pkg/preflight/ports.go
+++ b/dhctl/pkg/preflight/ports.go
@@ -24,7 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 )
 
-func (pc *PreflightCheck) CheckAvailabilityPorts() error {
+func (pc *Checker) CheckAvailabilityPorts() error {
 	if app.PreflightSkipAvailabilityPorts {
 		log.InfoLn("Availability ports preflight check was skipped")
 		return nil

--- a/dhctl/pkg/preflight/ports.go
+++ b/dhctl/pkg/preflight/ports.go
@@ -48,6 +48,5 @@ func (pc *Checker) CheckAvailabilityPorts() error {
 	}
 
 	log.DebugLn(string(out))
-	log.InfoLn("Checking availability ports success")
 	return nil
 }

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -34,8 +34,8 @@ import (
 )
 
 var (
-	ErrBadProxyConfig      = errors.New("bad proxy config")
-	ErrRegistryUnreachable = errors.New("could not reach registry over proxy")
+	ErrBadProxyConfig      = errors.New("Bad proxy config")
+	ErrRegistryUnreachable = errors.New("Could not reach registry over proxy")
 )
 
 const ProxyTunnelPort = "22323"
@@ -138,7 +138,7 @@ func getProxyFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, []string, 
 
 	proxyUrl, err := url.Parse(proxyAddr)
 	if err != nil {
-		return nil, nil, fmt.Errorf(`%w: %w`, ErrBadProxyConfig, err)
+		return nil, nil, fmt.Errorf(`%s: %w`, ErrBadProxyConfig, err)
 	}
 
 	return proxyUrl, noProxyAddresses, nil

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -40,7 +40,7 @@ var (
 
 const ProxyTunnelPort = "22323"
 
-func (pc *PreflightCheck) CheckRegistryAccessThroughProxy() error {
+func (pc *Checker) CheckRegistryAccessThroughProxy() error {
 	if app.PreflightSkipRegistryThroughProxy {
 		log.InfoLn("Checking if registry is accessible through proxy was skipped")
 		return nil

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -88,7 +88,6 @@ Please chech connectivity from control-plane node to proxy an from proxy to cont
 		return err
 	}
 
-	log.InfoLn("Checked registry access through proxy successfully")
 	return nil
 }
 

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -28,7 +28,7 @@ const (
 	DefaultTunnelRemotePort = 22322
 )
 
-func (pc *PreflightCheck) CheckSSHTunel() error {
+func (pc *Checker) CheckSSHTunel() error {
 	if app.PreflightSkipSSHForword {
 		log.InfoLn("SSH forward preflight check was skipped")
 		return nil

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -49,7 +49,6 @@ Please check connectivity to control-plane host or
 check that sshd config 'AllowTcpForwarding' set to 'yes' on control-plane node.`, err)
 	}
 
-	log.InfoLn("Checking ssh tunnel success")
 	tun.Stop()
 	return nil
 }

--- a/dhctl/pkg/preflight/suite_test.go
+++ b/dhctl/pkg/preflight/suite_test.go
@@ -26,11 +26,11 @@ import (
 
 type PreflightChecksTestSuite struct {
 	suite.Suite
-	checker PreflightCheck
+	checker Checker
 }
 
 func (s *PreflightChecksTestSuite) SetupSuite() {
-	s.checker = NewPreflightCheck(nil, nil, nil)
+	s.checker = NewChecker(nil, nil, nil)
 }
 
 func (s *PreflightChecksTestSuite) SetupTest() {


### PR DESCRIPTION
## Description

Adjusted image tag selection logic to allow usage of deckhouse version tag from `/deckhouse/version` for installation. Deckhouse is now bootstrapped using this tag.

Also preflight checks code was refactored.

And refactored preflight check error messages.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes #3251 

![image](https://github.com/deckhouse/deckhouse/assets/30695496/19b86d6d-52c8-48dc-9b68-3add2e6a9e51)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/bc5d8c0a-2c3e-47af-be98-6925ffdb9591)


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Allow installing Deckhouse from tag. Refactor preflight checks code.
impact_level: default
```
