### PR TITLE
add linstor debug info generator

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -149,7 +149,7 @@ func createTarball(withLinstor bool) *bytes.Buffer {
 		{
 			File: "linstor-drbd-operator-logs.txt",
 			Cmd:  "kubectl",
-			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/sds-drbd-operator", "--tail", "3000"},
+			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/piraeus-operator", "--tail", "3000"},
 		},
 	}
 

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -65,7 +65,7 @@ func saveLinstorSosInfo(tarWriter *tar.Writer) error {
 	if err != nil {
 		return fmt.Errorf("execute %s command: %v", "kubectl -n d8-linstor get po ...", err)
 	}
-	podName := strings.TrimSpace(string(output))
+	podName := strings.Trim(strings.TrimSpace(string(output)), "'")
 	reportGetCmd := []string{"exec", "-n", "d8-linstor", podName, "--", "linstor", "sos-report", "create"}
 
 	reportGenOut, err := exec.Command("kubectl", reportGetCmd...).CombinedOutput()

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -259,13 +259,13 @@ func createTarball(withLinstor bool) *bytes.Buffer {
 	if withLinstor {
 		debugCommands = append(debugCommands, linstorCommands...)
 		if err := saveLinstorSosInfo(tarWriter); err != nil {
-			fmt.Fprint(os.Stderr, err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	}
 
 	for _, cmd := range debugCommands {
 		if err := cmd.Save(tarWriter); err != nil {
-			fmt.Fprint(os.Stderr, err.Error())
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	}
 

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -68,9 +68,9 @@ func saveLinstorSosInfo(tarWriter *tar.Writer) error {
 	podName := strings.TrimSpace(string(output))
 	reportGetCmd := []string{"exec", "-n", "d8-linstor", podName, "--", "linstor", "sos-report", "create"}
 
-	reportGenOut, err := exec.Command("kubectl", reportGetCmd...).Output()
+	reportGenOut, err := exec.Command("kubectl", reportGetCmd...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("execute kubectl %s command: %v", strings.Join(reportGetCmd, " "), err)
+		return fmt.Errorf("execute kubectl %s command with output %s: %v", strings.Join(reportGetCmd, " "), string(reportGenOut), err)
 	}
 	lines := strings.Split(string(reportGenOut), "\n")
 	if len(lines)-2 < 0 {

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -123,34 +123,29 @@ func createTarball(withLinstor bool) *bytes.Buffer {
 
 	linstorCommands := []Command{
 		{
-			File: "linstor-sos-info.",
-			Cmd:  "kubectl exec -n d8-linstor deploy/linstor-controller -- linstor",
-			Args: []string{"get", "events", "--sort-by=.metadata.creationTimestamp", "-A", "-o", "json"},
-		},
-		{
 			File: "linstor-csi-node-logs.txt",
 			Cmd:  "kubectl",
-			Args: []string{"-n d8-linstor", "logs", "daemonset.apps/linstor-csi-node", "-c", "linstor-csi-plugin", "--tail", "3000"},
+			Args: []string{"-n", "d8-linstor", "logs", "daemonset.apps/linstor-csi-node", "-c", "linstor-csi-plugin", "--tail", "3000"},
 		},
 		{
 			File: "linstor-node-logs.txt",
 			Cmd:  "kubectl",
-			Args: []string{"-n d8-linstor", "logs", "daemonset.apps/linstor-node", "-c", "linstor-satellite", "--tail", "3000"},
+			Args: []string{"-n", "d8-linstor", "logs", "daemonset.apps/linstor-node", "-c", "linstor-satellite", "--tail", "3000"},
 		},
 		{
 			File: "linstor-controller-logs.txt",
 			Cmd:  "kubectl",
-			Args: []string{"-n d8-linstor", "logs", "deployment.apps/linstor-controller", "-c", "linstor-controller", "--tail", "3000"},
+			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/linstor-controller", "-c", "linstor-controller", "--tail", "3000"},
 		},
 		{
 			File: "linstor-csi-controller-logs.txt",
 			Cmd:  "kubectl",
-			Args: []string{"-n d8-linstor", "logs", "deployment.apps/linstor-csi-controller", "--tail", "3000"},
+			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/linstor-csi-controller", "--tail", "3000"},
 		},
 		{
 			File: "linstor-drbd-operator-logs.txt",
 			Cmd:  "kubectl",
-			Args: []string{"-n d8-linstor", "logs", "deployment.apps/sds-drbd-operator", "--tail", "3000"},
+			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/sds-drbd-operator", "--tail", "3000"},
 		},
 	}
 

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -66,7 +66,7 @@ func saveLinstorSosInfo(tarWriter *tar.Writer) error {
 		return fmt.Errorf("execute %s command: %v", "kubectl -n d8-linstor get po ...", err)
 	}
 	podName := strings.TrimSpace(string(output))
-	reportGetCmd := []string{"exec", "-n", "d8-linstor", podName, "--", "sh", "-c", "\"linstor", "sos-report", "create", "|grep SOS|", "awk", "'{print $NF}'\""}
+	reportGetCmd := []string{"exec", "-n", "d8-linstor", podName, "--", "linstor", "sos-report", "create"}
 
 	reportGenOut, err := exec.Command("kubectl", reportGetCmd...).Output()
 	if err != nil {

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -65,14 +65,15 @@ func saveLinstorSosInfo(tarWriter *tar.Writer) error {
 	if err != nil {
 		return fmt.Errorf("execute %s command: %v", "kubectl -n d8-linstor get po ...", err)
 	}
-	podName := strings.Trim(strings.TrimSpace(string(output)), "'")
+	lines := strings.Split(string(output), "\n")
+	podName := strings.Trim(lines[0], "' ")
 	reportGetCmd := []string{"exec", "-n", "d8-linstor", podName, "--", "linstor", "sos-report", "create"}
 
 	reportGenOut, err := exec.Command("kubectl", reportGetCmd...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("execute kubectl %s command with output %s: %v", strings.Join(reportGetCmd, " "), string(reportGenOut), err)
 	}
-	lines := strings.Split(string(reportGenOut), "\n")
+	lines = strings.Split(string(reportGenOut), "\n")
 	if len(lines)-2 < 0 {
 		return fmt.Errorf("wrong output of command sos-report create: %s", strings.Join(reportGetCmd, " "))
 	}

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -147,9 +147,29 @@ func createTarball(withLinstor bool) *bytes.Buffer {
 			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/linstor-csi-controller", "--tail", "3000"},
 		},
 		{
-			File: "linstor-drbd-operator-logs.txt",
+			File: "linstor-piraeus-operator-logs.txt",
 			Cmd:  "kubectl",
 			Args: []string{"-n", "d8-linstor", "logs", "deployment.apps/piraeus-operator", "--tail", "3000"},
+		},
+		{
+			File: "linstor-failed-sched-events.json",
+			Cmd:  "kubectl",
+			Args: []string{"get", "events", "--sort-by=.metadata.creationTimestamp", "-A", "-o", "json", "--field-selector=reason==FailedScheduling"},
+		},
+		{
+			File: "linstor-failed-createpod-events.json",
+			Cmd:  "kubectl",
+			Args: []string{"get", "events", "--sort-by=.metadata.creationTimestamp", "-A", "-o", "json", "--field-selector=reason==FailedCreatePodContainer"},
+		},
+		{
+			File: "linstor-failed-attach-events.json",
+			Cmd:  "kubectl",
+			Args: []string{"get", "events", "--sort-by=.metadata.creationTimestamp", "-A", "-o", "json", "--field-selector=reason==FailedAttachVolume"},
+		},
+		{
+			File: "linstor-failed-mount-events.json",
+			Cmd:  "kubectl",
+			Args: []string{"get", "events", "--sort-by=.metadata.creationTimestamp", "-A", "-o", "json", "--field-selector=reason==FailedMount"},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add feature to collect linstor debug info from deckhouse controller

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: feature
summary: Add feature to collect linstor debug info from deckhouse controller
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
