### PR TITLE
[candi] fix working of bootstrap cloud-networks setup scripts

### DIFF
--- a/ee/candi/cloud-providers/openstack/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/openstack/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -5,7 +5,6 @@
 */}}
 shopt -s extglob
 
-ip_addr_show_output=$(ip -json addr show)
 configured_macs="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
 for mac in $configured_macs; do
   ifname="$(ip -o link show | grep "link/ether $mac" | cut -d ":" -f2 | tr -d " ")|"

--- a/ee/candi/cloud-providers/vsphere/bashible/bundles/astra/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bundles/astra/bootstrap-networks.sh.tpl
@@ -5,12 +5,11 @@
 */}}
 shopt -s extglob
 
-ip_addr_show_output=$(ip -json addr show)
 primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
-primary_ifname="$(echo "$ip_addr_show_output" | jq -re --arg mac "$primary_mac" '.[] | select(.address == $mac) | .ifname')"
+primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 
 if [ -z "$primary_ifname" ]; then
-  primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml  | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
+  primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
 fi
 
 for i in /sys/class/net/!($primary_ifname); do
@@ -19,7 +18,7 @@ for i in /sys/class/net/!($primary_ifname); do
   fi
 
   ifname=$(basename "$i")
-  mac="$(echo "$ip_addr_show_output" | jq -re --arg ifname "$ifname" '.[] | select(.ifname == $ifname) | .address')"
+  mac="$(ip link show dev $ifname | grep "link/ether" | sed "s/  //g" | cut -d " " -f2)"
 
   cat > /etc/netplan/100-cim-"$ifname".yaml <<BOOTSTRAP_NETWORK_EOF
 network:

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -1,6 +1,14 @@
 {{- define "bootstrap_script" }}
