### PR TITLE
[docs][capi] Documentation updates

### DIFF
--- a/candi/openapi/doc-ru-node_group.yaml
+++ b/candi/openapi/doc-ru-node_group.yaml
@@ -507,6 +507,37 @@ spec:
                       properties:
                         criSocketPath:
                           description: Путь к сокету CRI.
+                staticInstances:
+                  description: |
+                    Параметры настройки машин статичных узлов кластера.
+                  properties:
+                    labelSelector:
+                      description: |
+                        Настройка фильтра меток (label) по ресурсам.
+
+                        Если указаны одновременно `matchExpressions` и `matchLabels`, учитываются оба фильтра (операция `И`).
+
+                         Пустое значение `labelSelector` соответствует всем объектам. Нулевое — никаким.
+                      properties:
+                        matchExpressions:
+                          description: |
+                            Список фильтров на основе выражений.
+
+                            Итоговый результат — результат пересечения множеств, определяемых всеми фильтрами в списке (операция `И`).
+                          items:
+                            properties:
+                              key:
+                                description: Имя метки.
+                              operator:
+                                description: Оператор сравнения.
+                              values:
+                                description: Значение метки.
+                        matchLabels:
+                          description: |
+                            Фильтр на основе совпадения/несовпадения меток.
+                    count:
+                      description: |
+                         Количество виртуальных машин, которые нужно создать.
                 cloudInstances:
                   description: |
                     Параметры заказа облачных виртуальных машин.

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -10,6 +10,12 @@
   - '*/docs/internal/'
   - '005-external-module-manager/crds/external-module-*'
   - '040-node-manager/crds/mcm.yaml'
+  - '040-node-manager/crds/cluster.yaml'
+  - '040-node-manager/crds/extension-config.yaml'
+  - '040-node-manager/crds/machine.yaml'
+  - '040-node-manager/crds/machine-*.yaml'
+  - '040-node-manager/crds/staticcontrolplane.yaml'
+  - '040-node-manager/crds/staticmachine*.yaml'
   - '110-istio/crds/istio'
   - '490-virtualization/crds/kubevirt.yaml'
   includePaths: ['*/docs/','*/openapi/','*/crds/', '*/oss.yaml']

--- a/modules/040-node-manager/crds/doc-ru-nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/crds/doc-ru-nodegroupconfiguration.yaml
@@ -30,7 +30,7 @@ spec:
                   description: Список NodeGroup, к которым нужно применять шаг конфигурации. Для выбора всех NodeGroups нужно указать '*'.
                 bundles:
                   description: |
-                    Список bundle'ов, для которых быдет выполняться скрипт. Для выбора всех bundle'ов нужно указать `'*'`.
+                    Список bundle'ов, для которых будет выполняться скрипт. Для выбора всех bundle'ов нужно указать `'*'`.
 
                     Список возможных bundle'ов такой же, как у параметра [allowedBundles](configuration.html#parameters-allowedbundles) модуля.
 


### PR DESCRIPTION
Ref: b5cb17b87e9ff0e870438e69aedb18e1f58993fe

Ref: https://github.com/deckhouse/deckhouse/pull/5432

## Description
Remove internal CRDs from the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove internal CRDs from the documentation.
impact_level: low
```
