### PR TITLE
[external-module-manager] Handle absent versions of deployed modules

### DIFF
--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -233,41 +233,24 @@ func findExistingModuleSymlink(rootPath, moduleName string) (string, error) {
 }
 
 func isModuleExistsOnFS(symlinksDir, symlinkPath, modulePath string) bool {
-	fmt.Println("REL--------------------")
 	targetPath, err := filepath.EvalSymlinks(symlinkPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-
-			fmt.Println("REL11111", symlinkPath, err)
-		}
-		fmt.Println("REL1", err)
 		return false
-	}
-
-	fmt.Println("REL12", targetPath)
-
-	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
-		fmt.Println("REL112", err)
 	}
 
 	if filepath.IsAbs(targetPath) {
 		targetPath, err = filepath.Rel(symlinksDir, targetPath)
 		if err != nil {
-			fmt.Println("REL2", err)
 			return false
 		}
-	}
-
-	fmt.Println("REL333333", targetPath)
-
-	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
-		fmt.Println("REL21", err)
 	}
 
 	return targetPath == modulePath
 }
 
 func enableModule(oldSymlinkPath, newSymlinkPath, modulePath string) error {
+	fmt.Println("REL--------------------")
+
 	if oldSymlinkPath != "" {
 		if _, err := os.Lstat(oldSymlinkPath); err == nil {
 			err = os.Remove(oldSymlinkPath)
@@ -277,12 +260,18 @@ func enableModule(oldSymlinkPath, newSymlinkPath, modulePath string) error {
 		}
 	}
 
+	fmt.Println("REL", newSymlinkPath)
+
 	if _, err := os.Lstat(newSymlinkPath); err == nil {
 		err = os.Remove(newSymlinkPath)
 		if err != nil {
 			return err
 		}
+	} else {
+		fmt.Println("REL1", newSymlinkPath)
 	}
+
+	fmt.Println("REL2", modulePath, newSymlinkPath)
 
 	return os.Symlink(modulePath, newSymlinkPath)
 }

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -235,14 +235,28 @@ func findExistingModuleSymlink(rootPath, moduleName string) (string, error) {
 func isModuleExistsOnFS(symlinksDir, symlinkPath, modulePath string) bool {
 	targetPath, err := filepath.EvalSymlinks(symlinkPath)
 	if err != nil {
+		fmt.Println("REL1", err)
 		return false
+	}
+
+	fmt.Println("REL12", targetPath)
+
+	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+		fmt.Println("REL112", err)
 	}
 
 	if filepath.IsAbs(targetPath) {
 		targetPath, err = filepath.Rel(symlinksDir, targetPath)
 		if err != nil {
+			fmt.Println("REL2", err)
 			return false
 		}
+	}
+
+	fmt.Println("REL333333", targetPath)
+
+	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+		fmt.Println("REL21", err)
 	}
 
 	return targetPath == modulePath

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -235,6 +235,10 @@ func findExistingModuleSymlink(rootPath, moduleName string) (string, error) {
 func isModuleExistsOnFS(symlinksDir, symlinkPath, modulePath string) bool {
 	targetPath, err := filepath.EvalSymlinks(symlinkPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+
+			fmt.Println("REL11111", symlinkPath, err)
+		}
 		fmt.Println("REL1", err)
 		return false
 	}

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -268,7 +268,12 @@ func enableModule(oldSymlinkPath, newSymlinkPath, modulePath string) error {
 			return err
 		}
 	} else {
-		fmt.Println("REL1", newSymlinkPath)
+		fmt.Println("REL1", newSymlinkPath, err)
+	}
+
+	if _, err := os.Stat(modulePath); os.IsNotExist(err) {
+		// path/to/whatever does not exist
+		fmt.Println("REL3", err)
 	}
 
 	fmt.Println("REL2", modulePath, newSymlinkPath)

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -233,6 +233,7 @@ func findExistingModuleSymlink(rootPath, moduleName string) (string, error) {
 }
 
 func isModuleExistsOnFS(symlinksDir, symlinkPath, modulePath string) bool {
+	fmt.Println("REL--------------------")
 	targetPath, err := filepath.EvalSymlinks(symlinkPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/modules/005-external-module-manager/hooks/apply_release_test.go
+++ b/modules/005-external-module-manager/hooks/apply_release_test.go
@@ -149,6 +149,7 @@ status:
 		Context("ModuleRelease was changed with another weight", func() {
 			BeforeEach(func() {
 				testCreateModuleOnFS(tmpDir, "echoserver", "v0.0.1")
+				testCreateModuleOnFS(tmpDir, "echoserver", "v0.0.2")
 				f.KubeStateSet(``) // Empty cluster
 				st := f.KubeStateSet(`
 ---

--- a/modules/005-external-module-manager/hooks/apply_release_test.go
+++ b/modules/005-external-module-manager/hooks/apply_release_test.go
@@ -22,15 +22,13 @@ import (
 	"strings"
 	"testing"
 
-	module_manager "github.com/deckhouse/deckhouse/go_lib/deckhouse-config/module-manager"
-
-	deckhouse_config "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	deckhouse_config "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
+	module_manager "github.com/deckhouse/deckhouse/go_lib/deckhouse-config/module-manager"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -199,7 +197,7 @@ status:
 		Context("Target module does not exist on fs", func() {
 			BeforeEach(func() {
 				mm, _ := module_manager.InitBasic("", "")
-				mm.RegisterModules()
+				_ = mm.RegisterModules()
 				deckhouse_config.InitService(mm)
 				st := f.KubeStateSet(`
 ---
@@ -231,11 +229,12 @@ status:
 	})
 })
 
+// nolint: unparam
 func testCreateModuleOnFS(tmpDir, moduleName, moduleVersion string) {
 	modulePath := path.Join(tmpDir, moduleName, moduleVersion)
 	_ = os.MkdirAll(modulePath, 0666)
-	os.Create(path.Join(modulePath, "Chart.yaml"))
-	os.Create(path.Join(modulePath, "values.yaml"))
+	_, _ = os.Create(path.Join(modulePath, "Chart.yaml"))
+	_, _ = os.Create(path.Join(modulePath, "values.yaml"))
 }
 
 func TestSymlinkFinder(t *testing.T) {


### PR DESCRIPTION
## Description
Handle absent modules from sources

## Why do we need it, and what problem does it solve?
If we have `Deployed` release of a source module and absent symlink for this module, deckhouse will try to restore it. But if target module version does not exist, we will get infinite deckhouse restart.
This fix will will suspend broken release with the detailed message

```
# kubectl get modulerelease
some-module-v0.1.12   Suspended    6h34m            Desired version of module met problems: not found
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Handle deployed source modules with absent version directory. Avoid infinite deckhouse restart on absent module.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
