### PR TITLE
[prometheus] switch grafana to ubuntu container

### DIFF
--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -3,7 +3,6 @@ ARG BASE_NODE_16_ALPINE
 ARG BASE_GOLANG_17_BUSTER
 ARG BASE_GOLANG_20_ALPINE
 ARG BASE_UBUNTU
-ARG BASE_DISTROLESS
 ARG GRAFANA_VERSION="8.5.13"
 ARG STATUSMAP_VERSION="0.5.1"
 ARG BUNDLED_PLUGINS="petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel"
@@ -179,7 +178,13 @@ RUN chown -R 64535:64535 /usr/share/grafana && \
 RUN chmod 0700 ./bin/grafana-server && \
     chmod 0700 ./bin/grafana-cli
 
-FROM $BASE_DISTROLESS
+FROM $BASE_UBUNTU
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install libfontconfig curl ca-certificates openssl unzip git && \
+    apt-get clean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=entrypoint /app/entrypoint /usr/local/bin/
 COPY --from=grafana-distr /usr/share/grafana/ /usr/share/grafana/

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -178,7 +178,14 @@ RUN chown -R 64535:64535 /usr/share/grafana && \
 RUN chmod 0700 ./bin/grafana-server && \
     chmod 0700 ./bin/grafana-cli
 
+# The some custom  plugins has dependencies on libraries that are not in the distroless container
 FROM $BASE_UBUNTU
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install ca-certificates && \
+    apt-get clean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=entrypoint /app/entrypoint /usr/local/bin/
 COPY --from=grafana-distr /usr/share/grafana/ /usr/share/grafana/

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -180,12 +180,6 @@ RUN chmod 0700 ./bin/grafana-server && \
 
 FROM $BASE_UBUNTU
 
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install libfontconfig curl ca-certificates openssl unzip git && \
-    apt-get clean && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY --from=entrypoint /app/entrypoint /usr/local/bin/
 COPY --from=grafana-distr /usr/share/grafana/ /usr/share/grafana/
 COPY --from=grafana-distr /etc/grafana/ /etc/grafana/


### PR DESCRIPTION
## Description
Switching grafana to ubuntu container.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The alexanderzobnin-zabbix-appliance plugin has dependencies on libraries that are not in the distroless container
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
An issue from customer
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
The alexanderzobnin-zabbix-appliance plugin working
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Switch Grafana to using the Ubuntu container.
impact: Grafana will restart.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
