### PR TITLE
[node-manager] added alert on impossible node drain

### DIFF
--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -19,6 +19,7 @@ package hooks
 import (
 	"context"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -177,11 +178,13 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 		close(drainingNodesC)
 	}()
 
+	input.MetricsCollector.Expire("d8_node_draining")
 	for drainedNode := range drainingNodesC {
 		if drainedNode.Err != nil {
 			input.LogEntry.Errorf("node %q drain failed: %s", drainedNode.NodeName, drainedNode.Err)
 			event := drainedNode.buildEvent()
 			input.PatchCollector.Create(event, object_patch.UpdateIfExists())
+			input.MetricsCollector.Set("d8_node_draining", 1, map[string]string{"node": drainedNode.NodeName, "message": drainedNode.Err.Error()})
 			continue
 		}
 		input.PatchCollector.MergePatch(newDrainedAnnotationPatch(drainedNode.DrainingSource), "v1", "Node", "", drainedNode.NodeName)

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -19,7 +19,6 @@ package hooks
 import (
 	"context"
 	"io"
-	"strings"
 	"sync"
 	"time"
 

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -19,6 +19,7 @@ package hooks
 import (
 	"context"
 	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -162,6 +163,13 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 
 		wg.Add(1)
 		go func(node drainingNode) {
+			//
+			if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
+				if node.Name == "foo-2" {
+					drainHelper.PodSelector = "a: b._c"
+				}
+			}
+
 			err = drain.RunNodeDrain(drainHelper, node.Name)
 			drainingNodesC <- drainedNodeRes{
 				NodeName:       node.Name,

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -163,7 +163,6 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 
 		wg.Add(1)
 		go func(node drainingNode) {
-			//
 			if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 				if node.Name == "foo-2" {
 					drainHelper.PodSelector = "a: b._c"

--- a/modules/040-node-manager/hooks/handle_draining_test.go
+++ b/modules/040-node-manager/hooks/handle_draining_test.go
@@ -29,7 +29,6 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
@@ -189,6 +188,8 @@ metadata:
     update.node.deckhouse.io/draining: "bashible"
 `)
 			f.BindingContexts.Set(st)
+			testMoveNodesToStaticClient(f)
+			f.RunHook()
 
 			dnode := drainedNodeRes{
 				NodeName:       "foo-1",
@@ -199,8 +200,6 @@ metadata:
 			event = dnode.buildEvent()
 			unst, _ := sdk.ToUnstructured(event)
 			_, _ = f.BindingContextController.FakeCluster().Client.Dynamic().Resource(schema.GroupVersionResource{Resource: "events", Group: "events.k8s.io", Version: "v1"}).Namespace("default").Create(context.Background(), unst, v1.CreateOptions{})
-			testMoveNodesToStaticClient(f)
-			f.RunHook()
 		})
 
 		It("Should generate event", func() {
@@ -216,23 +215,25 @@ metadata:
 			k8sClient := f.BindingContextController.FakeCluster().Client
 			node1Core, _ := k8sClient.CoreV1().Nodes().Get(context.Background(), "foo-1", v1.GetOptions{})
 			Expect(node1Core.Spec.Unschedulable).To(BeTrue())
-			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(2))
 			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("Node", "foo-1").Field(`metadata.annotations.update\.node\.deckhouse\.io/drained`).Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("Node", "foo-1").Field(`metadata.annotations.update\.node\.deckhouse\.io/draining`).Exists()).To(BeTrue())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
 				Group:  "d8_node_draining",
 				Action: "expire",
 			}))
 
-			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_node_draining",
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"messages": "foo-bar-error",
-					"node":     "foo-1",
-				},
-			}))
+			//Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+			//	Name:   "d8_node_draining",
+			//	Action: "set",
+			//	Value:  pointer.Float64(1.0),
+			//	Labels: map[string]string{
+			//		"messages": "foo-bar-error",
+			//		"node":     "foo-1",
+			//	},
+			//}))
 		})
 	})
 })

--- a/modules/040-node-manager/hooks/handle_draining_test.go
+++ b/modules/040-node-manager/hooks/handle_draining_test.go
@@ -29,6 +29,7 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
@@ -176,20 +177,8 @@ data:
 
 		BeforeEach(func() {
 
-			st := f.KubeStateSet(`
----
-apiVersion: v1
-kind: Node
-metadata:
-  name: foo-1
-  labels:
-    node.deckhouse.io/group: "master"
-  annotations:
-    update.node.deckhouse.io/draining: "bashible"
-`)
+			st := f.KubeStateSet("")
 			f.BindingContexts.Set(st)
-			testMoveNodesToStaticClient(f)
-			f.RunHook()
 
 			dnode := drainedNodeRes{
 				NodeName:       "foo-1",
@@ -210,30 +199,50 @@ metadata:
 			Expect(ev.Field("regarding.kind").String()).To(Equal("Node"))
 			Expect(ev.Field("regarding.name").String()).To(Equal("foo-1"))
 		})
+	})
+
+	Context("simulate error metrics", func() {
+		BeforeEach(func() {
+
+			st := f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: foo-2
+  labels:
+    node.deckhouse.io/group: "master"
+  annotations:
+    update.node.deckhouse.io/draining: "bashible"
+`)
+			f.BindingContexts.Set(st)
+			testMoveNodesToStaticClient(f)
+			f.RunHook()
+		})
 
 		It("Should generate metrics", func() {
 			k8sClient := f.BindingContextController.FakeCluster().Client
-			node1Core, _ := k8sClient.CoreV1().Nodes().Get(context.Background(), "foo-1", v1.GetOptions{})
+			node1Core, _ := k8sClient.CoreV1().Nodes().Get(context.Background(), "foo-2", v1.GetOptions{})
 			Expect(node1Core.Spec.Unschedulable).To(BeTrue())
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesGlobalResource("Node", "foo-1").Field(`metadata.annotations.update\.node\.deckhouse\.io/drained`).Exists()).To(BeFalse())
-			Expect(f.KubernetesGlobalResource("Node", "foo-1").Field(`metadata.annotations.update\.node\.deckhouse\.io/draining`).Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("Node", "foo-2").Field(`metadata.annotations.update\.node\.deckhouse\.io/drained`).Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("Node", "foo-2").Field(`metadata.annotations.update\.node\.deckhouse\.io/draining`).Exists()).To(BeTrue())
 			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(1))
+			Expect(m).To(HaveLen(2))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
 				Group:  "d8_node_draining",
 				Action: "expire",
 			}))
 
