### PR TITLE
[dhctl] Add SSH debug options if dhctl debug is enabled and increase ssh timeouts

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -352,8 +352,6 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 				return err
 			},
 		})
-	} else {
-		return fmt.Errorf("Internal error. Cluster UUID is empty.")
 	}
 
 	if cfg.KubeDNSAddress != "" {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -40,20 +40,16 @@ func TestDeckhouseInstall(t *testing.T) {
 			func() error {
 				return CreateDeckhouseManifests(fakeClient, &Config{})
 			},
-			true,
+			false,
 		},
 		{
 			"Double install",
 			func() error {
-				err := CreateDeckhouseManifests(fakeClient, &Config{
-					UUID: "aaaaa",
-				})
+				err := CreateDeckhouseManifests(fakeClient, &Config{})
 				if err != nil {
 					return err
 				}
-				return CreateDeckhouseManifests(fakeClient, &Config{
-					UUID: "aaaaa",
-				})
+				return CreateDeckhouseManifests(fakeClient, &Config{})
 			},
 			false,
 		},
@@ -61,7 +57,6 @@ func TestDeckhouseInstall(t *testing.T) {
 			"With docker cfg",
 			func() error {
 				err := CreateDeckhouseManifests(fakeClient, &Config{
-					UUID:     "aaaaa",
 					Registry: config.RegistryData{DockerCfg: "YW55dGhpbmc="},
 				})
 				if err != nil {
@@ -88,7 +83,6 @@ func TestDeckhouseInstall(t *testing.T) {
 					ProviderClusterConfig: []byte(`test`),
 					TerraformState:        []byte(`test`),
 					DeckhouseConfig:       map[string]interface{}{"test": "test"},
-					UUID:                  "aaaaa",
 				}
 				err := CreateDeckhouseManifests(fakeClient, &conf)
 				if err != nil {

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -45,7 +45,7 @@ func (pc *Checker) CheckSSHTunel() error {
 	err := tun.Up()
 	if err != nil {
 		return fmt.Errorf(`Cannot setup tunnel to control-plane host: %w.
-Please check connectivity to control-plane host or
+Please check connectivity to control-plane host or bastion or
 check that sshd config 'AllowTcpForwarding' set to 'yes' on control-plane node.`, err)
 	}
 

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -45,7 +45,7 @@ func (pc *Checker) CheckSSHTunel() error {
 	err := tun.Up()
 	if err != nil {
 		return fmt.Errorf(`Cannot setup tunnel to control-plane host: %w.
-Please check connectivity to control-plane host or bastion or
+Please check connectivity to control-plane host or
 check that sshd config 'AllowTcpForwarding' set to 'yes' on control-plane node.`, err)
 	}
 

--- a/dhctl/pkg/system/ssh/cmd/scp.go
+++ b/dhctl/pkg/system/ssh/cmd/scp.go
@@ -20,6 +20,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/process"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )
@@ -88,6 +90,10 @@ func (s *SCP) SCP() *SCP {
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "UserKnownHostsFile=.ssh_known_hosts",
 		"-o", "PasswordAuthentication=no",
+	}
+
+	if app.IsDebug {
+		args = append(args, "-vvv")
 	}
 
 	if s.Session.ExtraArgs != "" {

--- a/dhctl/pkg/system/ssh/cmd/scp.go
+++ b/dhctl/pkg/system/ssh/cmd/scp.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/process"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )

--- a/dhctl/pkg/system/ssh/cmd/ssh.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/process"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )
@@ -77,6 +78,10 @@ func (s *SSH) Cmd() *exec.Cmd {
 		"-o", "ServerAliveCountMax=2",
 		"-o", "ConnectTimeout=5",
 		"-o", "PasswordAuthentication=no",
+	}
+
+	if app.IsDebug {
+		args = append(args, "-vvv")
 	}
 
 	if s.Session.ExtraArgs != "" {

--- a/dhctl/pkg/system/ssh/cmd/ssh.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/process"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )
@@ -136,6 +137,8 @@ func (s *SSH) Cmd() *exec.Cmd {
 		args = append(args, "--" /* cmd.Path */, s.CommandName)
 		args = append(args, s.CommandArgs...)
 	}
+
+	log.DebugF("SSH arguments %v\n", args)
 
 	sshCmd := exec.Command("ssh", args...)
 	sshCmd.Env = env

--- a/dhctl/pkg/system/ssh/cmd/ssh.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh.go
@@ -74,9 +74,9 @@ func (s *SSH) Cmd() *exec.Cmd {
 		"-o", "ControlPersist=600s",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "UserKnownHostsFile=.ssh_known_hosts",
-		"-o", "ServerAliveInterval=7",
-		"-o", "ServerAliveCountMax=2",
-		"-o", "ConnectTimeout=5",
+		"-o", "ServerAliveInterval=10",
+		"-o", "ServerAliveCountMax=3",
+		"-o", "ConnectTimeout=15",
 		"-o", "PasswordAuthentication=no",
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add SSH debug options if dhctl debug is enabled and increase ssh timeouts

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
ssh debug  flags did not work.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add SSH debug options if dhctl debug is enabled and increase ssh timeouts.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
