### PR TITLE
[cloud-provider-yandex] fix working in hybrid environments

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.8.0
-digest: sha256:f5a98932e4ffc046f42102efc890e545e027649c98f635237a582b760a430bae
-generated: "2023-09-20T09:35:57.31878+03:00"
+  version: 1.9.0
+digest: sha256:4f511d72126b8a366503a8eb1036653da14b0cc72e39115d485e94f3009fa36d
+generated: "2023-10-09T16:55:52.186643+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.8.0"
+    version: "1.9.0"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.8.0
+version: 1.9.0

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
@@ -116,6 +116,7 @@ tolerations:
   {{- end }}
 {{- end }}
 
+
 {{- /* Check cluster type. */ -}}
 {{- /* Returns not empty string if this is cloud or hybrid cluster */ -}}
 {{- define "_helm_lib_cloud_or_hybrid_cluster" }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
@@ -123,11 +123,12 @@ tolerations:
     {{- if eq .Values.global.clusterConfiguration.clusterType "Cloud" }}
       "not empty string"
     {{- /* We consider non-cloud clusters with enabled cloud-provider-.* module as Hybrid clusters */ -}}
-    {{- /* For now, only VSphere and OpenStack support hybrid installations */ -}}
-    {{- else if ( .Values.global.enabledModules | has "cloud-provider-vsphere") }}
-      "not empty string"
-    {{- else if ( .Values.global.enabledModules | has "cloud-provider-openstack") }}
-      "not empty string"
+    {{- else }}
+      {{- range $v := .Values.global.enabledModules }}
+        {{- if hasPrefix "cloud-provider-" $v }}
+          "not empty string"
+        {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
@@ -112,6 +112,8 @@ spec:
                 secretKeyRef:
                   name: cloud-controller-manager
                   key: service-acount-json
+            - name: YANDEX_CLOUD_FOLDER_ID
+              value: {{ .Values.cloudProviderYandex.internal.providerClusterConfiguration.provider.folderID | quote }}
             - name: YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID
               value: {{ .Values.cloudProviderYandex.internal.defaultLbListenerSubnetId | quote }}
             - name: YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -33,7 +33,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: '${IMAGE_ID}'
+    imageID: 'fd8emvfmfoaordspe1jr'
     diskSizeGB: 50
     externalIPAddresses:
     - Auto

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -265,23 +265,14 @@ function prepare_environment() {
 
   case "$PROVIDER" in
   "Yandex.Cloud")
-    if [[ $CRI == "Containerd" ]]; then
-      ssh_user="cloud-user"
-      # RedOS 7.3
-      IMAGE_ID="fd8q0kjl4l1iovds9f29"
-    else
-      ssh_user="ubuntu"
-      # Ubuntu 22.04 LTS
-      IMAGE_ID="fd8emvfmfoaordspe1jr"
-    fi
-
     # shellcheck disable=SC2016
     env CLOUD_ID="$(base64 -d <<< "$LAYOUT_YANDEX_CLOUD_ID")" FOLDER_ID="$(base64 -d <<< "$LAYOUT_YANDEX_FOLDER_ID")" \
         SERVICE_ACCOUNT_JSON="$(base64 -d <<< "$LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON")" \
-        KUBERNETES_VERSION="$KUBERNETES_VERSION" CRI="$CRI" DEV_BRANCH="$DEV_BRANCH" PREFIX="$PREFIX" DECKHOUSE_DOCKERCFG="$DECKHOUSE_DOCKERCFG" IMAGE_ID="$IMAGE_ID" \
-        envsubst '${DECKHOUSE_DOCKERCFG} ${PREFIX} ${DEV_BRANCH} ${KUBERNETES_VERSION} ${CRI} ${CLOUD_ID} ${FOLDER_ID} ${SERVICE_ACCOUNT_JSON} ${IMAGE_ID}' \
+        KUBERNETES_VERSION="$KUBERNETES_VERSION" CRI="$CRI" DEV_BRANCH="$DEV_BRANCH" PREFIX="$PREFIX" DECKHOUSE_DOCKERCFG="$DECKHOUSE_DOCKERCFG" \
+        envsubst '${DECKHOUSE_DOCKERCFG} ${PREFIX} ${DEV_BRANCH} ${KUBERNETES_VERSION} ${CRI} ${CLOUD_ID} ${FOLDER_ID} ${SERVICE_ACCOUNT_JSON}' \
         <"$cwd/configuration.tpl.yaml" >"$cwd/configuration.yaml"
 
+    ssh_user="ubuntu"
     ;;
 
   "GCP")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix working in hybrid environments for cloud-provider-yandex.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In hybrid environment cloud-provider-yandex does not work properly.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: fix working in hybrid environments for cloud-provider-yandex
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
