### PR TITLE
[candi] Allow underscore in httpProxy and httpsProxy

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -133,7 +133,7 @@ apiVersions:
         properties:
           httpProxy:
             type: string
-            pattern: '^https?://[0-9a-zA-Z\.\-:@]+$'
+            pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
             description: |
               Proxy URL for HTTP requests.
 
@@ -143,7 +143,7 @@ apiVersions:
             - 'https://user:password@proxy.company.my:8443'
           httpsProxy:
             type: string
-            pattern: '^https?://[0-9a-zA-Z\.\-:@]+$'
+            pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
             description: |
               Proxy URL for HTTPS requests.
 


### PR DESCRIPTION
## Description

Allow underscore in httpProxy and httpsProxy settings

## Why do we need it, and what problem does it solve?
If a user uses underscore to authenticate with a proxy, for example http://user_proxy:password@proxy:3128, then he receives a validation error

## What is the expected result?
User can use username with underscore in httpProxy

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
