### PR TITLE
[user-authz] fix webhook crash on empty request data

### DIFF
--- a/ee/modules/140-user-authz/images/webhook/go.mod
+++ b/ee/modules/140-user-authz/images/webhook/go.mod
@@ -3,6 +3,7 @@ module user-authz-webhook
 go 1.19
 
 require (
+	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 )
@@ -39,7 +40,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.27.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect

--- a/ee/modules/140-user-authz/images/webhook/web/hook/handler.go
+++ b/ee/modules/140-user-authz/images/webhook/web/hook/handler.go
@@ -75,6 +75,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var request WebhookRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		h.logger.Printf("cannot unmarshal kubernetes request: %v", err)
+		http.Error(w, "Invalid json request", http.StatusBadRequest)
+		return
 	}
 
 	h.authorizeRequest(&request)

--- a/ee/modules/140-user-authz/images/webhook/web/hook/handler.go
+++ b/ee/modules/140-user-authz/images/webhook/web/hook/handler.go
@@ -74,8 +74,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var request WebhookRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		// this case is exceptional
-		h.logger.Fatalf("cannot unmarshal kubernetes request: %v", err)
+		h.logger.Printf("cannot unmarshal kubernetes request: %v", err)
 	}
 
 	h.authorizeRequest(&request)
@@ -112,7 +111,7 @@ func (h *Handler) authorizeNamespacedRequest(request *WebhookRequest, entry *Dir
 			}
 		}
 	} else {
-	// there is no filters - assume a positive outcome
+		// there is no filters - assume a positive outcome
 		request.Status.Denied = false
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The termination of the process when receiving invalid data has been removed. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
(Close https://github.com/deckhouse/deckhouse/issues/5644)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Now invalid data works the same as empty json

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:140-user-authz
type: fix
summary: webhook no longer crashes if called without data
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
