### PR TITLE
[registrypackages] Fix disable old containerd for ubuntu 18.04

### DIFF
--- a/modules/007-registrypackages/images/containerd/scripts/install
+++ b/modules/007-registrypackages/images/containerd/scripts/install
@@ -36,7 +36,7 @@ cp -f containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2
 cp -f containerd.service /lib/systemd/system/containerd-deckhouse.service
 systemctl daemon-reload
 
-if [[ -f /etc/systemd/system/containerd.service ]] || [[ -f /usr/lib/systemd/system/containerd.service ]]; then
+if [[ -f /etc/systemd/system/containerd.service ]] || [[ -f /usr/lib/systemd/system/containerd.service ]] || [[ -f /lib/systemd/system/containerd.service ]]; then
   systemctl disable --now containerd.service &> /dev/null
 fi
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed disabling the old containerd service in ubuntu 18.04.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Tests

<details>

```shell
root@node-f17788da-64c5f-fl257:~# systemctl status containerd.service 
● containerd.service - containerd container runtime
   Loaded: loaded (/lib/systemd/system/containerd.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2023-07-05 08:36:46 UTC; 3 months 7 days ago
     Docs: https://containerd.io
 Main PID: 1013752 (containerd)
    Tasks: 235
   CGroup: /system.slice/containerd.service
           ├─ 235402 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id e2d69ba8974d6d92f0680ff46e99ee276c1952dd0cd003ff597422030be947b3 -address /run/containerd/containerd.sock
           ├─ 980040 /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id 5b49fbbf3c513d88c66a21557329fb82ea62fdd377fd251b7a45dede927a9b05 -address /run/containerd/containerd.sock
           ├─ 989607 /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id 8ede4163ad07a16086ecc3b95912922df703a4eb6cb7bd46a3628b3592288e02 -address /run/containerd/containerd.sock
           ├─1008768 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 97b5ac1bf9c7acf90505bb175798ac51ca6ca4d477f4139d330c4e0002f5c05d -address /run/containerd/containerd.sock
           ├─1011922 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id d9afb42e19505c201acb81e3b2d965d0c4d3d1b55e299af7af5dd46c80ab7e88 -address /run/containerd/containerd.sock
           ├─1013752 /opt/deckhouse/bin/containerd
           ├─1014051 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 5b14dccdc99af38e7df0dd560c95e19d2e380f3838f2fb07744ff388726e5d17 -address /run/containerd/containerd.sock
           ├─1017644 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 1e365668a64d1cad8e7a3983d36a779206284268d96ce930d8899d9f5976f66e -address /run/containerd/containerd.sock
           ├─1018437 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id c44e793b6b27d5efe0cafc56a900fd84c078c703d1ca5740cdecc6cdff09bf8a -address /run/containerd/containerd.sock
           ├─1019129 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id bc5546d2a86bf1237694d6974863793af264129607ae958868f6a570a694019f -address /run/containerd/containerd.sock
           ├─1025243 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id f1806b81b131e352fa73edda7f82744b79207532f1caf3dcc717b1a0088c1c15 -address /run/containerd/containerd.sock
           ├─1034889 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 2f9e599b18af35c575ff0681d89137e07d19393032d948498068c81eb415672c -address /run/containerd/containerd.sock
           ├─1036832 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id a81876ac26839ef5661d16d9c493392ce25d5394d06b1519707f03339d97ea3c -address /run/containerd/containerd.sock
           ├─1061495 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 61bb8d62c1f00f445a9ac412ed58e0eb4c1bccd787db54384814fedf64644e61 -address /run/containerd/containerd.sock
           ├─1564631 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 695c0e2b458f82fa56175be691af60e75ed8b6289c3138cc7dd06c2e9e82eba1 -address /run/containerd/containerd.sock
           ├─1692096 /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id f3f75a2f991568315e95b1a774ac11ac80c449f648014dc7d5cec97dcc86c5d1 -address /run/containerd/containerd.sock
           └─1783798 /opt/deckhouse/bin/containerd-shim-runc-v2 -namespace k8s.io -id 2d5062e05c73f86ee1f7809c8852bf3ab68e5d9dc5a229b48ed530f9c1f709c8 -address /run/containerd/containerd.sock

Oct 12 11:03:03 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:03.460222475Z" level=info msg="RemoveContainer for \"b69a2a0c3272d37ab7b20930a6716778ba4ee74e41fb4b133a67db633eabfb09\" returns successfu
Oct 12 11:03:03 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:03.461376812Z" level=error msg="ContainerStatus for \"194fc57600ffe48f04f87ac43bf7480a0c27225b8450e6cf3a41916b0d85f812\" failed" error="r
Oct 12 11:03:03 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:03.462910932Z" level=error msg="ContainerStatus for \"b69a2a0c3272d37ab7b20930a6716778ba4ee74e41fb4b133a67db633eabfb09\" failed" error="r
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.611980347Z" level=info msg="StopPodSandbox for \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\""
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.620599586Z" level=info msg="TearDown network for sandbox \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\" successf
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.620650429Z" level=info msg="StopPodSandbox for \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\" returns successful
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.621155964Z" level=info msg="RemovePodSandbox for \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\""
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.621457416Z" level=info msg="Forcibly stopping sandbox \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\""
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.636376888Z" level=info msg="TearDown network for sandbox \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\" successf
Oct 12 11:03:17 node-f17788da-64c5f-fl257 containerd[1013752]: time="2023-10-12T11:03:17.642849170Z" level=info msg="RemovePodSandbox \"13e2e094d78539dcffb2c95c515ee216a84ee0abdbea76e56ece9a571f5f59c2\" returns successfully
root@node-f17788da-64c5f-fl257:~# if [[ -f /etc/systemd/system/containerd.service ]] || [[ -f /usr/lib/systemd/system/containerd.service ]] || [[ -f /lib/systemd/system/containerd.service ]]; then echo hi; fi
hi
root@node-f17788da-64c5f-fl257:~#
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: Fixed disabling the old containerd service in ubuntu 18.04
impact: containerd on ubuntu will be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
