### PR TITLE
[linstor] automatically fix symlinks for devices

### DIFF
--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -18,9 +18,16 @@ RUN mkdir /opt/gradle && cd /opt/gradle \
  && unzip gradle-6.9.3-bin.zip \
  && ln -s /opt/gradle/gradle-6.9.3/bin/gradle /usr/local/bin/gradle
 
+# Copy patches
+COPY ./patches /patches
+
 RUN git clone ${LINSTOR_GITREPO} /linstor-server
 WORKDIR /linstor-server
-RUN git checkout v${LINSTOR_VERSION}
+RUN git checkout v${LINSTOR_VERSION} \
+ && git config --global user.email "builder@deckhouse.io" \
+ && git config --global user.name "deckhouse" \
+ && git am /patches/*.patch \
+ && git tag -f v${LINSTOR_VERSION}
 
 RUN git config --global url."https://github.com/".insteadOf git://github.com/ \
  && make debrelease \

--- a/modules/041-linstor/images/linstor-server/patches/README.md
+++ b/modules/041-linstor/images/linstor-server/patches/README.md
@@ -2,12 +2,9 @@
 
 ### Automatically fix symlinks for devices
 
-Introduce an additional handler that checks for the device path before each such modification.
-If the device is not found, it attempts to fix the symlink using dmsetup output.
-
 This change is workaround for specific set of issues, often related to udev,
 which lead to the disappearance of symlinks for LVM devices on a working system.
 These issues commonly manifest during device resizing and deactivation,
-causing LINSTOR expceptions when accessing DRBD super-block of volume.
+causing LINSTOR exceptions when accessing DRBD super-block of volume.
 
 - Upstream: https://github.com/LINBIT/linstor-server/pull/370

--- a/modules/041-linstor/images/linstor-server/patches/README.md
+++ b/modules/041-linstor/images/linstor-server/patches/README.md
@@ -1,0 +1,13 @@
+## Patches
+
+### Automatically fix symlinks for devices
+
+Introduce an additional handler that checks for the device path before each such modification.
+If the device is not found, it attempts to fix the symlink using dmsetup output.
+
+This change is workaround for specific set of issues, often related to udev,
+which lead to the disappearance of symlinks for LVM devices on a working system.
+These issues commonly manifest during device resizing and deactivation,
+causing LINSTOR expceptions when accessing DRBD super-block of volume.
+
+- Upstream: https://github.com/LINBIT/linstor-server/pull/370

--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -3,13 +3,10 @@ From: Andrei Kvapil <kvapss@gmail.com>
 Date: Tue, 3 Oct 2023 13:32:21 +0200
 Subject: [PATCH] Automatically fix symlinks for devices
 
-Introduce an additional handler that checks for the device path before each such modification.
-If the device is not found, it attempts to fix the symlink using dmsetup output.
-
 This change is workaround for specific set of issues, often related to udev,
 which lead to the disappearance of symlinks for LVM devices on a working system.
 These issues commonly occur during device resizing and deactivation,
-causing LINSTOR expceptions diring accessing DRBD super-block of volume.
+causing LINSTOR exceptions during accessing DRBD super-block of volume.
 
 fixes: https://github.com/LINBIT/linstor-server/issues/326
 
@@ -140,7 +137,7 @@ index 16034c550..9fc09fa3e 100644
          }
  
 +        if (!Files.exists(Paths.get(metaDiskPath))) {
-+            errorReporter.logWarning("Device path %s does not exists, fixing symlink", metaDiskPath);
++            errorReporter.logWarning("Device path %s does not exist, fixing symlink", metaDiskPath);
 +            try
 +            {
 +                DmSetupUtils.fixSymlinkForDevice(extCmdFactory.create(), metaDiskPath);

--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -1,0 +1,159 @@
+From 2f4e83bf4de23408a37621b10e6caf5f771c863c Mon Sep 17 00:00:00 2001
+From: Andrei Kvapil <kvapss@gmail.com>
+Date: Tue, 3 Oct 2023 13:32:21 +0200
+Subject: [PATCH] Automatically fix symlinks for devices
+
+Introduce an additional handler that checks for the device path before each such modification.
+If the device is not found, it attempts to fix the symlink using dmsetup output.
+
+This change is workaround for specific set of issues, often related to udev,
+which lead to the disappearance of symlinks for LVM devices on a working system.
+These issues commonly occur during device resizing and deactivation,
+causing LINSTOR expceptions diring accessing DRBD super-block of volume.
+
+fixes: https://github.com/LINBIT/linstor-server/issues/326
+
+Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
+---
+ .../linstor/layer/dmsetup/DmSetupUtils.java   | 79 ++++++++++++++++++-
+ .../linbit/linstor/layer/drbd/DrbdLayer.java  | 13 +++
+ 2 files changed, 91 insertions(+), 1 deletion(-)
+
+diff --git a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
+index ba753577d..cc90ad898 100644
+--- a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
++++ b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
+@@ -18,6 +18,8 @@ import com.linbit.utils.StringUtils;
+ import javax.annotation.Nullable;
+ 
+ import java.io.IOException;
++import java.nio.file.Files;
++import java.nio.file.Paths;
+ import java.util.HashSet;
+ import java.util.Set;
+ import java.util.regex.Matcher;
+@@ -29,7 +31,7 @@ public class DmSetupUtils
+     private static final String DM_SETUP_MESSAGE_FLUSH_ON_SUSPEND = "flush_on_suspend";
+ 
+     private static final Pattern DM_SETUP_LS_PATTERN = Pattern.compile(
+-        "^([^\\s]+)\\s+\\(([0-9]+)(?::\\s|,\\s)([0-9]+)\\)$",
++        "^([^\\s]+)\\s+\\(([0-9]+)[:,]\\s*([0-9]+)\\)$",
+         Pattern.MULTILINE
+     );
+ 
+@@ -187,6 +189,81 @@ public class DmSetupUtils
+         return ret;
+     }
+ 
++    public static void fixSymlinkForDevice(ExtCmd extCmd, String devicePath) throws StorageException
++    {
++        try
++        {
++            OutputData outputData = extCmd.exec("dmsetup", "ls");
++            ExtCmdUtils.checkExitCode(
++                outputData,
++                StorageException::new,
++                "listing devices from dmsetup ls failed "
++            );
++
++            String stdOut = new String(outputData.stdoutData);
++            Matcher matcher = DM_SETUP_LS_PATTERN.matcher(stdOut);
++            String dmName = resolveDMName(devicePath);
++            String dmPath = "/dev/mapper/" + dmName;
++            String minor = null;
++
++            while (matcher.find())
++            {
++                String devName = matcher.group(1);
++                minor = matcher.group(3);
++
++                if (devName.equals(dmName))
++                {
++                    break;
++                }
++            }
++
++            if (minor == null)
++            {
++                throw new StorageException(
++                    "Device \"" + dmName + "\" (generated from \"" + devicePath + "\") not found in dmsetup output:\n\n" + stdOut
++                );
++            }
++
++            for (String path : new String[]{devicePath, dmPath}) {
++                if (Files.exists(Paths.get(path))) {
++                    continue;
++                }
++                OutputData symlinkOutput = extCmd.exec("ln", "-s", "../dm-" + minor, path);
++                ExtCmdUtils.checkExitCode(
++                    symlinkOutput,
++                    StorageException::new,
++                    "Failed to create device symlink"
++                );
++            }
++        }
++        catch (IOException ioExc)
++        {
++            throw new StorageException(
++                "Failed to fix device symlink",
++                ioExc
++            );
++        }
++        catch (ChildProcessTimeoutException exc)
++        {
++            throw new StorageException(
++                "Fixing device symlink timed out",
++                exc
++            );
++        }
++    }
++
++    public static String resolveDMName(String devicePath)
++    {
++        String[] parts = devicePath.replaceFirst("^/dev/", "").split("/");
++        if (parts[0].equals("mapper"))
++        {
++            return parts[1];
++        }
++        parts[0] = parts[0].replace("-", "--");
++        parts[1] = parts[1].replace("-", "--");
++        return String.join("-", parts[0], parts[1]);
++    }
++
+     public static void remove(ExtCmd extCmd, String identifier) throws StorageException
+     {
+         Commands.genericExecutor(
+diff --git a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
+index 16034c550..9fc09fa3e 100644
+--- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
++++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
+@@ -37,6 +37,7 @@ import com.linbit.linstor.core.objects.Volume;
+ import com.linbit.linstor.core.pojos.LocalPropsChangePojo;
+ import com.linbit.linstor.dbdrivers.DatabaseException;
+ import com.linbit.linstor.layer.DeviceLayer;
++import com.linbit.linstor.layer.dmsetup.DmSetupUtils;
+ import com.linbit.linstor.layer.drbd.drbdstate.DrbdConnection;
+ import com.linbit.linstor.layer.drbd.drbdstate.DrbdEventPublisher;
+ import com.linbit.linstor.layer.drbd.drbdstate.DrbdResource;
+@@ -1143,6 +1144,18 @@ public class DrbdLayer implements DeviceLayer
+             metaDiskPath = drbdVlmData.getDataDevice();
+         }
+ 
++        if (!Files.exists(Paths.get(metaDiskPath))) {
++            errorReporter.logWarning("Device path %s does not exists, fixing symlink", metaDiskPath);
++            try
++            {
++                DmSetupUtils.fixSymlinkForDevice(extCmdFactory.create(), metaDiskPath);
++            }
++            catch (StorageException exc)
++            {
++                errorReporter.reportError(exc);
++            }
++        }
++
+         MdSuperblockBuffer mdUtils = new MdSuperblockBuffer();
+         try
+         {
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
## Description

Automatically fix symlinks for devices

Upstream PR https://github.com/LINBIT/linstor-server/pull/370

## Why do we need it, and what problem does it solve?

This change is workaround for specific set of issues, often related to udev,
which lead to the disappearance of symlinks for LVM devices on a working system.
These issues commonly occur during device resizing and deactivation,
causing LINSTOR exceptions during accessing DRBD super-block of volume.

## Why do we need it in the patch release (if we do)?
There is a customer who faces the problem quite often.

## What is the expected result?

When symlink to device is not exists, linstor will try to make it first.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: fix
summary: automatically fix symlinks for devices
impact_level: default
```
