### PR TITLE
[matrix-tests] distroless image linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ In addition to common GitHub features, here are some other online resources rela
 * [Telegram chat](https://t.me/deckhouse) to discuss (there's a dedicated [Telegram chat in Russian](https://t.me/deckhouse_ru) as well);
 * [Deckhouse blog](https://blog.deckhouse.io/) to read the latest articles about Deckhouse.
 * Check our [work board](https://github.com/orgs/deckhouse/projects/2) and [roadmap](https://github.com/orgs/deckhouse/projects/6) for more insights.
+

--- a/README.md
+++ b/README.md
@@ -58,4 +58,3 @@ In addition to common GitHub features, here are some other online resources rela
 * [Telegram chat](https://t.me/deckhouse) to discuss (there's a dedicated [Telegram chat in Russian](https://t.me/deckhouse_ru) as well);
 * [Deckhouse blog](https://blog.deckhouse.io/) to read the latest articles about Deckhouse.
 * Check our [work board](https://github.com/orgs/deckhouse/projects/2) and [roadmap](https://github.com/orgs/deckhouse/projects/6) for more insights.
-

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -213,7 +213,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 				// "from:" right after "image:"
 				if linePos-lastWerfImagePos == 1 {
 					if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-						log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
+						log.Printf("\nSKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
 						continue
 					}
 
@@ -239,7 +239,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 	for i, fromInstruction := range dockerfileFromInstructions {
 		lastInstruction := i == len(dockerfileFromInstructions)-1
 		if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-			log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
+			log.Printf("\nSKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
 			continue
 		}
 

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -213,7 +213,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 				// "from:" right after "image:"
 				if linePos-lastWerfImagePos == 1 {
 					if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-						log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n\n", name, relativeFilePath, fromTrimmed)
+						log.Printf("WARNING!!! SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n\n", name, relativeFilePath, fromTrimmed)
 						continue
 					}
 
@@ -239,7 +239,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 	for i, fromInstruction := range dockerfileFromInstructions {
 		lastInstruction := i == len(dockerfileFromInstructions)-1
 		if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-			log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n\n", name, relativeFilePath, fromInstruction)
+			log.Printf("WARNING!!! SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n\n", name, relativeFilePath, fromInstruction)
 			continue
 		}
 

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -65,7 +65,10 @@ func isImageNameUnacceptable(imageName string) (bool, string) {
 	return false, ""
 }
 
-func checkImageNamesInDockerAndWerfFiles(lintRuleErrorsList *errors.LintRuleErrorsList, name, path string) {
+func checkImageNamesInDockerAndWerfFiles(
+	lintRuleErrorsList *errors.LintRuleErrorsList,
+	name, path string,
+) {
 	var filePaths []string
 	imagesPath := filepath.Join(path, imagesDir)
 
@@ -79,13 +82,11 @@ func checkImageNamesInDockerAndWerfFiles(lintRuleErrorsList *errors.LintRuleErro
 		}
 
 		switch filepath.Base(fullPath) {
-		case "werf.inc.yaml",
-			"Dockerfile":
+		case "werf.inc.yaml", "Dockerfile":
 			filePaths = append(filePaths, fullPath)
 		}
 		return nil
 	})
-
 	if err != nil {
 		lintRuleErrorsList.Add(errors.NewLintRuleError(
 			"MODULE001",
@@ -176,7 +177,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 	}
 
 	for i, fromInstruction := range dockerfileFromInstructions {
-		lastInstruction := i == len(fromInstruction)-1
+		lastInstruction := i == len(dockerfileFromInstructions)-1
 		result, message := isDockerfileInstructionUnacceptable(fromInstruction, lastInstruction)
 		if result {
 			return errors.NewLintRuleError(
@@ -192,7 +193,8 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 }
 
 func isWerfInstructionUnacceptable(from string) (bool, string) {
-	if !strings.HasPrefix(from, `{{ .Images.BASE_`) && !strings.HasPrefix(from, `{{ $.Images.BASE_`) {
+	if !strings.HasPrefix(from, `{{ .Images.BASE_DISTROLESS`) &&
+		!strings.HasPrefix(from, `{{ $.Images.BASE_DISTROLESS`) {
 		return true, "`from:` parameter for `image:` should be one of our BASE_ images"
 	}
 	return false, ""
@@ -204,8 +206,8 @@ func isDockerfileInstructionUnacceptable(from string, final bool) (bool, string)
 	}
 
 	if final {
-		if !strings.HasPrefix(from, "$BASE_") {
-			return true, "Last `FROM` instruction should use one of our $BASE_ images"
+		if !strings.HasPrefix(from, "$BASE_DISTROLESS") {
+			return true, "Last `FROM` instruction should use one of our $BASE_DISTROLESS images"
 		}
 	} else {
 		matched, _ := regexp.MatchString("@sha256:[A-Fa-f0-9]{64}", from)

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -213,7 +213,8 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 				// "from:" right after "image:"
 				if linePos-lastWerfImagePos == 1 {
 					if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-						log.Printf("\nSKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
+						log.Println("SKIP DISTROLESS CHECK!!!")
+						log.Printf("\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
 						continue
 					}
 
@@ -239,7 +240,8 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 	for i, fromInstruction := range dockerfileFromInstructions {
 		lastInstruction := i == len(dockerfileFromInstructions)-1
 		if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-			log.Printf("\nSKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
+			log.Println("SKIP DISTROLESS CHECK!!!")
+			log.Printf("\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
 			continue
 		}
 

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -213,8 +213,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 				// "from:" right after "image:"
 				if linePos-lastWerfImagePos == 1 {
 					if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-						log.Println("SKIP DISTROLESS CHECK!!!")
-						log.Printf("\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
+						log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n\n", name, relativeFilePath, fromTrimmed)
 						continue
 					}
 
@@ -240,8 +239,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 	for i, fromInstruction := range dockerfileFromInstructions {
 		lastInstruction := i == len(dockerfileFromInstructions)-1
 		if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-			log.Println("SKIP DISTROLESS CHECK!!!")
-			log.Printf("\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
+			log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n\n", name, relativeFilePath, fromInstruction)
 			continue
 		}
 

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -19,6 +19,7 @@ package modules
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -212,7 +213,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 				// "from:" right after "image:"
 				if linePos-lastWerfImagePos == 1 {
 					if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-						fmt.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
+						log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromTrimmed)
 						continue
 					}
 
@@ -238,7 +239,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 	for i, fromInstruction := range dockerfileFromInstructions {
 		lastInstruction := i == len(dockerfileFromInstructions)-1
 		if skipDistrolessImageCheckIfNeeded(relativeFilePath) {
-			fmt.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
+			log.Printf("SKIP DISTROLESS CHECK!!!\nmodule = %s, image = %s\nvalue - %s\n", name, relativeFilePath, fromInstruction)
 			continue
 		}
 


### PR DESCRIPTION
## Description
Distroless image linter
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We want to verify that Deckhouse images are Distroless images.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Matrix tests is PASS
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: matrix-tests
type: feature
summary: Distroless image linter
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
