### PR TITLE
[podreloader] distroless

### DIFF
--- a/modules/465-pod-reloader/images/pod-reloader/Dockerfile
+++ b/modules/465-pod-reloader/images/pod-reloader/Dockerfile
@@ -1,6 +1,0 @@
-ARG BASE_ALPINE
-FROM stakater/reloader:v0.0.124@sha256:a793387fb7969f2648a5d5c97b656d4941f85ab81ff3ec2e9a928d511928fa97 AS reloader
-
-FROM $BASE_ALPINE
-COPY --from=reloader /manager /usr/local/bin/manager
-ENTRYPOINT ["/usr/local/bin/manager"]

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -1,0 +1,24 @@
+---
+artifact: {{ .ModuleName }}/reloader-artifact
+from: {{ .Images.BASE_GOLANG_19_ALPINE }}
+git:
+- add: /reloader
+  to: /reloader
+shell:
+  install:
+    - apk add --no-cache git
+    - mkdir -p /src
+    - cd /src
+    - git clone --depth 1 -b v1.0.42 https://github.com/stakater/Reloader.git .
+    - cd reloader
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /reloader main.go
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- artifact: {{ .ModuleName }}/reloader-artifact
+  add: /reloader
+  to: /reloader
+  before: setup
+docker:
+  ENTRYPOINT: ["/reloader"]

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -6,7 +6,9 @@ shell:
     - apk add --no-cache git
     - mkdir -p /src
     - cd /src
-    - git clone --depth 1 -b v1.0.42 https://github.com/stakater/Reloader.git .
+    - git clone --depth 1 -b v1.0.42 {{ $.SOURCE_REPO }}/stakater/Reloader.git .
+    - export GO_VERSION=${GOLANG_VERSION}
+    - export GOPROXY={{ $.GOPROXY }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /reloader main.go
     - chown 64535:64535 /reloader
     - chmod 0700 /reloader

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -1,9 +1,6 @@
 ---
-artifact: {{ .ModuleName }}/reloader-artifact
+artifact: {{ .ModuleName }}/podreloader-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
-git:
-- add: /reloader
-  to: /reloader
 shell:
   install:
     - apk add --no-cache git
@@ -15,7 +12,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/reloader-artifact
+- artifact: {{ .ModuleName }}/podreloader-artifact
   add: /reloader
   to: /reloader
   before: setup

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -8,6 +8,8 @@ shell:
     - cd /src
     - git clone --depth 1 -b v1.0.42 https://github.com/stakater/Reloader.git .
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /reloader main.go
+    - chown 64535:64535 /reloader
+    - chmod 0700 /reloader
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -10,7 +10,6 @@ shell:
     - mkdir -p /src
     - cd /src
     - git clone --depth 1 -b v1.0.42 https://github.com/stakater/Reloader.git .
-    - cd reloader
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /reloader main.go
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -1,5 +1,5 @@
 ---
-artifact: {{ .ModuleName }}/podreloader-artifact
+artifact: {{ .ModuleName }}/reloader-artifact
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:
   install:
@@ -12,7 +12,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/podreloader-artifact
+- artifact: {{ .ModuleName }}/reloader-artifact
   add: /reloader
   to: /reloader
   before: setup


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The podreloader docker image is now distroless.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Tests

<details>

```shell
v.snurnitsin@thinkpad:/tmp/tmp$ docker save dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:bfe3f35dd56fcc08334fffcb54294af96549fe53d4279b2eba0e03b3d1cc32c1 > 1.tar
v.snurnitsin@thinkpad:/tmp/tmp$ tar xvf 1.tar 
30526b51275d9a1659f5348b7aa34b0c228d15edfd91ab97560cd73cfeced9ac/
30526b51275d9a1659f5348b7aa34b0c228d15edfd91ab97560cd73cfeced9ac/VERSION
30526b51275d9a1659f5348b7aa34b0c228d15edfd91ab97560cd73cfeced9ac/json
30526b51275d9a1659f5348b7aa34b0c228d15edfd91ab97560cd73cfeced9ac/layer.tar
5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396/
5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396/VERSION
5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396/json
5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396/layer.tar
6f3b47e4743716867338f986e9d610d14717d6e1214f013b97634a512a368d1a.json
baef073e354c4355169c716d86bc41490550d7329ffbeb3f61282f662c6cfa4f/
baef073e354c4355169c716d86bc41490550d7329ffbeb3f61282f662c6cfa4f/VERSION
baef073e354c4355169c716d86bc41490550d7329ffbeb3f61282f662c6cfa4f/json
baef073e354c4355169c716d86bc41490550d7329ffbeb3f61282f662c6cfa4f/layer.tar
manifest.json
v.snurnitsin@thinkpad:/tmp/tmp$ tree -h
[4.0K]  .
├── [ 41M]  1.tar
├── [4.0K]  30526b51275d9a1659f5348b7aa34b0c228d15edfd91ab97560cd73cfeced9ac
│   ├── [ 482]  json
│   ├── [2.5K]  layer.tar
│   └── [   3]  VERSION
├── [4.0K]  5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396
│   ├── [2.6K]  json
│   ├── [ 38M]  layer.tar
│   └── [   3]  VERSION
├── [5.5K]  6f3b47e4743716867338f986e9d610d14717d6e1214f013b97634a512a368d1a.json
├── [4.0K]  baef073e354c4355169c716d86bc41490550d7329ffbeb3f61282f662c6cfa4f
│   ├── [ 406]  json
│   ├── [3.3M]  layer.tar
│   └── [   3]  VERSION
└── [ 343]  manifest.json

4 directories, 12 files
v.snurnitsin@thinkpad:/tmp/tmp$ cd 5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396
v.snurnitsin@thinkpad:/tmp/tmp/5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396$ tar xvf layer.tar 
reloader
v.snurnitsin@thinkpad:/tmp/tmp/5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396$ ldd reloader 
        not a dynamic executable
v.snurnitsin@thinkpad:/tmp/tmp/5b6d519671356c1db31c2b33fd2ddda7d0e6233cf4a4c8aa498d804e8778f396$
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: podreloader
type: feature
summary: The podreloader docker image is now distroless
impact: pod-reloader pod will be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