-			//Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
-			//	Name:   "d8_node_draining",
-			//	Action: "set",
-			//	Value:  pointer.Float64(1.0),
-			//	Labels: map[string]string{
-			//		"messages": "foo-bar-error",
-			//		"node":     "foo-1",
-			//	},
-			//}))
+			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_node_draining",
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"node":    "foo-2",
+					"message": "unable to parse requirement: <nil>: Invalid value: \"a:\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+				},
+			}))
 		})
 	})
 })

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -611,7 +611,7 @@ func calculateNodeStatus(node updateApprovalNode, ng updateNodeGroup, desiredChe
 }
 
 var metricStatuses = []string{
-	"WaitingForApproval", "Approved", "DrainingForDisruption", "WaitingForDisruptionApproval",
+	"WaitingForApproval", "Approved", "DrainingForDisruption", "Draining", "Drained", "WaitingForDisruptionApproval",
 	"WaitingForManualDisruptionApproval", "DisruptionApproved", "ToBeUpdated", "UpToDate", "UpdateFailedNoConfigChecksum",
 }
 

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -575,6 +575,12 @@ func calculateNodeStatus(node updateApprovalNode, ng updateNodeGroup, desiredChe
 	case node.IsApproved && node.IsDisruptionRequired && node.IsDraining:
 		return "DrainingForDisruption"
 
+	case node.IsDraining:
+		return "Draining"
+
+	case node.IsDrained:
+		return "Drained"
+
 	case node.IsApproved && node.IsDisruptionRequired && ng.Disruptions.ApprovalMode == "Automatic":
 		return "WaitingForDisruptionApproval"
 

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -519,7 +519,7 @@ func updateApprovalFilterNode(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if _, ok := node.Annotations["update.node.deckhouse.io/disruption-required"]; ok {
 		isDisruptionRequired = true
 	}
-	if v, ok := node.Annotations[drainingAnnotationKey]; ok && v == "bashible" {
+	if _, ok := node.Annotations[drainingAnnotationKey]; ok {
 		isDraining = true
 	}
 	if _, ok := node.Annotations["update.node.deckhouse.io/disruption-approved"]; ok {
@@ -533,7 +533,7 @@ func updateApprovalFilterNode(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if !ok {
 		nodeGroup = ""
 	}
-	if v, ok := node.Annotations[drainedAnnotationKey]; ok && v == "bashible" {
+	if _, ok := node.Annotations[drainedAnnotationKey]; ok {
 		isDrained = true
 	}
 

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -208,6 +208,7 @@
       summary: The {{ $labels.node }} Node is stuck in draining.
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} NodeGroup. The Node has learned about the update, requested and received approval, started the update, ran into a step that causes possible downtime, and stuck in draining in order to get disruption approval automatically.
+
         You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'`
 
   - alert: NodeStuckInDraining

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -192,7 +192,7 @@
 
   - alert: NodeStuckInDrainingForDisruptionDuringUpdate
     expr: |
-      max by (message, node) d8_node_draining == 1
+      max by (message, node) (d8_node_draining) == 1
     for: 5m
     labels:
       tier: cluster

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -192,11 +192,8 @@
 
   - alert: NodeStuckInDrainingForDisruptionDuringUpdate
     expr: |
-      max by (node,node_group) (
-        node_group_node_status{status="DrainingForDisruption"} *
-        on(node) group_left() (max by(node) ((kube_node_status_condition == 1)))
-      )> 0
-    for: 2h
+      max by (message, node) d8_node_draining == 1
+    for: 5m
     labels:
       tier: cluster
       severity_level: "6"
@@ -209,7 +206,7 @@
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} NodeGroup. The Node has learned about the update, requested and received approval, started the update, ran into a step that causes possible downtime, and stuck in draining in order to get disruption approval automatically.
 
-        You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'`
+        You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'`
 
   - alert: D8BashibleApiserverLocked
     expr: d8_bashible_apiserver_locked == 1

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -192,8 +192,11 @@
 
   - alert: NodeStuckInDrainingForDisruptionDuringUpdate
     expr: |
-      max by (message, node) (d8_node_draining) == 1
-    for: 5m
+      max by (node,node_group) (
+        node_group_node_status{status="DrainingForDisruption"} *
+        on(node) group_left() (max by(node) ((kube_node_status_condition == 1)))
+      )> 0
+    for: 2h
     labels:
       tier: cluster
       severity_level: "6"
@@ -202,6 +205,23 @@
       plk_protocol_version: "1"
       plk_create_group_if_not_exists__cluster_has_nodes_stuck_in_draining_for_disruption_during_update: "ClusterHasNodesStuckInDrainingForDisruptionDuringUpdate,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__cluster_has_nodes_stuck_in_draining_for_disruption_during_update: "ClusterHasNodesStuckInDrainingForDisruptionDuringUpdate,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: The {{ $labels.node }} Node is stuck in draining.
+      description: |
+        There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} NodeGroup. The Node has learned about the update, requested and received approval, started the update, ran into a step that causes possible downtime, and stuck in draining in order to get disruption approval automatically.
+        You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'`
+
+  - alert: NodeStuckInDraining
+    expr: |
+      max by (message, node) (d8_node_draining) == 1
+    for: 5m
+    labels:
+      tier: cluster
+      severity_level: "6"
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__cluster_has_nodes_stuck_in_draining: "ClusterHasNodesStuckInDraining,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__cluster_has_nodes_stuck_in_draining: "ClusterHasNodesStuckInDraining,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: The {{ $labels.node }} Node is stuck in draining.
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} NodeGroup. The Node has learned about the update, requested and received approval, started the update, ran into a step that causes possible downtime, and stuck in draining in order to get disruption approval automatically.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -230,7 +230,7 @@
       plk_labels_as_annotations: message
       summary: The {{ $labels.node }} Node is stuck in draining.
       description: |
-        The {{ $labels.node } Node of the {{ $labels.node_group }} NodeGroup stuck in draining.
+        The {{ $labels.node }} Node of the {{ $labels.node_group }} NodeGroup stuck in draining.
 
         You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'`
 

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -234,7 +234,7 @@
 
         You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'`
 
-        the error message is: {{ $labels.message }}
+        The error message is: {{ $labels.message }}
   - alert: D8BashibleApiserverLocked
     expr: d8_bashible_apiserver_locked == 1
     for: 15m

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -213,7 +213,11 @@
 
   - alert: NodeStuckInDraining
     expr: |
-      max by (message, node) (d8_node_draining * on (node) group_left () kube_node_info) == 1
+      max by (message, node, node_group) (
+        d8_node_draining *
+        on (node) group_left (node_group) node_group_node_status{status="Draining"} *
+        on (node) group_left () (max by (node) ((kube_node_status_condition == 1)))
+      ) > 0
     for: 5m
     labels:
       tier: cluster
@@ -223,12 +227,14 @@
       plk_protocol_version: "1"
       plk_create_group_if_not_exists__cluster_has_nodes_stuck_in_draining: "ClusterHasNodesStuckInDraining,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__cluster_has_nodes_stuck_in_draining: "ClusterHasNodesStuckInDraining,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_labels_as_annotations: message
       summary: The {{ $labels.node }} Node is stuck in draining.
       description: |
-        There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} NodeGroup. The Node has learned about the update, requested and received approval, started the update, ran into a step that causes possible downtime, and stuck in draining in order to get disruption approval automatically.
+        The {{ $labels.node } Node of the {{ $labels.node_group }} NodeGroup stuck in draining.
 
         You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'`
 
+        the error message is: {{ $labels.message }}
   - alert: D8BashibleApiserverLocked
     expr: d8_bashible_apiserver_locked == 1
     for: 15m

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -235,6 +235,7 @@
         You can get more info by running: `kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'`
 
         The error message is: {{ $labels.message }}
+
   - alert: D8BashibleApiserverLocked
     expr: d8_bashible_apiserver_locked == 1
     for: 15m

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -213,7 +213,7 @@
 
   - alert: NodeStuckInDraining
     expr: |
-      max by (message, node) (d8_node_draining) == 1
+      max by (message, node) (d8_node_draining * on (node) group_left () kube_node_info) == 1
     for: 5m
     labels:
       tier: cluster


### PR DESCRIPTION
## Description
added NodeStuckInDraining alert 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/5173
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: added alert on impossible node drain
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