-  {{- $context := index . 0 }}
-  {{- $ng := index . 1 }}
+  {{- $context := index . 0 -}}
+  {{- $ng := index . 1 -}}
+  {{- $tpl_context := dict -}}
+  {{- $_ := set $tpl_context "Release" $context.Release -}}
+  {{- $_ := set $tpl_context "Chart" $context.Chart -}}
+  {{- $_ := set $tpl_context "Files" $context.Files -}}
+  {{- $_ := set $tpl_context "Capabilities" $context.Capabilities -}}
+  {{- $_ := set $tpl_context "Template" $context.Template -}}
+  {{- $_ := set $tpl_context "Values" $context.Values -}}
+  {{- $_ := set $tpl_context "nodeGroup" $ng -}}
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
@@ -83,13 +91,14 @@ function run_cloud_network_setup() {
   {{- if hasKey $context.Values.nodeManager.internal "cloudProvider" }}
     {{- if $bootstrap_script_common := $context.Files.Get (printf "candi/cloud-providers/%s/bashible/common-steps/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type)  }}
   cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh <<"EOF"
-      {{- tpl $bootstrap_script_common (list $context $ng) }}
+      {{- tpl $bootstrap_script_common $tpl_context | nindent 0 }}
 EOF
     {{- else }}
       {{- range $path, $_ := $context.Files.Glob (printf "candi/cloud-providers/%s/bashible/bundles/*/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type) }}
         {{- $bundle := (dir $path | base) }}
-  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh'
-        {{- tpl ($context.Files.Get $path) (list $context $ng)}}
+  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
+        {{ tpl ($context.Files.Get $path) $tpl_context | nindent 0 }}
+EOF
       {{- end }}
     {{- end }}
   {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -93,12 +93,14 @@ function run_cloud_network_setup() {
   cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh <<"EOF"
       {{- tpl $bootstrap_script_common $tpl_context | nindent 0 }}
 EOF
+  chmod +x ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh
     {{- else }}
       {{- range $path, $_ := $context.Files.Glob (printf "candi/cloud-providers/%s/bashible/bundles/*/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type) }}
         {{- $bundle := (dir $path | base) }}
   cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
         {{ tpl ($context.Files.Get $path) $tpl_context | nindent 0 }}
 EOF
+  chmod +x ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
       {{- end }}
     {{- end }}
   {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -82,13 +82,13 @@ function get_phase2() {
 function run_cloud_network_setup() {
   {{- if hasKey $context.Values.nodeManager.internal "cloudProvider" }}
     {{- if $bootstrap_script_common := $context.Files.Get (printf "candi/cloud-providers/%s/bashible/common-steps/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type)  }}
-  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
+  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh <<"EOF"
       {{- tpl $bootstrap_script_common (list $context $ng) }}
 EOF
     {{- else }}
       {{- range $path, $_ := $context.Files.Glob (printf "candi/cloud-providers/%s/bashible/bundles/*/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type) }}
         {{- $bundle := (dir $path | base) }}
-  cat > $BOOTSTRAP_DIR/cloud-provider-bootstrap-networks-{{ $bundle }}.sh'
+  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh'
         {{- tpl ($context.Files.Get $path) (list $context $ng)}}
       {{- end }}
     {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -90,17 +90,17 @@ function get_phase2() {
 function run_cloud_network_setup() {
   {{- if hasKey $context.Values.nodeManager.internal "cloudProvider" }}
     {{- if $bootstrap_script_common := $context.Files.Get (printf "candi/cloud-providers/%s/bashible/common-steps/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type)  }}
-  cat > /tmp/cloud-provider-bootstrap-networks.sh <<"EOF"
+  cat > /root/cloud-provider-bootstrap-networks.sh <<"EOF"
       {{- tpl $bootstrap_script_common $tpl_context | nindent 0 }}
 EOF
-  chmod +x /tmp/cloud-provider-bootstrap-networks.sh
+  chmod +x /root/cloud-provider-bootstrap-networks.sh
     {{- else }}
       {{- range $path, $_ := $context.Files.Glob (printf "candi/cloud-providers/%s/bashible/bundles/*/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type) }}
         {{- $bundle := (dir $path | base) }}
-  cat > /tmp/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
+  cat > /root/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
         {{ tpl ($context.Files.Get $path) $tpl_context | nindent 0 }}
 EOF
-  chmod +x /tmp/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
+  chmod +x /root/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
       {{- end }}
     {{- end }}
   {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -74,7 +74,7 @@ EOF
 function get_phase2() {
   check_python
   bootstrap_bundle_name="${BUNDLE}.{{ $ng.name }}"
-  token="$(</var/lib/bashible/bootstrap-token)"
+  token="$(<${BOOTSTRAP_DIR}/bootstrap-token)"
   while true; do
     for server in {{ $context.Values.nodeManager.internal.clusterMasterAddresses | join " " }}; do
       url="https://${server}/apis/bashible.deckhouse.io/v1alpha1/bootstrap/${bootstrap_bundle_name}"
@@ -107,17 +107,18 @@ EOF
   {{- /*
   # Execute cloud provider specific network bootstrap script. It will organize connectivity to kube-apiserver.
   */}}
-  if [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh ]] ; then
-    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh; do
-      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
-      sleep 10
-    done
-  elif [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh ]] ; then
-    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh; do
-      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
-      sleep 10
-    done
-  fi
+
+#  if [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh ]] ; then
+#    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh; do
+#      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
+#      sleep 10
+#    done
+#  elif [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh ]] ; then
+#    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh; do
+#      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
+#      sleep 10
+#    done
+#  fi
 }
 
 BUNDLE="$(detect_bundle)"

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -90,17 +90,17 @@ function get_phase2() {
 function run_cloud_network_setup() {
   {{- if hasKey $context.Values.nodeManager.internal "cloudProvider" }}
     {{- if $bootstrap_script_common := $context.Files.Get (printf "candi/cloud-providers/%s/bashible/common-steps/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type)  }}
-  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh <<"EOF"
+  cat > /tmp/cloud-provider-bootstrap-networks.sh <<"EOF"
       {{- tpl $bootstrap_script_common $tpl_context | nindent 0 }}
 EOF
-  chmod +x ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh
+  chmod +x /tmp/cloud-provider-bootstrap-networks.sh
     {{- else }}
       {{- range $path, $_ := $context.Files.Glob (printf "candi/cloud-providers/%s/bashible/bundles/*/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type) }}
         {{- $bundle := (dir $path | base) }}
-  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
+  cat > /tmp/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
         {{ tpl ($context.Files.Get $path) $tpl_context | nindent 0 }}
 EOF
-  chmod +x ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
+  chmod +x /tmp/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
       {{- end }}
     {{- end }}
   {{- end }}
@@ -108,17 +108,17 @@ EOF
   # Execute cloud provider specific network bootstrap script. It will organize connectivity to kube-apiserver.
   */}}
 
-#  if [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh ]] ; then
-#    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh; do
-#      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
-#      sleep 10
-#    done
-#  elif [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh ]] ; then
-#    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh; do
-#      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
-#      sleep 10
-#    done
-#  fi
+  if [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh ]] ; then
+    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh; do
+      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
+      sleep 10
+    done
+  elif [[ -f ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh ]] ; then
+    until ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-${BUNDLE}.sh; do
+      >&2 echo "Failed to execute cloud provider specific bootstrap. Retry in 10 seconds."
+      sleep 10
+    done
+  fi
 }
 
 BUNDLE="$(detect_bundle)"

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -1,14 +1,14 @@
 {{- define "bootstrap_script" }}
-  {{- $context := index . 0 -}}
-  {{- $ng := index . 1 -}}
-  {{- $tpl_context := dict -}}
-  {{- $_ := set $tpl_context "Release" $context.Release -}}
-  {{- $_ := set $tpl_context "Chart" $context.Chart -}}
-  {{- $_ := set $tpl_context "Files" $context.Files -}}
-  {{- $_ := set $tpl_context "Capabilities" $context.Capabilities -}}
-  {{- $_ := set $tpl_context "Template" $context.Template -}}
-  {{- $_ := set $tpl_context "Values" $context.Values -}}
-  {{- $_ := set $tpl_context "nodeGroup" $ng -}}
+  {{- $context := index . 0 }}
+  {{- $ng := index . 1 }}
+  {{- $tpl_context := dict }}
+  {{- $_ := set $tpl_context "Release" $context.Release }}
+  {{- $_ := set $tpl_context "Chart" $context.Chart }}
+  {{- $_ := set $tpl_context "Files" $context.Files }}
+  {{- $_ := set $tpl_context "Capabilities" $context.Capabilities }}
+  {{- $_ := set $tpl_context "Template" $context.Template }}
+  {{- $_ := set $tpl_context "Values" $context.Values }}
+  {{- $_ := set $tpl_context "nodeGroup" $ng }}
 #!/usr/bin/env bash
 set -Eeuo pipefail
 

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -90,17 +90,17 @@ function get_phase2() {
 function run_cloud_network_setup() {
   {{- if hasKey $context.Values.nodeManager.internal "cloudProvider" }}
     {{- if $bootstrap_script_common := $context.Files.Get (printf "candi/cloud-providers/%s/bashible/common-steps/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type)  }}
-  cat > /root/cloud-provider-bootstrap-networks.sh <<"EOF"
+  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh <<"EOF"
       {{- tpl $bootstrap_script_common $tpl_context | nindent 0 }}
 EOF
-  chmod +x /root/cloud-provider-bootstrap-networks.sh
+  chmod +x ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks.sh
     {{- else }}
       {{- range $path, $_ := $context.Files.Glob (printf "candi/cloud-providers/%s/bashible/bundles/*/bootstrap-networks.sh.tpl" $context.Values.nodeManager.internal.cloudProvider.type) }}
         {{- $bundle := (dir $path | base) }}
-  cat > /root/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
+  cat > ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh <<"EOF"
         {{ tpl ($context.Files.Get $path) $tpl_context | nindent 0 }}
 EOF
-  chmod +x /root/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
+  chmod +x ${BOOTSTRAP_DIR}/cloud-provider-bootstrap-networks-{{ $bundle }}.sh
       {{- end }}
     {{- end }}
   {{- end }}

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -14,7 +14,7 @@ write_files:
 - path: '/var/lib/bashible/bootstrap.sh'
   permissions: '0700'
   content: |
-    {{- include "bootstrap_script" (dict "Files" $context.Files "nodeGroupName" $ng.name "apiserverEndpoints" $context.Values.nodeManager.internal.clusterMasterAddresses) | indent 4 }}
+    {{- include "bootstrap_script" (list $context $ng) | indent 4 }}
 
 - path: '/var/lib/bashible/ca.crt'
   permissions: '0644'

--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
@@ -7,7 +7,7 @@
 mkdir -p /var/lib/bashible
 
 cat > /var/lib/bashible/bootstrap.sh <<"END"
-{{- include "bootstrap_script" (dict "Files" $context.Files "nodeGroupName" $ng.name "apiserverEndpoints" $context.Values.nodeManager.internal.clusterMasterAddresses) }}
+{{- include "bootstrap_script" (list $context $ng) }}
 END
 chmod +x /var/lib/bashible/bootstrap.sh
 

--- a/testing/cloud_layouts/vSphere/Standard/resources.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/resources.yaml
@@ -27,7 +27,9 @@ spec:
   numCPUs: 4
   memory: 8192
   rootDiskSize: 20
-  mainNetwork: DEVOPS_36
+  mainNetwork: msk3-k8s-1203
+  additionalNetworks:
+    - DEVOPS_36
   datastore: 3par_4_Lun105
 ---
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix working of bootstrap cloud-networks setup scripts after #4907.
Changed vsphere cloud test to test two-interface nodes and cloud-network bootstrap scripts.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Cloud-networks setup scripts should run before we try to fetch second-phase bootstrap scripts from bashible apiserver. If we cannot run cloud network setup scripts at the first phase, we cannot give access to apiserver in the case of two or more interfaces on the node (cloud-init scripts setup only first interface by default and if first interface is external network we need to configure internal network interface by himself).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: fix working of bootstrap cloud-networks setup scripts
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
