### PR TITLE
[candi] Update version_map.yml

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -13,7 +13,9 @@ bashible: &bashible
     '9':
   altlinux:
     'p10':
+    '10.0':
     '10.1':
+    '10.2':
 k8s:
   '1.24':
     status: available


### PR DESCRIPTION
## Description

Add ALT Linux 10.0, 10.2 to the version_map.yml.

Ref: https://github.com/deckhouse/deckhouse/pull/6215

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: candi
type: chore
summary: Add ALT Linux 10.0, 10.2 to the version_map.yml.
impact_level: low
```
