### PR TITLE
[docs] Add note about default user from cloud.cfg

### DIFF
--- a/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT.md
+++ b/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT.md
@@ -119,6 +119,8 @@ Deckhouse uses `cloud-init` to configure a virtual machine after startup. To do 
 * open-vm-tools
 * [`cloud-init-vmware-guestinfo`](https://github.com/vmware-archive/cloud-init-vmware-guestinfo#installation) (for `cloud-init` versions older than 21.3)
 
+To add ssh keys to user's authorized keys, `default_user` must be specified in `/etc/cloud/cloud.cfg`.
+
 ## Infrastructure
 
 ### Networking

--- a/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT_RU.md
+++ b/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT_RU.md
@@ -124,6 +124,8 @@ Deckhouse использует `cloud-init` для настройки вирту
 * open-vm-tools
 * [`cloud-init-vmware-guestinfo`](https://github.com/vmware-archive/cloud-init-vmware-guestinfo#installation) (для версий `cloud-init` старше 21.3)
 
+Для добавления ssh-ключа, в `/etc/cloud/cloud.cfg` должен быть указан `default_user`.
+
 ## Инфраструктура
 
 ### Сети


### PR DESCRIPTION
## Description
When ordering new nodes in vSphere, deckhouse adds an ssh key to `default_user` from `cloud.cfg` . If one is not specified, the key is not added and the host cannot be accessed through ssh. 

## Why do we need it, and what problem does it solve?
Some clients have their own image (VM Template) with a custom `cloud.cfg` without `default_user`. They faced a problem during installation and couldn't understand why deckhouse doesn't add the ssh key.

## Why do we need it in the patch release (if we do)?
We don't

## Changelog entries

```changes
section: docs
type: chore
summary: Add note about default user from cloud.cfg.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
