### PR TITLE
[docs][node-manager] Hide staticcluster CRD on the site

### DIFF
--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -14,6 +14,7 @@
   - '040-node-manager/crds/extension-config.yaml'
   - '040-node-manager/crds/machine.yaml'
   - '040-node-manager/crds/machine-*.yaml'
+  - '040-node-manager/crds/staticcluster.yaml'
   - '040-node-manager/crds/staticcontrolplane.yaml'
   - '040-node-manager/crds/staticmachine*.yaml'
   - '110-istio/crds/istio'


### PR DESCRIPTION
## Description
Hide staticcluster CRD on the site.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Hide staticcluster CRD on the site.
impact_level: low
```
