### PR TITLE
[dhctl] feat(dhctl-for-commander): use given cluster-configuration data in commander mode in the converge operation

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
@@ -1,0 +1,81 @@
+package deckhouse
+
+import (
+	"context"
+	"encoding/json"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func ConvergeDeckhouseConfiguration(ctx context.Context, kubeCl *client.KubernetesClient, clusterUUID string, clusterConfig []byte, providerClusterConfig []byte) error {
+	tasks := []actions.ManifestTask{
+		{
+			Name:     `Secret "d8-cluster-configuration"`,
+			Manifest: func() interface{} { return manifests.SecretWithClusterConfig(clusterConfig) },
+			CreateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+				return err
+			},
+		},
+		{
+			Name: `Secret "d8-provider-cluster-configuration"`,
+			Manifest: func() interface{} {
+				return manifests.SecretWithProviderClusterConfig(
+					providerClusterConfig, nil,
+				)
+			},
+			CreateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				data, err := json.Marshal(manifest.(*apiv1.Secret))
+				if err != nil {
+					return err
+				}
+				_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(ctx,
+					"d8-provider-cluster-configuration",
+					types.MergePatchType,
+					data,
+					metav1.PatchOptions{},
+				)
+				return err
+			},
+		},
+		{
+			Name: `ConfigMap "d8-cluster-uuid"`,
+			Manifest: func() interface{} {
+				return manifests.ClusterUUIDConfigMap(clusterUUID)
+			},
+			CreateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Update(ctx, manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
+				return err
+			},
+		},
+	}
+
+	return log.Process("default", "Converge deckhouse configuration", func() error {
+		for _, task := range tasks {
+			err := task.CreateOrUpdate()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -31,13 +31,15 @@ import (
 
 // TODO(remove-global-app): Support all needed parameters in Params, remove usage of app.*
 type Params struct {
-	SSHClient              *ssh.Client
-	InitialState           phases.DhctlState
-	ResetInitialState      bool
-	OnPhaseFunc            phases.OnPhaseFunc
-	CommanderMode          bool
-	AutoDismissDestructive bool
-	AutoApprove            bool
+	SSHClient                                 *ssh.Client
+	InitialState                              phases.DhctlState
+	ResetInitialState                         bool
+	OnPhaseFunc                               phases.OnPhaseFunc
+	CommanderMode                             bool
+	CommanderClusterConfigurationData         []byte
+	CommanderProviderClusterConfigurationData []byte
+	AutoDismissDestructive                    bool
+	AutoApprove                               bool
 
 	*client.KubernetesInitParams
 }
@@ -115,6 +117,8 @@ func (c *Converger) Converge() error {
 	runner := converge.NewRunner(kubeCl, inLockRunner, stateCache).
 		WithPhasedExecutionContext(c.PhasedExecutionContext).
 		WithCommanderMode(c.Params.CommanderMode).
+		WithCommanderClusterConfigurationData(c.Params.CommanderClusterConfigurationData).
+		WithCommanderProviderClusterConfigurationData(c.Params.CommanderProviderClusterConfigurationData).
 		WithChangeSettings(&terraform.ChangeActionSettings{
 			AutoDismissDestructive: c.AutoDismissDestructive,
 			AutoApprove:            c.AutoApprove,


### PR DESCRIPTION
## Description

Introduced **optional** commander-mode for converge operation. In this mode dhctl converge operation:
* uses ClusterConfiguration and ProviderClusterConfiguration which are externally provided, rather than in-cluster;
* overrides in-cluster ClusterConfiguration and ProviderClusterConfiguration with externally provided data using phase called "InstallDeckhousePhase". Which is exactly same phase used in the bootstrap operation to create in-cluster configuration. By analogy converge updates this configuration on the same phase (possibly InstallDeckhouse phase could be called just DeckhousePhase, like BaseInfraPhase rather than InstallBaseInfraPhase).
* we use externally initialized state-cache rather than dhctl state stored in-cluster, then write resulting dhctl state into the cluster;

## Why do we need it, and what problem does it solve?

In commander mode all state and configuration data stored in the commander DB.

## Why do we need it in the patch release (if we do)?

No need.

## What is the expected result?

Optional commander-mode which does not affect original flow. 