### PR TITLE
[linstor] disable  usermode_helper

### DIFF
--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -34,6 +34,14 @@ spec:
 
     bb-log-info "we need drbd on node: "$is_linstor_data_node
 
+    # Usermode helper has been disabled according to vendor recommendations. More information can be found here:
+    # https://github.com/LINBIT/drbd/commit/819285d065f1f81bad7b97e32a64017b5e15948d
+    # https://github.com/LINBIT/linstor-server/issues/121
+    # https://github.com/piraeusdatastore/piraeus-operator/issues/134
+    bb-sync-file /etc/modprobe.d/drbd.conf - << "EOF"
+    options drbd usermode_helper=disabled
+    EOF
+
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
         sed -i 's/^drbd$//' /etc/modules

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -34,6 +34,14 @@ spec:
 
     bb-log-info "we need drbd on node: "$is_linstor_data_node
 
+    # Usermode helper has been disabled according to vendor recommendations. More information can be found here:
+    # https://github.com/LINBIT/drbd/commit/819285d065f1f81bad7b97e32a64017b5e15948d
+    # https://github.com/LINBIT/linstor-server/issues/121
+    # https://github.com/piraeusdatastore/piraeus-operator/issues/134
+    bb-sync-file /etc/modprobe.d/drbd.conf - << "EOF"
+    options drbd usermode_helper=disabled
+    EOF
+
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
         sed -i 's/^drbd$//' /etc/modules

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -34,6 +34,14 @@ spec:
 
     bb-log-info "we need drbd on node: "$is_linstor_data_node
 
+    # Usermode helper has been disabled according to vendor recommendations. More information can be found here:
+    # https://github.com/LINBIT/drbd/commit/819285d065f1f81bad7b97e32a64017b5e15948d
+    # https://github.com/LINBIT/linstor-server/issues/121
+    # https://github.com/piraeusdatastore/piraeus-operator/issues/134
+    bb-sync-file /etc/modprobe.d/drbd.conf - << "EOF"
+    options drbd usermode_helper=disabled
+    EOF
+
     if [ $is_linstor_data_node == "false" ]; then
       if [ -e "/proc/drbd" ]; then
         sed -i 's/^drbd$//' /etc/modules


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Usermode helper has been disabled according to vendor recommendations. More information can be found here:
[Commit](https://github.com/LINBIT/drbd/commit/819285d065f1f81bad7b97e32a64017b5e15948d)
[Issue](https://github.com/LINBIT/linstor-server/issues/121)
[Issue](https://github.com/piraeusdatastore/piraeus-operator/issues/134)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Information from vendor:
```
This change is intended to help containerization of DRBD components.
Especially the ones that interact with the kernel.

The goal is to even load the kernel module from a container, but for now
assume we loaded the ko on the host. Then, in the container, we create
resources and therefore interact with the host kernel. One thing the
host kernel does is it calls various usermode helpers.

The mechanism is to call the usermode helper (basically
unconditionally), and then userspace decides which handler to run.  But
in a containerized world, we do not want to have "state" on the host
(drbd-utils + handlers).
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This is pretty important  changes for LINSTOR stability.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

This will make the operation of LINSTOR module more stable (installation on our servers managed from containers).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: chore
summary: Disabled usermode_helper param on LINSTOR nodes for more stable management.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
