### PR TITLE
[runtime-audit-engine] Set Notice priority for rules requiring notification of security officer

### DIFF
--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -340,7 +340,7 @@ spec:
           kactivity and kcreate and serviceaccount and response_successful
         desc: Detect any attempt to create a service account
         output: K8s Serviceaccount Created (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -351,7 +351,7 @@ spec:
           kactivity and kdelete and serviceaccount and response_successful
         desc: Detect any attempt to delete a service account
         output: K8s Serviceaccount Deleted (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -362,7 +362,7 @@ spec:
           kactivity and kcreate and (clusterrole or role) and response_successful
         desc: Detect any attempt to create a cluster role/role
         output: K8s Cluster Role Created (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -372,7 +372,7 @@ spec:
         condition: kactivity and kdelete and (clusterrole or role) and response_successful
         desc: Detect any attempt to delete a cluster role/role
         output: K8s Cluster Role Deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -383,7 +383,7 @@ spec:
           kactivity and kcreate and clusterrolebinding and response_successful
         desc: Detect any attempt to create a clusterrolebinding
         output: K8s Cluster Role Binding Created (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -395,7 +395,7 @@ spec:
         desc: Detect any attempt to delete a clusterrolebinding
         output: |
           K8s Cluster Role Binding Deleted (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -407,7 +407,7 @@ spec:
         desc: An attempt to read container image file in the containerd directory
         output: |
           File below a known containerd directory opened for reading (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - container_image_access
@@ -429,7 +429,7 @@ spec:
         desc: Not all pods are under integrity control in a system namespace
         output: |
           Not all containers are running with the sha256 sum as a tag in a system namespace, which is a potential integrity control mechanism misconfiguration (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason image=%ka.req.pod.containers.image)
-        priority: Informational
+        priority: Notice
         tags:
           - fstec
           - integrity_control


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Set Notice priority for rules requiring notification of security officer

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Increased priority allows clarifying alerts [creation](https://deckhouse.io/documentation/v1/modules/650-runtime-audit-engine/faq.html#how-to-create-an-alert).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: Set Notice priority for rules requiring notification of security officer
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
