### PR TITLE
[ingress-nginx] backport fix for endpointslices missing conditions

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
@@ -7,6 +7,7 @@ COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
 COPY patches/metrics-SetSSLExpireTime.patch /
+COPY patches/endpointslice-missing-conditions.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v1.6.4 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -14,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /makefile.patch && \
     patch -p1 < /healthcheck.patch && \
     patch -p1 < /metrics-SetSSLExpireTime.patch && \
+    patch -p1 < /endpointslice-missing-conditions.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
@@ -40,3 +40,9 @@ Without always option toggled, ingress-nginx does not set the cookie in case if 
 Annotation `nginx.ingress.kubernetes.io/auth-always-set-cookie` does not work. Anyway, we can't use it, because we need this behavior for all ingresses.
 
 https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### Endpointslice missing ready conditions
+
+Ingress controller panics if there is an ingress, pointing to a service with the endpointslice lacking 'condtitions.ready' field. Fixex in 1.7.
+
+https://github.com/kubernetes/ingress-nginx/pull/9550/files

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/endpointslice-missing-conditions.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/endpointslice-missing-conditions.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/controller/endpointslices.go b/internal/ingress/controller/endpointslices.go
+index 34d5266..56e7a2d 100644
+--- a/internal/ingress/controller/endpointslices.go
++++ b/internal/ingress/controller/endpointslices.go
+@@ -128,7 +128,7 @@ func getEndpointsFromSlices(s *corev1.Service, port *corev1.ServicePort, proto c
+ 		}
+ 
+ 		for _, ep := range eps.Endpoints {
+-			if !(*ep.Conditions.Ready) {
++			if (ep.Conditions.Ready != nil) && !(*ep.Conditions.Ready) {
+ 				continue
+ 			}
+ 			epHasZone := false


### PR DESCRIPTION
## Description
Backport [fix](https://github.com/kubernetes/ingress-nginx/pull/9550) from ingress controller 1.7 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It fixes ingress controller panic [issue](https://github.com/kubernetes/ingress-nginx/pull/9550) when an endpointslice doesn't have valid conditions field.
Closes #5811
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Ingress controller doesn't panic but rather skip invalid endpointslices.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix ingress controller panic when an endpointslice doesn't have .conditions field.
impact: All ingress controllers' pods will be recreated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
