### PR TITLE
[dhctl] feat(dhctl-for-commander): use given cluster-configuration data and dhctl state in commander mode in the destroy, bootstrap-abort and converge operations

### DIFF
--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -64,11 +64,14 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 			return fmt.Errorf(destroyCacheErrorMessage, err)
 		}
 
-		destroyer := destroy.NewClusterDestroyer(&destroy.Params{
+		destroyer, err := destroy.NewClusterDestroyer(&destroy.Params{
 			SSHClient:     sshClient,
 			StateCache:    cache.Global(),
 			SkipResources: app.SkipResources,
 		})
+		if err != nil {
+			return err
+		}
 
 		return destroyer.DestroyCluster(app.SanityCheck)
 	})

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
@@ -127,16 +128,37 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
-		if err = cache.InitWithOptions(sshClient.Check().String(), cache.CacheOptions{}); err != nil {
-			return fmt.Errorf(bootstrapAbortInvalidCacheMessage, sshClient.Check().String(), err)
-		}
-		destroyer = destroy.NewClusterDestroyer(&destroy.Params{
-			SSHClient:   sshClient,
-			StateCache:  cache.Global(),
-			OnPhaseFunc: b.OnPhaseFunc,
 
+		if !b.CommanderMode {
+			if err = cache.InitWithOptions(sshClient.Check().String(), cache.CacheOptions{}); err != nil {
+				return fmt.Errorf(bootstrapAbortInvalidCacheMessage, sshClient.Check().String(), err)
+			}
+		}
+
+		destroyParams := &destroy.Params{
+			SSHClient:     sshClient,
+			StateCache:    cache.Global(),
+			OnPhaseFunc:   b.OnPhaseFunc,
 			SkipResources: app.SkipResources,
-		})
+		}
+
+		if b.CommanderMode {
+			clusterConfigurationData, err := metaConfig.ClusterConfigYAML()
+			if err != nil {
+				return err
+			}
+			providerClusterConfigurationData, err := metaConfig.ProviderClusterConfigYAML()
+			if err != nil {
+				return err
+			}
+			destroyParams.CommanderMode = true
+			destroyParams.CommanderModeParams = commander.NewCommanderModeParams(clusterConfigurationData, providerClusterConfigurationData)
+		}
+
+		destroyer, err = destroy.NewClusterDestroyer(destroyParams)
+		if err != nil {
+			return err
+		}
 
 		log.InfoLn("Deckhouse installation was started before. Destroy cluster")
 		return nil

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -76,6 +76,7 @@ type Params struct {
 	ResetInitialState          bool
 	DisableBootstrapClearCache bool
 	OnPhaseFunc                phases.OnPhaseFunc
+	CommanderMode              bool
 
 	ConfigPath              string
 	ResourcesPath           string

--- a/dhctl/pkg/operations/commander/meta_config.go
+++ b/dhctl/pkg/operations/commander/meta_config.go
@@ -1,0 +1,24 @@
+package commander
+
+import (
+	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+)
+
+func ParseMetaConfig(stateCache state.Cache, clusterConfigurationData, providerClusterConfigurationData []byte) (*config.MetaConfig, error) {
+	clusterUUIDBytes, err := stateCache.Load("uuid")
+	if err != nil {
+		return nil, fmt.Errorf("error loading cluster uuid from state cache: %w", err)
+	}
+	clusterUUID := string(clusterUUIDBytes)
+
+	configData := fmt.Sprintf("%s\n---\n%s", clusterConfigurationData, providerClusterConfigurationData)
+	metaConfig, err := config.ParseConfigFromData(configData)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse config: %w", err)
+	}
+	metaConfig.UUID = clusterUUID
+
+	return metaConfig, nil
+}

