### PR TITLE
[ingress-nginx] apply postpone update to main controller of HostWithFailover inlet

### DIFF
--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -138,7 +138,7 @@ func safeControllerUpdate(input *go_hook.HookInput) (err error) {
 
 		// postpone main controller's pod update for the first time so that failover controller could catch up with the hook
 		if !podForDelete.PostponedUpdate {
-			input.LogEntry.Warnf("Update for %s/%s pod was postponed because of possible race condition", podForDelete.ControllerName, podForDelete.Name)
+			input.LogEntry.Infof("Assuring that %s/%s has met update conditions", podForDelete.ControllerName, podForDelete.Name)
 			metadata := map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"annotations": map[string]interface{}{

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -144,8 +144,10 @@ func safeControllerUpdate(input *go_hook.HookInput) (err error) {
 			metadata := map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"labels": map[string]interface{}{
+						"lifecycle.apps.kruise.io/state": nil,
+					},
+					"annotations": map[string]interface{}{
 						"ingress.deckhouse.io/update-postponed": time.Now().Format(time.RFC3339),
-						"lifecycle.apps.kruise.io/state":        nil,
 					},
 				},
 			}
@@ -207,7 +209,7 @@ func applyIngressPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
 	}
 
-	_, updateWasPostponed := pod.Labels["ingress.deckhouse.io/update-postponed"]
+	_, updateWasPostponed := pod.Annotations["ingress.deckhouse.io/update-postponed"]
 
 	return ingressControllerPod{
 		Name:               pod.Name,

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -381,7 +381,7 @@ status:
 			Expect(f).To(ExecuteSuccessfully())
 			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
 			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeTrue())
-			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/update-postponed").Exists()).To(BeTrue())
+			Expect(pod.Field("metadata.annotations.ingress\\.deckhouse\\.io/update-postponed").Exists()).To(BeTrue())
 		})
 	})
 
@@ -393,10 +393,10 @@ kind: Pod
 metadata:
   annotations:
     lifecycle.apps.kruise.io/timestamp: ` + time.Now().Format(time.RFC3339) + `
+    ingress.deckhouse.io/update-postponed: "2023-09-28T14:44:21Z"
   labels:
     app: controller
     ingress.deckhouse.io/block-deleting: "true"
