### PR TITLE
[linstor] changes in controller liveness probe

### DIFF
--- a/modules/041-linstor/images/linstor-server/liveness.sh
+++ b/modules/041-linstor/images/linstor-server/liveness.sh
@@ -21,10 +21,24 @@ fi
 
 # Sometimes nodes can be shown as Online without established connection to them.
 # This is a workaround for https://github.com/LINBIT/linstor-server/issues/331, https://github.com/LINBIT/linstor-server/issues/219
-if test -f "/var/log/linstor-controller/linstor-Controller.log"; then
-  tail -n 1000 /var/log/linstor-controller/linstor-Controller.log | grep -q 'Target decrypted buffer is too small' && exit 1
-  # Because shell keeps last exit code, we must force exit with code 0. If not, we will have exit code 1 because of grep, that not founded anything
-  exit 0
-else
+
+# Collect list of satellite nodes
+SATELLITES_ONLINE=$(linstor -m --output-version=v1 node list | jq -r '.[][] | select(.type == "SATELLITE" and .connection_status == "ONLINE").name')
+if [ -z "$SATELLITES_ONLINE" ]; then
   exit 0
 fi
+
+# Check online nodes with lost connection
+if [ $(linstor -m --output-version=v1 storage-pool list -s DfltDisklessStorPool -n $SATELLITES_ONLINE | jq '.[][].reports[]?.message' | grep 'No active connection to satellite' | wc -l) -ne 0 ]; then
+  exit 1
+fi
+
+# Check if there are symptoms of lost connection in linstor controller logs
+if test -f "/var/log/linstor-controller/linstor-Controller.log"; then
+  if [ $(tail -n 1000 /var/log/linstor-controller/linstor-Controller.log | grep 'Target decrypted buffer is too small' | wc -l) -ne 0 ]; then
+    exit 1
+  fi
+fi
+
+# Because shell keeps last exit code, we must force exit with code 0. If not, we will have exit code 1 because of grep, that not founded anything
+exit 0

--- a/modules/041-linstor/images/piraeus-operator/patches/050-change-liveness-probe.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/050-change-liveness-probe.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/controller/linstorcontroller/linstorcontroller_controller.go b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
-index 52fd46f..9219bbb 100644
+index 52fd46f..373ade6 100644
 --- a/pkg/controller/linstorcontroller/linstorcontroller_controller.go
 +++ b/pkg/controller/linstorcontroller/linstorcontroller_controller.go
-@@ -873,9 +873,8 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
+@@ -873,11 +873,11 @@ func newDeploymentForResource(controllerResource *piraeusv1.LinstorController) *
  	// as well as images without leader election helper
  	livenessProbe := corev1.Probe{
  		ProbeHandler: corev1.ProbeHandler{
@@ -13,4 +13,7 @@ index 52fd46f..9219bbb 100644
 +				Command: []string{"./liveness.sh"},
  			},
  		},
++		TimeoutSeconds: 15,
  	}
+ 
+ 	meta := getObjectMeta(controllerResource, "%s-controller")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changes in controller liveness probe

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Currently, the controller may lose connection with the satellite and not attempt to restore it. However, when viewing the list of satellites, they all appear online.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Restarting the controller when the connection with the satellites is lost with the above-mentioned symptoms.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Changes in controller liveness probe
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
