### PR TITLE
[ingress-nginx] add auth cookie header always

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=artifact /src/rootfs/bin/amd64/nginx-ingress-controller /src/rootfs/
 COPY --from=controller_0_26_1 /usr/local/openresty/luajit /usr/local/openresty/luajit
 COPY patches/balancer-lua.patch /
 COPY patches/nginx-tmpl.patch /
+COPY patches/auth-cookie-always.patch /
 COPY rootfs /
 
 RUN apk update \
@@ -110,6 +111,7 @@ RUN apk update \
   && cd / \
   && patch -p1 < /balancer-lua.patch \
   && patch -p1 < /nginx-tmpl.patch \
+  && patch -p1 < /auth-cookie-always.patch \
   && rm -rf /*.patch
 WORKDIR /
 USER www-data

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
@@ -33,3 +33,10 @@ Run the build locally, not inside the container.
 Fixes namespace which is given by metric nginx_ingress_controller_ssl_expire_time_seconds.
 
 https://github.com/kubernetes/ingress-nginx/pull/10274
+
+### Always set auth cookie
+
+Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+Annotation `nginx.ingress.kubernetes.io/auth-always-set-cookie` does not work. Anyway, we can't use it, because we need this behavior for all ingresses.
+
+https://github.com/kubernetes/ingress-nginx/pull/8213

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/auth-cookie-always.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/auth-cookie-always.patch
@@ -1,0 +1,15 @@
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+--- a/rootfs/etc/nginx/template/nginx.tmpl	(revision b64e885b6265136a860a05f78df06fbc61b31772)
++++ b/rootfs/etc/nginx/template/nginx.tmpl	(date 1695892177652)
+@@ -1316,11 +1316,7 @@
+             {{ else }}
+             auth_request        {{ $authPath }};
+             auth_request_set    $auth_cookie $upstream_http_set_cookie;
+-            {{ if $externalAuth.AlwaysSetCookie }}
+             add_header          Set-Cookie $auth_cookie always;
+-            {{ else }}
+-            add_header          Set-Cookie $auth_cookie;
+-            {{ end }}
+             {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders false }}
+             {{ $line }}
+             {{- end }}

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/auth-cookie-always.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/auth-cookie-always.patch
@@ -1,6 +1,6 @@
 diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
---- a/rootfs/etc/nginx/template/nginx.tmpl	(revision b64e885b6265136a860a05f78df06fbc61b31772)
-+++ b/rootfs/etc/nginx/template/nginx.tmpl	(date 1695892177652)
+--- a/etc/nginx/template/nginx.tmpl
++++ b/etc/nginx/template/nginx.tmpl
 @@ -1316,11 +1316,7 @@
              {{ else }}
              auth_request        {{ $authPath }};

--- a/modules/402-ingress-nginx/templates/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/controller/configmap.yaml
@@ -84,7 +84,6 @@ data:
                 AES256-SHA:AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA"
   {{- end }}
   server-tokens: "false"
-  global-auth-always-set-cookie: "true"
 
   # IMPORTANT!!! There is a substantial nuance in ingress-nginx behavior:
   #   * It ignores proxy-real-ip-cidr config param, unless c is set to true;


### PR DESCRIPTION
## Description
Set `add_header          Set-Cookie $auth_cookie always;` to avoid user logout on response codes >= 400

## Why do we need it, and what problem does it solve?
We have this patch in the controller 1.1 but it was missed in the controller 1.6

## Why do we need it in the patch release (if we do)?
Users can have force logout randomly. It's a regression bug.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix bug with absent auth cookie, which leads to logout users sometimes from web pages with authorization.
impact: Ingress controller 1.6 will restart.
impact_level: high
```
