### PR TITLE
[deckhouse] don't respect DeckhouseRelease applyAfter on manual updates

### DIFF
--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -487,7 +487,7 @@ global:
 	})
 
 	// manual release creation, for testing in a cluster
-	Context("Generate release", func() {
+	XContext("Generate release", func() {
 		const releaseJSON = `
 			{"canary":{"alpha":{"enabled":true,"interval":"5m","waves":2},"beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5},"stable":{"enabled":true,"interval":"30m","waves":6}},"disruptions":{"1.36":["ingressNginx"]},"requirements":{"ingressNginx":"0.33","k8s":"1.19.0"},"version":"v1.666.0"}
 	`
@@ -507,9 +507,9 @@ global:
 		})
 		It("Manual release creation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			// rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.666.0")
-			// fmt.Println("\n" + rl.ToYaml())
-			// time.Sleep(300 * time.Millisecond)
+			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.666.0")
+			fmt.Println("\n" + rl.ToYaml())
+			time.Sleep(300 * time.Millisecond)
 		})
 	})
 

--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -225,7 +225,6 @@ status:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
-			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
 			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.0").Field("status.phase").String()).To(Equal("Pending"))
 		})
 	})
@@ -488,7 +487,7 @@ global:
 	})
 
 	// manual release creation, for testing in a cluster
-	XContext("Generate release", func() {
+	Context("Generate release", func() {
 		const releaseJSON = `
 			{"canary":{"alpha":{"enabled":true,"interval":"5m","waves":2},"beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5},"stable":{"enabled":true,"interval":"30m","waves":6}},"disruptions":{"1.36":["ingressNginx"]},"requirements":{"ingressNginx":"0.33","k8s":"1.19.0"},"version":"v1.666.0"}
 	`
@@ -508,9 +507,9 @@ global:
 		})
 		It("Manual release creation", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.666.0")
-			fmt.Println("\n" + rl.ToYaml())
-			time.Sleep(300 * time.Millisecond)
+			// rl := f.KubernetesGlobalResource("DeckhouseRelease", "v1.666.0")
+			// fmt.Println("\n" + rl.ToYaml())
+			// time.Sleep(300 * time.Millisecond)
 		})
 	})
 

--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -205,7 +205,7 @@ func (du *DeckhouseUpdater) checkMinorReleaseConditions(predictedRelease *Deckho
 	}
 
 	// check: canary settings
-	if predictedRelease.ApplyAfter != nil {
+	if predictedRelease.ApplyAfter != nil && !du.inManualMode {
 		if du.now.Before(*predictedRelease.ApplyAfter) {
 			du.input.LogEntry.Infof("Release %s is postponed by canary process. Waiting", predictedRelease.Name)
 			du.updateStatus(predictedRelease, fmt.Sprintf("Release is postponed until: %s", predictedRelease.ApplyAfter.Format(time.RFC822)), v1alpha1.PhasePending)
@@ -548,11 +548,9 @@ func (du *DeckhouseUpdater) patchManualRelease(release DeckhouseRelease) Deckhou
 
 	if !release.ManuallyApproved {
 		release.Status.Approved = false
-		release.Status.Message = waitingManualApprovalMsg
 		du.totalPendingManualReleases++
 	} else {
 		release.Status.Approved = true
-		release.Status.Message = ""
 	}
 
 	return release


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Don't respect DeckhouseRelease applyAfter on manual updates

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
https://github.com/deckhouse/deckhouse/issues/6188

## What is the expected result?
In manual mode, deckhouse is updated regardless of the presence of the applyAfter release field
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Canary release disabled for manual update mode
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
