### PR TITLE
[dhctl] FIX AWS install

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -325,6 +325,8 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 				return err
 			},
 		})
+	} else {
+		return fmt.Errorf("Internal error. Cluster UUID is empty.")
 	}
 
 	if cfg.KubeDNSAddress != "" {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -40,23 +40,30 @@ func TestDeckhouseInstall(t *testing.T) {
 			func() error {
 				return CreateDeckhouseManifests(fakeClient, &Config{})
 			},
-			false,
+			true,
 		},
 		{
 			"Double install",
 			func() error {
-				err := CreateDeckhouseManifests(fakeClient, &Config{})
+				err := CreateDeckhouseManifests(fakeClient, &Config{
+					UUID: "aaaaa",
+				})
 				if err != nil {
 					return err
 				}
-				return CreateDeckhouseManifests(fakeClient, &Config{})
+				return CreateDeckhouseManifests(fakeClient, &Config{
+					UUID: "aaaaa",
+				})
 			},
 			false,
 		},
 		{
 			"With docker cfg",
 			func() error {
-				err := CreateDeckhouseManifests(fakeClient, &Config{Registry: config.RegistryData{DockerCfg: "YW55dGhpbmc="}})
+				err := CreateDeckhouseManifests(fakeClient, &Config{
+					UUID:     "aaaaa",
+					Registry: config.RegistryData{DockerCfg: "YW55dGhpbmc="},
+				})
 				if err != nil {
 					return err
 				}
@@ -81,6 +88,7 @@ func TestDeckhouseInstall(t *testing.T) {
 					ProviderClusterConfig: []byte(`test`),
 					TerraformState:        []byte(`test`),
 					DeckhouseConfig:       map[string]interface{}{"test": "test"},
+					UUID:                  "aaaaa",
 				}
 				err := CreateDeckhouseManifests(fakeClient, &conf)
 				if err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -223,7 +223,11 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 
 	printBanner()
 
-	showWarningAboutUsageDontUsePublicImagesFlagIfNeed()
+	clusterUUID, err := generateClusterUUID(stateCache)
+	if err != nil {
+		return err
+	}
+	metaConfig.UUID = clusterUUID
 
 	deckhouseInstallConfig, err := deckhouse.PrepareDeckhouseInstallConfig(metaConfig)
 	if err != nil {
@@ -237,12 +241,6 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	preflightCheck := preflight.NewPreflightCheck(sshClient, deckhouseInstallConfig)
 
 	bootstrapState := NewBootstrapState(stateCache)
-
-	clusterUUID, err := generateClusterUUID(stateCache)
-	if err != nil {
-		return err
-	}
-	metaConfig.UUID = clusterUUID
 
 	if shouldStop, err := b.PhasedExecutionContext.StartPhase(phases.BaseInfraPhase, true); err != nil {
 		return err
@@ -447,17 +445,6 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 
 func printBanner() {
 	log.InfoLn(banner)
-}
-
-func showWarningAboutUsageDontUsePublicImagesFlagIfNeed() {
-	deprecationBanner := "" +
-		`!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! DO NOT USE --dont-use-public-control-plane-images FLAG                               !
-! IT IS DEPRECATED AND WILL BE REMOVED IN THE FUTURE                                   !
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`
-	if app.DontUsePublicControlPlaneImages {
-		log.ErrorLn(deprecationBanner)
-	}
 }
 
 func generateClusterUUID(stateCache state.Cache) (string, error) {

--- a/modules/002-deckhouse/hooks/change_host_ip.go
+++ b/modules/002-deckhouse/hooks/change_host_ip.go
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 */
 
 package hooks

--- a/modules/002-deckhouse/hooks/change_host_ip.go
+++ b/modules/002-deckhouse/hooks/change_host_ip.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package hooks


### PR DESCRIPTION
## Description
Secret with cluster uuid was not created.
Cluster uuid is required now.
And remove deprecated banner.

## Why do we need it, and what problem does it solve?
AWS cluster did not bootstrap

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: FIX AWS install
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
