### PR TITLE
[prometheus] fix fix-permissions init-container to run under kesl security

### DIFF
--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -66,7 +66,7 @@ spec:
     - sh
     - -c
     - chown -vfR 64535:64535 /prometheus-db/
-    image: {{ include "helm_lib_module_image" (list . "prometheus") }}
+    image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions
     securityContext:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -70,7 +70,7 @@ spec:
     - sh
     - -c
     - chown -vfR 64535:64535 /prometheus-db/
-    image: {{ include "helm_lib_module_image" (list . "prometheus") }}
+    image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
     imagePullPolicy: IfNotPresent
     name: fix-permissions
     securityContext:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix fix-permissions init-container to run under kesl security. In prometheus we use main prometheus image as init container which cause a problems with container start. We change init container image to alpine.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When kesl security scanner is enabled, prometheus pods do not start due to problem with init containers.
In logs:
```
Oct 06 10:47:44 dev-worker-2a6158ff-6764d-2grk2 containerd[622]: time="2023-10-06T10:47:44.263309413Z" level=info msg="CreateContainer within sandbox \"a0f03a15e7fb6026999dae88ca78bcd4b09a97d27cd3b5c8e690efc846b72f0c\" for container &ContainerMetadata{Name:permissions,Attempt:0,}"
Oct 06 10:47:44 dev-worker-2a6158ff-6764d-2grk2 containerd[622]: time="2023-10-06T10:47:44.264267653Z" level=error msg="CreateContainer within sandbox \"a0f03a15e7fb6026999dae88ca78bcd4b09a97d27cd3b5c8e690efc846b72f0c\" for &ContainerMetadata{Name:permissions,Attempt:0,} failed" error="failed to reserve container name \"permissions_prometheus-main-0_d8-monitoring_2249ccc6-6984-44e2-b3e6-0a50c91145fc_0\": name \"permissions_prometheus-main-0_d8-monitoring_2249ccc6-6984-44e2-b3e6-0a50c91145fc_0\" is reserved for \"4645c3ff54914313436474dfa082e01a620b32adfca224c0c67ee4be8830dd20\""
Oct 06 10:47:56 dev-worker-2a6158ff-6764d-2grk2 containerd[622]: time="2023-10-06T10:47:56.278175353Z" level=info msg="CreateContainer within sandbox \"a0f03a15e7fb6026999dae88ca78bcd4b09a97d27cd3b5c8e690efc846b72f0c\" for container &ContainerMetadata{Name:permissions,Attempt:0,}"
Oct 06 10:47:56 dev-worker-2a6158ff-6764d-2grk2 containerd[622]: time="2023-10-06T10:47:56.278920991Z" level=error msg="CreateContainer within sandbox \"a0f03a15e7fb6026999dae88ca78bcd4b09a97d27cd3b5c8e690efc846b72f0c\" for &ContainerMetadata{Name:permissions,Attempt:0,} failed" error="failed to reserve container name \"permissions_prometheus-main-0_d8-monitoring_2249ccc6-6984-44e2-b3e6-0a50c91145fc_0\": name \"permissions_prometheus-main-0_d8-monitoring_2249ccc6-6984-44e2-b3e6-0a50c91145fc_0\" is reserved for \"4645c3ff54914313436474dfa082e01a620b32adfca224c0c67ee4be8830dd20\""
Oct 06 10:48:07 dev-worker-2a6158ff-6764d-2grk2 containerd[622]: time="2023-10-06T10:48:07.363819575Z" level=info msg="CreateContainer within sandbox \"a0f03a15e7fb6026999dae88ca78bcd4b09a97d27cd3b5c8e690efc846b72f0c\" for container &ContainerMetadata{Name:permissions,Attempt:0,}"
Oct 06 10:48:07 dev-worker-2a6158ff-6764d-2grk2 containerd[622]: time="2023-10-06T10:48:07.364342438Z" level=error msg="CreateContainer within sandbox \"a0f03a15e7fb6026999dae88ca78bcd4b09a97d27cd3b5c8e690efc846b72f0c\" for &ContainerMetadata{Name:permissions,Attempt:0,} failed" error="failed to reserve container name \"permissions_prometheus-main-0_d8-monitoring_2249ccc6-6984-44e2-b3e6-0a50c91145fc_0\": name \"permissions_prometheus-main-0_d8-monitoring_2249ccc6-6984-44e2-b3e6-0a50c91145fc_0\" is reserved for \"4645c3ff54914313436474dfa082e01a620b32adfca224c0c67ee4be8830dd20\""
```
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: fix
summary: fix fix-permissions init-container to run under kesl security
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
