### PR TITLE
[dhctl] fix(dhctl-for-commander): dhctl cluster config validation

### DIFF
--- a/dhctl/pkg/config/errors.go
+++ b/dhctl/pkg/config/errors.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "errors"
+
+var ErrSchemaNotFound = errors.New("schema not found")

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -96,7 +96,7 @@ func (s *SchemaStore) Validate(doc *[]byte) (*SchemaIndex, error) {
 
 	err := yaml.Unmarshal(*doc, &index)
 	if err != nil {
-		return nil, fmt.Errorf("json unmarshal: %v", err)
+		return nil, fmt.Errorf("yaml unmarshal: %w", err)
 	}
 
 	err = s.ValidateWithIndex(&index, doc)
@@ -124,7 +124,7 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte) error {
 
 	schema := s.getV1alpha1CompatibilitySchema(index)
 	if schema == nil {
-		return fmt.Errorf("Schema for %s wasn't found.", index.String())
+		return fmt.Errorf("%w: no schema for index %s", ErrSchemaNotFound, index.String())
 	}
 
 	isValid, err := openAPIValidate(doc, schema)


### PR DESCRIPTION
## Description
Moved cluster config validation from `commands` package to separated `configure` package.
This will allow to import validation functionality (`ParseClusterConfiguration`) into DeckhouseCommander (and probably into other projects as needed)