### PR TITLE
[candi] cluster-api static controller various improvements

### DIFF
--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -61,9 +61,8 @@ unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 # Install necessary packages.
 basic_bootstrap_${BUNDLE}
 
-bootstrap_job_log_pid=""
-
-# Put bootstrap log information to Machine resource status
+{{- if or (eq .nodeGroup.nodeType "CloudEphemeral") (hasKey .nodeGroup "staticInstances") }}
+# Put bootstrap log information to Machine resource status if it is a cloud installation or cluster-api static machine
 patch_pending=true
 output_log_port=8000
 while [ "$patch_pending" = true ] ; do
@@ -101,6 +100,7 @@ while [ "$patch_pending" = true ] ; do
     fi
   done
 done
+{{- end }}
 
 # IMPORTANT !!! Centos/Redhat put jq in /usr/local/bin but it is not in PATH.
 export PATH="/opt/deckhouse/bin:$PATH"

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -74,6 +74,12 @@ while [ "$patch_pending" = true ] ; do
       sleep 1
     done
 
+    machine_name="$(hostname -s)"
+    if [ -f ${BOOTSTRAP_DIR}/machine-name ]; then
+      machine_name="$(<${BOOTSTRAP_DIR}/machine-name)"
+      rm -f ${BOOTSTRAP_DIR}/machine-name
+    fi
+
     if curl -sS --fail -x "" \
       --max-time 10 \
       -XPATCH \
@@ -82,7 +88,7 @@ while [ "$patch_pending" = true ] ; do
       -H "Content-Type: application/json-patch+json" \
       --cacert "$BOOTSTRAP_DIR/ca.crt" \
       --data "[{\"op\":\"add\",\"path\":\"/status/bootstrapStatus\", \"value\": {\"description\": \"Use 'nc ${tcp_endpoint} ${output_log_port}' to get bootstrap logs.\", \"logsEndpoint\": \"${tcp_endpoint}:${output_log_port}\"} }]" \
-      "https://$server/apis/deckhouse.io/v1alpha1/instances/$(hostname -s)/status" ; then
+      "https://$server/apis/deckhouse.io/v1alpha1/instances/${machine_name}/status" ; then
 
       echo "Successfully patched instance $(hostname -s) status."
       patch_pending=false

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -29,6 +29,7 @@ shopt -s failglob
 BOOTSTRAP_DIR="/var/lib/bashible"
 TMPDIR="/opt/deckhouse/tmp"
 mkdir -p "$BOOTSTRAP_DIR" "$TMPDIR"
+exec >"$TMPDIR/bootstrap.log" 2>&1
 
 # Directory contains sensitive information
 chmod 0700 $BOOTSTRAP_DIR

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -90,12 +90,12 @@ while [ "$patch_pending" = true ] ; do
       --data "[{\"op\":\"add\",\"path\":\"/status/bootstrapStatus\", \"value\": {\"description\": \"Use 'nc ${tcp_endpoint} ${output_log_port}' to get bootstrap logs.\", \"logsEndpoint\": \"${tcp_endpoint}:${output_log_port}\"} }]" \
       "https://$server/apis/deckhouse.io/v1alpha1/instances/${machine_name}/status" ; then
 
-      echo "Successfully patched instance $(hostname -s) status."
+      echo "Successfully patched instance ${machine_name} status."
       patch_pending=false
 
       break
     else
-      >&2 echo "Failed to patch instance $(hostname -s) status."
+      >&2 echo "Failed to patch instance ${machine_name} status."
       sleep 10
       continue
     fi

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -63,7 +63,6 @@ basic_bootstrap_${BUNDLE}
 
 bootstrap_job_log_pid=""
 
-  {{- if eq .nodeGroup.nodeType "CloudEphemeral" }}
 # Put bootstrap log information to Machine resource status
 patch_pending=true
 output_log_port=8000
