### PR TITLE
[linstor] changed controller's liveness probe

### DIFF
--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -203,6 +203,7 @@ RUN curl -Lfo /usr/bin/piraeus-entry.sh ${PIRAEUS_GITREPO}/raw/${PIRAEUS_COMMIT_
 
 # Add liveness probe script
 COPY liveness.sh /liveness.sh
+RUN chmod 755 /liveness.sh
 
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/modules/041-linstor/images/linstor-server/liveness.sh
+++ b/modules/041-linstor/images/linstor-server/liveness.sh
@@ -14,17 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This is default linstor controller liveness probe
+if ! curl -sf http://localhost:9999/ > /dev/null; then exit 1; fi
+
 # Sometimes nodes can be shown as Online without established connection to them.
 # This is a workaround for https://github.com/LINBIT/linstor-server/issues/331
 
-# Collect list of satellite nodes
-SATELLITES_ONLINE=$(linstor -m --output-version=v1 n l | jq -r '.[][] | select(.type == "SATELLITE" and .connection_status == "ONLINE").name' || true)
-if [ -z "$SATELLITES_ONLINE" ]; then
-  exit 0
-fi
-
-# Check online nodes with lost connection
-linstor -m --output-version=v1 sp l -s DfltDisklessStorPool -n $SATELLITES_ONLINE | jq '.[][].reports[]?.message' | grep 'No active connection to satellite'
-if [ $? -eq 0 ]; then
-  exit 1
-fi
+# This is temporary hack for some cases, when linstor controller looks alive, but in fact it stuck
+tail -n 1000 /var/log/linstor-controller/linstor-Controller.log | grep -q 'Target decrypted buffer is too small' && exit 1 || exit 0

--- a/modules/041-linstor/images/linstor-server/liveness.sh
+++ b/modules/041-linstor/images/linstor-server/liveness.sh
@@ -18,7 +18,5 @@
 if ! curl -sf http://localhost:9999/ > /dev/null; then exit 1; fi
 
 # Sometimes nodes can be shown as Online without established connection to them.
-# This is a workaround for https://github.com/LINBIT/linstor-server/issues/331
-
-# This is temporary hack for some cases, when linstor controller looks alive, but in fact it stuck
-tail -n 1000 /var/log/linstor-controller/linstor-Controller.log | grep -q 'Target decrypted buffer is too small' && exit 1 || exit 0
+# This is a workaround for https://github.com/LINBIT/linstor-server/issues/331, https://github.com/LINBIT/linstor-server/issues/219
+tail -n 1000 /var/log/linstor-controller/linstor-Controller.log | grep -q 'Target decrypted buffer is too small' && exit 1

--- a/modules/041-linstor/images/linstor-server/liveness.sh
+++ b/modules/041-linstor/images/linstor-server/liveness.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This is default linstor controller liveness probe
-if ! curl -sf http://localhost:9999/ > /dev/null; then exit 1; fi
+if ! curl --connect-timeout 3 -sf http://localhost:9999/ > /dev/null; then exit 1; fi
 
 # Sometimes nodes can be shown as Online without established connection to them.
 # This is a workaround for https://github.com/LINBIT/linstor-server/issues/331, https://github.com/LINBIT/linstor-server/issues/219

--- a/modules/041-linstor/images/piraeus-operator/patches/050-change-liveness-probe.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/050-change-liveness-probe.patch
@@ -1,0 +1,16 @@
+diff --git a/pkg/controller/linstorcontroller/linstorcontroller_controller.go b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+index 52fd46f..9219bbb 100644
+--- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
++++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
+@@ -873,9 +873,8 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
+ 	// as well as images without leader election helper
+ 	livenessProbe := corev1.Probe{
+ 		ProbeHandler: corev1.ProbeHandler{
+-			HTTPGet: &corev1.HTTPGetAction{
+-				Path: "/",
+-				Port: intstr.FromInt(healthzPort),
++			Exec: &corev1.ExecAction{
++				Command: []string{"./liveness.sh"},
+ 			},
+ 		},
+ 	}

--- a/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -133,29 +133,3 @@ spec:
         {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
         {{- end }}
-  - name: liveness
-    {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}
-    image: {{ include "helm_lib_module_image" (list . "linstorServer") }}
-    command: [ "/bin/sh", "-ec", "while sleep 60; do /liveness.sh > /dev/termination-log; done" ]
-    terminationMessagePath: "/dev/termination-log"
-    volumeMounts:
-    - mountPath: /etc/linstor
-      name: linstor-conf
-    - mountPath: /etc/linstor/https
-      name: linstor-https
-    - mountPath: /etc/linstor/https-pem
-      name: linstor-https-pem
-      readOnly: true
-    - mountPath: /etc/linstor/client
-      name: linstor-client
-    - mountPath: /etc/linstor/ssl
-      name: linstor-ssl
-    - mountPath: /etc/linstor/ssl-pem
-      name: linstor-ssl-pem
-      readOnly: true
-    resources:
-      requests:
-        {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 8 }}
-        {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-        {{- include "linstor_liveness_resources" . | nindent 6 }}
-        {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Workaround for several annoying issues in LINSTOR related to hanging controller.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The PR is a step to stable LINSTOR.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Our customers are eager to have this PR in their clusters.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correctly working linstor controller liveness probe

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Workaround for several annoying issues in LINSTOR related to hanging controller.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
