### PR TITLE
[monitoring-ping] switch to distroless

### DIFF
--- a/modules/000-common/images/python-static/Setup.local
+++ b/modules/000-common/images/python-static/Setup.local
@@ -1,0 +1,103 @@
+# -*- makefile -*-
+
+# ---
+# Built-in modules required to get a functioning interpreter;
+# cannot be built as shared!
+*static*
+
+# module C APIs are used in core
+atexit atexitmodule.c
+faulthandler faulthandler.c
+posix posixmodule.c
+_signal signalmodule.c
+_tracemalloc _tracemalloc.c
+
+# modules used by importlib, deepfreeze, freeze, runpy, and sysconfig
+_codecs _codecsmodule.c
+_collections _collectionsmodule.c
+errno errnomodule.c
+_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c
+itertools itertoolsmodule.c
+_sre _sre/sre.c
+_thread _threadmodule.c
+time timemodule.c
+_weakref _weakref.c
+
+# commonly used core modules
+_abc _abc.c
+_functools _functoolsmodule.c
+_locale _localemodule.c
+_operator _operator.c
+_stat _stat.c
+_symtable symtablemodule.c
+
+_asyncio _asynciomodule.c
+_bisect _bisectmodule.c
+_contextvars _contextvarsmodule.c
+_csv _csv.c
+_datetime _datetimemodule.c
+_decimal _decimal/_decimal.c
+_heapq _heapqmodule.c
+_json _json.c
+_lsprof _lsprof.c rotatingtree.c
+_multiprocessing -I$(srcdir)/Modules/_multiprocessing _multiprocessing/multiprocessing.c _multiprocessing/semaphore.c
+_opcode _opcode.c
+_pickle _pickle.c
+_queue _queuemodule.c
+_random _randommodule.c
+_socket socketmodule.c
+_statistics _statisticsmodule.c
+_struct _struct.c
+_typing _typingmodule.c
+_zoneinfo _zoneinfo.c
+array arraymodule.c
+audioop audioop.c
+binascii binascii.c
+cmath cmathmodule.c
+math mathmodule.c
+mmap mmapmodule.c
+select selectmodule.c
+
+_posixsubprocess _posixsubprocess.c
+_posixshmem -I$(srcdir)/Modules/_multiprocessing _multiprocessing/posixshmem.c -lrt
+fcntl fcntlmodule.c
+grp grpmodule.c
+ossaudiodev ossaudiodev.c
+resource resource.c
+spwd spwdmodule.c
+syslog syslogmodule.c
+termios termios.c
+
+# hashing builtins
+_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c
+_md5 md5module.c
+_sha1 sha1module.c
+_sha256 sha256module.c
+_sha512 sha512module.c
+_sha3 _sha3/sha3module.c
+
+# text encodings and unicode
+_codecs_cn cjkcodecs/_codecs_cn.c
+_codecs_hk cjkcodecs/_codecs_hk.c
+_codecs_iso2022 cjkcodecs/_codecs_iso2022.c
+_codecs_jp cjkcodecs/_codecs_jp.c
+_codecs_kr cjkcodecs/_codecs_kr.c
+_codecs_tw cjkcodecs/_codecs_tw.c
+_multibytecodec cjkcodecs/multibytecodec.c
+unicodedata unicodedata.c
+
+_bz2 _bz2module.c -lbz2
+_ctypes _ctypes/_ctypes.c _ctypes/callbacks.c _ctypes/callproc.c _ctypes/stgdict.c _ctypes/cfield.c -ldl -lffi -DHAVE_FFI_PREP_CIF_VAR -DHAVE_FFI_PREP_CLOSURE_LOC -DHAVE_FFI_CLOSURE_ALLOC
+# The _dbm module supports NDBM, GDBM with compat module, and Berkeley DB.
+_dbm _dbmmodule.c -lgdbm_compat -DUSE_GDBM_COMPAT
+_gdbm _gdbmmodule.c -lgdbm
+_lzma _lzmamodule.c -llzma
+#_uuid _uuidmodule.c -luuid
+zlib  zlibmodule.c -lz
+pyexpat pyexpat.c
+
+# for systems without $HOME env, used by site._getuserbase()
+pwd pwdmodule.c
+
+# ssl
+_ssl _ssl.c