@@ -85,18 +84,17 @@ while [ "$patch_pending" = true ] ; do
       --data "[{\"op\":\"add\",\"path\":\"/status/bootstrapStatus\", \"value\": {\"description\": \"Use 'nc ${tcp_endpoint} ${output_log_port}' to get bootstrap logs.\", \"logsEndpoint\": \"${tcp_endpoint}:${output_log_port}\"} }]" \
       "https://$server/apis/deckhouse.io/v1alpha1/instances/$(hostname -s)/status" ; then
 
-      echo "Successfully patched machine $(hostname -s) status."
+      echo "Successfully patched instance $(hostname -s) status."
       patch_pending=false
 
       break
     else
-      >&2 echo "Failed to patch machine $(hostname -s) status."
+      >&2 echo "Failed to patch instance $(hostname -s) status."
       sleep 10
       continue
     fi
   done
 done
-  {{- end }}
 
 # IMPORTANT !!! Centos/Redhat put jq in /usr/local/bin but it is not in PATH.
 export PATH="/opt/deckhouse/bin:$PATH"

--- a/modules/040-node-manager/crds/cluster.yaml
+++ b/modules/040-node-manager/crds/cluster.yaml
@@ -17,8 +17,6 @@ spec:
     kind: Cluster
     listKind: ClusterList
     plural: clusters
-    shortNames:
-      - cl
     singular: cluster
   scope: Namespaced
   versions:

--- a/modules/040-node-manager/crds/extension-config.yaml
+++ b/modules/040-node-manager/crds/extension-config.yaml
@@ -17,8 +17,6 @@ spec:
     kind: ExtensionConfig
     listKind: ExtensionConfigList
     plural: extensionconfigs
-    shortNames:
-    - ext
     singular: extensionconfig
   scope: Cluster
   versions:

--- a/modules/040-node-manager/crds/machine-deployment.yaml
+++ b/modules/040-node-manager/crds/machine-deployment.yaml
@@ -17,8 +17,6 @@ spec:
     kind: MachineDeployment
     listKind: MachineDeploymentList
     plural: machinedeployments
-    shortNames:
-      - md
     singular: machinedeployment
   scope: Namespaced
   versions:

--- a/modules/040-node-manager/crds/machine-health-check.yaml
+++ b/modules/040-node-manager/crds/machine-health-check.yaml
@@ -17,9 +17,6 @@ spec:
     kind: MachineHealthCheck
     listKind: MachineHealthCheckList
     plural: machinehealthchecks
-    shortNames:
-      - mhc
-      - mhcs
     singular: machinehealthcheck
   scope: Namespaced
   versions:

--- a/modules/040-node-manager/crds/machine-pools.yaml
+++ b/modules/040-node-manager/crds/machine-pools.yaml
@@ -17,8 +17,6 @@ spec:
     kind: MachinePool
     listKind: MachinePoolList
     plural: machinepools
-    shortNames:
-      - mp
     singular: machinepool
   scope: Namespaced
   versions:

--- a/modules/040-node-manager/crds/machine-sets.yaml
+++ b/modules/040-node-manager/crds/machine-sets.yaml
@@ -17,8 +17,6 @@ spec:
     kind: MachineSet
     listKind: MachineSetList
     plural: machinesets
-    shortNames:
-      - ms
     singular: machineset
   scope: Namespaced
   versions:

--- a/modules/040-node-manager/crds/machine.yaml
+++ b/modules/040-node-manager/crds/machine.yaml
@@ -15,8 +15,6 @@ spec:
     kind: Machine
     listKind: MachineList
     plural: machines
-    shortNames:
-      - ma
     singular: machine
   scope: Namespaced
   versions:

--- a/modules/040-node-manager/hooks/generate_capi_static_kubeconfig_secret.go
+++ b/modules/040-node-manager/hooks/generate_capi_static_kubeconfig_secret.go
@@ -61,15 +61,13 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: staticInstancesNodeGroupFilter,
 		},
 	},
-	OnAfterHelm: &go_hook.OrderedConfig{
-		Order: 10,
-	},
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "capi_static_kubeconfig_secret",
 			Crontab: "0 1 * * *",
 		},
 	},
