### PR TITLE
[cert-manager] switch to distroless

### DIFF
--- a/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
@@ -1,14 +1,11 @@
 {{- $version := "1.12.3" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
 - artifact: {{ $.ModuleName }}/cert-manager-controller-artifact-{{ $version | replace "." "-" }}
   add: /build/cert-manager/_bin/server/acmesolver-linux-amd64
   to: /bin/acmesolver
   before: setup
-shell:
-  beforeInstall:
-  - apk add --no-cache ca-certificates
 docker:
   USER: 65534
   ENTRYPOINT: ["/bin/acmesolver"]

--- a/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
@@ -1,13 +1,10 @@
 {{- $version := "1.12.3" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
 - artifact: {{ $.ModuleName }}/cert-manager-controller-artifact-{{ $version | replace "." "-" }}
   add: /build/cert-manager/_bin/server/cainjector-linux-amd64
   to: /bin/cainjector
   before: setup
-shell:
-  beforeInstall:
-  - apk add --no-cache ca-certificates
 docker:
   ENTRYPOINT: ["/bin/cainjector"]

--- a/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
@@ -1,14 +1,11 @@
 {{- $version := "1.12.3" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /build/cert-manager/_bin/server/controller-linux-amd64
   to: /bin/cert-manager-controller
   before: setup
-shell:
-  beforeInstall:
-  - apk add --no-cache ca-certificates
 docker:
   ENTRYPOINT: ["/bin/cert-manager-controller"]
 ---
@@ -30,8 +27,8 @@ shell:
   install:
   - mkdir /build
   - cd /build
-  - git clone -b "v{{ $version }}" --single-branch --depth=1 https://github.com/jetstack/cert-manager.git
+  - git clone -b "v{{ $version }}" --single-branch --depth=1 {{ $.SOURCE_REPO }}/jetstack/cert-manager.git
   - cd /build/cert-manager
   - test -d /patches && for patchfile in /patches/*.patch ; do patch -p1 < ${patchfile}; done
   - export RELEASE_VERSION="v{{ $version }}-flant"
-  - make CTR=jq _bin/server/controller-linux-amd64 _bin/server/acmesolver-linux-amd64 _bin/server/webhook-linux-amd64 _bin/server/cainjector-linux-amd64
+  - GOPROXY={{ $.GOPROXY }} make CTR=jq _bin/server/controller-linux-amd64 _bin/server/acmesolver-linux-amd64 _bin/server/webhook-linux-amd64 _bin/server/cainjector-linux-amd64

--- a/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
@@ -1,13 +1,10 @@
 {{- $version := "1.12.3" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_ALPINE }}
+fromImage: common/distroless
 import:
 - artifact: {{ $.ModuleName }}/cert-manager-controller-artifact-{{ $version | replace "." "-" }}
   add: /build/cert-manager/_bin/server/webhook-linux-amd64
   to: /bin/webhook
   before: setup
-shell:
-  beforeInstall:
-  - apk add --no-cache ca-certificates
 docker:
   ENTRYPOINT: ["/bin/webhook"]


### PR DESCRIPTION
## Description
Switch cert-manager to use distroless image.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Unification of the approach to the development of module images
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cert-manager
type: feature
summary: Switch cert-manager to use distroless image.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
