### PR TITLE
Linstor/fix symlink 1.52

### DIFF
--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -1,4 +1,4 @@
-From 63f32955077f935a28477599d90b02b134935faf Mon Sep 17 00:00:00 2001
+From c72f5942bd665c245fcd51113764335a49046306 Mon Sep 17 00:00:00 2001
 From: Andrei Kvapil <kvapss@gmail.com>
 Date: Tue, 3 Oct 2023 13:32:21 +0200
 Subject: [PATCH] Automatically fix symlinks for devices
@@ -14,8 +14,8 @@ Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
 ---
  .../linstor/layer/dmsetup/DmSetupUtils.java   | 79 ++++++++++++++++++-
  .../linbit/linstor/layer/drbd/DrbdLayer.java  | 13 +++
- .../storage/utils/StltProviderUtils.java      |  9 +++
- 3 files changed, 100 insertions(+), 1 deletion(-)
+ .../linstor/layer/storage/utils/Commands.java | 14 ++++
+ 3 files changed, 105 insertions(+), 1 deletion(-)
 
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
 index ba753577d..cc90ad898 100644
@@ -152,32 +152,44 @@ index 16034c550..d44d2bc57 100644
          MdSuperblockBuffer mdUtils = new MdSuperblockBuffer();
          try
          {
-diff --git a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
-index a1643daa5..ef6f4240a 100644
---- a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
-+++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
-@@ -3,6 +3,10 @@ package com.linbit.linstor.layer.storage.utils;
+diff --git a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/Commands.java b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/Commands.java
+index a63c78cba..1228cb74e 100644
+--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/Commands.java
++++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/Commands.java
+@@ -8,6 +8,7 @@ import com.linbit.SizeConv.SizeUnit;
  import com.linbit.extproc.ExtCmd;
- import com.linbit.linstor.storage.StorageException;
- import com.linbit.linstor.storage.interfaces.categories.resource.VlmProviderObject;
+ import com.linbit.extproc.ExtCmd.OutputData;
+ import com.linbit.extproc.ExtCmdUtils;
 +import com.linbit.linstor.layer.dmsetup.DmSetupUtils;
-+
+ import com.linbit.linstor.storage.StorageException;
+ import com.linbit.utils.StringUtils;
+ 
+@@ -17,6 +18,11 @@ import java.util.Collection;
+ import java.util.Collections;
+ import java.util.List;
+ 
 +import java.nio.file.Files;
 +import java.nio.file.Paths;
- 
- public class StltProviderUtils
- {
-@@ -15,6 +19,11 @@ public class StltProviderUtils
-             String devicePath = vlmData.getDevicePath();
-             if (devicePath != null)
-             {
-+                if (!Files.exists(Paths.get(devicePath))) {
-+                    errorReporter.logWarning("Device path %s does not exist, fixing symlink", devicePath);
-+                    DmSetupUtils.fixSymlinkForDevice(extCmd, devicePath);
-+                }
++import java.time.LocalDateTime;
++import java.time.format.DateTimeFormatter;
 +
-                 size = getAllocatedSize(devicePath, extCmd);
-             }
-             else
+ public class Commands
+ {
+     public interface RetryHandler
+@@ -191,6 +197,14 @@ public class Commands
+     )
+         throws StorageException
+     {
++
++        if (!Files.exists(Paths.get(devicePath))) {
++          DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd/HH:mm:ss:SSS");
++          LocalDateTime now = LocalDateTime.now();
++          System.out.println(dtf.format(now) + " [GetBlockSizeInKib] WARN - Device path " + devicePath + " does not exist, fixing symlink");
++          DmSetupUtils.fixSymlinkForDevice(extCmd, devicePath);
++        }
++
+         OutputData output = genericExecutor(
+             extCmd,
+             new String[] {"blockdev", "--getsize64", devicePath},
 -- 
 2.39.3 (Apple Git-145)

--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -1,4 +1,4 @@
-From 2f4e83bf4de23408a37621b10e6caf5f771c863c Mon Sep 17 00:00:00 2001
+From 4823d8a23f1cd7bbefd16fa5e44aed45b869ac4b Mon Sep 17 00:00:00 2001
 From: Andrei Kvapil <kvapss@gmail.com>
 Date: Tue, 3 Oct 2023 13:32:21 +0200
 Subject: [PATCH] Automatically fix symlinks for devices
@@ -14,8 +14,8 @@ Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
 ---
  .../linstor/layer/dmsetup/DmSetupUtils.java   | 79 ++++++++++++++++++-
  .../linbit/linstor/layer/drbd/DrbdLayer.java  | 13 +++
- .../storage/utils/StltProviderUtils.java      |  6 ++
- 3 files changed, 97 insertions(+), 1 deletion(-)
+ .../storage/utils/StltProviderUtils.java      |  9 +++
+ 3 files changed, 100 insertions(+), 1 deletion(-)
 
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
 index ba753577d..cc90ad898 100644
@@ -153,18 +153,21 @@ index 16034c550..d44d2bc57 100644
          try
          {
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
-index a1643daa5..2bf347d08 100644
+index a1643daa5..da87adb4d 100644
 --- a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
 +++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
-@@ -3,6 +3,7 @@ package com.linbit.linstor.layer.storage.utils;
+@@ -3,6 +3,10 @@ package com.linbit.linstor.layer.storage.utils;
  import com.linbit.extproc.ExtCmd;
  import com.linbit.linstor.storage.StorageException;
  import com.linbit.linstor.storage.interfaces.categories.resource.VlmProviderObject;
 +import com.linbit.linstor.layer.dmsetup.DmSetupUtils;
++
++import java.nio.file.Files;
++import java.nio.file.Paths;
  
  public class StltProviderUtils
  {
-@@ -15,6 +16,11 @@ public class StltProviderUtils
+@@ -15,6 +19,11 @@ public class StltProviderUtils
              String devicePath = vlmData.getDevicePath();
              if (devicePath != null)
              {

--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -1,4 +1,4 @@
-From 4823d8a23f1cd7bbefd16fa5e44aed45b869ac4b Mon Sep 17 00:00:00 2001
+From 63f32955077f935a28477599d90b02b134935faf Mon Sep 17 00:00:00 2001
 From: Andrei Kvapil <kvapss@gmail.com>
 Date: Tue, 3 Oct 2023 13:32:21 +0200
 Subject: [PATCH] Automatically fix symlinks for devices
@@ -153,7 +153,7 @@ index 16034c550..d44d2bc57 100644
          try
          {
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
-index a1643daa5..da87adb4d 100644
+index a1643daa5..ef6f4240a 100644
 --- a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
 +++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
 @@ -3,6 +3,10 @@ package com.linbit.linstor.layer.storage.utils;
@@ -173,7 +173,7 @@ index a1643daa5..da87adb4d 100644
              {
 +                if (!Files.exists(Paths.get(devicePath))) {
 +                    errorReporter.logWarning("Device path %s does not exist, fixing symlink", devicePath);
-+                    DmSetupUtils.fixSymlinkForDevice(extCmdFactory.create(), devicePath);
++                    DmSetupUtils.fixSymlinkForDevice(extCmd, devicePath);
 +                }
 +
                  size = getAllocatedSize(devicePath, extCmd);

--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -14,7 +14,8 @@ Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
 ---
  .../linstor/layer/dmsetup/DmSetupUtils.java   | 79 ++++++++++++++++++-
  .../linbit/linstor/layer/drbd/DrbdLayer.java  | 13 +++
- 2 files changed, 91 insertions(+), 1 deletion(-)
+ .../storage/utils/StltProviderUtils.java      |  6 ++
+ 3 files changed, 97 insertions(+), 1 deletion(-)
 
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
 index ba753577d..cc90ad898 100644
@@ -121,7 +122,7 @@ index ba753577d..cc90ad898 100644
      {
          Commands.genericExecutor(
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
-index 16034c550..9fc09fa3e 100644
+index 16034c550..d44d2bc57 100644
 --- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
 +++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
 @@ -37,6 +37,7 @@ import com.linbit.linstor.core.objects.Volume;
@@ -151,6 +152,29 @@ index 16034c550..9fc09fa3e 100644
          MdSuperblockBuffer mdUtils = new MdSuperblockBuffer();
          try
          {
+diff --git a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
+index a1643daa5..2bf347d08 100644
+--- a/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
++++ b/satellite/src/main/java/com/linbit/linstor/layer/storage/utils/StltProviderUtils.java
+@@ -3,6 +3,7 @@ package com.linbit.linstor.layer.storage.utils;
+ import com.linbit.extproc.ExtCmd;
+ import com.linbit.linstor.storage.StorageException;
+ import com.linbit.linstor.storage.interfaces.categories.resource.VlmProviderObject;
++import com.linbit.linstor.layer.dmsetup.DmSetupUtils;
+ 
+ public class StltProviderUtils
+ {
+@@ -15,6 +16,11 @@ public class StltProviderUtils
+             String devicePath = vlmData.getDevicePath();
+             if (devicePath != null)
+             {
++                if (!Files.exists(Paths.get(devicePath))) {
++                    errorReporter.logWarning("Device path %s does not exist, fixing symlink", devicePath);
++                    DmSetupUtils.fixSymlinkForDevice(extCmdFactory.create(), devicePath);
++                }
++
+                 size = getAllocatedSize(devicePath, extCmd);
+             }
+             else
 -- 
-2.32.0 (Apple Git-132)
-
+2.39.3 (Apple Git-145)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
