### PR TITLE
[pod-reloader] Run as deckhouse user

### DIFF
--- a/modules/465-pod-reloader/templates/deployment.yaml
+++ b/modules/465-pod-reloader/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: {{ $.Chart.Name }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
         - name: manager
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}

--- a/modules/465-pod-reloader/templates/rbac-for-us.yaml
+++ b/modules/465-pod-reloader/templates/rbac-for-us.yaml
@@ -49,6 +49,19 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
* Run pod-reloader from deckhouse user.
* Added access to `cronjobs` and `jobs`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
* Running from the d8 user fixes error `access /reloader: permission denied`.
* Extending access rights eliminates warnings.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Tests

<details>

```shell
root@kube-master-0:~# kubectl -n d8-pod-reloader get po
NAME                            READY   STATUS    RESTARTS   AGE
pod-reloader-7654f7dd7d-p9k8f   2/2     Running   0          5m22s
root@kube-master-0:~# kubectl -n d8-pod-reloader logs pod-reloader-7654f7dd7d-p9k8f 
Defaulted container "manager" out of: manager, kube-rbac-proxy
time="2023-10-20T08:26:50Z" level=info msg="Environment: Kubernetes"
{"level":"info","msg":"Starting Reloader","time":"2023-10-20T08:26:50Z"}
{"level":"warning","msg":"KUBERNETES_NAMESPACE is unset, will detect changes in all namespaces.","time":"2023-10-20T08:26:50Z"}
{"level":"info","msg":"created controller for: configMaps","time":"2023-10-20T08:26:50Z"}
{"level":"info","msg":"Starting Controller to watch resource type: configMaps","time":"2023-10-20T08:26:50Z"}
{"level":"info","msg":"created controller for: secrets","time":"2023-10-20T08:26:50Z"}
{"level":"info","msg":"Starting Controller to watch resource type: secrets","time":"2023-10-20T08:26:50Z"}
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: pod-reloader
type: fix
summary:  Run pod-reloader from deckhouse user.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
