### PR TITLE
[user-authn] Make the spec.userID parameter of the User resource as deprecated

### DIFF
--- a/modules/010-user-authn-crd/crds/doc-ru-user.yaml
+++ b/modules/010-user-authn-crd/crds/doc-ru-user.yaml
@@ -1,7 +1,7 @@
 spec:
   versions:
     - name: v1alpha1
-      schema: &schema
+      schema:
         openAPIV3Schema:
           description: |
             Содержит информацию о статическом пользователе.
@@ -17,9 +17,9 @@ spec:
                     **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/) для выдачи прав конкретному пользователю в качестве имени пользователя в custom resource [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
                 password:
                   description: |
-                    Хэшированный пароль пользователя.
+                    Хэш пароля пользователя в явном виде или закодированный в Base64.
 
-                    Для получения хэшированного пароля можно воспользоваться командой `echo "$password" | htpasswd -inBC 10 "" | tr -d ':\n' | sed 's/$2y/$2a/'`. Или воспользоваться [онлайн-сервисом](https://bcrypt-generator.com/).
+                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
                 userID:
                   description: |
                     Уникальное имя (ID) пользователя.
@@ -60,14 +60,14 @@ spec:
               properties:
                 email:
                   description: |
-                    E-mail пользователя.
+                    Email пользователя.
 
                     **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/), для выдачи прав конкретному пользователю в качестве имени пользователя в CR [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
                 password:
                   description: |
-                    Хэшированный пароль пользователя.
+                    Хэш пароля пользователя в явном виде или закодированный в Base64.
 
-                    Для получения хэшированного пароля можно воспользоваться командой `echo "$password" | htpasswd -inBC 10 "" | tr -d ':\n' | sed 's/$2y/$2a/'`. Или воспользоваться [онлайн-сервисом](https://bcrypt-generator.com/).
+                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
                 userID:
                   description: |
                     Уникальное имя (ID) пользователя.
@@ -77,8 +77,7 @@ spec:
                   description: |
                     Список групп, в которых у пользователя есть членство.
 
-                    Больше не используется. Добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
-
+                    Т.к. параметр устарел, добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
                 ttl:
                   description: |
                     Время жизни учетной записи пользователя (TTL).
@@ -99,41 +98,3 @@ spec:
                 groups:
                   description: |
                     Список групп, в которых у пользователя есть членство.
-    - name: v2alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            Содержит информацию о статическом пользователе.
-          properties:
-            spec:
-              properties:
-                email:
-                  description: |
-                    E-mail пользователя.
-
-                    **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/), для выдачи прав конкретному пользователю в качестве имени пользователя в CR [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
-                password:
-                  description: |
-                    Хэш пароля пользователя в явном виде или закодированный в Base64.
-
-                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
-                userID:
-                  description: |
-                    Уникальное имя (ID) пользователя.
-                ttl:
-                  description: |
-                    Время жизни учетной записи пользователя (TTL).
-
-                    Задается в виде строки с указанием часов и минут: 30m, 1h, 2h30m, 24h.
-
-                    Указать TTL можно только 1 раз. При повторном изменении TTL дата `expireAt` не обновляется.
-            status:
-              type: object
-              properties:
-                expireAt:
-                  type: string
-                  description: |
-                    Дата окончания действия учетной записи пользователя:
-                    * Появляется только при заполнении поля `.spec.ttl`.
-                    * При достижении этой даты учетная запись будет удалена.
-                    * Синхронизируется раз в 5 минут. Возможен временной лаг между датой в этом поле и датой фактического удаления пользователя.

--- a/modules/010-user-authn-crd/crds/doc-ru-user.yaml
+++ b/modules/010-user-authn-crd/crds/doc-ru-user.yaml
@@ -1,7 +1,7 @@
 spec:
   versions:
     - name: v1alpha1
-      schema: &schema
+      schema:
         openAPIV3Schema:
           description: |
             Содержит информацию о статическом пользователе.
@@ -17,9 +17,9 @@ spec:
                     **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/) для выдачи прав конкретному пользователю в качестве имени пользователя в custom resource [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
                 password:
                   description: |
-                    Хэшированный пароль пользователя.
+                    Хэш пароля пользователя в явном виде или закодированный в Base64.
 
-                    Для получения хэшированного пароля можно воспользоваться командой `echo "$password" | htpasswd -inBC 10 "" | tr -d ':\n' | sed 's/$2y/$2a/'` или [онлайн-сервисом](https://bcrypt-generator.com/).
+                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
                 userID:
                   description: |
                     Уникальное имя (ID) пользователя.
@@ -27,8 +27,7 @@ spec:
                   description: |
                     Список групп, в которых у пользователя есть членство.
 
-                    Больше не используется. Добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
-
+                    Т.к. параметр устарел, добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
                 ttl:
                   description: |
                     Время жизни учетной записи пользователя (TTL).
@@ -50,12 +49,12 @@ spec:
                   description: |
                     Список групп, в которых у пользователя есть членство.
     - name: v1
-      schema: *schema
-    - name: v2alpha1
       schema:
         openAPIV3Schema:
           description: |
             Содержит информацию о статическом пользователе.
+
+            [Пример использования...](usage.html#пример-создания-статического-пользователя)
           properties:
             spec:
               properties:
@@ -69,9 +68,51 @@ spec:
                     Хэш пароля пользователя в явном виде или закодированный в Base64.
 
                     Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
-                userID:
+                groups:
                   description: |
-                    Уникальное имя (ID) пользователя.
+                    Список групп, в которых у пользователя есть членство.
+
+                    Т.к. параметр устарел, добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
+                ttl:
+                  description: |
+                    Время жизни учетной записи пользователя (TTL).
+
+                    Задаётся в виде строки с указанием часов и минут: 30m, 1h, 2h30m, 24h.
+
+                    Указать TTL можно только 1 раз. При повторном изменении TTL, дата `expireAt` не обновляется.
+            status:
+              type: object
+              properties:
+                expireAt:
+                  type: string
+                  description: |
+                    Дата окончания действия учетной записи пользователя.
+                    * Появляется только при заполнении поля `.spec.ttl`.
+                    * При достижении этой даты учетная запись будет удалена.
+                    * Синхронизируется раз в 5 минут. Возможен временной лаг между датой в этом поле и датой фактического удаления пользователя.
+                groups:
+                  description: |
+                    Список групп, в которых у пользователя есть членство.
+    - name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          description: |
+            Содержит информацию о статическом пользователе.
+
+            [Пример использования...](usage.html#пример-создания-статического-пользователя)
+          properties:
+            spec:
+              properties:
+                email:
+                  description: |
+                    E-mail пользователя.
+
+                    **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/), для выдачи прав конкретному пользователю в качестве имени пользователя в CR [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
+                password:
+                  description: |
+                    Хэш пароля пользователя в явном виде или закодированный в Base64.
+
+                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
                 ttl:
                   description: |
                     Время жизни учетной записи пользователя (TTL).

--- a/modules/010-user-authn-crd/crds/doc-ru-user.yaml
+++ b/modules/010-user-authn-crd/crds/doc-ru-user.yaml
@@ -1,7 +1,7 @@
 spec:
   versions:
     - name: v1alpha1
-      schema:
+      schema: &schema
         openAPIV3Schema:
           description: |
             Содержит информацию о статическом пользователе.
@@ -17,9 +17,9 @@ spec:
                     **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/) для выдачи прав конкретному пользователю в качестве имени пользователя в custom resource [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
                 password:
                   description: |
-                    Хэш пароля пользователя в явном виде или закодированный в Base64.
+                    Хэшированный пароль пользователя.
 
-                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
+                    Для получения хэшированного пароля можно воспользоваться командой `echo "$password" | htpasswd -inBC 10 "" | tr -d ':\n' | sed 's/$2y/$2a/'`. Или воспользоваться [онлайн-сервисом](https://bcrypt-generator.com/).
                 userID:
                   description: |
                     Уникальное имя (ID) пользователя.
@@ -60,19 +60,25 @@ spec:
               properties:
                 email:
                   description: |
-                    Email пользователя.
+                    E-mail пользователя.
 
-                    **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/) для выдачи прав конкретному пользователю в качестве имени пользователя в custom resource [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
+                    **Важно!** При использовании совместно с модулем [user-authz](https://deckhouse.ru/documentation/v1/modules/140-user-authz/), для выдачи прав конкретному пользователю в качестве имени пользователя в CR [ClusterAuthorizationRule](https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) необходимо указывать `email`.
                 password:
                   description: |
-                    Хэш пароля пользователя в явном виде или закодированный в Base64.
+                    Хэшированный пароль пользователя.
 
-                    Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
+                    Для получения хэшированного пароля можно воспользоваться командой `echo "$password" | htpasswd -inBC 10 "" | tr -d ':\n' | sed 's/$2y/$2a/'`. Или воспользоваться [онлайн-сервисом](https://bcrypt-generator.com/).
+                userID:
+                  description: |
+                    Уникальное имя (ID) пользователя.
+
+                    Больше не используется. Заполняется автоматический.
                 groups:
                   description: |
                     Список групп, в которых у пользователя есть членство.
 
-                    Т.к. параметр устарел, добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
+                    Больше не используется. Добавление пользователя в группы теперь осуществляется через ресурс [Group](#group).
+
                 ttl:
                   description: |
                     Время жизни учетной записи пользователя (TTL).
@@ -98,8 +104,6 @@ spec:
         openAPIV3Schema:
           description: |
             Содержит информацию о статическом пользователе.
-
-            [Пример использования...](usage.html#пример-создания-статического-пользователя)
           properties:
             spec:
               properties:
@@ -113,6 +117,9 @@ spec:
                     Хэш пароля пользователя в явном виде или закодированный в Base64.
 
                     Для получения хэша пароля в Base64 можно воспользоваться командой `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Также можно воспользоваться онлайн-сервисом (например, https://bcrypt-generator.com/).
+                userID:
+                  description: |
+                    Уникальное имя (ID) пользователя.
                 ttl:
                   description: |
                     Время жизни учетной записи пользователя (TTL).

--- a/modules/010-user-authn-crd/crds/user.yaml
+++ b/modules/010-user-authn-crd/crds/user.yaml
@@ -43,7 +43,7 @@ spec:
                 password:
                   type: string
                   description: |
-                    User password hash in plaintext or Base64 encoded.
+                    User password hash in plaintext or Base64-encoded.
 
                     Use the following command to encode the password hash in Base64: `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Alternatively, you can use an online service (such as https://bcrypt-generator.com/).
                   example: 'JDJ5JDEwJE9HN1lOOUhnOXU5NmY2cGp4R3NIcS56NWQuOVQxQ0VrdWIud3BRdVJ5Sy5QQU5INlpKNDguCgo='
@@ -57,7 +57,7 @@ spec:
                   description: |
                     Static user groups.
 
-                    Since the parameter has been deprecated, use the [Group](#group) resource to add users to groups.
+                    Deprecated. Use the [Group](#group) resource.
                   items:
                     type: string
                 ttl:
@@ -99,13 +99,6 @@ spec:
           format: date-time
     - name: v1
       served: true
-      storage: false
-      schema: *schema
-      subresources: *subresources
-      additionalPrinterColumns: *additionalPrinterColumns
-
-    - name: v2alpha1
-      served: true
       storage: true
       schema:
         openAPIV3Schema:
@@ -133,11 +126,26 @@ spec:
                 password:
                   type: string
                   description: |
-                    User password hash in plaintext or Base64 encoded.
+                    User password hash in plaintext or Base64-encoded.
 
                     Use the following command to encode the password hash in Base64: `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Alternatively, you can use an online service (such as https://bcrypt-generator.com/).
-                  example: '$2a$10$F9ey7zW.sVliT224RFxpWeMsgzO.D9YRG54a8T36/K2MCiT41nzmC'
-                  pattern: '^\$2[ayb]\$.{56}$'
+                  example: 'JDJ5JDEwJE9HN1lOOUhnOXU5NmY2cGp4R3NIcS56NWQuOVQxQ0VrdWIud3BRdVJ5Sy5QQU5INlpKNDguCgo='
+                userID:
+                  type: string
+                  x-doc-deprecated: true
+                  description: |
+                    Unique issuer user ID. It equals to .metadata.name.
+
+                    Deprecated and shouldn't be set manually.
+                groups:
+                  type: array
+                  x-doc-deprecated: true
+                  description: |
+                    Static user groups.
+
+                    Deprecated. Use the [Group](#group) resource.
+                  items:
+                    type: string
                 ttl:
                   type: string
                   pattern: '^([0-9]+h([0-9]+m)?|[0-9]+m)$'
@@ -156,11 +164,11 @@ spec:
                     * It is shown only of the `.spec.ttl` field is set.
                     * The user account will be deleted at the specified date.
                     * This parameter is synchronized every 5 minutes. There may be a time lag between the moment specified in this field and the moment of actual deletion of the user account.
+                groups:
+                  type: array
+                  description: |
+                    Static user groups.
+                  items:
+                    type: string
       subresources: *subresources
-      additionalPrinterColumns:
-        - jsonPath: .spec.email
-          name: Email
-          type: string
-        - jsonPath: .status.expireAt
-          name: Expire_at
-          type: string
+      additionalPrinterColumns: &additionalPrinterColumns

--- a/modules/010-user-authn-crd/crds/user.yaml
+++ b/modules/010-user-authn-crd/crds/user.yaml
@@ -36,14 +36,14 @@ spec:
                 email:
                   type: string
                   description: |
-                    User E-mail.
+                    User email.
 
                     **Caution!** Note that if used together with the [user-authz](https://deckhouse.io/documentation/v1/modules/140-user-authz/) module, you must specify an `email` to grant rights to the specific user as the user name in the [ClusterAuthorizationRule](https://deckhouse.io/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) CR.
                   example: 'user@domain.com'
                 password:
                   type: string
                   description: |
-                    User password hash in plaintext or Base64-encoded.
+                    User password hash in plaintext or Base64 encoded.
 
                     Use the following command to encode the password hash in Base64: `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Alternatively, you can use an online service (such as https://bcrypt-generator.com/).
                   example: 'JDJ5JDEwJE9HN1lOOUhnOXU5NmY2cGp4R3NIcS56NWQuOVQxQ0VrdWIud3BRdVJ5Sy5QQU5INlpKNDguCgo='
@@ -57,7 +57,7 @@ spec:
                   description: |
                     Static user groups.
 
-                    Deprecated. Use the [Group](#group) resource.
+                    Since the parameter has been deprecated, use the [Group](#group) resource to add users to groups.
                   items:
                     type: string
                 ttl:
@@ -65,8 +65,10 @@ spec:
                   pattern: '^([0-9]+h([0-9]+m)?|[0-9]+m)$'
                   description: |
                     Static user TTL.
-                    * It is specified as a string containing the time unit in hours and minutes: 30m, 1h, 2h30m, 24h.
-                    * You can only set the TTL once. The `expireAt` date will not be updated if you change it again.
+
+                    It is specified as a string containing the time unit in hours and minutes: 30m, 1h, 2h30m, 24h.
+
+                    You can only set the TTL once. The `expireAt` date will not be updated if you change it again.
                   example: '24h'
             status:
               type: object
@@ -119,14 +121,14 @@ spec:
                 email:
                   type: string
                   description: |
-                    User E-mail.
+                    User email.
 
                     **Caution!** Note that if used together with the [user-authz](https://deckhouse.io/documentation/v1/modules/140-user-authz/) module, you must specify an `email` to grant rights to the specific user as the user name in the [ClusterAuthorizationRule](https://deckhouse.io/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) CR.
                   example: 'user@domain.com'
                 password:
                   type: string
                   description: |
-                    User password hash in plaintext or Base64-encoded.
+                    User password hash in plaintext or Base64 encoded.
 
                     Use the following command to encode the password hash in Base64: `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Alternatively, you can use an online service (such as https://bcrypt-generator.com/).
                   example: 'JDJ5JDEwJE9HN1lOOUhnOXU5NmY2cGp4R3NIcS56NWQuOVQxQ0VrdWIud3BRdVJ5Sy5QQU5INlpKNDguCgo='
@@ -143,7 +145,7 @@ spec:
                   description: |
                     Static user groups.
 
-                    Deprecated. Use the [Group](#group) resource.
+                    Since the parameter has been deprecated, use the [Group](#group) resource to add users to groups.
                   items:
                     type: string
                 ttl:
@@ -151,8 +153,10 @@ spec:
                   pattern: '^([0-9]+h([0-9]+m)?|[0-9]+m)$'
                   description: |
                     Static user TTL.
-                    * It is specified as a string containing the time unit in hours and minutes: 30m, 1h, 2h30m, 24h.
-                    * You can only set the TTL once. The `expireAt` date will not be updated if you change it again.
+
+                    It is specified as a string containing the time unit in hours and minutes: 30m, 1h, 2h30m, 24h.
+
+                    You can only set the TTL once. The `expireAt` date will not be updated if you change it again.
                   example: '24h'
             status:
               type: object

--- a/modules/010-user-authn-crd/crds/user.yaml
+++ b/modules/010-user-authn-crd/crds/user.yaml
@@ -43,7 +43,7 @@ spec:
                 password:
                   type: string
                   description: |
-                    User password hash in plaintext or Base64-encoded.
+                    User password hash in plaintext or Base64 encoded.
 
                     Use the following command to encode the password hash in Base64: `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Alternatively, you can use an online service (such as https://bcrypt-generator.com/).
                   example: 'JDJ5JDEwJE9HN1lOOUhnOXU5NmY2cGp4R3NIcS56NWQuOVQxQ0VrdWIud3BRdVJ5Sy5QQU5INlpKNDguCgo='
@@ -57,7 +57,7 @@ spec:
                   description: |
                     Static user groups.
 
-                    Deprecated. Use the [Group](#group) resource.
+                    Since the parameter has been deprecated, use the [Group](#group) resource to add users to groups.
                   items:
                     type: string
                 ttl:
@@ -99,7 +99,68 @@ spec:
           format: date-time
     - name: v1
       served: true
-      storage: true
+      storage: false
       schema: *schema
       subresources: *subresources
       additionalPrinterColumns: *additionalPrinterColumns
+
+    - name: v2alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Contains information about the static user.
+
+            [Usage example...](usage.html#an-example-of-creating-a-static-user)
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                  description: |
+                    User E-mail.
+
+                    **Caution!** Note that if used together with the [user-authz](https://deckhouse.io/documentation/v1/modules/140-user-authz/) module, you must specify an `email` to grant rights to the specific user as the user name in the [ClusterAuthorizationRule](https://deckhouse.io/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule) CR.
+                  example: 'user@domain.com'
+                password:
+                  type: string
+                  description: |
+                    User password hash in plaintext or Base64 encoded.
+
+                    Use the following command to encode the password hash in Base64: `echo "<PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0`. Alternatively, you can use an online service (such as https://bcrypt-generator.com/).
+                  example: '$2a$10$F9ey7zW.sVliT224RFxpWeMsgzO.D9YRG54a8T36/K2MCiT41nzmC'
+                  pattern: '^\$2[ayb]\$.{56}$'
+                ttl:
+                  type: string
+                  pattern: '^([0-9]+h([0-9]+m)?|[0-9]+m)$'
+                  description: |
+                    Static user TTL.
+                    * It is specified as a string containing the time unit in hours and minutes: 30m, 1h, 2h30m, 24h.
+                    * You can only set the TTL once. The `expireAt` date will not be updated if you change it again.
+                  example: '24h'
+            status:
+              type: object
+              properties:
+                expireAt:
+                  type: string
+                  description: |
+                    User account expiration date.
+                    * It is shown only of the `.spec.ttl` field is set.
+                    * The user account will be deleted at the specified date.
+                    * This parameter is synchronized every 5 minutes. There may be a time lag between the moment specified in this field and the moment of actual deletion of the user account.
+      subresources: *subresources
+      additionalPrinterColumns:
+        - jsonPath: .spec.email
+          name: Email
+          type: string
+        - jsonPath: .status.expireAt
+          name: Expire_at
+          type: string

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -260,7 +260,6 @@ metadata:
 spec:
   email: admin@yourcompany.com
   password: $2a$10$etblbZ9yfZaKgbvysf1qguW3WULdMnxwWFrkoKpRH1yeWa5etjjAa
-  userID: some-unique-user-id
   groups:
   - Everyone
   - admins

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -260,6 +260,7 @@ metadata:
 spec:
   email: admin@yourcompany.com
   password: $2a$10$etblbZ9yfZaKgbvysf1qguW3WULdMnxwWFrkoKpRH1yeWa5etjjAa
+  userID: some-unique-user-id
   groups:
   - Everyone
   - admins

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -260,6 +260,7 @@ metadata:
 spec:
   email: admin@yourcompany.com
   password: $2a$10$etblbZ9yfZaKgbvysf1qguW3WULdMnxwWFrkoKpRH1yeWa5etjjAa
+  userID: some-unique-user-id
   ttl: 24h
 ```
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -260,7 +260,6 @@ metadata:
 spec:
   email: admin@yourcompany.com
   password: $2a$10$etblbZ9yfZaKgbvysf1qguW3WULdMnxwWFrkoKpRH1yeWa5etjjAa
-  userID: some-unique-user-id
   ttl: 24h
 ```
 

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -56,6 +56,7 @@ type DexUser struct {
 type DexUserSpec struct {
 	Email    string   `json:"email"`
 	Password string   `json:"password"`
+	UserID   string   `json:"userID,omitempty"`
 	Groups   []string `json:"groups,omitempty"`
 	TTL      string   `json:"ttl,omitempty"`
 }
@@ -136,6 +137,10 @@ func getDexUsers(input *go_hook.HookInput) error {
 		groups = set.New(groups...).Slice()
 
 		dexUser.Spec.Groups = groups
+
+		if dexUser.Spec.UserID == "" {
+			dexUser.Spec.UserID = dexUser.Name
+		}
 
 		var expireAt string
 

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -138,9 +138,7 @@ func getDexUsers(input *go_hook.HookInput) error {
 
 		dexUser.Spec.Groups = groups
 
-		if dexUser.Spec.UserID == "" {
-			dexUser.Spec.UserID = dexUser.Name
-		}
+		dexUser.Spec.UserID = dexUser.Name
 
 		var expireAt string
 

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -56,7 +56,6 @@ type DexUser struct {
 type DexUserSpec struct {
 	Email    string   `json:"email"`
 	Password string   `json:"password"`
-	UserID   string   `json:"userID,omitempty"`
 	Groups   []string `json:"groups,omitempty"`
 	TTL      string   `json:"ttl,omitempty"`
 }
@@ -137,10 +136,6 @@ func getDexUsers(input *go_hook.HookInput) error {
 		groups = set.New(groups...).Slice()
 
 		dexUser.Spec.Groups = groups
-
-		if dexUser.Spec.UserID == "" {
-			dexUser.Spec.UserID = dexUser.Name
-		}
 
 		var expireAt string
 

--- a/modules/150-user-authn/hooks/get_dex_user_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds_test.go
@@ -478,4 +478,37 @@ status:
 		})
 	})
 
+
+	Context("Cluster with User having userID set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: User
+metadata:
+  name: admin
+spec:
+  email: admin@example.com
+  password: password
+  userID: myadmin
+`))
+			f.RunHook()
+		})
+		It("User's userID field should be overridden", func() {
+			Expect(f.ValuesGet("userAuthn.internal.dexUsersCRDs").String()).To(MatchUnorderedJSON(`
+[
+  {
+    "name": "admin",
+    "spec": {
+      "email": "admin@example.com",
+      "password": "password",
+      "userID": "admin"
+    },
+    "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
+    "status": {}
+  }
+]`))
+		})
+	})
+
 })

--- a/modules/150-user-authn/hooks/get_dex_user_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds_test.go
@@ -93,8 +93,7 @@ spec:
     "spec": {
       "email": "admin@example.com",
       "groups": ["Gods"],
-      "password": "password",
-      "userID": "admin"
+      "password": "password"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -173,8 +172,7 @@ spec:
   "name": "admin",
   "spec": {
     "email": "adminNext@example.com",
-    "password": "password",
-    "userID": "admin"
+    "password": "password"
   },
   "encodedName": "mfsg22lonzsxq5camv4gc3lqnrss4y3pnxf7fhheqqrcgji",
   "status": {}
@@ -213,8 +211,7 @@ spec:
     "name": "admin",
     "spec": {
       "email": "admin@example.com",
-      "password": "password",
-      "userID": "admin"
+      "password": "password"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -223,8 +220,7 @@ spec:
     "name": "user",
     "spec": {
       "email": "user@example.com",
-      "password": "passwordNext",
-      "userID": "user"
+      "password": "passwordNext"
     },
     "encodedName": "ovzwk4samv4gc3lqnrss4y3pnxf7fhheqqrcgji",
     "status": {}
@@ -254,8 +250,7 @@ spec:
     "name": "admin",
     "spec": {
       "email": "admin@example.com",
-      "password": "password",
-      "userID": "admin"
+      "password": "password"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -323,8 +318,7 @@ spec:
         "group-2",
         "group-3"
       ],
-      "password": "password",
-      "userID": "admin"
+      "password": "password"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -374,8 +368,7 @@ spec:
       "groups": [
         "group-1"
       ],
-      "password": "password",
-      "userID": "admin"
+      "password": "password"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -427,8 +420,7 @@ spec:
       "password": "password",
       "groups": [
         "group-1"
-      ],
-      "userID": "admin"
+      ]
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -465,8 +457,7 @@ status:
     "name": "admin",
     "spec": {
       "email": "admin@example.com",
-      "password": "password",
-      "userID": "admin"
+      "password": "password"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}

--- a/modules/150-user-authn/hooks/get_dex_user_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds_test.go
@@ -478,7 +478,6 @@ status:
 		})
 	})
 
-
 	Context("Cluster with User having userID set", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`

--- a/modules/150-user-authn/hooks/get_dex_user_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds_test.go
@@ -93,7 +93,8 @@ spec:
     "spec": {
       "email": "admin@example.com",
       "groups": ["Gods"],
-      "password": "password"
+      "password": "password",
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -172,7 +173,8 @@ spec:
   "name": "admin",
   "spec": {
     "email": "adminNext@example.com",
-    "password": "password"
+    "password": "password",
+    "userID": "admin"
   },
   "encodedName": "mfsg22lonzsxq5camv4gc3lqnrss4y3pnxf7fhheqqrcgji",
   "status": {}
@@ -211,7 +213,8 @@ spec:
     "name": "admin",
     "spec": {
       "email": "admin@example.com",
-      "password": "password"
+      "password": "password",
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -220,7 +223,8 @@ spec:
     "name": "user",
     "spec": {
       "email": "user@example.com",
-      "password": "passwordNext"
+      "password": "passwordNext",
+      "userID": "user"
     },
     "encodedName": "ovzwk4samv4gc3lqnrss4y3pnxf7fhheqqrcgji",
     "status": {}
@@ -250,7 +254,8 @@ spec:
     "name": "admin",
     "spec": {
       "email": "admin@example.com",
-      "password": "password"
+      "password": "password",
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -318,7 +323,8 @@ spec:
         "group-2",
         "group-3"
       ],
-      "password": "password"
+      "password": "password",
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -368,7 +374,8 @@ spec:
       "groups": [
         "group-1"
       ],
-      "password": "password"
+      "password": "password",
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -420,7 +427,8 @@ spec:
       "password": "password",
       "groups": [
         "group-1"
-      ]
+      ],
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}
@@ -457,7 +465,8 @@ status:
     "name": "admin",
     "spec": {
       "email": "admin@example.com",
-      "password": "password"
+      "password": "password",
+      "userID": "admin"
     },
     "encodedName": "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf",
     "status": {}

--- a/modules/150-user-authn/template_tests/dex_config_test.go
+++ b/modules/150-user-authn/template_tests/dex_config_test.go
@@ -99,7 +99,6 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     groups:
     - Everyone
     password: userPassword
-    userID: user
 - encodedName: encodedAdmin
   name: adminName
   spec:
@@ -108,7 +107,6 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     - Everyone
     - Admins
     password: adminPassword
-    userID: admin
 `)
 			hec.HelmRender()
 		})
@@ -136,7 +134,6 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     groups:
     - Everyone
     password: userPassword
-    userID: user
 - encodedName: encodedAdmin
   name: adminName
   spec:
@@ -145,7 +142,6 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     - Everyone
     - Admins
     password: adminPassword
-    userID: admin
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.providers", `
 - id: gitlabID

--- a/modules/150-user-authn/template_tests/dex_config_test.go
+++ b/modules/150-user-authn/template_tests/dex_config_test.go
@@ -99,6 +99,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     groups:
     - Everyone
     password: userPassword
+    userID: user
 - encodedName: encodedAdmin
   name: adminName
   spec:
@@ -107,6 +108,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     - Everyone
     - Admins
     password: adminPassword
+    userID: admin
 `)
 			hec.HelmRender()
 		})
@@ -134,6 +136,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     groups:
     - Everyone
     password: userPassword
+    userID: user
 - encodedName: encodedAdmin
   name: adminName
   spec:
@@ -142,6 +145,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex-config", func() {
     - Everyone
     - Admins
     password: adminPassword
+    userID: admin
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.providers", `
 - id: gitlabID

--- a/modules/150-user-authn/template_tests/user_test.go
+++ b/modules/150-user-authn/template_tests/user_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     groups:
     - Everyone
     password: $2a$10$7rxcwh8r2Rcnwc3jDysqhOrbskLBjtx1zvzWaQVPFO78DDAMZHhLC
+    userID: user
 - encodedName: base64EncodedUser
   name: base64UserName
   spec:
@@ -67,6 +68,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     - Everyone
     - Admins
     password: $2a$10$E/MjyzFi6GZkta9GHd8zCeuYigbLenXv18jkxOZ6vhoWsKnaxNJou
+    userID: admin
 `)
 			hec.HelmRender()
 		})
@@ -75,6 +77,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(userPassword.Exists()).To(BeTrue())
 			Expect(userPassword.Field("email").String()).To(Equal("user@example.com"))
 			Expect(userPassword.Field("username").String()).To(Equal("userName"))
+			Expect(userPassword.Field("userID").String()).To(Equal("user"))
 			Expect(userPassword.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(userPassword.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -82,6 +85,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(base64Password.Exists()).To(BeTrue())
 			Expect(base64Password.Field("email").String()).To(Equal("base64@example.com"))
 			Expect(base64Password.Field("username").String()).To(Equal("base64UserName"))
+			Expect(base64Password.Field("userID").String()).To(Equal("base64User"))
 			Expect(base64Password.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(base64Password.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -89,6 +93,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(adminPassword.Exists()).To(BeTrue())
 			Expect(adminPassword.Field("email").String()).To(Equal("admintest@example.com"))
 			Expect(adminPassword.Field("username").String()).To(Equal("adminName"))
+			Expect(adminPassword.Field("userID").String()).To(Equal("admin"))
 			Expect(adminPassword.Field("hash").String()).To(Equal("JDJhJDEwJEUvTWp5ekZpNkdaa3RhOUdIZDh6Q2V1WWlnYkxlblh2MThqa3hPWjZ2aG9Xc0tuYXhOSm91"))
 			Expect(adminPassword.Field("groups").String()).To(MatchJSON(`["Everyone","Admins"]`))
 		})

--- a/modules/150-user-authn/template_tests/user_test.go
+++ b/modules/150-user-authn/template_tests/user_test.go
@@ -51,7 +51,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     groups:
     - Everyone
     password: $2a$10$7rxcwh8r2Rcnwc3jDysqhOrbskLBjtx1zvzWaQVPFO78DDAMZHhLC
-    userID: user
 - encodedName: base64EncodedUser
   name: base64UserName
   spec:
@@ -68,7 +67,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     - Everyone
     - Admins
     password: $2a$10$E/MjyzFi6GZkta9GHd8zCeuYigbLenXv18jkxOZ6vhoWsKnaxNJou
-    userID: admin
 `)
 			hec.HelmRender()
 		})
@@ -77,7 +75,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(userPassword.Exists()).To(BeTrue())
 			Expect(userPassword.Field("email").String()).To(Equal("user@example.com"))
 			Expect(userPassword.Field("username").String()).To(Equal("userName"))
-			Expect(userPassword.Field("userID").String()).To(Equal("user"))
 			Expect(userPassword.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(userPassword.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -85,7 +82,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(base64Password.Exists()).To(BeTrue())
 			Expect(base64Password.Field("email").String()).To(Equal("base64@example.com"))
 			Expect(base64Password.Field("username").String()).To(Equal("base64UserName"))
-			Expect(base64Password.Field("userID").String()).To(Equal("base64User"))
 			Expect(base64Password.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(base64Password.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -93,7 +89,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(adminPassword.Exists()).To(BeTrue())
 			Expect(adminPassword.Field("email").String()).To(Equal("admintest@example.com"))
 			Expect(adminPassword.Field("username").String()).To(Equal("adminName"))
-			Expect(adminPassword.Field("userID").String()).To(Equal("admin"))
 			Expect(adminPassword.Field("hash").String()).To(Equal("JDJhJDEwJEUvTWp5ekZpNkdaa3RhOUdIZDh6Q2V1WWlnYkxlblh2MThqa3hPWjZ2aG9Xc0tuYXhOSm91"))
 			Expect(adminPassword.Field("groups").String()).To(MatchJSON(`["Everyone","Admins"]`))
 		})

--- a/modules/150-user-authn/template_tests/user_test.go
+++ b/modules/150-user-authn/template_tests/user_test.go
@@ -51,7 +51,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     groups:
     - Everyone
     password: $2a$10$7rxcwh8r2Rcnwc3jDysqhOrbskLBjtx1zvzWaQVPFO78DDAMZHhLC
-    userID: user
 - encodedName: base64EncodedUser
   name: base64UserName
   spec:
@@ -59,7 +58,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     groups:
     - Everyone
     password: JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD
-    userID: base64User
 - encodedName: encodedAdmin
   name: adminName
   spec:
@@ -68,7 +66,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
     - Everyone
     - Admins
     password: $2a$10$E/MjyzFi6GZkta9GHd8zCeuYigbLenXv18jkxOZ6vhoWsKnaxNJou
-    userID: admin
 `)
 			hec.HelmRender()
 		})
@@ -77,7 +74,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(userPassword.Exists()).To(BeTrue())
 			Expect(userPassword.Field("email").String()).To(Equal("user@example.com"))
 			Expect(userPassword.Field("username").String()).To(Equal("userName"))
-			Expect(userPassword.Field("userID").String()).To(Equal("user"))
 			Expect(userPassword.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(userPassword.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -85,7 +81,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(base64Password.Exists()).To(BeTrue())
 			Expect(base64Password.Field("email").String()).To(Equal("base64@example.com"))
 			Expect(base64Password.Field("username").String()).To(Equal("base64UserName"))
-			Expect(base64Password.Field("userID").String()).To(Equal("base64User"))
 			Expect(base64Password.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(base64Password.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -93,7 +88,6 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(adminPassword.Exists()).To(BeTrue())
 			Expect(adminPassword.Field("email").String()).To(Equal("admintest@example.com"))
 			Expect(adminPassword.Field("username").String()).To(Equal("adminName"))
-			Expect(adminPassword.Field("userID").String()).To(Equal("admin"))
 			Expect(adminPassword.Field("hash").String()).To(Equal("JDJhJDEwJEUvTWp5ekZpNkdaa3RhOUdIZDh6Q2V1WWlnYkxlblh2MThqa3hPWjZ2aG9Xc0tuYXhOSm91"))
 			Expect(adminPassword.Field("groups").String()).To(MatchJSON(`["Everyone","Admins"]`))
 		})

--- a/modules/150-user-authn/templates/dex/passwords.yaml
+++ b/modules/150-user-authn/templates/dex/passwords.yaml
@@ -14,7 +14,6 @@ metadata:
 email: {{ $crd.spec.email | lower | quote }}
 hash: {{ $pass | quote }}
 username: {{ $crd.name | quote }}
-userID: {{ $crd.spec.userID }}
   {{- if $crd.spec.groups }}
 groups:
 {{- range $group := $crd.spec.groups }}

--- a/modules/150-user-authn/templates/dex/passwords.yaml
+++ b/modules/150-user-authn/templates/dex/passwords.yaml
@@ -14,6 +14,7 @@ metadata:
 email: {{ $crd.spec.email | lower | quote }}
 hash: {{ $pass | quote }}
 username: {{ $crd.name | quote }}
+userID: {{ $crd.spec.userID }}
   {{- if $crd.spec.groups }}
 groups:
 {{- range $group := $crd.spec.groups }}

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -32,6 +32,7 @@ kubernetes:
       {
         "name": .metadata.name,
         "email": .spec.email,
+        "userID": .spec.userID,
         "groups": .spec.groups
       }
 kubernetesValidating:
@@ -50,11 +51,19 @@ function __main__() {
   operation=$(context::jq -r '.review.request.operation')
   userName=$(context::jq -r '.review.request.object.metadata.name')
   email=$(context::jq -r '.review.request.object.spec.email')
+  userID=$(context::jq -r '.review.request.object.spec.userID')
   groups=$(context::jq -r '.review.request.object.spec.groups // ""')
 
   if userWithTheSameEmail="$(context::jq -er --arg name "$userName" --arg email "$email" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"users.deckhouse.io \"$userName\", user \"$userWithTheSameEmail\" is already using email \"$email\"" }
+EOF
+    return 0
+  fi
+
+  if userWithTheSameUserID="$(context::jq -er --arg name "$userName" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid) | .name' 2>&1)"; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"users.deckhouse.io \"$userName\", user \"$userWithTheSameUserID\" is already using userID '$userID'" }
 EOF
     return 0
   fi

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -31,6 +31,7 @@ kubernetes:
     jqFilter: |
       {
         "name": .metadata.name,
+        "userID": .spec.userID,
         "email": .spec.email,
         "groups": .spec.groups
       }
@@ -49,12 +50,20 @@ EOF
 function __main__() {
   operation=$(context::jq -r '.review.request.operation')
   userName=$(context::jq -r '.review.request.object.metadata.name')
+  userID=$(context::jq -r '.review.request.object.spec.userID')
   email=$(context::jq -r '.review.request.object.spec.email')
   groups=$(context::jq -r '.review.request.object.spec.groups // ""')
 
   if userWithTheSameEmail="$(context::jq -er --arg name "$userName" --arg email "$email" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"users.deckhouse.io \"$userName\", user \"$userWithTheSameEmail\" is already using email \"$email\"" }
+EOF
+    return 0
+  fi
+
+  if ([ "$operation" == "CREATE" ] || [ "$operation" == "UPDATE" ]) && [ "$userID" != ::]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true, "message":"\".spec.userID\" is deprecated and shouldn't be set manually (if set, its value is ignored)" }
 EOF
     return 0
   fi

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -63,7 +63,7 @@ EOF
 
   if ([ "$operation" == "CREATE" ] || [ "$operation" == "UPDATE" ]) && [ "$userID" != "" ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":true, "message":"\".spec.userID\" is deprecated and shouldn't be set manually (if set, its value is ignored)" }
+{"allowed":true, "warnings":["\".spec.userID\" is deprecated and shouldn't be set manually (if set, its value is ignored)"]}
 EOF
     return 0
   fi

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -61,7 +61,7 @@ EOF
     return 0
   fi
 
-  if ([ "$operation" == "CREATE" ] || [ "$operation" == "UPDATE" ]) && [ "$userID" != ::]; then
+  if ([ "$operation" == "CREATE" ] || [ "$operation" == "UPDATE" ]) && [ "$userID" != "" ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true, "message":"\".spec.userID\" is deprecated and shouldn't be set manually (if set, its value is ignored)" }
 EOF

--- a/modules/150-user-authn/webhooks/validating/user
+++ b/modules/150-user-authn/webhooks/validating/user
@@ -32,7 +32,6 @@ kubernetes:
       {
         "name": .metadata.name,
         "email": .spec.email,
-        "userID": .spec.userID,
         "groups": .spec.groups
       }
 kubernetesValidating:
@@ -51,19 +50,11 @@ function __main__() {
   operation=$(context::jq -r '.review.request.operation')
   userName=$(context::jq -r '.review.request.object.metadata.name')
   email=$(context::jq -r '.review.request.object.spec.email')
-  userID=$(context::jq -r '.review.request.object.spec.userID')
   groups=$(context::jq -r '.review.request.object.spec.groups // ""')
 
   if userWithTheSameEmail="$(context::jq -er --arg name "$userName" --arg email "$email" '.snapshots.users[].filterResult | select(.name != $name) | select(.email == $email) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"users.deckhouse.io \"$userName\", user \"$userWithTheSameEmail\" is already using email \"$email\"" }
-EOF
-    return 0
-  fi
-
-  if userWithTheSameUserID="$(context::jq -er --arg name "$userName" --arg userid "$userID" '.snapshots.users[].filterResult | select(.name != $name) | select(.userID == $userid) | .name' 2>&1)"; then
-    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"users.deckhouse.io \"$userName\", user \"$userWithTheSameUserID\" is already using userID '$userID'" }
 EOF
     return 0
   fi


### PR DESCRIPTION
## Description

Make the spec.userID parameter of the User resource as deprecated and update relevant documentation.

## Why do we need it, and what problem does it solve?
Remove unneeded field and or related functionality.
Closes #5995
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
There would be no userID field and any related functionality.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: chore
summary: Make the spec.userID parameter of the User resource as deprecated.
```