-    ingress.deckhouse.io/update-postponed: "2023-09-28T14:44:21Z"
     lifecycle.apps.kruise.io/state: "PreparingDelete"
     name: test
   name: controller-test-bw8sc

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package hooks
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -29,7 +27,7 @@ var _ = Describe("ingress-nginx :: hooks :: safe_daemonset_update ::", func() {
 	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`, "")
 	f.RegisterCRD("apps.kruise.io", "v1alpha1", "DaemonSet", true)
 
-	Context("Failover pods are ready", func() {
+	Context("Failover pods are ready, update postponed", func() {
 		BeforeEach(func() {
 			st := f.KubeStateSet(`
 apiVersion: v1
@@ -37,6 +35,78 @@ kind: Pod
 metadata:
   annotations:
     lifecycle.apps.kruise.io/timestamp: "2023-09-28T14:44:21Z"
+  labels:
+    app: controller
+    ingress.deckhouse.io/block-deleting: "true"
+    lifecycle.apps.kruise.io/state: "PreparingDelete"
+    name: test
+  name: controller-test-bw8sc
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - name: controller
+  nodeName: ndev-worker-5e11c78a-5f688-kw6c5
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2023-03-24T15:02:56Z"
+    status: "True"
+    type: Ready
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  annotations:
+    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
+  labels:
+    app: controller
+    ingress-nginx-failover: ""
+    name: test-failover
+  name: controller-test-failover
+  namespace: d8-ingress-nginx
+spec: {}
+status:
+  desiredNumberScheduled: 3
+  numberAvailable: 3
+  updatedNumberScheduled: 3
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  annotations:
+    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
+  labels:
+    app: proxy-failover
+    name: test
+  name: proxy-test-failover
+  namespace: d8-ingress-nginx
+spec: {}
+status:
+  desiredNumberScheduled: 3
+  numberAvailable: 3
+  updatedNumberScheduled: 3
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Shouldn't remove blocking label", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
+			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeTrue())
+			Expect(pod.Field("metadata.annotations.ingress\\.deckhouse\\.io/update-postponed-at").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("Failover pods are ready, pod update was postponed", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    ingress.deckhouse.io/update-postponed-at: "2023-03-24T15:02:56Z"
   labels:
     app: controller
     ingress.deckhouse.io/block-deleting: "true"
@@ -310,150 +380,6 @@ status:
 			Expect(f).To(ExecuteSuccessfully())
 			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
 			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeTrue())
-		})
-	})
-
-	Context("Hook executed too fast", func() {
-		BeforeEach(func() {
-			st := f.KubeStateSet(`
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    lifecycle.apps.kruise.io/timestamp: ` + time.Now().Format(time.RFC3339) + `
-  labels:
-    app: controller
-    ingress.deckhouse.io/block-deleting: "true"
-    lifecycle.apps.kruise.io/state: "PreparingDelete"
-    name: test
-  name: controller-test-bw8sc
-  namespace: d8-ingress-nginx
-spec:
-  containers:
-  - name: controller
-  nodeName: ndev-worker-5e11c78a-5f688-kw6c5
-status:
-  conditions:
-  - lastProbeTime: null
-    lastTransitionTime: "2023-03-24T15:02:56Z"
-    status: "True"
-    type: Ready
----
-apiVersion: apps.kruise.io/v1alpha1
-kind: DaemonSet
-metadata:
-  annotations:
-    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
-  labels:
-    app: controller
-    ingress-nginx-failover: ""
-    name: test-failover
-  name: controller-test-failover
-  namespace: d8-ingress-nginx
-spec: {}
-status:
-  desiredNumberScheduled: 3
-  numberAvailable: 3
-  updatedNumberScheduled: 3
----
-apiVersion: apps.kruise.io/v1alpha1
-kind: DaemonSet
-metadata:
-  annotations:
-    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
-  labels:
-    app: proxy-failover
-    name: test
-  name: proxy-test-failover
-  namespace: d8-ingress-nginx
-spec: {}
-status:
-  desiredNumberScheduled: 3
-  numberAvailable: 3
-  updatedNumberScheduled: 3
-`)
-
-			f.BindingContexts.Set(st)
-			f.RunHook()
-		})
-
-		It("Should keep blocking and postponed labels", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
-			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeTrue())
-			Expect(pod.Field("metadata.annotations.ingress\\.deckhouse\\.io/update-postponed").Exists()).To(BeTrue())
-		})
-	})
-
-	Context("Hook executed for a postponed pod", func() {
-		BeforeEach(func() {
-			st := f.KubeStateSet(`
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    lifecycle.apps.kruise.io/timestamp: ` + time.Now().Format(time.RFC3339) + `
-    ingress.deckhouse.io/update-postponed: "2023-09-28T14:44:21Z"
-  labels:
-    app: controller
-    ingress.deckhouse.io/block-deleting: "true"
-    lifecycle.apps.kruise.io/state: "PreparingDelete"
-    name: test
-  name: controller-test-bw8sc
-  namespace: d8-ingress-nginx
-spec:
-  containers:
-  - name: controller
-  nodeName: ndev-worker-5e11c78a-5f688-kw6c5
-status:
-  conditions:
-  - lastProbeTime: null
-    lastTransitionTime: "2023-03-24T15:02:56Z"
-    status: "True"
-    type: Ready
----
-apiVersion: apps.kruise.io/v1alpha1
-kind: DaemonSet
-metadata:
-  annotations:
-    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
-  labels:
-    app: controller
-    ingress-nginx-failover: ""
-    name: test-failover
-  name: controller-test-failover
-  namespace: d8-ingress-nginx
-spec: {}
-status:
-  desiredNumberScheduled: 3
-  numberAvailable: 3
-  updatedNumberScheduled: 3
----
-apiVersion: apps.kruise.io/v1alpha1
-kind: DaemonSet
-metadata:
-  annotations:
-    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
-  labels:
-    app: proxy-failover
-    name: test
-  name: proxy-test-failover
-  namespace: d8-ingress-nginx
-spec: {}
-status:
-  desiredNumberScheduled: 3
-  numberAvailable: 3
-  updatedNumberScheduled: 3
-`)
-
-			f.BindingContexts.Set(st)
-			f.RunHook()
-		})
-
-		It("Should remove blocking label", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
-			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -33,6 +36,8 @@ var _ = Describe("ingress-nginx :: hooks :: safe_daemonset_update ::", func() {
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    lifecycle.apps.kruise.io/timestamp: "2023-09-28T14:44:21Z"
   labels:
     app: controller
     ingress.deckhouse.io/block-deleting: "true"
@@ -102,6 +107,8 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    lifecycle.apps.kruise.io/timestamp: "2023-09-28T14:44:21Z"
   labels:
     app: controller
     ingress.deckhouse.io/block-deleting: "true"
@@ -171,6 +178,8 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    lifecycle.apps.kruise.io/timestamp: "2023-09-28T14:44:21Z"
   labels:
     app: controller
     ingress.deckhouse.io/block-deleting: "true"
@@ -240,6 +249,8 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    lifecycle.apps.kruise.io/timestamp: "2023-09-28T14:44:21Z"
   labels:
     app: controller
     ingress.deckhouse.io/block-deleting: "true"
@@ -298,6 +309,77 @@ status:
 
 		It("Should keep blocking label", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
+			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("Hook executed too fast", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    lifecycle.apps.kruise.io/timestamp: ` + fmt.Sprintf("%s", time.Now().Format(time.RFC3339)) + `
+  labels:
+    app: controller
+    ingress.deckhouse.io/block-deleting: "true"
+    lifecycle.apps.kruise.io/state: "PreparingDelete"
+    name: test
+  name: controller-test-bw8sc
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - name: controller
+  nodeName: ndev-worker-5e11c78a-5f688-kw6c5
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2023-03-24T15:02:56Z"
+    status: "True"
+    type: Ready
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  annotations:
+    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
+  labels:
+    app: controller
+    ingress-nginx-failover: ""
+    name: test-failover
+  name: controller-test-failover
+  namespace: d8-ingress-nginx
+spec: {}
+status:
+  desiredNumberScheduled: 3
+  numberAvailable: 3
+  updatedNumberScheduled: 3
+---
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  annotations:
+    ingress-nginx-controller.deckhouse.io/checksum: a6fca03cfb274eaa9d1def32dde2bd730ac204baa941ddd88685b47e9b487787
+  labels:
+    app: proxy-failover
+    name: test
+  name: proxy-test-failover
+  namespace: d8-ingress-nginx
+spec: {}
+status:
+  desiredNumberScheduled: 3
+  numberAvailable: 3
+  updatedNumberScheduled: 3
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Should keep blocking label", func() {
+			Expect(f).To(Not(ExecuteSuccessfully()))
 			pod := f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-test-bw8sc")
 			Expect(pod.Field("metadata.labels.ingress\\.deckhouse\\.io/block-deleting").Exists()).To(BeTrue())
 		})


### PR DESCRIPTION
## Description
Add `ExecutionMinInterval: 5 * time.Second` and `ExecutionBurst:       1` settings to `safe_daemonset_update` hook so it doesn't trigger to often during updates.

Update `safe_daemonset_update` hook logic for `HostWithFailover` inlet by introducing postponed updates.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
When an update of main controller is postponed (not more than once), failover controller gets some extra time for launching its updates so that the hook could take them into consideration. This way we get rid of the situation when the hook allows main controller to launch its update ahead of failover controller's updates, resulting in having both controllers updated simultaneously.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
it fixes a noticeable and annoying issue.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
HostWithFailover inlet doesn't have its main and failover controllers updated at the same time.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Add postpone updates for main controller of HostWithFailover inlet.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
