### PR TITLE
[chrony] Move chronyd back to host network namespace

### DIFF
--- a/modules/470-chrony/images/chrony/start.sh
+++ b/modules/470-chrony/images/chrony/start.sh
@@ -30,18 +30,18 @@ driftfile /var/run/chrony/chrony.drift
 makestep 1.0 -1
 rtcsync
 bindaddress 0.0.0.0
+cmdallow 127/8
 EOF
 
 case ${NTP_ROLE} in
   "source")
-    echo "allow ${POD_SUBNET}" >> /var/run/chrony/chrony.conf
-    echo "deny 127/8" >> /var/run/chrony/chrony.conf
     echo "local stratum 5" >> /var/run/chrony/chrony.conf
+    echo "allow" >> /var/run/chrony/chrony.conf
   ;;
   "sink")
+    echo "local stratum 9" >> /var/run/chrony/chrony.conf
+    echo "allow 127/8" >> /var/run/chrony/chrony.conf
     echo "pool ${CHRONY_MASTERS_SERVICE} iburst" >> /var/run/chrony/chrony.conf
-    echo "port 0" >> /var/run/chrony/chrony.conf
-    echo "local stratum 10" >> /var/run/chrony/chrony.conf
   ;;
 esac
 

--- a/modules/470-chrony/template_tests/module_test.go
+++ b/modules/470-chrony/template_tests/module_test.go
@@ -104,10 +104,6 @@ var _ = Describe("Module :: chrony :: helm template ::", func() {
           {
             "name": "NTP_SERVERS",
             "value": "pool.ntp.org. ntp.ubuntu.com."
-          },
-          {
-            "name": "POD_SUBNET",
-            "value": "10.111.0.0/16"
           }
         ]
 `))

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -55,7 +55,8 @@ spec:
         tier: node
         app: chrony
     spec:
-      dnsPolicy: ClusterFirst
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}

--- a/modules/470-chrony/templates/deployment.yaml
+++ b/modules/470-chrony/templates/deployment.yaml
@@ -73,8 +73,6 @@ spec:
               value: source
             - name: NTP_SERVERS
               value: {{ join " " $ntpServers | quote }}
-            - name: POD_SUBNET
-              value: {{ .Values.global.clusterConfiguration.podSubnetCIDR | quote }}
       volumes:
         - name: tz-config
           hostPath:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Enabled `hostNetwork` for chrony pods

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This is required for `node-manager`'s NTP collector to be able to access Node's NTP server.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This PR fixes node time alerts in `node-manager`

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony
type: fix
summary: Run chrony pods in host network namespace.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