--- a/modules/000-common/images/python-static/werf.inc.yaml
+++ b/modules/000-common/images/python-static/werf.inc.yaml
@@ -1,0 +1,30 @@
+---
+artifact: {{ .ModuleName }}/build-python-static-artifact
+from: {{ .Images.BASE_UBUNTU }}
+git:
+- add: /{{ $.ModulePath }}modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/Setup.local
+  to: /build/src/Modules/Setup.local
+  stageDependencies:
+    install:
+    - '**/*'
+shell:
+  install:
+  - mkdir /build && cd /build
+  - apt update && apt install -y --no-install-recommends build-essential tar gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev uuid-dev zlib1g-dev coreutils ca-certificates
+  - export PYTHON_VERSION=3.11.6 BUILD_THREADS=4 PYTHON_PREFIX=/opt/python-static
+  - git clone -b v${PYTHON_VERSION} --single-branch --depth=1 {{ $.SOURCE_REPO }}/python/cpython.git ./src
+  - cd ./src
+  - ./configure LDFLAGS="-static" --disable-shared --prefix=${PYTHON_PREFIX} --enable-optimizations --with-ensurepip=install
+  - make LDFLAGS="-static" LINKFORSHARED=" " -j ${BUILD_THREADS}
+  - make install -j ${BUILD_THREADS}
+  - chown -R 64535:64535 ${PYTHON_PREFIX}
+  - chmod 0700 ${PYTHON_PREFIX}/bin/python3
+  - chmod 0700 ${PYTHON_PREFIX}/bin/pip3
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+fromImage: common/distroless
+import:
+- artifact: {{ $.ModuleName }}/build-python-static-artifact
+  add: /opt/python-static
+  to: /opt/python-static
+  before: setup

--- a/modules/000-common/images/python-static/werf.inc.yaml
+++ b/modules/000-common/images/python-static/werf.inc.yaml
@@ -3,7 +3,7 @@ artifact: {{ .ModuleName }}/build-python-static-artifact
 from: {{ .Images.BASE_UBUNTU }}
 git:
 - add: /{{ $.ModulePath }}modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/Setup.local
-  to: /build/src/Modules/Setup.local
+  to: /build/Setup.local
   stageDependencies:
     install:
     - '**/*'
@@ -12,6 +12,7 @@ shell:
   - apt update && apt install -y --no-install-recommends build-essential tar gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev uuid-dev zlib1g-dev coreutils ca-certificates git
   - export PYTHON_VERSION=3.11.6 BUILD_THREADS=4 PYTHON_PREFIX=/opt/python-static
   - git clone -b v${PYTHON_VERSION} --single-branch --depth=1 {{ $.SOURCE_REPO }}/python/cpython.git /build/src
+  - cp /build/Setup.local /build/src/Modules/Setup.local
   - cd /build/src
   - ./configure LDFLAGS="-static" --disable-shared --prefix=${PYTHON_PREFIX} --enable-optimizations --with-ensurepip=install
   - make LDFLAGS="-static" LINKFORSHARED=" " -j ${BUILD_THREADS}

--- a/modules/000-common/images/python-static/werf.inc.yaml
+++ b/modules/000-common/images/python-static/werf.inc.yaml
@@ -9,7 +9,6 @@ git:
     - '**/*'
 shell:
   install:
-  - mkdir /build
   - apt update && apt install -y --no-install-recommends build-essential tar gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev uuid-dev zlib1g-dev coreutils ca-certificates git
   - export PYTHON_VERSION=3.11.6 BUILD_THREADS=4 PYTHON_PREFIX=/opt/python-static
   - git clone -b v${PYTHON_VERSION} --single-branch --depth=1 {{ $.SOURCE_REPO }}/python/cpython.git /build/src

--- a/modules/000-common/images/python-static/werf.inc.yaml
+++ b/modules/000-common/images/python-static/werf.inc.yaml
@@ -9,11 +9,11 @@ git:
     - '**/*'
 shell:
   install:
-  - mkdir /build && cd /build
+  - mkdir /build
   - apt update && apt install -y --no-install-recommends build-essential tar gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev uuid-dev zlib1g-dev coreutils ca-certificates git
   - export PYTHON_VERSION=3.11.6 BUILD_THREADS=4 PYTHON_PREFIX=/opt/python-static