--- a/dhctl/pkg/operations/commander/operation_params.go
+++ b/dhctl/pkg/operations/commander/operation_params.go
@@ -1,0 +1,19 @@
+package commander
+
+type CommanderModeParams struct {
+	ClusterConfigurationData         []byte
+	ProviderClusterConfigurationData []byte
+}
+
+func NewCommanderModeParams(clusterConfigurationData, providerClusterConfigurationData []byte) *CommanderModeParams {
+	if clusterConfigurationData == nil {
+		panic("cluster configuration param required")
+	}
+	if providerClusterConfigurationData == nil {
+		panic("provider cluster configuration param required")
+	}
+	return &CommanderModeParams{
+		ClusterConfigurationData:         clusterConfigurationData,
+		ProviderClusterConfigurationData: providerClusterConfigurationData,
+	}
+}

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -16,6 +16,7 @@ package converge
 
 import (
 	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	"time"
 
@@ -31,17 +32,15 @@ import (
 
 // TODO(remove-global-app): Support all needed parameters in Params, remove usage of app.*
 type Params struct {
-	SSHClient                                 *ssh.Client
-	InitialState                              phases.DhctlState
-	ResetInitialState                         bool
-	OnPhaseFunc                               phases.OnPhaseFunc
-	CommanderMode                             bool
-	CommanderClusterConfigurationData         []byte
-	CommanderProviderClusterConfigurationData []byte
-	AutoDismissDestructive                    bool
-	AutoApprove                               bool
+	SSHClient              *ssh.Client
+	OnPhaseFunc            phases.OnPhaseFunc
+	AutoDismissDestructive bool
+	AutoApprove            bool
 
 	*client.KubernetesInitParams
+
+	CommanderMode bool
+	*commander.CommanderModeParams
 }
 
 type Converger struct {
@@ -81,30 +80,30 @@ func (c *Converger) Converge() error {
 		return err
 	}
 
-	cacheIdentity := ""
-	if app.KubeConfigInCluster {
-		cacheIdentity = "in-cluster"
+	if !c.CommanderMode {
+		cacheIdentity := ""
+		if app.KubeConfigInCluster {
+			cacheIdentity = "in-cluster"
+		}
+		if c.SSHClient != nil {
+			cacheIdentity = c.SSHClient.Check().String()
+		}
+		if app.KubeConfig != "" {
+			cacheIdentity = cache.GetCacheIdentityFromKubeconfig(
+				app.KubeConfig,
+				app.KubeConfigContext,
+			)
+		}
+		if cacheIdentity == "" {
+			return fmt.Errorf("Incorrect cache identity. Need to pass --ssh-host or --kube-client-from-cluster or --kubeconfig")
+		}
+
+		err = cache.InitWithOptions(cacheIdentity, cache.CacheOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to initialize cache %s: %w", cacheIdentity, err)
+		}
 	}
 
-	if c.SSHClient != nil {
-		cacheIdentity = c.SSHClient.Check().String()
-	}
-
-	if app.KubeConfig != "" {
-		cacheIdentity = cache.GetCacheIdentityFromKubeconfig(
-			app.KubeConfig,
-			app.KubeConfigContext,
-		)
-	}
-
-	if cacheIdentity == "" {
-		return fmt.Errorf("Incorrect cache identity. Need to pass --ssh-host or --kube-client-from-cluster or --kubeconfig")
-	}
-
-	err = cache.InitWithOptions(cacheIdentity, cache.CacheOptions{InitialState: c.InitialState, ResetInitialState: c.ResetInitialState})
-	if err != nil {
-		return fmt.Errorf("unable to initialize cache %s: %w", cacheIdentity, err)
-	}
 	inLockRunner := converge.NewInLockLocalRunner(kubeCl, "local-converger")
 
 	stateCache := cache.Global()
@@ -117,8 +116,8 @@ func (c *Converger) Converge() error {
 	runner := converge.NewRunner(kubeCl, inLockRunner, stateCache).
 		WithPhasedExecutionContext(c.PhasedExecutionContext).
 		WithCommanderMode(c.Params.CommanderMode).
-		WithCommanderClusterConfigurationData(c.Params.CommanderClusterConfigurationData).
-		WithCommanderProviderClusterConfigurationData(c.Params.CommanderProviderClusterConfigurationData).
+		WithCommanderClusterConfigurationData(c.Params.CommanderModeParams.ClusterConfigurationData).
+		WithCommanderProviderClusterConfigurationData(c.Params.CommanderModeParams.ProviderClusterConfigurationData).
 		WithChangeSettings(&terraform.ChangeActionSettings{
 			AutoDismissDestructive: c.AutoDismissDestructive,
 			AutoApprove:            c.AutoApprove,

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -15,7 +15,9 @@
 package destroy
 
 import (
+	"fmt"
 	infra "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	dhctlstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
@@ -28,6 +30,9 @@ type Params struct {
 	OnPhaseFunc phases.OnPhaseFunc
 
 	SkipResources bool
+
+	CommanderMode bool
+	*commander.CommanderModeParams
 }
 
 type ClusterDestroyer struct {
@@ -43,11 +48,22 @@ type ClusterDestroyer struct {
 	*phases.PhasedExecutionContext
 }
 
-func NewClusterDestroyer(params *Params) *ClusterDestroyer {
+func NewClusterDestroyer(params *Params) (*ClusterDestroyer, error) {
 	state := NewDestroyState(params.StateCache)
 	pec := phases.NewPhasedExecutionContext(params.OnPhaseFunc)
 	d8Destroyer := NewDeckhouseDestroyer(params.SSHClient, state)
-	terraStateLoader := terraform.NewLazyTerraStateLoader(terraform.NewCachedTerraStateLoader(d8Destroyer, state.cache))
+
+	var terraStateLoader terraform.StateLoader
+	if params.CommanderMode {
+		metaConfig, err := commander.ParseMetaConfig(state.cache, params.ClusterConfigurationData, params.ProviderClusterConfigurationData)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse meta configuration: %w", err)
+		}
+		terraStateLoader = terraform.NewFileTerraStateLoader(state.cache, metaConfig)
+	} else {
+		terraStateLoader = terraform.NewLazyTerraStateLoader(terraform.NewCachedTerraStateLoader(d8Destroyer, state.cache))
+	}
+
 	clusterInfra := infra.NewClusterInfraWithOptions(terraStateLoader, state.cache, infra.ClusterInfraOptions{PhasedExecutionContext: pec})
 
 	return &ClusterDestroyer{
@@ -61,7 +77,7 @@ func NewClusterDestroyer(params *Params) *ClusterDestroyer {
 		skipResources: params.SkipResources,
 
 		PhasedExecutionContext: pec,
-	}
+	}, nil
 }
 
 func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {


### PR DESCRIPTION
## Description

Introduced **optional** commander-mode for converge operation. In this mode dhctl destroy, converge and abort operations:
* use ClusterConfiguration and ProviderClusterConfiguration which are externally provided, rather than in-cluster;
* use externally initialized state-cache rather than dhctl state stored in-cluster, then write resulting dhctl state into the cluster.

## Why do we need it, and what problem does it solve?

In commander mode all state and configuration data stored in the commander DB.

## Why do we need it in the patch release (if we do)?

No need.

## What is the expected result?

Optional commander-mode which does not affect original flow. 