### PR TITLE
[distroless] move cloud-data-discoverer binaries to distroless

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -21,6 +21,8 @@ shell:
   setup:
     - cd {{ $discovererAbsPath }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /discoverer
+    - chown 64535:64535 /discoverer
+    - chmod 0755 /discoverer
 
 git:
 - add: /{{ $discovererRelPath }}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ .Images.BASE_ALPINE }}
-fromCacheVersion: "2023-03-24.0"
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ .Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer

--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
@@ -20,6 +20,8 @@ shell:
   setup:
     - cd {{ $discovererAbsPath }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /discoverer
+    - chown 64535:64535 /discoverer
+    - chmod 0755 /discoverer
 
 git:
 - add: /{{ $discovererRelPath }}

--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ .Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -20,6 +20,8 @@ shell:
   setup:
     - cd {{ $discovererAbsPath }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /discoverer
+    - chown 64535:64535 /discoverer
+    - chmod 0755 /discoverer
 
 git:
 - add: /{{ $discovererRelPath }}

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ .Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -20,6 +20,8 @@ shell:
   setup:
     - cd {{ $discovererAbsPath }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /discoverer
+    - chown 64535:64535 /discoverer
+    - chmod 0755 /discoverer
 
 git:
 - add: /{{ $discovererRelPath }}

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
cloud-data-discoverer binaries use distroless images and built from our repos instead of using alpine:go images.

- [x] cloud-provider-aws
- [x] cloud-provider-azure
- [x] cloud-provider-gcp
- [x] ee/cloud-provider-openstack
<!---
- [ ] cloud-provider-yandex
- [ ] ee/cloud-provider-vsphere
-->
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR is a part of moving Deckhouse to distroless.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: chore
summary: "`cloud-data-discoverer` use distroless based image."
impact_level: default
---
section: cloud-provider-azure
type: chore
summary: "`cloud-data-discoverer` use distroless based image."
impact_level: default
---
section: cloud-provider-gcp
type: chore
summary: "`cloud-data-discoverer` use distroless based image."
impact_level: default
---
section: ee/cloud-provider-openstack
type: chore
summary: "`cloud-data-discoverer` use distroless based image."
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
