### PR TITLE
[dhctl] fix(dhctl-for-commander): fixed empty completedPhase param in the on-phase callback of phased-execution-context

### DIFF
--- a/dhctl/pkg/infrastructure/cluster.go
+++ b/dhctl/pkg/infrastructure/cluster.go
@@ -103,7 +103,7 @@ func (r *ClusterInfra) DestroyCluster(autoApprove bool) error {
 	}
 
 	if r.PhasedExecutionContext != nil {
-		return r.PhasedExecutionContext.CommitState(r.cache)
+		return r.PhasedExecutionContext.CompletePhase(r.cache)
 	} else {
 		return nil
 	}

--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -172,7 +172,7 @@ func (r *Runner) converge() error {
 		}
 
 		if r.PhasedExecutionContext != nil {
-			if err := r.PhasedExecutionContext.CommitState(r.stateCache); err != nil {
+			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache); err != nil {
 				return err
 			}
 		}
@@ -197,7 +197,7 @@ func (r *Runner) converge() error {
 		}
 
 		if r.PhasedExecutionContext != nil {
-			if err := r.PhasedExecutionContext.CommitState(r.stateCache); err != nil {
+			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache); err != nil {
 				return err
 			}
 		}
@@ -273,7 +273,7 @@ func (r *Runner) converge() error {
 	}
 
 	if r.PhasedExecutionContext != nil {
-		return r.PhasedExecutionContext.CommitState(r.stateCache)
+		return r.PhasedExecutionContext.CompletePhase(r.stateCache)
 	} else {
 		return nil
 	}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -206,7 +206,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		stateCache.Delete(state.TombstoneKey)
 	}
 
-	if err := b.PhasedExecutionContext.Init(stateCache); err != nil {
+	if err := b.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
 		return err
 	}
 	defer b.PhasedExecutionContext.Finalize(stateCache)
@@ -447,7 +447,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		})
 	}
 
-	return b.PhasedExecutionContext.CommitAndComplete(stateCache)
+	return b.PhasedExecutionContext.CompletePhaseAndPipeline(stateCache)
 }
 
 func printBanner() {

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -108,7 +108,7 @@ func (c *Converger) Converge() error {
 
 	stateCache := cache.Global()
 
-	if err := c.PhasedExecutionContext.Init(stateCache); err != nil {
+	if err := c.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
 		return err
 	}
 	defer c.PhasedExecutionContext.Finalize(stateCache)
@@ -127,7 +127,7 @@ func (c *Converger) Converge() error {
 		return fmt.Errorf("converge problem: %v", err)
 	}
 
-	return c.PhasedExecutionContext.Complete(stateCache)
+	return c.PhasedExecutionContext.CompletePipeline(stateCache)
 }
 
 func (c *Converger) AutoConverge() error {

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -85,7 +85,7 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 
 	defer d.d8Destroyer.UnlockConverge(true)
 
-	if err := d.PhasedExecutionContext.Init(d.stateCache); err != nil {
+	if err := d.PhasedExecutionContext.InitPipeline(d.stateCache); err != nil {
 		return err
 	}
 	defer d.PhasedExecutionContext.Finalize(d.stateCache)
@@ -99,7 +99,7 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 		if err := d.d8Destroyer.DeleteResources(); err != nil {
 			return err
 		}
-		if err := d.PhasedExecutionContext.CommitState(d.stateCache); err != nil {
+		if err := d.PhasedExecutionContext.CompletePhase(d.stateCache); err != nil {
 			return err
 		}
 	}
@@ -134,5 +134,5 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 	}
 
 	d.state.Clean()
-	return d.PhasedExecutionContext.Complete(d.stateCache)
+	return d.PhasedExecutionContext.CompletePipeline(d.stateCache)
 }


### PR DESCRIPTION
Also refactored methods names of the PhasedExecutionContext.