+	AllowFailure: true,
 }, dependency.WithExternalDependencies(generateStaticKubeconfigSecret))
 
 func generateStaticKubeconfigSecret(input *go_hook.HookInput, dc dependency.Container) error {

--- a/modules/040-node-manager/hooks/generate_capi_static_kubeconfig_secret.go
+++ b/modules/040-node-manager/hooks/generate_capi_static_kubeconfig_secret.go
@@ -52,6 +52,7 @@ var (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/capi",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "node_group",
@@ -59,6 +60,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Kind:       "NodeGroup",
 			FilterFunc: staticInstancesNodeGroupFilter,
 		},
+	},
+	OnAfterHelm: &go_hook.OrderedConfig{
+		Order: 10,
 	},
 	Schedule: []go_hook.ScheduleConfig{
 		{

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
@@ -141,7 +141,7 @@ func (c *Client) bootstrap(ctx context.Context, instanceScope *scope.InstanceSco
 	}
 
 	done := c.spawn(instanceScope.MachineScope.StaticMachine.Spec.ProviderID, func() bool {
-		err := ssh.ExecSSHCommand(instanceScope, fmt.Sprintf("mkdir /var/lib/bashible || exit 0 && echo '%s' > /var/lib/bashible/node-spec-provider-id && echo '%s' | base64 -d | bash", instanceScope.MachineScope.StaticMachine.Spec.ProviderID, base64.StdEncoding.EncodeToString(bootstrapScript)), nil)
+		err := ssh.ExecSSHCommand(instanceScope, fmt.Sprintf("mkdir /var/lib/bashible || exit 0 && echo '%s' > /var/lib/bashible/node-spec-provider-id && echo '%s' > /var/lib/bashible/machine-name && echo '%s' | base64 -d | bash", instanceScope.MachineScope.StaticMachine.Spec.ProviderID, instanceScope.MachineScope.Machine.Name, base64.StdEncoding.EncodeToString(bootstrapScript)), nil)
 		if err != nil {
 			// If Node reboots, the ssh connection will close, and we will get an error.
 			instanceScope.Logger.Error(err, "Failed to bootstrap StaticInstance: failed to exec ssh command")

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -147,4 +147,5 @@ get_phase2 | bash
 if [ -n "${bootstrap_job_log_pid-}" ] && kill -s 0 "${bootstrap_job_log_pid-}" 2>/dev/null; then
   kill -9 "${bootstrap_job_log_pid-}"
 fi
+echo "Bootstrap finished"
 {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -131,7 +131,7 @@ function run_log_output() {
     socat -u FILE:/var/log/cloud-init-output.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
     bootstrap_job_log_pid=$!
   else
-    while true; do cat /var/log/cloud-init-output.log | nc -l "$tcp_endpoint" "$output_log_port"; done &
+    while true; do cat /var/log/cloud-init-output.log | nc -l "$output_log_port"; done &
     bootstrap_job_log_pid=$!
   fi
 }

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -135,7 +135,6 @@ function run_log_output() {
     bootstrap_job_log_pid=$!
   fi
 }
-
 BUNDLE="$(detect_bundle)"
 run_cloud_network_setup
 run_log_output
@@ -144,8 +143,8 @@ get_phase2 | bash
   {{- /*
 # Stop output bootstrap logs
   */}}
-if [ -n "${bootstrap_job_log_pid-}" ] && kill -s 0 "${bootstrap_job_log_pid-}" 2>/dev/null; then
-  kill -9 "${bootstrap_job_log_pid-}"
+echo "Killing pid ${bootstrap_job_log_pid}"
+if [ -n "${bootstrap_job_log_pid}" ] && kill -s 0 "${bootstrap_job_log_pid}" 2>/dev/null; then
+  kill -9 "${bootstrap_job_log_pid}"
 fi
-echo "Bootstrap finished"
 {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -131,7 +131,7 @@ function run_log_output() {
     socat -u FILE:/var/log/cloud-init-output.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
     bootstrap_job_log_pid=$!
   else
-    while true; do cat /var/log/cloud-init-output.log | nc -l "$output_log_port"; done &
+    while true; do cat /var/log/cloud-init-output.log | nc -l 8000; done &
     bootstrap_job_log_pid=$!
   fi
 }

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -131,7 +131,7 @@ function run_log_output() {
     socat -u FILE:${TMPDIR}/bootstrap.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
     bootstrap_job_log_pid=$!
   else
-    while true; do cat ${TMPDIR}/bootstrap.log | nc -l 8000; done &
+    tail -n 100 -f ${TMPDIR}/bootstrap.log | nc -l 8000 &
     bootstrap_job_log_pid=$!
   fi
 }

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -127,10 +127,7 @@ function run_log_output() {
   {{- /*
   # Start output bootstrap logs
   */}}
-  if type socat >/dev/null 2>&1; then
-    socat -u FILE:${TMPDIR}/bootstrap.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
-    bootstrap_job_log_pid=$!
-  else
+  if type nc >/dev/null 2>&1; then
     tail -n 100 -f ${TMPDIR}/bootstrap.log | nc -l 8000 &
     bootstrap_job_log_pid=$!
   fi
@@ -143,8 +140,7 @@ get_phase2 | bash
   {{- /*
 # Stop output bootstrap logs
   */}}
-echo "Killing pid ${bootstrap_job_log_pid}"
-if [ -n "${bootstrap_job_log_pid}" ] && kill -s 0 "${bootstrap_job_log_pid}" 2>/dev/null; then
+if [ -n "${bootstrap_job_log_pid}" ]; then
   kill -9 "${bootstrap_job_log_pid}"
 fi
 {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -128,10 +128,10 @@ function run_log_output() {
   # Start output bootstrap logs
   */}}
   if type socat >/dev/null 2>&1; then
-    socat -u FILE:/var/log/cloud-init-output.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
+    socat -u FILE:${TMPDIR}/bootstrap.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
     bootstrap_job_log_pid=$!
   else
-    while true; do cat /var/log/cloud-init-output.log | nc -l 8000; done &
+    while true; do cat ${TMPDIR}/bootstrap.log | nc -l 8000; done &
     bootstrap_job_log_pid=$!
   fi
 }

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -29,6 +29,4 @@ write_files:
 
 runcmd:
 - /var/lib/bashible/bootstrap.sh
-output:
-  all: "| tee -a /var/log/cloud-init-output.log"
 {{ end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. Fix CAPI kubeconfig hook, which cannot work on fresh installations. Running this hook after helm deployment.

2. Send name of capi machine to the bootstrapped node to properly patch corresponding instance status field.

3. Instance for cluster-api static instance now enriched with logs info same as for cloud instances.
```
bootstrapStatus:
    description: Use 'nc x.x.x.x 8000' to get bootstrap logs.
    logsEndpoint: x.x.x.x:8000
```
To see the logs from instance run command from master node:
`nc x.x.x.x 8000` now tails logs.

Bootstrap logs now saved to `/opt/deckhouse/tmp/bootstrap.log`.

4. Removed shortNames from CAPI crds.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
1. On the fresh install if we try to deploy NG with staticInstances field, we've got an error from deckhouse controller, due to improper order of running `generate_capi_static_kubeconfig_secret.go`. This hook runs before helm and fails due to absence cluster.x-k8s.io resource.

2. When we bootstrap static instance thru CAPS, we cannot properly patch status of instance resource, because instance resource name equals to CAPI machine name, but linux host name can differ from CAPI machine name. 

3. When we bootstrap cluster-api static instances we cannot see bootstrap logs from instance.

4. Cluster-api crds short names overlaps with our crds.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Send bootstrap logs from cluster-api static instances.
impact_level: default
---
section: candi
type: fix
summary: Fix CAPI kubeconfig hook, which cannot work on fresh installations.
impact_level: default
---
section: candi
type: fix
summary: Removed `shortNames` from CAPI CRDs.
impact_level: default
```
