### PR TITLE
[cloud-provider-yandex][docs] Setting custom storageclass as default FAQ

### DIFF
--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -45,19 +45,18 @@ If the dhcpOptions parameter is set, all DNS are routed to the DNS servers speci
 
 **Do not use** this option if the recursive DNSs specified cannot resolve the same list of zones that the recursive DNSs in the Yandex Cloud subnet can resolve.
 
-
 ## How to set custom StorageClass as default?
 
 Setting custom StorageClass as default:
 
 1. Add following annotation to your new StorageClass:
 
-```shell
-kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
-```
+   ```shell
+   kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
+   ```
 
 2. Insert StorageClass name in [spec](configuration.html#parameters-storageclass-default) `storageClass.default` in ModuleConfig `cloud-provider-yandex`. This will remove the annotation from previous StorageClass:
 
-```shell
-kubectl edit mc cloud-provider-yandex
-```
+   ```shell
+   kubectl edit mc cloud-provider-yandex
+   ```

--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -44,3 +44,20 @@ Pay attention to the following nuances:
 If the dhcpOptions parameter is set, all DNS are routed to the DNS servers specified. These DNS servers **must** serve DNS requests to the Internet and (if needed) resolve intranet resources.
 
 **Do not use** this option if the recursive DNSs specified cannot resolve the same list of zones that the recursive DNSs in the Yandex Cloud subnet can resolve.
+
+
+## How to set custom StorageClass as default?
+
+Setting custom StorageClass as default:
+
+1. Add following annotation to your new StorageClass:
+
+```shell
+kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
+```
+
+2. Insert StorageClass name in [spec](configuration.html#parameters-storageclass-default) `storageClass.default` in ModuleConfig `cloud-provider-yandex`. This will remove the annotation from previous StorageClass:
+
+```shell
+kubectl edit mc cloud-provider-yandex
+```

--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -45,9 +45,9 @@ If the dhcpOptions parameter is set, all DNS are routed to the DNS servers speci
 
 **Do not use** this option if the recursive DNSs specified cannot resolve the same list of zones that the recursive DNSs in the Yandex Cloud subnet can resolve.
 
-## How to set custom StorageClass as default?
+## How to set a custom StorageClass as default?
 
-Do the following steps to set a custom StorageClass as default:
+Do the following to set a custom StorageClass as default:
 
 1. Add `storageclass.kubernetes.io/is-default-class='true'` annotation to the StorageClass:
 
@@ -55,7 +55,7 @@ Do the following steps to set a custom StorageClass as default:
    kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
    ```
 
-2. Specify the StorageClass name in the [storageClass.default](configuration.html#parameters-storageclass-default) parameter in the `cloud-provider-yandex` module settings. Note that after that, the `storageclass.kubernetes.io/is-default-class='true'` annotation will be removed from the StorageClass, which was previously specified in the module settings as the default.
+2. Specify the StorageClass name in the [storageClass.default](configuration.html#parameters-storageclass-default) parameter in the `cloud-provider-yandex` module settings. Note that after doing so, the `storageclass.kubernetes.io/is-default-class='true'` annotation will be removed from the StorageClass that was previously listed in the module settings as the default one.
 
    ```shell
    kubectl edit mc cloud-provider-yandex

--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -47,15 +47,15 @@ If the dhcpOptions parameter is set, all DNS are routed to the DNS servers speci
 
 ## How to set custom StorageClass as default?
 
-Setting custom StorageClass as default:
+Do the following steps to set a custom StorageClass as default:
 
-1. Add following annotation to your new StorageClass:
+1. Add `storageclass.kubernetes.io/is-default-class='true'` annotation to the StorageClass:
 
    ```shell
    kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
    ```
 
-2. Insert StorageClass name in [spec](configuration.html#parameters-storageclass-default) `storageClass.default` in ModuleConfig `cloud-provider-yandex`. This will remove the annotation from previous StorageClass:
+2. Specify the StorageClass name in the [storageClass.default](configuration.html#parameters-storageclass-default) parameter in the `cloud-provider-yandex` module settings. Note that after that, the `storageclass.kubernetes.io/is-default-class='true'` annotation will be removed from the StorageClass, which was previously specified in the module settings as the default.
 
    ```shell
    kubectl edit mc cloud-provider-yandex

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -51,12 +51,12 @@ reserved: true
 
 1. Добавить на него аннотацию:
 
-```shell
-kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
-```
+   ```shell
+   kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
+   ```
 
 2. Вставить имя нового StorageClass в [опцию](configuration.html#parameters-storageclass-default) `storageClass.default` в ModuleConfig `cloud-provider-yandex`. Это снимет аннотацию со предыдущего StorageClass по-умолчанию
 
-```shell
-kubectl edit mc cloud-provider-yandex
-```
+   ```shell
+   kubectl edit mc cloud-provider-yandex
+   ```

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -44,3 +44,19 @@ reserved: true
 При использовании опции `dhcpOptions` все DNS-запросы начнут идти через указанные DNS-серверы. Эти DNS-серверы **должны** разрешать внешние DNS-имена, а также при необходимости разрешать DNS-имена внутренних ресурсов.
 
 **Не используйте** эту опцию, если указанные рекурсивные DNS-серверы не могут разрешать тот же список зон, что сможет разрешать рекурсивный DNS-сервер в подсети Yandex Cloud.
+
+## Как назначить свой StorageClass по-умолчанию?
+
+Для установки кастомного StorageClass для использования по умолчанию:
+
+1. Добавить на него аннотацию:
+
+```shell
+kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
+```
+
+2. Вставить имя нового StorageClass в [опцию](configuration.html#parameters-storageclass-default) `storageClass.default` в ModuleConfig `cloud-provider-yandex`. Это снимет аннотацию со предыдущего StorageClass по-умолчанию
+
+```shell
+kubectl edit mc cloud-provider-yandex
+```

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -47,7 +47,7 @@ reserved: true
 
 ## Как назначить произвольный StorageClass используемым по умолчанию?
 
-Для назначения произвольного StorageClass'а используемым по умолчанию, выполните следующие шаги:
+Чтобы назначить произвольный StorageClass используемым по умолчанию, выполните следующие шаги:
 
 1. Добавьте на StorageClass аннотацию `storageclass.kubernetes.io/is-default-class='true'`:
 
@@ -55,7 +55,7 @@ reserved: true
    kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
    ```
 
-2. Укажите имя StorageClass'а в параметре [storageClass.default](configuration.html#parameters-storageclass-default) в настройках модуля `cloud-provider-yandex`. Обратите внимание, что после этого аннотация `storageclass.kubernetes.io/is-default-class='true'` снимется со StorageClass, который был указан в настройках модуля ранее как используемый по умолчанию.
+2. Укажите имя StorageClass'а в параметре [storageClass.default](configuration.html#parameters-storageclass-default) в настройках модуля `cloud-provider-yandex`. Обратите внимание, что после этого аннотация `storageclass.kubernetes.io/is-default-class='true'` снимется со StorageClass'а, который ранее был указан в настройках модуля как используемый по умолчанию.
 
    ```shell
    kubectl edit mc cloud-provider-yandex

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -45,17 +45,17 @@ reserved: true
 
 **Не используйте** эту опцию, если указанные рекурсивные DNS-серверы не могут разрешать тот же список зон, что сможет разрешать рекурсивный DNS-сервер в подсети Yandex Cloud.
 
-## Как назначить свой StorageClass по-умолчанию?
+## Как назначить произвольный StorageClass используемым по умолчанию?
 
-Для установки кастомного StorageClass для использования по умолчанию:
+Для назначения произвольного StorageClass'а используемым по умолчанию, выполните следующие шаги:
 
-1. Добавить на него аннотацию:
+1. Добавьте на StorageClass аннотацию `storageclass.kubernetes.io/is-default-class='true'`:
 
    ```shell
    kubectl annotate sc $STORAGECLASS storageclass.kubernetes.io/is-default-class='true'
    ```
 
-2. Вставить имя нового StorageClass в [опцию](configuration.html#parameters-storageclass-default) `storageClass.default` в ModuleConfig `cloud-provider-yandex`. Это снимет аннотацию со предыдущего StorageClass по-умолчанию
+2. Укажите имя StorageClass'а в параметре [storageClass.default](configuration.html#parameters-storageclass-default) в настройках модуля `cloud-provider-yandex`. Обратите внимание, что после этого аннотация `storageclass.kubernetes.io/is-default-class='true'` снимется со StorageClass, который был указан в настройках модуля ранее как используемый по умолчанию.
 
    ```shell
    kubectl edit mc cloud-provider-yandex


### PR DESCRIPTION

## Description
Add FAQ paragraph on how to set custom StorageClass as default
## Why do we need it, and what problem does it solve?
Original issue https://github.com/deckhouse/deckhouse/issues/6213

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: chore
summary: Minor documentation updates.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