-  - git clone -b v${PYTHON_VERSION} --single-branch --depth=1 {{ $.SOURCE_REPO }}/python/cpython.git ./src
-  - cd ./src
+  - git clone -b v${PYTHON_VERSION} --single-branch --depth=1 {{ $.SOURCE_REPO }}/python/cpython.git /build/src
+  - cd /build/src
   - ./configure LDFLAGS="-static" --disable-shared --prefix=${PYTHON_PREFIX} --enable-optimizations --with-ensurepip=install
   - make LDFLAGS="-static" LINKFORSHARED=" " -j ${BUILD_THREADS}
   - make install -j ${BUILD_THREADS}

--- a/modules/000-common/images/python-static/werf.inc.yaml
+++ b/modules/000-common/images/python-static/werf.inc.yaml
@@ -10,7 +10,7 @@ git:
 shell:
   install:
   - mkdir /build && cd /build
-  - apt update && apt install -y --no-install-recommends build-essential tar gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev uuid-dev zlib1g-dev coreutils ca-certificates
+  - apt update && apt install -y --no-install-recommends build-essential tar gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev uuid-dev zlib1g-dev coreutils ca-certificates git
   - export PYTHON_VERSION=3.11.6 BUILD_THREADS=4 PYTHON_PREFIX=/opt/python-static
   - git clone -b v${PYTHON_VERSION} --single-branch --depth=1 {{ $.SOURCE_REPO }}/python/cpython.git ./src
   - cd ./src

--- a/modules/340-monitoring-ping/images/monitoring-ping/Dockerfile
+++ b/modules/340-monitoring-ping/images/monitoring-ping/Dockerfile
@@ -1,6 +1,0 @@
-ARG BASE_PYTHON_ALPINE
-FROM $BASE_PYTHON_ALPINE
-COPY monitoring-ping.py requirements.txt /
-WORKDIR /
-RUN pip3 install --upgrade pip && pip3 install -r requirements.txt && apk add --no-cache fping
-ENTRYPOINT ["python3", "/monitoring-ping.py"]

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -4,7 +4,7 @@ from: {{ .Images.BASE_UBUNTU }}
 shell:
   install:
   - mkdir build && cd build
-  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf
+  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf autotools-dev
   - git clone -b v5.1 --single-branch --depth=1 {{ $.SOURCE_REPO }}/schweikert/fping.git ./src
   - cd ./src
   - autoreconf -i

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -30,6 +30,6 @@ import:
 shell:
   install:
   - cd /src
-  - /opt/pythnon-static/bin/pip3 install -r requirements.txt
+  - /opt/python-static/bin/pip3 install -r requirements.txt
 docker:
-  ENTRYPOINT: ["/opt/pythnon-static/bin/python3", "/src/monitoring-ping.py"]
+  ENTRYPOINT: ["/opt/python-static/bin/python3", "/src/monitoring-ping.py"]

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -29,7 +29,6 @@ import:
   before: setup
 shell:
   install:
-  -
   - cd /src
   - /opt/pythnon-static/bin/pip3 install -r requirements.txt
 docker:

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -25,7 +25,7 @@ git:
 import:
 - artifact: {{ $.ModuleName }}/build-fping-static-artifact
   add: /opt/fping-static/sbin/fping
-  to: /usr/local/sbin/fping
+  to: /usr/sbin/fping
   before: setup
 shell:
   install:

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -4,7 +4,7 @@ from: {{ .Images.BASE_UBUNTU }}
 shell:
   install:
   - mkdir build && cd build
-  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates
+  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf
   - git clone -b v5.1 --single-branch --depth=1 {{ $.SOURCE_REPO }}/schweikert/fping.git ./src
   - cd ./src
   - autoreconf -i

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -1,0 +1,36 @@
+---
+artifact: {{ .ModuleName }}/build-fping-static-artifact
+from: {{ .Images.BASE_UBUNTU }}
+shell:
+  install:
+  - mkdir build && cd build
+  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates
+  - git clone -b v5.1 --single-branch --depth=1 {{ $.SOURCE_REPO }}/schweikert/fping.git ./src
+  - cd ./src
+  - autoreconf -i
+  - ./configure LDFLAGS="-static" --prefix=/opt/fping-static
+  - make
+  - make install
+  - chown -R 64535:64535 /opt/fping-static
+  - chmod 0700 /opt/fping-static/sbin/fping
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/python-static
+git:
+- add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/
+  to: /src
+  stageDependencies:
+    install:
+    - '**/*'
+import:
+- artifact: {{ $.ModuleName }}/build-fping-static-artifact
+  add: /opt/fping-static/sbin/fping
+  to: /usr/local/sbin/fping
+  before: setup
+shell:
+  install:
+  -
+  - cd /src
+  - /opt/pythnon-static/bin/pip3 install -r requirements.txt
+docker:
+  ENTRYPOINT: ["/opt/pythnon-static/bin/python3", "/src/monitoring-ping.py"]

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -4,7 +4,7 @@ from: {{ .Images.BASE_UBUNTU }}
 shell:
   install:
   - mkdir build && cd build
