### PR TITLE
[node-manager] Fix D8MachineControllerManagerPodIsNotRunning alert

### DIFF
--- a/modules/040-node-manager/monitoring/prometheus-rules/machine-controller-manager.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/machine-controller-manager.tpl
@@ -18,7 +18,6 @@
       summary: The {{`{{$labels.pod}}`}} Pod is NOT Ready.
 
   - alert: D8MachineControllerManagerPodIsNotRunning
-    expr: max by (namespace, pod, phase) (kube_pod_status_phase{namespace="d8-cloud-instance-manager",phase!="Running",pod=~"machine-controller-manager-.*"} > 0)
     expr: absent(kube_pod_status_phase{namespace="d8-cloud-instance-manager",phase="Running",pod=~"machine-controller-manager-.*"})
     for: 10m
     labels:


### PR DESCRIPTION
## Description
Delete duplicated the expr field in the D8MachineControllerManagerPodIsNotRunning alert template.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Delete duplicated the expr field in the D8MachineControllerManagerPodIsNotRunning alert template.
impact_level: low
```
