### PR TITLE
[linstor] fixed DRBD kernel module load

### DIFF
--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -83,6 +83,11 @@ spec:
       fi
 
       if [ "${current_version}" == "${desired_version}" ]; then
+        if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+          sed -i '/^drbd$/d' /etc/modules
+        fi
+        bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
+
         bb-log-info "Desired drbd version is already loaded, nothing to do"
         exit 0
       fi
@@ -129,7 +134,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    echo 'drbd' | tee -a /etc/modules
+    if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+      sed -i '/^drbd$/d' /etc/modules
+    fi
+    bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod
     modprobe drbd
     modprobe dm-thin-pool

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -83,7 +83,7 @@ spec:
       fi
 
       if [ "${current_version}" == "${desired_version}" ]; then
-        if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+        if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
@@ -134,7 +134,7 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+    if grep -q -E '^drbd$' /etc/modules; then
       sed -i '/^drbd$/d' /etc/modules
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -88,7 +88,7 @@ spec:
       fi
 
       if [ "${current_version}" == "${desired_version}" ]; then
-        if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+        if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
@@ -139,7 +139,7 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/${kernel_version_in_use}/kernel/drivers/
-    if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+    if grep -q -E '^drbd$' /etc/modules; then
       sed -i '/^drbd$/d' /etc/modules
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -88,6 +88,11 @@ spec:
       fi
 
       if [ "${current_version}" == "${desired_version}" ]; then
+        if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+          sed -i '/^drbd$/d' /etc/modules
+        fi
+        bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
+
         bb-log-info "Desired drbd version is already loaded, nothing to do"
         exit 0
       fi
@@ -134,7 +139,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/${kernel_version_in_use}/kernel/drivers/
-    echo 'drbd' | tee -a /etc/modules
+    if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+      sed -i '/^drbd$/d' /etc/modules
+    fi
+    bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod
     modprobe drbd
     modprobe dm-thin-pool

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -85,7 +85,7 @@ spec:
       fi
 
       if [ "${current_version}" == "${desired_version}" ]; then
-        if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+        if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
         bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
@@ -136,7 +136,7 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+    if grep -q -E '^drbd$' /etc/modules; then
       sed -i '/^drbd$/d' /etc/modules
     fi
     bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"

--- a/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -85,6 +85,11 @@ spec:
       fi
 
       if [ "${current_version}" == "${desired_version}" ]; then
+        if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+          sed -i '/^drbd$/d' /etc/modules
+        fi
+        bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
+
         bb-log-info "Desired drbd version is already loaded, nothing to do"
         exit 0
       fi
@@ -131,7 +136,10 @@ spec:
     make install
     cd drbd
     cp *.ko /lib/modules/$kernel_version_in_use/kernel/drivers/
-    echo 'drbd' | tee -a /etc/modules
+    if [ $(egrep -e "^drbd$" "/etc/modules" | wc -l) -ne 0 ]; then
+      sed -i '/^drbd$/d' /etc/modules
+    fi
+    bb-sync-file /etc/modules-load.d/d8_drbd.conf - <<< "drbd"
     depmod
     modprobe drbd
     modprobe dm-thin-pool


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changed the method of loading DRBD kernel module on the nodes with active LINSTOR satellites.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

On some recent versions of CentOS-based distributions, the old method of loading DRBD has stopped working.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Some of our clients occasionally experience issues due to DRBD's module not loaded in CentOS-based distros. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correctly loaded DRBD module on any OS version.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: fix
summary: Changed the method of loading DRBD kernel module on the nodes with active LINSTOR satellites.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
