### PR TITLE
[cluster-api-provider-static] add validating webhook to prevent capi …

### DIFF
--- a/candi/bashible/common-steps/node-group/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_create_static_node_cleanup_script.sh.tpl
@@ -14,12 +14,16 @@
 {{- if or (eq .nodeGroup.nodeType "Static") (eq .runType "ClusterBootstrap") }}
 bb-sync-file /var/lib/bashible/cleanup_static_node.sh - << "EOF"
 #!/bin/bash
+
 if [ -z $1 ] || [ "$1" != "--yes-i-am-sane-and-i-understand-what-i-am-doing" ];  then
   >&2 echo "Needed flag isn't passed, exit without any action"
   exit 1
 fi
 
 systemctl stop bashible.service bashible.timer
+for pid in $(ps ax | grep "bash /var/lib/bashible/bashible" | grep -v grep | awk '{print $1}'); do
+  kill $pid
+done
 systemctl stop sysctl-tuner.service sysctl-tuner.timer
 systemctl stop old-csi-mount-cleaner.service old-csi-mount-cleaner.timer
 systemctl stop d8-containerd-cgroup-migration.service

--- a/modules/040-node-manager/images/caps-controller-manager/internal/controller/deckhouse.io/staticinstance_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/internal/controller/deckhouse.io/staticinstance_controller.go
@@ -17,11 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha1"
-	infrav1 "caps-controller-manager/api/infrastructure/v1alpha1"
-	controller "caps-controller-manager/internal/controller/infrastructure"
-	"caps-controller-manager/internal/scope"
 	"context"
+	"time"
+
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +33,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
+
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha1"
+	infrav1 "caps-controller-manager/api/infrastructure/v1alpha1"
+	controller "caps-controller-manager/internal/controller/infrastructure"
+	"caps-controller-manager/internal/scope"
 )
 
 // StaticInstanceReconciler reconciles a StaticInstance object
@@ -87,10 +89,6 @@ func (r *StaticInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		err := instanceScope.Close(ctx)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
-
 			logger.Error(err, "failed to close instance scope")
 		}
 	}()

--- a/modules/040-node-manager/images/caps-controller-manager/internal/controller/deckhouse.io/staticinstance_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/internal/controller/deckhouse.io/staticinstance_controller.go
@@ -87,6 +87,10 @@ func (r *StaticInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		err := instanceScope.Close(ctx)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
+
 			logger.Error(err, "failed to close instance scope")
 		}
 	}()

--- a/modules/040-node-manager/webhooks/validating/node
+++ b/modules/040-node-manager/webhooks/validating/node
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+DECKHOUSE_CONFIG_MAP=${DECKHOUSE_CONFIG_MAP:-deckhouse}
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetesValidating:
+- name: capi-node-policy.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["UPDATE"]
+    resources:   ["nodes"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+
+  saUser="$(context::jq -r '.review.request.userInfo.username')"
+  if [[ "$saUser" != "system:serviceaccount:d8-cloud-instance-manager:capi-controller-manager" ]]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+    return 0
+  fi
+
+  nodeProviderID="$(context::jq -r '.review.request.object.spec.providerID')"
+  if ! grep -qE "^static:///[0-9a-z-]+$" <<< "$nodeProviderID"; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":".spec.providerID field should be in the form \"static:///aaaasdsddsd\", but got \"$nodeProviderID\""}
+EOF
+    return 0
+  fi
+
+  if ! context::jq -r '.review.request.object.metadata.annotations."cluster.x-k8s.io/machine"'; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":".metadata.annotations should have \"cluster.x-k8s.io/machine\" key"}
+EOF
+    return 0
+  fi
+
+  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+}
+
+hook::run "$@"

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -87,7 +87,7 @@ function __main__() {
     nodeGroupNameLen=$(context::jq -r '.review.request.object.metadata.name | length')
     # Dynamic node name is <clusterPrefix>-<nodeGroupName>-<hashes> and one of kubernetes node label contains it.
     # Label value must be >= 63 characters
-    if $(( 63 - $clusterPrefixLen - 1 - $nodeGroupNameLen - 21 )) < 0; then
+    if [[ $(( 63 - clusterPrefixLen - 1 - nodeGroupNameLen - 21 )) -lt 0 ]]; then
       cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"it is forbidden for this cluster to set (cluster prefix + node group name) longer then 42 symbols"}
 EOF


### PR DESCRIPTION
…to touch nodes created not from capi

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
add validating webhook to prevent capi-controller to touch nodes created not from capi.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
