### PR TITLE
[cloud-providers-azure] vNetCIDR field description improved

### DIFF
--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -82,6 +82,8 @@ apiVersions:
       subnetCIDR:
         description: |
           A subnet from the `vNetCIDR` address space for cluster nodes.
+
+          **Caution!** Please note that if you are setting up peering, vpn or linking networks of other clusters, the value should not overlap.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.1.2.0/24

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -75,15 +75,16 @@ apiVersions:
           By default, `*`.
       vNetCIDR:
         description: |
-          An address space of the virtual network in the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) format.
-
+          An address space of the [virtual network](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#virtual-networks) in the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) format.
+          A virtual network is a virtual, isolated portion of the Azure public network. Each virtual network is dedicated to your subscription.
           **Caution!** Please note that if you are setting up peering, vpn or linking networks of other clusters, the value should not overlap.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.0.0.0/16
       subnetCIDR:
         description: |
-          A subnet from the `vNetCIDR` address space for cluster nodes.
+          A [subnet](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) from the `vNetCIDR` address space for cluster nodes.
+          A virtual network can be segmented into one or more subnets up to the limits.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.1.2.0/24

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -76,14 +76,17 @@ apiVersions:
       vNetCIDR:
         description: |
           An address space of the [virtual network](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#virtual-networks) in the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) format.
+
           A virtual network is a virtual, isolated portion of the Azure public network. Each virtual network is dedicated to your subscription.
-          **Caution!** Please note that if you are setting up peering, vpn or linking networks of other clusters, the value should not overlap.
+
+          **Note!** If you are setting up peering, using vpn or linking networks of other clusters, network address spaces should not overlap.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.0.0.0/16
       subnetCIDR:
         description: |
           A [subnet](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) from the `vNetCIDR` address space for cluster nodes.
+
           A virtual network can be segmented into one or more subnets up to the limits.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -76,14 +76,14 @@ apiVersions:
       vNetCIDR:
         description: |
           An address space of the virtual network in the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) format.
+
+          **Caution!** Please note that if you are setting up peering, vpn or linking networks of other clusters, the value should not overlap.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.0.0.0/16
       subnetCIDR:
         description: |
           A subnet from the `vNetCIDR` address space for cluster nodes.
-
-          **Caution!** Please note that if you are setting up peering, vpn or linking networks of other clusters, the value should not overlap.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.1.2.0/24

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -79,7 +79,7 @@ apiVersions:
 
           A virtual network is a virtual, isolated portion of the Azure public network. Each virtual network is dedicated to your subscription.
 
-          **Note!** If you are setting up peering, using vpn or linking networks of other clusters, network address spaces should not overlap.
+          **Caution!** If you are setting up peering, using vpn or linking networks of other clusters, network address spaces should not overlap.
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.0.0.0/16

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -38,12 +38,13 @@ apiVersions:
           По умолчанию `*`.
       vNetCIDR:
         description: |
-          Адресное пространство виртуальной сети в формате [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
-
+          Адресное пространство [виртуальной сети](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#virtual-networks) в формате [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
+          Виртуальная сеть — это виртуальная изолированная часть общедоступной сети Azure. Каждая виртуальная сеть выделена для вашей подписки.
           **Важно!** Надо учитывать что в случаи настройки пиринга, vpn или связывания сетей других кластеров значение не должно пересекаться.
       subnetCIDR:
         description: |
-          Подсеть из адресного пространства `vNetCIDR`, в которой будут работать узлы кластера.
+          [Подсеть](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) из адресного пространства `vNetCIDR`, в которой будут работать узлы кластера.
+          Виртуальную сеть можно сегментировать на одну или несколько подсетей в пределах ограничений.
       peeredVNets:
         description: |
           Массив VNet, с которыми будет объединена сеть кластера.

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -39,11 +39,14 @@ apiVersions:
       vNetCIDR:
         description: |
           Адресное пространство [виртуальной сети](https://learn.microsoft.com/ru-ru/azure/virtual-network/virtual-network-vnet-plan-design-arm#virtual-networks) в формате [CIDR](https://ru.wikipedia.org/wiki/%D0%91%D0%B5%D1%81%D0%BA%D0%BB%D0%B0%D1%81%D1%81%D0%BE%D0%B2%D0%B0%D1%8F_%D0%B0%D0%B4%D1%80%D0%B5%D1%81%D0%B0%D1%86%D0%B8%D1%8F).
+
           Виртуальная сеть — это виртуальная изолированная часть общедоступной сети Azure. Каждая виртуальная сеть выделена для вашей подписки.
-          **Важно!** Надо учитывать что в случаи настройки пиринга, vpn или связывания сетей других кластеров значение не должно пересекаться.
+          
+          **Важно!** Нужно учитывать, что в случае настройки пиринга, использования VPN или связывания сетей других кластеров, адресное пространство сетей не должно пересекаться.
       subnetCIDR:
         description: |
           [Подсеть](https://learn.microsoft.com/ru-ru/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) из адресного пространства `vNetCIDR`, в которой будут работать узлы кластера.
+
           Виртуальную сеть можно сегментировать на одну или несколько подсетей в пределах ограничений.
       peeredVNets:
         description: |

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -38,12 +38,12 @@ apiVersions:
           По умолчанию `*`.
       vNetCIDR:
         description: |
-          Адресное пространство [виртуальной сети](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#virtual-networks) в формате [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
+          Адресное пространство [виртуальной сети](https://learn.microsoft.com/ru-ru/azure/virtual-network/virtual-network-vnet-plan-design-arm#virtual-networks) в формате [CIDR](https://ru.wikipedia.org/wiki/%D0%91%D0%B5%D1%81%D0%BA%D0%BB%D0%B0%D1%81%D1%81%D0%BE%D0%B2%D0%B0%D1%8F_%D0%B0%D0%B4%D1%80%D0%B5%D1%81%D0%B0%D1%86%D0%B8%D1%8F).
           Виртуальная сеть — это виртуальная изолированная часть общедоступной сети Azure. Каждая виртуальная сеть выделена для вашей подписки.
           **Важно!** Надо учитывать что в случаи настройки пиринга, vpn или связывания сетей других кластеров значение не должно пересекаться.
       subnetCIDR:
         description: |
-          [Подсеть](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) из адресного пространства `vNetCIDR`, в которой будут работать узлы кластера.
+          [Подсеть](https://learn.microsoft.com/ru-ru/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) из адресного пространства `vNetCIDR`, в которой будут работать узлы кластера.
           Виртуальную сеть можно сегментировать на одну или несколько подсетей в пределах ограничений.
       peeredVNets:
         description: |

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -39,6 +39,8 @@ apiVersions:
       vNetCIDR:
         description: |
           Адресное пространство виртуальной сети в формате [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
+
+          **Важно!** Надо учитывать что в случаи настройки пиринга, vpn или связывания сетей других кластеров значение не должно пересекаться.
       subnetCIDR:
         description: |
           Подсеть из адресного пространства `vNetCIDR`, в которой будут работать узлы кластера.


### PR DESCRIPTION
## Description
vNetCIDR field description improved
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
https://github.com/deckhouse/deckhouse/issues/3944
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-providers-azure
type: chore
summary: Improve `vNetCIDR` field description.
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