-  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf autotools-dev
+  - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf autotools-dev automake
   - git clone -b v5.1 --single-branch --depth=1 {{ $.SOURCE_REPO }}/schweikert/fping.git ./src
   - cd ./src
   - autoreconf -i

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,7 +51,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: monitoring-ping
       initContainers:
       - command:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -52,21 +52,21 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       serviceAccountName: monitoring-ping
-      securityContext:
-        allowPrivilegeEscalation: true
-        capabilities:
-          add:
-          - NET_RAW
-          - DAC_OVERRIDE
-          drop:
-          - ALL
-        readOnlyRootFilesystem: true
-        runAsGroup: 0
-        runAsNonRoot: false
-        runAsUser: 0
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_RAW
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
         env:
           - name: MY_NODE_NAME
             valueFrom:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,8 +51,25 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_deckhouse" . | nindent 6 }}
       serviceAccountName: monitoring-ping
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - chown -vfR 64535:64535 /node-exporter-textfile/
+        image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
+        imagePullPolicy: IfNotPresent
+        name: fix-permissions
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - name: textfile
+          mountPath: /node-exporter-textfile
+        resources:
+          requests:
+            {{ include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -52,7 +52,8 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
 
-      {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ -}}
+      {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ }}
+
       securityContext:
         allowPrivilegeEscalation: true
         capabilities:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,6 +51,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      serviceAccountName: monitoring-ping
       securityContext:
         allowPrivilegeEscalation: true
         capabilities:
@@ -63,7 +64,6 @@ spec:
         runAsGroup: 0
         runAsNonRoot: false
         runAsUser: 0
-      serviceAccountName: monitoring-ping
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,9 +51,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-
-      {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ }}
-
       securityContext:
         allowPrivilegeEscalation: true
         capabilities:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -56,7 +56,9 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping
-        {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ }}
+        {{- /*
+          UID: 0 GID:0 using for privilege access for fping because using hostNetwork
+        */ }}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -58,7 +58,7 @@ spec:
         name: monitoring-ping
         {{- /*
           UID: 0 GID:0 using for privilege access for fping because using hostNetwork
-        */ }}
+        */}}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -56,7 +56,7 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping
-        {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ -}}
+        {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ }}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,29 +51,23 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ -}}
+      securityContext:
+        allowPrivilegeEscalation: true
+        capabilities:
+          add:
+          - NET_RAW
+          - DAC_OVERRIDE
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
       serviceAccountName: monitoring-ping
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - chown -vfR 64535:64535 /node-exporter-textfile/
-        image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
-        imagePullPolicy: IfNotPresent
-        name: fix-permissions
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - name: textfile
-          mountPath: /node-exporter-textfile
-        resources:
-          requests:
-            {{ include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add"  (list . (list "NET_RAW")) | nindent 8 }}
         env:
           - name: MY_NODE_NAME
             valueFrom:

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,6 +51,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+
       {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ -}}
       securityContext:
         allowPrivilegeEscalation: true

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -51,10 +51,12 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: monitoring-ping
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping
+        {{- /* UID: 0 GID:0 using for privilege access for fping because using hostNetwork */ -}}
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -138,6 +138,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"kubeRbacProxy":             "imageHash-common-kubeRbacProxy",
 		"nginxStatic":               "imageHash-common-nginxStatic",
 		"pause":                     "imageHash-common-pause",
+		"pythonStatic":              "imageHash-common-pythonStatic",
 		"shellOperator":             "imageHash-common-shellOperator",
 	},
 	"containerizedDataImporter": map[string]interface{}{


### PR DESCRIPTION
## Description
Switch monitoring-ping to use distroless image and static build a python
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Unification of the approach to the development of module images
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-ping
type: feature
summary: Switch monitoring-ping to use distroless image and static build a python
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
