### PR TITLE
[monitoring] added a job to sift metrics from custom exporters

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/persistent-volume-claim.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/persistent-volume-claim.yaml
@@ -20,7 +20,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info
+          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
         )
       )
     for: 5m
@@ -57,7 +57,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info
+          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
         )
       )
     for: 5m
@@ -94,7 +94,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info
+          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
         )
       )
     for: 5m
@@ -131,7 +131,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info
+          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
         )
       )
     for: 2m

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
@@ -46,9 +46,9 @@
       summary: Many kubelets cannot be scraped
   - alert: K8SKubeletTooManyPods
 {{- if semverCompare "<1.19" .Values.global.discovery.kubernetesVersion }}
-    expr: kubelet_running_pod_count > on(node) (kube_node_status_capacity{resource="pods",unit="integer"}) * 0.9
+    expr: kubelet_running_pod_count > on(node) (kube_node_status_capacity{job="kube-state-metrics",resource="pods",unit="integer"}) * 0.9
 {{- else }}
-    expr: kubelet_running_pods > on(node) (kube_node_status_capacity{resource="pods",unit="integer"}) * 0.9
+    expr: kubelet_running_pods > on(node) (kube_node_status_capacity{job="kube-state-metrics",resource="pods",unit="integer"}) * 0.9
 {{- end }}
     for: 10m
     labels:
@@ -56,5 +56,5 @@
     annotations:
       plk_protocol_version: "1"
       description: Kubelet {{ `{{ $labels.node }}` }} is running {{ `{{ $value }}` }} pods, close
-        to the limit of {{ `{{ printf "kube_node_status_capacity{resource=\"pods\",unit=\"integer\",node=\"%s\"}" $labels.node | query | first | value }}` }}
+        to the limit of {{ `{{ printf "kube_node_status_capacity{job=\"kube-state-metrics\",resource=\"pods\",unit=\"integer\",node=\"%s\"}" $labels.node | query | first | value }}` }}
       summary: Kubelet is close to pod limit


### PR DESCRIPTION
## Description
Added a job to sift metrics from custom exporters
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
if custom exporter gives metrics from alerts but with different labels it breaks alerts
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: fix
summary: added a job to sift metrics from custom exporters in persistent-volume-claim and coreos.kubelet
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
