### PR TITLE
[docs] Add warning about deprecated sshPublicKey parameter of the nodeUser

### DIFF
--- a/modules/040-node-manager/crds/nodeuser.yaml
+++ b/modules/040-node-manager/crds/nodeuser.yaml
@@ -50,6 +50,7 @@ spec:
                   x-doc-required: true
                 sshPublicKey:
                   type: string
+                  x-doc-deprecated: true
                   description: |
                     Node user SSH public key.
 


### PR DESCRIPTION
## Description
Add warning about deprecated `sshPublicKey` parameter of the `nodeUser` resource.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add warning about deprecated `sshPublicKey` parameter of the `nodeUser` resource.
impact_level: low
```
