### PR TITLE
[candi] disable in-tree rbd plugin for k8s>=1.24

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -3,8 +3,8 @@ RotateKubeletServerCertificate default is true, but CIS becnhmark wants it to be
 https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 */}}
 {{- $featureGates := list "EndpointSliceTerminatingCondition=true" "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" | join "," }}
-{{- if semverCompare "< 1.23" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = list $featureGates "EphemeralContainers=true" | join "," }}
+{{- if semverCompare ">= 1.24" .clusterConfiguration.kubernetesVersion }}
+    {{- $featureGates = list $featureGates "InTreePluginRBDUnregister=true" | join "," }}
 {{- end }}
 {{- if semverCompare "< 1.25" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "CustomResourceValidationExpressions=true" | join "," }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -2,12 +2,15 @@
 RotateKubeletServerCertificate default is true, but CIS becnhmark wants it to be explicitly enabled
 https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 */}}
-{{- $featureGates := list "EndpointSliceTerminatingCondition=true" "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" "InTreePluginRBDUnregister=true" | join "," }}
+{{- $featureGates := list "EndpointSliceTerminatingCondition=true" "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" | join "," }}
 {{- if semverCompare "< 1.25" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "CustomResourceValidationExpressions=true" | join "," }}
 {{- end }}
 {{- if semverCompare "< 1.27" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "DaemonSetUpdateSurge=true" | join "," }}
+{{- end }}
+{{- if semverCompare "< 1.28" .clusterConfiguration.kubernetesVersion }}
+    {{- $featureGates = list $featureGates "InTreePluginRBDUnregister=true" | join "," }}
 {{- end }}
 
 apiVersion: kubeadm.k8s.io/v1beta3

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -2,10 +2,7 @@
 RotateKubeletServerCertificate default is true, but CIS becnhmark wants it to be explicitly enabled
 https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 */}}
-{{- $featureGates := list "EndpointSliceTerminatingCondition=true" "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" | join "," }}
-{{- if semverCompare ">= 1.24" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = list $featureGates "InTreePluginRBDUnregister=true" | join "," }}
-{{- end }}
+{{- $featureGates := list "EndpointSliceTerminatingCondition=true" "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" "InTreePluginRBDUnregister=true" | join "," }}
 {{- if semverCompare "< 1.25" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "CustomResourceValidationExpressions=true" | join "," }}
 {{- end }}

--- a/modules/040-control-plane-manager/images/kube-controller-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/werf.inc.yaml
@@ -7,6 +7,22 @@ that we include for now to support in-tree Ceph Volume Provisioner
   {{- $version := toString $key }}
   {{- $patch := toString $value.patch }}
   {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
+  {{- if semverCompare ">= 1.24" $version }}
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
+fromImage: common/distroless
+import:
+- image: common/pause
+  add: /pause
+  to: /pause
+  before: setup
+- artifact: common/kubernetes-artifact-{{ $image_version }}
+  add: /src/_output/bin/kube-controller-manager
+  to: /usr/bin/kube-controller-manager
+  before: setup
+docker:
+  ENTRYPOINT: ["/usr/bin/kube-controller-manager"]
+  {{- else }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 from: {{ $.Images.BASE_UBUNTU }}
@@ -35,4 +51,5 @@ docker:
     DEBIAN_FRONTEND: noninteractive
     container: docker
   ENTRYPOINT: ["/usr/bin/kube-controller-manager"]
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disable in-tree rbd plugin for k8s>=1.24.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Mainly, in-tree rbd plugin is deprecated in the [k8s 1.28](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features). But we experienced some problems with in-tree rbd plugin and containerd (https://github.com/deckhouse/deckhouse/issues/304). So, when docker CRI was deprecated in k8s 1.24, we need also to deprecate use of in-tree rbd plugin. 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: disable in-tree rbd plugin for k8s>=1.24
impact: control-plane pods should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
