### PR TITLE
[linstor] number of parallel CSI workers hardcoded

### DIFF
--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -159,6 +159,10 @@ spec:
   csiResizerImage: {{ include "helm_lib_module_common_image" (list $ (list "csiExternalResizer" $kubeVersion.Major $kubeVersion.Minor | join "" )) }}
   csiSnapshotterImage: {{ include "helm_lib_module_common_image" (list $ (list "csiExternalSnapshotter" $kubeVersion.Major $kubeVersion.Minor | join "" )) }}
   {{- end }}
+  csiAttacherWorkerThreads: 1
+  csiProvisionerWorkerThreads: 1
+  csiResizerWorkerThreads: 1
+  csiSnapshotterWorkerThreads: 1
   linstorHttpsClientSecret: linstor-client-https-cert
   priorityClassName: ""
   controllerReplicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Hardcoded the number of parallel CSI workers (attacher, provisioner, snapshotter, resizer).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now LINSTOR always get 10 concurrent processes of each CSI worker type. We hardcoded this value to 1, this will make LINSTOR more stable.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We have customers, who are experiencing issues due to too many parallel running processes.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

More stable LINSTOR module work.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: feature
summary: A setting has been added to specify the number of parallel CSI workers (attacher, provisioner, snapshotter, resizer).
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
