### PR TITLE
[e2e] change openstack Selectel zone to ru-3b

### DIFF
--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -49,4 +49,4 @@ masterNodeGroup:
     flavorName: m1.large
     imageName: "debian-11-genericcloud-amd64-20220911-1135"
   volumeTypeMap:
-    ru-3a: "fast.ru-3b"
+    ru-3b: "fast.ru-3b"

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -28,7 +28,7 @@ kind: OpenStackClusterConfiguration
 layout: Standard
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="
 zones:
-  - ru-3a
+  - ru-3b
 standard:
   internalNetworkDNSServers:
     - 8.8.8.8
@@ -49,4 +49,4 @@ masterNodeGroup:
     flavorName: m1.large
     imageName: "debian-11-genericcloud-amd64-20220911-1135"
   volumeTypeMap:
-    ru-3a: "fast.ru-3a"
+    ru-3a: "fast.ru-3b"

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -1,5 +1,5 @@
 variable "az_zone" {
-  default = "ru-3a"
+  default = "ru-3b"
 }
 
 variable "region" {
@@ -7,7 +7,7 @@ variable "region" {
 }
 
 variable "volume_type" {
-  default = "fast.ru-3a"
+  default = "fast.ru-3b"
 }
 
 variable "flavor_name_large" {


### PR DESCRIPTION
## Description
Change availability zone for Openstack and static e2e tests.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: chore
summary: Change availability zone for Openstack and static e2e tests.
impact_level: low
```
