### PR TITLE
[dhctl] Deckhouse registry mirroring

### DIFF
--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -1,0 +1,102 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/mirror"
+)
+
+func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
+	cmd := parent.Command("mirror", "Copy Deckhouse registry for air-gaped installation.")
+	app.DefineMirrorFlags(cmd)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		if app.MirrorRegistryHost != "" {
+			return log.Process("mirror", "Push mirrored Deckhouse Registry images to private registry", func() error {
+				return mirrorPushDeckhouseToPrivateRegistry()
+			})
+		}
+
+		return log.Process("mirror", "Pull Deckhouse to local filesystem", func() error {
+			return mirrorPullDeckhouseToLocalFilesystem()
+		})
+	})
+
+	return cmd
+}
+
+func mirrorPushDeckhouseToPrivateRegistry() error {
+	mirrorCtx := &mirror.Context{
+		Insecure:       app.MirrorInsecure,
+		RegistryHost:   app.MirrorRegistryHost,
+		RegistryRepo:   app.MirrorDeckhouseRegistryRepo,
+		ImagesPath:     app.MirrorImagesPath,
+		ValidationMode: mirror.ValidationMode(app.MirrorValidationMode),
+	}
+
+	if app.MirrorRegistryUsername != "" {
+		mirrorCtx.RegistryAuth = authn.FromConfig(authn.AuthConfig{
+			Username: app.MirrorRegistryUsername,
+			Password: app.MirrorRegistryPassword,
+		})
+	}
+
+	return operations.PushMirrorToRegistry(mirrorCtx)
+}
+
+func mirrorPullDeckhouseToLocalFilesystem() error {
+	mirrorCtx := &mirror.Context{
+		Insecure:     app.MirrorInsecure,
+		RegistryHost: app.MirrorRegistryHost,
+		RegistryRepo: app.MirrorDeckhouseRegistryRepo,
+		RegistryAuth: authn.FromConfig(authn.AuthConfig{
+			Username: "license-token",
+			Password: app.MirrorDHLicenseToken,
+		}),
+		ImagesPath:     app.MirrorImagesPath,
+		ValidationMode: mirror.ValidationMode(app.MirrorValidationMode),
+		MinVersion:     app.MirrorMinVersion,
+	}
+
+	var versionsToMirror []*semver.Version
+	var err error
+	err = log.Process("mirror", "Looking for required Deckhouse releases", func() error {
+		versionsToMirror, err = mirror.VersionsToCopy(mirrorCtx)
+		if err != nil {
+			return fmt.Errorf("find versions to mirror: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = log.Process("mirror", "Pull images", func() error {
+		return operations.MirrorRegistryToLocalFS(mirrorCtx, versionsToMirror)
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -28,7 +28,7 @@ import (
 )
 
 func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
-	cmd := parent.Command("mirror", "Copy Deckhouse registry for air-gaped installation.")
+	cmd := parent.Command("mirror", "Copy Deckhouse images from Deckhouse registry to local filesystem and to third-party registry")
 	app.DefineMirrorFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -38,7 +38,7 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 			})
 		}
 
-		return log.Process("mirror", "Pull Deckhouse to local filesystem", func() error {
+		return log.Process("mirror", "Pull Deckhouse images from registry to local filesystem", func() error {
 			return mirrorPullDeckhouseToLocalFilesystem()
 		})
 	})

--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -33,7 +33,7 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		if app.MirrorRegistryHost != "" {
-			return log.Process("mirror", "Push mirrored Deckhouse Registry images to private registry", func() error {
+			return log.Process("mirror", "Push mirrored Deckhouse images from local filesystem to private registry", func() error {
 				return mirrorPushDeckhouseToPrivateRegistry()
 			})
 		}

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -64,6 +64,7 @@ func main() {
 
 	commands.DefineConvergeCommand(kpApp)
 	commands.DefineAutoConvergeCommand(kpApp)
+	commands.DefineMirrorCommand(kpApp)
 
 	lockCmd := kpApp.Command("lock", "Converge cluster lock")
 	{

--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/alessio/shellescape v1.4.1
@@ -49,6 +50,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect

--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -80,12 +80,13 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("validation", "Validation of mirrored indexes and images. "+
 		`Defaults to "fast" validation, which only checks if manifests and indexes are compliant with OCI specs, `+
 		`"full" validation also checks images contents for corruption`).
+		Hidden().
 		Default(mirrorFastValidation).
 		Envar(configEnvName("MIRROR_VALIDATION")).
 		EnumVar(&MirrorValidationMode, mirrorNoValidation, mirrorFastValidation, mirrorFullValidation)
 	cmd.Flag("images", "Directory for pulled images.").
 		Short('i').
-		Default("/tmp/d8-images").
+		Required().
 		Envar(configEnvName("MIRROR_IMAGES_PATH")).
 		StringVar(&MirrorImagesPath)
 	cmd.Flag("insecure", "Skip TLS checks.").
@@ -100,8 +101,8 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 
 		if MirrorRegistryHost != "" && MirrorDHLicenseToken != "" {
 			return errors.New("You have specified both --license and --registry flags. This is not how it works.\n\n" +
-				"Leave only --license if you want to pull Deckhouse from public registry.\n" +
-				"Leave only --registry if you already pulled Deckhouse and want to push it to your private registry.")
+				"Leave only --license if you want to pull Deckhouse images from public registry.\n" +
+				"Leave only --registry if you already pulled Deckhouse images and want to push it to your private registry.")
 		}
 
 		if mirrorMinVersionString != "" {

--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -1,0 +1,135 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	enterpriseEditionRepo = "registry.deckhouse.io/deckhouse/ee"
+	flantEditionRepo      = "registry.deckhouse.io/deckhouse/fe"
+)
+
+const (
+	mirrorNoValidation   = "off"
+	mirrorFastValidation = "fast"
+	mirrorFullValidation = "full"
+)
+
+var (
+	MirrorRegistryHost     = ""
+	MirrorRegistryUsername = ""
+	MirrorRegistryPassword = ""
+	MirrorInsecure         = false
+	MirrorDHLicenseToken   = ""
+	MirrorImagesPath       = ""
+
+	mirrorMinVersionString                 = ""
+	MirrorMinVersion       *semver.Version = nil
+
+	mirrorFlantEdition          = false
+	MirrorDeckhouseRegistryRepo = enterpriseEditionRepo
+
+	MirrorValidationMode = ""
+)
+
+func DefineMirrorFlags(cmd *kingpin.CmdClause) {
+	cmd.Flag("license", "Pull Deckhouse images to local machine using license key. Conflicts with --registry.").
+		Short('l').
+		Envar(configEnvName("MIRROR_LICENSE")).
+		StringVar(&MirrorDHLicenseToken)
+	cmd.Flag("registry", "Push Deckhouse images to your private registry, specified as registry-host[:port]. Conflicts with --license.").
+		Short('r').
+		Envar(configEnvName("MIRROR_PRIVATE_REGISTRY")).
+		StringVar(&MirrorRegistryHost)
+	cmd.Flag("registry-login", "Username to log into your registry.").
+		Short('u').
+		Envar(configEnvName("MIRROR_USER")).
+		StringVar(&MirrorRegistryUsername)
+	cmd.Flag("registry-password", "Password to log into your registry.").
+		Short('p').
+		Envar(configEnvName("MIRROR_PASS")).
+		StringVar(&MirrorRegistryPassword)
+	cmd.Flag("fe", "Copy Flant Edition images instead of Enterprise Edition.").
+		Envar(configEnvName("MIRROR_FE")).
+		BoolVar(&mirrorFlantEdition)
+	cmd.Flag("min-version", "Minimal Deckhouse release to copy. Cannot be above current Rock Solid release.").
+		Short('v').
+		Envar(configEnvName("MIRROR_MIN_VERSION")).
+		StringVar(&mirrorMinVersionString)
+	cmd.Flag("validation", "Validation of mirrored indexes and images. "+
+		`Defaults to "fast" validation, which only checks if manifests and indexes are compliant with OCI specs, `+
+		`"full" validation also checks images contents for corruption`).
+		Default(mirrorFastValidation).
+		Envar(configEnvName("MIRROR_VALIDATION")).
+		EnumVar(&MirrorValidationMode, mirrorNoValidation, mirrorFastValidation, mirrorFullValidation)
+	cmd.Flag("images", "Directory for pulled images.").
+		Short('i').
+		Default("/tmp/d8-images").
+		Envar(configEnvName("MIRROR_IMAGES_PATH")).
+		StringVar(&MirrorImagesPath)
+	cmd.Flag("insecure", "Skip TLS checks.").
+		BoolVar(&MirrorInsecure)
+
+	cmd.PreAction(func(c *kingpin.ParseContext) error {
+		var err error
+
+		if MirrorRegistryHost == "" && MirrorDHLicenseToken == "" {
+			return errors.New("One of --license or --registry is required.")
+		}
+
+		if MirrorRegistryHost != "" && MirrorDHLicenseToken != "" {
+			return errors.New("You have specified both --license and --registry flags. This is not how it works.\n\n" +
+				"Leave only --license if you want to pull Deckhouse from public registry.\n" +
+				"Leave only --registry if you already pulled Deckhouse and want to push it to your private registry.")
+		}
+
+		if mirrorMinVersionString != "" {
+			MirrorMinVersion, err = semver.NewVersion(mirrorMinVersionString)
+			if err != nil {
+				return fmt.Errorf("Minimal deckhouse version: %w", err)
+			}
+		}
+
+		if MirrorRegistryPassword != "" && MirrorRegistryUsername == "" {
+			return errors.New("Registry username not specified")
+		}
+
+		if mirrorFlantEdition {
+			MirrorDeckhouseRegistryRepo = flantEditionRepo
+		}
+
+		MirrorImagesPath = filepath.Clean(MirrorImagesPath)
+		stats, err := os.Stat(MirrorImagesPath)
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			break
+		case err != nil && !errors.Is(err, fs.ErrNotExist):
+			return fmt.Errorf("stat %s: %w", MirrorImagesPath, err)
+		case !stats.IsDir():
+			return fmt.Errorf("%s should be a directory", MirrorImagesPath)
+		}
+
+		return nil
+	})
+}

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -159,6 +159,7 @@ func NewPrettyLogger(opts LoggerOptions) *PrettyLogger {
 			"terraform": {"🌱 ~ Terraform: %s", TerraformOptions()},
 			"converge":  {"🛸 ~ Converge: %s", ConvergeOptions()},
 			"bootstrap": {"⛵ ~ Bootstrap: %s", BootstrapOptions()},
+			"mirror":    {"🪞 ~ Mirror: %s", MirrorOptions()},
 			"default":   {"%s", BoldOptions()},
 		},
 		isDebug: opts.IsDebug,

--- a/dhctl/pkg/log/options.go
+++ b/dhctl/pkg/log/options.go
@@ -28,6 +28,15 @@ func BootstrapOptions() logboek.LogProcessOptions {
 		},
 	}
 }
+func MirrorOptions() logboek.LogProcessOptions {
+	return logboek.LogProcessOptions{
+		LevelLogProcessOptions: logboek.LevelLogProcessOptions{
+			Style: &logboek.Style{
+				Attributes: []color.Attribute{color.FgGreen, color.Bold},
+			},
+		},
+	}
+}
 
 func CommonOptions() logboek.LogProcessOptions {
 	return logboek.LogProcessOptions{

--- a/dhctl/pkg/operations/mirror.go
+++ b/dhctl/pkg/operations/mirror.go
@@ -25,8 +25,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
-	// "github.com/google/go-containerregistry/pkg/v1"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/mirror"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/maputil"
@@ -36,8 +34,8 @@ func MirrorRegistryToLocalFS(
 	mirrorCtx *mirror.Context,
 	versions []*semver.Version,
 ) error {
-	log.InfoF("Fetching Deckhouse Modules list...\t")
-	modules, err := mirror.Modules(mirrorCtx)
+	log.InfoF("Fetching Deckhouse modules list...\t")
+	modules, err := mirror.GetExternalModules(mirrorCtx)
 	if err != nil {
 		log.InfoLn("❌")
 		return fmt.Errorf("get Deckhouse modules: %w", err)

--- a/dhctl/pkg/operations/mirror.go
+++ b/dhctl/pkg/operations/mirror.go
@@ -1,0 +1,234 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	// "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/mirror"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/maputil"
+)
+
+func MirrorRegistryToLocalFS(
+	mirrorCtx *mirror.Context,
+	versions []*semver.Version,
+) error {
+	log.InfoF("Fetching Deckhouse Modules list...\t")
+	modules, err := mirror.Modules(mirrorCtx)
+	if err != nil {
+		log.InfoLn("❌")
+		return fmt.Errorf("get Deckhouse modules: %w", err)
+	}
+	log.InfoLn("✅")
+
+	log.InfoF("Creating OCI Image Layouts...\t")
+	layouts, err := mirror.CreateOCIImageLayouts(mirrorCtx.RegistryRepo, mirrorCtx.ImagesPath, modules)
+	if err != nil {
+		log.InfoLn("❌")
+		return fmt.Errorf("create OCI Image Layouts: %w", err)
+	}
+	log.InfoLn("✅")
+
+	mirror.FillLayoutsImages(mirrorCtx, layouts, versions)
+
+	log.InfoF("Searching for Deckhouse modules images...\t")
+	if err = mirror.FindDeckhouseModulesImages(mirrorCtx, layouts); err != nil {
+		log.InfoLn("❌")
+		return fmt.Errorf("find Deckhouse modules images: %w", err)
+	}
+	log.InfoLn("✅")
+
+	if err = mirror.PullInstallers(mirrorCtx, layouts); err != nil {
+		log.InfoLn("❌")
+		return fmt.Errorf("pull installers: %w", err)
+	}
+
+	log.InfoF("Searching for Deckhouse modules digests...\t")
+	for imageTag := range layouts.InstallImages {
+		digests, err := mirror.ExtractImageDigestsFromDeckhouseInstaller(mirrorCtx, imageTag, layouts.Install)
+		if err != nil {
+			log.InfoLn("❌")
+			return fmt.Errorf("extract images digests: %w", err)
+		}
+		maputil.Join(layouts.DeckhouseImages, digests)
+	}
+	log.InfoLn("✅")
+
+	if err = mirror.PullDeckhouseReleaseChannels(mirrorCtx, layouts); err != nil {
+		return fmt.Errorf("pull release channels: %w", err)
+	}
+	if err = mirror.PullDeckhouseImages(mirrorCtx, layouts); err != nil {
+		return fmt.Errorf("pull Deckhouse: %w", err)
+	}
+
+	if err = mirror.PullModules(mirrorCtx, layouts); err != nil {
+		return fmt.Errorf("pull Deckhouse modules: %w", err)
+	}
+
+	if err = validateLayoutsIfRequired(layouts, mirrorCtx.ValidationMode); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateLayoutsIfRequired(layouts *mirror.ImageLayouts, validationMode mirror.ValidationMode) error {
+	layoutsPaths := []layout.Path{layouts.Deckhouse, layouts.ReleaseChannel, layouts.Install}
+	for _, moduleImageLayout := range layouts.Modules {
+		layoutsPaths = append(layoutsPaths, moduleImageLayout.ModuleLayout)
+		layoutsPaths = append(layoutsPaths, moduleImageLayout.ReleasesLayout)
+	}
+	if err := mirror.ValidateLayouts(layoutsPaths, validationMode); err != nil {
+		return fmt.Errorf("OCI Image Layouts validation failure: %w", err)
+	}
+	return nil
+}
+
+func PushMirrorToRegistry(mirrorCtx *mirror.Context) error {
+	log.InfoF("Find Deckhouse images to push...\t")
+	ociLayouts, err := findLayoutsToPush(mirrorCtx)
+	if err != nil {
+		log.InfoLn("❌")
+		return fmt.Errorf("Find OCI Image Layouts to push: %w", err)
+	}
+	log.InfoLn("✅")
+
+	log.InfoF("Validating downloaded Deckhouse images...\t")
+	if err = mirror.ValidateLayouts(maputil.Values(ociLayouts), mirrorCtx.ValidationMode); err != nil {
+		log.InfoLn("❌")
+		return fmt.Errorf("OCI Image Layouts are invalid: %w", err)
+	}
+	log.InfoLn("✅")
+
+	for originalRepo, ociLayout := range ociLayouts {
+		log.InfoLn("Mirroring", originalRepo)
+		index, err := ociLayout.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("read image index from %s: %w", ociLayout, err)
+		}
+
+		indexManifest, err := index.IndexManifest()
+		if err != nil {
+			return fmt.Errorf("read index manifest: %w", err)
+		}
+
+		// docker:// prefix is a workaround for url.Parse poor parsing when url does not contain scheme.
+		registryURL, err := url.Parse("docker://" + originalRepo)
+		if err != nil {
+			return err
+		}
+
+		for _, manifest := range indexManifest.Manifests {
+			repo := mirrorCtx.RegistryHost + registryURL.Path
+			tag := manifest.Annotations["io.deckhouse.image.short_tag"]
+
+			log.InfoF("Pushing image %s...\t", repo+":"+tag)
+			img, err := index.Image(manifest.Digest)
+			if err != nil {
+				log.InfoLn("❌")
+				return fmt.Errorf("read image: %w", err)
+			}
+
+			refOpts := []name.Option{}
+			remoteOpts := []remote.Option{}
+			if mirrorCtx.Insecure {
+				refOpts = append(refOpts, name.Insecure)
+			}
+			if mirrorCtx.RegistryAuth != nil {
+				remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
+			}
+
+			ref, err := name.ParseReference(repo+":"+tag, refOpts...)
+			if err != nil {
+				log.InfoLn("❌")
+				return fmt.Errorf("parse oci layout reference: %w", err)
+			}
+			if err = remote.Write(ref, img, remoteOpts...); err != nil {
+				log.InfoLn("❌")
+				return fmt.Errorf("write %s to registry: %w", ref.String(), err)
+			}
+			log.InfoLn("✅")
+		}
+		log.InfoF("Repo %s is mirrored ✅\n", originalRepo)
+	}
+
+	return nil
+
+}
+
+func findLayoutsToPush(mirrorCtx *mirror.Context) (map[string]layout.Path, error) {
+	deckhouseIndexRef := mirrorCtx.RegistryRepo
+	installersIndexRef := filepath.Join(mirrorCtx.RegistryRepo, "install")
+	releasesIndexRef := filepath.Join(mirrorCtx.RegistryRepo, "release-channel")
+
+	deckhouseLayoutPath := filepath.Join(mirrorCtx.ImagesPath, deckhouseIndexRef)
+	installersLayoutPath := filepath.Join(mirrorCtx.ImagesPath, installersIndexRef)
+	releasesLayoutPath := filepath.Join(mirrorCtx.ImagesPath, releasesIndexRef)
+
+	deckhouseLayout, err := layout.FromPath(deckhouseLayoutPath)
+	if err != nil {
+		return nil, err
+	}
+	installersLayout, err := layout.FromPath(installersLayoutPath)
+	if err != nil {
+		return nil, err
+	}
+	releasesLayout, err := layout.FromPath(releasesLayoutPath)
+	if err != nil {
+		return nil, err
+	}
+
+	modulesPath := filepath.Join(mirrorCtx.ImagesPath, mirrorCtx.RegistryRepo, "modules")
+	ociLayouts := map[string]layout.Path{
+		deckhouseIndexRef:  deckhouseLayout,
+		installersIndexRef: installersLayout,
+		releasesIndexRef:   releasesLayout,
+	}
+
+	dirs, err := os.ReadDir(modulesPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, dir := range dirs {
+		if !dir.IsDir() {
+			continue
+		}
+
+		moduleRef := filepath.Join(mirrorCtx.RegistryRepo, "modules", dir.Name())
+		moduleReleasesRef := filepath.Join(mirrorCtx.RegistryRepo, "modules", dir.Name(), "release")
+		moduleLayout, err := layout.FromPath(filepath.Join(modulesPath, dir.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("create module layout from path: %w", err)
+		}
+		moduleReleaseLayout, err := layout.FromPath(filepath.Join(modulesPath, dir.Name(), "release"))
+		if err != nil {
+			return nil, fmt.Errorf("create module release layout from path: %w", err)
+		}
+		ociLayouts[moduleRef] = moduleLayout
+		ociLayouts[moduleReleasesRef] = moduleReleaseLayout
+	}
+	return ociLayouts, nil
+}

--- a/dhctl/pkg/operations/mirror/context.go
+++ b/dhctl/pkg/operations/mirror/context.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// Context hold data related to pending registry mirroring operation.
+type Context struct {
+	Insecure bool // --insecure
+
+	RegistryAuth authn.Authenticator // --registry-login + --registry-password (can be nil in this case) or --license depending on the operation requested
+	RegistryHost string              // --registry
+	RegistryRepo string
+
+	ImagesPath     string          // --images
+	ValidationMode ValidationMode  // --validation
+	MinVersion     *semver.Version // --min-version
+}

--- a/dhctl/pkg/operations/mirror/digests.go
+++ b/dhctl/pkg/operations/mirror/digests.go
@@ -1,0 +1,88 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+)
+
+func ExtractImageDigestsFromDeckhouseInstaller(
+	mirrorCtx *Context,
+	installerTag string,
+	installersLayout layout.Path,
+) (map[string]struct{}, error) {
+	index, err := installersLayout.ImageIndex()
+	if err != nil {
+		return nil, fmt.Errorf("read installer images index: %w", err)
+	}
+	indexManifest, err := index.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("read installers index manifest: %w", err)
+	}
+
+	installerHash := findDigestForInstallerTag(installerTag, indexManifest)
+	if installerHash == nil {
+		return nil, fmt.Errorf("no image tagged as %q found in index", installerTag)
+	}
+
+	img, err := index.Image(*installerHash)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read image from index: %w", err)
+	}
+
+	imagesDigestsJSON, err := readFileFromImage(img, "deckhouse/candi/images_digests.json")
+	if err != nil {
+		return nil, fmt.Errorf("read digests from %q: %w", installerTag, err)
+	}
+
+	digests := map[string]struct{}{}
+	if err = parseDigestsFromImagesDigestsJSON(mirrorCtx.RegistryRepo, imagesDigestsJSON, digests); err != nil {
+		return nil, fmt.Errorf("cannot parse images_digests.json: %w", err)
+	}
+
+	return digests, nil
+}
+
+func findDigestForInstallerTag(installerTag string, indexManifest *v1.IndexManifest) *v1.Hash {
+	for _, imageManifest := range indexManifest.Manifests {
+		for key, value := range imageManifest.Annotations {
+			if key == "org.opencontainers.image.ref.name" && value == installerTag {
+				tag := imageManifest.Digest
+				return &tag
+			}
+		}
+	}
+	return nil
+}
+
+func parseDigestsFromImagesDigestsJSON(registryRepo string, jsonDigests io.Reader, dst map[string]struct{}) error {
+	digestsByModule := map[string]map[string]string{}
+	if err := json.NewDecoder(jsonDigests).Decode(&digestsByModule); err != nil {
+		return fmt.Errorf("parse images_digests.json: %w", err)
+	}
+
+	for _, nameDigestTuple := range digestsByModule {
+		for _, imageID := range nameDigestTuple {
+			dst[registryRepo+"@"+imageID] = struct{}{}
+		}
+	}
+
+	return nil
+}

--- a/dhctl/pkg/operations/mirror/index.go
+++ b/dhctl/pkg/operations/mirror/index.go
@@ -1,0 +1,289 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/maputil"
+)
+
+type ImageLayouts struct {
+	Deckhouse       layout.Path
+	DeckhouseImages map[string]struct{}
+
+	Install       layout.Path
+	InstallImages map[string]struct{}
+
+	ReleaseChannel       layout.Path
+	ReleaseChannelImages map[string]struct{}
+
+	Modules map[string]ModuleImageLayout
+}
+
+type ModuleImageLayout struct {
+	ModuleLayout layout.Path
+	ModuleImages map[string]struct{}
+
+	ReleasesLayout layout.Path
+	ReleaseImages  map[string]struct{}
+}
+
+func CreateOCIImageLayouts(
+	registryRepo string,
+	rootFolder string,
+	modules []Module,
+) (*ImageLayouts, error) {
+	var err error
+	layouts := &ImageLayouts{Modules: map[string]ModuleImageLayout{}}
+
+	fsPaths := map[*layout.Path]string{
+		&layouts.Deckhouse:      filepath.Join(rootFolder, registryRepo),
+		&layouts.Install:        filepath.Join(rootFolder, registryRepo+"/install"),
+		&layouts.ReleaseChannel: filepath.Join(rootFolder, registryRepo+"/release-channel"),
+	}
+	for layoutPtr, fsPath := range fsPaths {
+		if err := createEmptyImageLayoutAtPath(fsPath); err != nil {
+			return nil, fmt.Errorf("create OCI Image Layout at %s: %w", fsPath, err)
+		}
+		*layoutPtr, err = layout.FromPath(fsPath)
+		if err != nil {
+			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
+		}
+	}
+
+	for _, module := range modules {
+		path := filepath.Join(rootFolder, registryRepo+"/modules/"+module.Name)
+		if err := createEmptyImageLayoutAtPath(path); err != nil {
+			return nil, fmt.Errorf("create OCI Image Layout at %s: %w", path, err)
+		}
+		moduleLayout, err := layout.FromPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
+		}
+
+		path = filepath.Join(rootFolder, registryRepo+"/modules/"+module.Name+"/release")
+		if err := createEmptyImageLayoutAtPath(path); err != nil {
+			return nil, fmt.Errorf("create OCI Image Layout at %s: %w", path, err)
+		}
+		moduleReleasesLayout, err := layout.FromPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
+		}
+
+		layouts.Modules[module.Name] = ModuleImageLayout{
+			ModuleLayout:   moduleLayout,
+			ModuleImages:   map[string]struct{}{},
+			ReleasesLayout: moduleReleasesLayout,
+			ReleaseImages:  map[string]struct{}{},
+		}
+	}
+
+	return layouts, nil
+}
+
+func createEmptyImageLayoutAtPath(path string) error {
+	layoutFilePath := filepath.Join(path, "oci-layout")
+	indexFilePath := filepath.Join(path, "index.json")
+	blobsPath := filepath.Join(path, "blobs")
+
+	if err := os.MkdirAll(blobsPath, 0755); err != nil {
+		return fmt.Errorf("mkdir for blobs: %w", err)
+	}
+
+	layoutContents := ociLayout{ImageLayoutVersion: "1.0.0"}
+	indexContents := indexSchema{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.index.v1+json",
+	}
+
+	rawJSON, err := json.MarshalIndent(indexContents, "", "    ")
+	if err != nil {
+		return fmt.Errorf("create index.json: %w", err)
+	}
+	if err = os.WriteFile(indexFilePath, rawJSON, 0644); err != nil {
+		return fmt.Errorf("create index.json: %w", err)
+	}
+
+	rawJSON, err = json.MarshalIndent(layoutContents, "", "    ")
+	if err != nil {
+		return fmt.Errorf("create oci-layout: %w", err)
+	}
+	if err = os.WriteFile(layoutFilePath, rawJSON, 0644); err != nil {
+		return fmt.Errorf("create oci-layout: %w", err)
+	}
+
+	return nil
+}
+
+type indexSchema struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	MediaType     string `json:"mediaType"`
+	Manifests     []struct {
+		MediaType string `json:"mediaType,omitempty"`
+		Size      int    `json:"size,omitempty"`
+		Digest    string `json:"digest,omitempty"`
+	} `json:"manifests"`
+}
+
+type ociLayout struct {
+	ImageLayoutVersion string `json:"imageLayoutVersion"`
+}
+
+func FillLayoutsImages(mirrorCtx *Context, layouts *ImageLayouts, deckhouseVersions []*semver.Version) {
+	layouts.DeckhouseImages = map[string]struct{}{
+		mirrorCtx.RegistryRepo + ":alpha":        {},
+		mirrorCtx.RegistryRepo + ":beta":         {},
+		mirrorCtx.RegistryRepo + ":early-access": {},
+		mirrorCtx.RegistryRepo + ":stable":       {},
+		mirrorCtx.RegistryRepo + ":rock-solid":   {},
+	}
+
+	layouts.InstallImages = map[string]struct{}{
+		mirrorCtx.RegistryRepo + "/install:alpha":        {},
+		mirrorCtx.RegistryRepo + "/install:beta":         {},
+		mirrorCtx.RegistryRepo + "/install:early-access": {},
+		mirrorCtx.RegistryRepo + "/install:stable":       {},
+		mirrorCtx.RegistryRepo + "/install:rock-solid":   {},
+	}
+
+	layouts.ReleaseChannelImages = map[string]struct{}{
+		mirrorCtx.RegistryRepo + "/release-channel:alpha":        {},
+		mirrorCtx.RegistryRepo + "/release-channel:beta":         {},
+		mirrorCtx.RegistryRepo + "/release-channel:early-access": {},
+		mirrorCtx.RegistryRepo + "/release-channel:stable":       {},
+		mirrorCtx.RegistryRepo + "/release-channel:rock-solid":   {},
+	}
+
+	for _, version := range deckhouseVersions {
+		layouts.DeckhouseImages[fmt.Sprintf("%s:v%s", mirrorCtx.RegistryRepo, version.String())] = struct{}{}
+		layouts.InstallImages[fmt.Sprintf("%s/install:v%s", mirrorCtx.RegistryRepo, version.String())] = struct{}{}
+		layouts.ReleaseChannelImages[fmt.Sprintf("%s/release-channel:v%s", mirrorCtx.RegistryRepo, version.String())] = struct{}{}
+	}
+}
+
+var digestRegex = regexp.MustCompile(`sha256:([a-f0-9]{64})`)
+
+func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error {
+	modulesNames := maputil.Keys(layouts.Modules)
+	for _, moduleName := range modulesNames {
+		moduleData := layouts.Modules[moduleName]
+		moduleData.ReleaseImages = map[string]struct{}{
+			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:alpha":        {},
+			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:beta":         {},
+			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:early-access": {},
+			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:stable":       {},
+			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:rock-solid":   {},
+		}
+
+		channelVersions, err := fetchVersionsFromModuleReleaseChannels(mirrorCtx, moduleData.ReleaseImages)
+		if err != nil {
+			return fmt.Errorf("fetch versions from %q release channels: %w", moduleName, err)
+		}
+
+		for _, moduleVersion := range channelVersions {
+			moduleData.ModuleImages[mirrorCtx.RegistryRepo+"/modules/"+moduleName+":"+moduleVersion] = struct{}{}
+			moduleData.ReleaseImages[mirrorCtx.RegistryRepo+"/modules/"+moduleName+"/release:"+moduleVersion] = struct{}{}
+		}
+
+		fetchDigestsFrom := maputil.Clone(moduleData.ModuleImages)
+		for imageTag := range fetchDigestsFrom {
+			nameOpts := []name.Option{}
+			remoteOpts := []remote.Option{}
+			if mirrorCtx.Insecure {
+				nameOpts = append(nameOpts, name.Insecure)
+			}
+			if mirrorCtx.RegistryAuth != nil {
+				remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
+			}
+
+			ref, err := name.ParseReference(imageTag, nameOpts...)
+			if err != nil {
+				return fmt.Errorf("get digests for %q version: %w", imageTag, err)
+			}
+
+			img, err := remote.Image(ref, remoteOpts...)
+			if err != nil {
+				return fmt.Errorf("get digests for %q version: %w", imageTag, err)
+			}
+
+			imagesDigestsJSON, err := readFileFromImage(img, "images_digests.json")
+			if err != nil {
+				return fmt.Errorf("get digests for %q version: %w", imageTag, err)
+			}
+
+			digests := digestRegex.FindAllString(imagesDigestsJSON.String(), -1)
+			for _, digest := range digests {
+				moduleData.ModuleImages[mirrorCtx.RegistryRepo+"/modules/"+moduleName+"@"+digest] = struct{}{}
+			}
+		}
+
+		layouts.Modules[moduleName] = moduleData
+	}
+
+	return nil
+}
+
+func fetchVersionsFromModuleReleaseChannels(
+	mirrorCtx *Context,
+	releaseChannelImages map[string]struct{},
+) (map[string]string, error) {
+	channelVersions := map[string]string{}
+	for imageTag := range releaseChannelImages {
+		opts := []name.Option{}
+		remoteOpts := []remote.Option{}
+		if mirrorCtx.Insecure {
+			opts = append(opts, name.Insecure)
+		}
+		if mirrorCtx.RegistryAuth != nil {
+			remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
+		}
+
+		ref, err := name.ParseReference(imageTag, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("pull %q release channel: %w", imageTag, err)
+		}
+
+		img, err := remote.Image(ref, remoteOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("pull %q release channel: %w", imageTag, err)
+		}
+
+		versionJSON, err := readFileFromImage(img, "version.json")
+		if err != nil {
+			return nil, fmt.Errorf("read version.json from %q: %w", imageTag, err)
+		}
+
+		tmp := &struct {
+			Version string `json:"version"`
+		}{}
+		if err = json.Unmarshal(versionJSON.Bytes(), tmp); err != nil {
+			return nil, fmt.Errorf("parse version.json: %w", err)
+		}
+
+		channelVersions[imageTag] = tmp.Version
+	}
+
+	return channelVersions, nil
+}

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -60,8 +60,8 @@ func CreateOCIImageLayouts(
 
 	fsPaths := map[*layout.Path]string{
 		&layouts.Deckhouse:      filepath.Join(rootFolder, registryRepo),
-		&layouts.Install:        filepath.Join(rootFolder, registryRepo+"/install"),
-		&layouts.ReleaseChannel: filepath.Join(rootFolder, registryRepo+"/release-channel"),
+		&layouts.Install:        filepath.Join(rootFolder, registryRepo, "install"),
+		&layouts.ReleaseChannel: filepath.Join(rootFolder, registryRepo, "release-channel"),
 	}
 	for layoutPtr, fsPath := range fsPaths {
 		if err := createEmptyImageLayoutAtPath(fsPath); err != nil {
@@ -74,7 +74,7 @@ func CreateOCIImageLayouts(
 	}
 
 	for _, module := range modules {
-		path := filepath.Join(rootFolder, registryRepo+"/modules/"+module.Name)
+		path := filepath.Join(rootFolder, registryRepo, "modules", module.Name)
 		if err := createEmptyImageLayoutAtPath(path); err != nil {
 			return nil, fmt.Errorf("create OCI Image Layout at %s: %w", path, err)
 		}
@@ -83,7 +83,7 @@ func CreateOCIImageLayouts(
 			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
 		}
 
-		path = filepath.Join(rootFolder, registryRepo+"/modules/"+module.Name+"/release")
+		path = filepath.Join(rootFolder, registryRepo, "modules", module.Name, "release")
 		if err := createEmptyImageLayoutAtPath(path); err != nil {
 			return nil, fmt.Errorf("create OCI Image Layout at %s: %w", path, err)
 		}

--- a/dhctl/pkg/operations/mirror/modules.go
+++ b/dhctl/pkg/operations/mirror/modules.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+type Module struct {
+	Name         string
+	RegistryPath string
+	Releases     []string
+}
+
+func Modules(mirrorCtx *Context) ([]Module, error) {
+	nameOpts := []name.Option{}
+	if mirrorCtx.Insecure {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	modulesRepo, err := name.NewRepository(mirrorCtx.RegistryRepo+"/modules", nameOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("parsing modules repo: %v", err)
+	}
+
+	modules, err := remote.List(modulesRepo, remote.WithAuth(mirrorCtx.RegistryAuth))
+	if err != nil {
+		return nil, fmt.Errorf("read Deckhouse modules from registry: %w", err)
+	}
+
+	result := make([]Module, 0, len(modules))
+	for _, module := range modules {
+		m := Module{
+			Name:         module,
+			RegistryPath: fmt.Sprintf("%s/modules/%s", mirrorCtx.RegistryRepo, module),
+			Releases:     []string{},
+		}
+		m.Releases, err = crane.ListTags(m.RegistryPath + "/release")
+		if err != nil {
+			return nil, fmt.Errorf("get releases for module %q: %w", m.RegistryPath, err)
+		}
+		result = append(result, m)
+	}
+
+	return result, nil
+}

--- a/dhctl/pkg/operations/mirror/pull.go
+++ b/dhctl/pkg/operations/mirror/pull.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func PullInstallers(mirrorCtx *Context, layouts *ImageLayouts) error {
+	log.InfoLn("Beginning to pull installers")
+	if err := pullImageSet(mirrorCtx.RegistryAuth, layouts.Install, layouts.InstallImages, mirrorCtx.Insecure); err != nil {
+		return err
+	}
+	log.InfoLn("✅ All required installers are pulled!")
+	return nil
+}
+
+func PullDeckhouseReleaseChannels(mirrorCtx *Context, layouts *ImageLayouts) error {
+	log.InfoLn("Beginning to pull Deckhouse release channels information")
+	if err := pullImageSet(mirrorCtx.RegistryAuth, layouts.ReleaseChannel, layouts.ReleaseChannelImages, mirrorCtx.Insecure); err != nil {
+		return err
+	}
+	log.InfoLn("✅ Deckhouse release channels are pulled!")
+	return nil
+}
+
+func PullDeckhouseImages(mirrorCtx *Context, layouts *ImageLayouts) error {
+	log.InfoLn("Beginning to pull Deckhouse, this may take a while")
+	if err := pullImageSet(mirrorCtx.RegistryAuth, layouts.Deckhouse, layouts.DeckhouseImages, mirrorCtx.Insecure); err != nil {
+		return err
+	}
+	log.InfoLn("✅ All required Deckhouse images are pulled!")
+	return nil
+}
+
+func pullImageSet(
+	authProvider authn.Authenticator,
+	targetLayout layout.Path,
+	imageSet map[string]struct{},
+	insecure bool,
+) error {
+	pullCount := 1
+	totalCount := len(imageSet)
+	for imageTag := range imageSet {
+		log.InfoF("[%d / %d] Pulling %s...\t", pullCount, totalCount, imageTag)
+
+		pullOpts := []name.Option{}
+		remoteOpts := []remote.Option{}
+		if insecure {
+			pullOpts = append(pullOpts, name.Insecure)
+		}
+		if authProvider != nil {
+			remoteOpts = append(remoteOpts, remote.WithAuth(authProvider))
+		}
+
+		ref, err := name.ParseReference(imageTag, pullOpts...)
+		if err != nil {
+			return fmt.Errorf("parse image reference %q: %w", imageTag, err)
+		}
+		img, err := remote.Image(ref, remoteOpts...)
+		if err != nil {
+			return fmt.Errorf("pull image %q: %w", imageTag, err)
+		}
+
+		err = targetLayout.AppendImage(img,
+			layout.WithPlatform(v1.Platform{Architecture: "amd64", OS: "linux"}),
+			layout.WithAnnotations(map[string]string{
+				"org.opencontainers.image.ref.name": imageTag,
+				"io.deckhouse.image.short_tag":      imageTag[strings.LastIndex(imageTag, ":")+1:],
+			}),
+		)
+		if err != nil {
+			return fmt.Errorf("pull image %q: %w", imageTag, err)
+		}
+		log.InfoLn("✅")
+		pullCount++
+	}
+	return nil
+}
+
+func PullModules(mirrorCtx *Context, layouts *ImageLayouts) error {
+	log.InfoLn("Beginning to pull Deckhouse modules")
+	for moduleName, moduleData := range layouts.Modules {
+		if err := pullImageSet(mirrorCtx.RegistryAuth, moduleData.ModuleLayout, moduleData.ModuleImages, mirrorCtx.Insecure); err != nil {
+			return fmt.Errorf("pull %q module: %w", moduleName, err)
+		}
+		if err := pullImageSet(mirrorCtx.RegistryAuth, moduleData.ReleasesLayout, moduleData.ReleaseImages, mirrorCtx.Insecure); err != nil {
+			return fmt.Errorf("pull %q module release information: %w", moduleName, err)
+		}
+	}
+	log.InfoLn("✅ Deckhouse modules pulled!")
+	return nil
+}

--- a/dhctl/pkg/operations/mirror/util.go
+++ b/dhctl/pkg/operations/mirror/util.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io/fs"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func readFileFromImage(img v1.Image, fileName string) (*bytes.Buffer, error) {
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("get image layers: %w", err)
+	}
+
+	for _, layer := range layers {
+		decompressedLayer, err := layer.Uncompressed()
+		if err != nil {
+			return nil, fmt.Errorf("decompress layer: %w", err)
+		}
+
+		tr := tar.NewReader(decompressedLayer)
+		for {
+			hdr, err := tr.Next()
+			if err != nil {
+				_ = decompressedLayer.Close()
+				break
+			}
+			if hdr.Name != fileName {
+				_ = decompressedLayer.Close()
+				continue
+			}
+
+			buf := &bytes.Buffer{}
+			if _, err = buf.ReadFrom(tr); err != nil {
+				return nil, fmt.Errorf("buffer file data from layer: %w", err)
+			}
+
+			return buf, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s: %w", fileName, fs.ErrNotExist)
+}

--- a/dhctl/pkg/operations/mirror/validate.go
+++ b/dhctl/pkg/operations/mirror/validate.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/validate"
+)
+
+type ValidationMode string
+
+const (
+	NoValidation   ValidationMode = "off"
+	FastValidation ValidationMode = "fast"
+	FullValidation ValidationMode = "full"
+)
+
+func ValidateLayouts(layouts []layout.Path, validationMode ValidationMode) error {
+	if validationMode == NoValidation {
+		return nil
+	}
+
+	opts := []validate.Option{}
+	if validationMode == FastValidation {
+		opts = append(opts, validate.Fast)
+	}
+
+	for _, path := range layouts {
+		index, err := path.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if err = validate.Index(index, opts...); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+	return nil
+}

--- a/dhctl/pkg/operations/mirror/versions.go
+++ b/dhctl/pkg/operations/mirror/versions.go
@@ -1,0 +1,131 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func VersionsToCopy(mirrorCtx *Context) ([]*semver.Version, error) {
+	rockSolidVersion, err := getRockSolidVersionFromRegistry(mirrorCtx)
+	if err != nil {
+		return nil, fmt.Errorf("get rock-solid release version from registry: %w", err)
+	}
+	mirrorFromVersion := *rockSolidVersion
+	if mirrorCtx.MinVersion != nil {
+		mirrorFromVersion = *mirrorCtx.MinVersion
+		if rockSolidVersion.LessThan(mirrorCtx.MinVersion) {
+			mirrorFromVersion = *rockSolidVersion
+		}
+	}
+
+	tags, err := getTagsFromRegistry(mirrorCtx)
+	if err != nil {
+		return nil, fmt.Errorf("get releases from github: %w", err)
+	}
+
+	versionsAboveMinimal := parseAndFilterVersionsAboveMinimal(&mirrorFromVersion, tags)
+	versionsAboveMinimal = filterOnlyLatestPatches(versionsAboveMinimal)
+
+	log.InfoF("Deckhouse releases to pull: %+v\n", versionsAboveMinimal)
+
+	return versionsAboveMinimal, nil
+}
+
+func getTagsFromRegistry(mirrorCtx *Context) ([]string, error) {
+	craneOpts := []crane.Option{}
+	if mirrorCtx.RegistryAuth != nil {
+		craneOpts = append(craneOpts, crane.WithAuth(mirrorCtx.RegistryAuth))
+	}
+	tags, err := crane.ListTags(mirrorCtx.RegistryRepo+"/release-channel", craneOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("get tags from Deckhouse registry: %w", err)
+	}
+
+	return tags, nil
+}
+
+func parseAndFilterVersionsAboveMinimal(minVersion *semver.Version, tags []string) []*semver.Version {
+	versionsAboveMinimal := make([]*semver.Version, 0)
+	for _, tag := range tags {
+		version, err := semver.NewVersion(tag)
+		if err != nil || minVersion.GreaterThan(version) {
+			continue
+		}
+		versionsAboveMinimal = append(versionsAboveMinimal, version)
+	}
+	return versionsAboveMinimal
+}
+
+func filterOnlyLatestPatches(versions []*semver.Version) []*semver.Version {
+	type majorMinor [2]uint64
+	patches := map[majorMinor]uint64{}
+	for _, version := range versions {
+		release := majorMinor{version.Major(), version.Minor()}
+		if patch := patches[release]; patch <= version.Patch() {
+			patches[release] = version.Patch()
+		}
+	}
+
+	topPatches := make([]*semver.Version, 0, len(patches))
+	for majMin, patch := range patches {
+		topPatches = append(topPatches, semver.MustParse(fmt.Sprintf("v%d.%d.%d", majMin[0], majMin[1], patch)))
+	}
+	return topPatches
+}
+
+func getRockSolidVersionFromRegistry(mirrorCtx *Context) (*semver.Version, error) {
+	refOpts := []name.Option{name.StrictValidation}
+	if mirrorCtx.Insecure {
+		refOpts = append(refOpts, name.Insecure)
+	}
+
+	ref, err := name.ParseReference(mirrorCtx.RegistryRepo+"/release-channel:rock-solid", refOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("parse rock solid release ref: %w", err)
+	}
+
+	rockSolidReleaseImage, err := remote.Image(ref, remote.WithAuth(mirrorCtx.RegistryAuth))
+	if err != nil {
+		return nil, fmt.Errorf("get rock-solid release channel data: %w", err)
+	}
+
+	versionJSON, err := readFileFromImage(rockSolidReleaseImage, "version.json")
+	if err != nil {
+		return nil, fmt.Errorf("cannot get rock-solid release channel version: %w", err)
+	}
+
+	tmp := &struct {
+		Version string `json:"version"`
+	}{}
+	if err = json.Unmarshal(versionJSON.Bytes(), tmp); err != nil {
+		return nil, fmt.Errorf("cannot find release channel version: %w", err)
+	}
+
+	ver, err := semver.NewVersion(tmp.Version)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find release channel version: %w", err)
+	}
+	return ver, nil
+
+}

--- a/dhctl/pkg/util/maputil/maputil.go
+++ b/dhctl/pkg/util/maputil/maputil.go
@@ -33,11 +33,36 @@ func ExcludeKeys(m map[string]string, excludeKeys ...string) map[string]string {
 	return res
 }
 
-func Values(m map[string]string) []string {
-	keysList := make([]string, 0, len(m))
-	for _, v := range m {
-		keysList = append(keysList, v)
+func Join[K comparable, V any](dst map[K]V, sources ...map[K]V) {
+	for _, src := range sources {
+		for k, v := range src {
+			dst[k] = v
+		}
+	}
+}
+
+func Clone[K comparable, V any](in map[K]V) (out map[K]V) {
+	out = make(map[K]V)
+	for k, v := range in {
+		out[k] = v
+	}
+	return
+}
+
+func Keys[K comparable, V any](m map[K]V) []K {
+	keysList := make([]K, 0, len(m))
+	for k := range m {
+		keysList = append(keysList, k)
 	}
 
 	return keysList
+}
+
+func Values[K comparable, V any](m map[K]V) []V {
+	valuesList := make([]V, 0, len(m))
+	for _, v := range m {
+		valuesList = append(valuesList, v)
+	}
+
+	return valuesList
 }

--- a/dhctl/pkg/util/maputil/maputil_test.go
+++ b/dhctl/pkg/util/maputil/maputil_test.go
@@ -96,3 +96,44 @@ func TestExcludeKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestJoin(t *testing.T) {
+	type args[K comparable, V any] struct {
+		dst     map[K]V
+		sources []map[K]V
+	}
+	type testCase[K comparable, V any] struct {
+		name string
+		args args[K, V]
+		want map[K]V
+	}
+	tests := []testCase[string, string]{
+		{
+			name: "Basic join",
+			args: args[string, string]{
+				dst: map[string]string{"key1": "val1", "key2": "val2"},
+				sources: []map[string]string{
+					{"key3": "val3"},
+					{"key4": "val4"},
+				},
+			},
+			want: map[string]string{"key1": "val1", "key2": "val2", "key3": "val3", "key4": "val4"},
+		},
+		{
+			name: "Overlapping keys",
+			args: args[string, string]{
+				dst: map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"},
+				sources: []map[string]string{
+					{"key3": "Deckhouse!"},
+					{"key4": "val4"},
+				},
+			},
+			want: map[string]string{"key1": "val1", "key2": "val2", "key3": "Deckhouse!", "key4": "val4"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Join(tt.args.dst, tt.args.sources...)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Added `mirror` subcommand for dhctl, that allows to copy a particular set of Deckhouse releases to a local filesystem and then push that copy to some third-party registry. 

This subcommand does not support copying of Community Edition images.

Example of copying current Deckhouse-release channels images to local filesystem mounted into `/d8-images`:

```bash
dhctl mirror -l "license-token" -i /d8-images
```

Or, to copy Deckhouse images starting from release 1.49 to local filesystem mounted into `/d8-images`.
```bash
dhctl mirror --license="license-token" --min-version="1.49" --images=/d8-images
```


To copy downloaded images into third-party registry:

```bash
dhctl mirror --images="/d8-images" --registry="registry.infra.int:5000" --registry-login="user" --registry-password="pass" 
```

Or in short flags

```bash
dhctl mirror -i "/d8-images" -r "registry.infra.int:5000" -u "user" -p "pass"
```

See `dhctl help mirror` for more information on flags:
```
usage: dhctl mirror --images="PATH" [<flags>]

Copy Deckhouse images from Deckhouse registry to local filesystem and to third-party registry

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
      --logger-type=pretty       Format logs output of a dhctl in different ways. ($DHCTL_CLI_LOGGER_TYPE)
      --tmp-dir="/var/folders/c0/rprsq8c55kb0c__gchv8fmz80000gn/T/dhctl"  
                                 Set temporary directory for debug purposes. ($DHCTL_CLI_TMP_DIR)
      --version                  Show application version.
  -l, --license=LICENSE          Pull Deckhouse images to local machine using license key. Conflicts with --registry. ($DHCTL_CLI_MIRROR_LICENSE)
  -r, --registry=REGISTRY        Push Deckhouse images to your private registry, specified as registry-host[:port]. Conflicts with --license. ($DHCTL_CLI_MIRROR_PRIVATE_REGISTRY)
  -u, --registry-login=REGISTRY-LOGIN  
                                 Username to log into your registry. ($DHCTL_CLI_MIRROR_USER)
  -p, --registry-password=REGISTRY-PASSWORD  
                                 Password to log into your registry. ($DHCTL_CLI_MIRROR_PASS)
      --fe                       Copy Flant Edition images instead of Enterprise Edition. ($DHCTL_CLI_MIRROR_FE)
  -v, --min-version=MIN-VERSION  Minimal Deckhouse release to copy. Cannot be above current Rock Solid release. ($DHCTL_CLI_MIRROR_MIN_VERSION)
  -i, --images                   Directory for pulled images. ($DHCTL_CLI_MIRROR_IMAGES_PATH)
      --insecure                 Skip TLS checks.

```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This is supposed to replace `d8-pull.sh`/`d8-push.sh` method of installation in air-gapped enviroments

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Implemented copying of Deckhouse images to third-party registries for air-gapped installation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
