### PR TITLE
[monitoring-kubernetes] Fix dashboards breakage caused by lens-hack

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
@@ -323,7 +323,7 @@
       "pluginVersion": "7.4.2",
       "targets": [
         {
-          "expr": "((node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\"}) / (node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"} )) * 100",
+          "expr": "((node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}) / (node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} )) * 100",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -331,7 +331,7 @@
           "step": 240
         },
         {
-          "expr": "100 - ((node_memory_MemAvailable_bytes{node=~\"$node\",job=\"node-exporter\"} * 100) / node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"})",
+          "expr": "100 - ((node_memory_MemAvailable_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} * 100) / node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -483,7 +483,7 @@
       "pluginVersion": "7.4.2",
       "targets": [
         {
-          "expr": "100 - ((node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",mountpoint=\"/\",fstype!=\"rootfs\"})",
+          "expr": "100 - ((node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",mountpoint=\"/\",fstype!=\"rootfs\",pod=\"\"} * 100) / node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",mountpoint=\"/\",fstype!=\"rootfs\",pod=\"\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -744,7 +744,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",mountpoint=\"/\",fstype!=\"rootfs\"}",
+          "expr": "node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",mountpoint=\"/\",fstype!=\"rootfs\",pod=\"\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -835,7 +835,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"}",
+          "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
           "intervalFactor": 1,
           "refId": "A",
           "step": 240
@@ -1052,7 +1052,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1061,7 +1061,7 @@
           "step": 240
         },
         {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1070,7 +1070,7 @@
           "step": 240
         },
         {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Busy Iowait",
@@ -1078,7 +1078,7 @@
           "step": 240
         },
         {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Busy IRQs",
@@ -1086,7 +1086,7 @@
           "step": 240
         },
         {
-          "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+          "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Busy Other",
@@ -1094,7 +1094,7 @@
           "step": 240
         },
         {
-          "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+          "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Idle",
@@ -1242,7 +1242,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"}",
+          "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1251,7 +1251,7 @@
           "step": 240
         },
         {
-          "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\"} - (node_memory_Cached_bytes{node=~\"$node\",job=\"node-exporter\"} + node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\"})",
+          "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - (node_memory_Cached_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} + node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1260,7 +1260,7 @@
           "step": 240
         },
         {
-          "expr": "node_memory_Cached_bytes{node=~\"$node\",job=\"node-exporter\"} + node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\"}",
+          "expr": "node_memory_Cached_bytes{node=~\"$node\",job=\"node-exporter\"} + node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "RAM Cache + Buffer",
@@ -1268,7 +1268,7 @@
           "step": 240
         },
         {
-          "expr": "node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\"}",
+          "expr": "node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "RAM Free",
@@ -1526,7 +1526,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100 - ((node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs'})",
+          "expr": "100 - ((node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs',pod=\"\"} * 100) / node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs',pod=\"\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{mountpoint}}",
@@ -1656,7 +1656,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "System - Processes executing in kernel mode",
@@ -1664,7 +1664,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "User - Normal processes executing in user mode",
@@ -1672,7 +1672,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Nice - Niced processes executing in user mode",
@@ -1680,7 +1680,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Idle - Waiting for something to happen",
@@ -1688,7 +1688,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Iowait - Waiting for I/O to complete",
@@ -1696,7 +1696,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Irq - Servicing interrupts",
@@ -1704,7 +1704,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Softirq - Servicing softirqs",
@@ -1712,7 +1712,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Steal - Time spent in other operating systems when running in a virtualized environment",
@@ -1720,7 +1720,7 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',node=~\"$node\",job=\"node-exporter\",pod=\"\"}[$__interval_sx4])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Guest - Time spent running a virtual CPU for a guest operating system",
@@ -1852,7 +1852,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_Cached_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_Slab_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_PageTables_bytes{node=~\"$node\",job=\"node-exporter\"} - node_memory_SwapCached_bytes{node=~\"$node\",job=\"node-exporter\"}",
+              "expr": "node_memory_MemTotal_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_Cached_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_Slab_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_PageTables_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"} - node_memory_SwapCached_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1896,7 +1896,7 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\"}",
+              "expr": "node_memory_Buffers_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1905,7 +1905,7 @@
               "step": 240
             },
             {
-              "expr": "node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\"}",
+              "expr": "node_memory_MemFree_bytes{node=~\"$node\",job=\"node-exporter\",pod=\"\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -2153,7 +2153,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs'} - node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs'}",
+              "expr": "node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs',pod=\"\"} - node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs',pod=\"\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{mountpoint}}",
@@ -8656,7 +8656,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs'}",
+              "expr": "node_filesystem_avail_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs',pod=\"\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -8675,7 +8675,7 @@
               "step": 240
             },
             {
-              "expr": "node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs'}",
+              "expr": "node_filesystem_size_bytes{node=~\"$node\",job=\"node-exporter\",device!~'rootfs',pod=\"\"}",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 1,

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
@@ -428,7 +428,7 @@
           "refId": "G"
         },
         {
-          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__range])\n  )",
+          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\",pod=\"\"}[$__range])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\",pod=\"\"}[$__range])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\",pod=\"\"}[$__range])\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -436,7 +436,7 @@
           "refId": "H"
         },
         {
-          "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__range]) + avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__range]))",
+          "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=~\"$node\",pod=\"\"}[$__range]) + avg_over_time(node_memory_Buffers_bytes{node=~\"$node\",pod=\"\"}[$__range]))",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1093,7 +1093,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__interval_sx3])\n  )",
+          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\",pod=\"\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\",pod=\"\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\",pod=\"\"}[$__interval_sx3])\n  )",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1191,7 +1191,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__interval_sx3])\n  )\n/\nsum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3]))\n* 100",
+          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\",pod=\"\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\",pod=\"\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\",pod=\"\"}[$__interval_sx3])\n  )\n/\nsum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3]))\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1319,14 +1319,14 @@
               "refId": "A"
             },
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_MemFree_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_MemFree_bytes{node=\"$node\",pod=\"\"}[$__interval_sx3]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Free",
               "refId": "B"
             },
             {
-              "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=\"$node\"}[$__interval_sx3])\n  )",
+              "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=\"$node\",pod=\"\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=\"$node\",pod=\"\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=\"$node\",pod=\"\"}[$__interval_sx3])\n  )",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1337,14 +1337,14 @@
               "step": 10
             },
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=\"$node\",pod=\"\"}[$__interval_sx3]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Cached",
               "refId": "D"
             },
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_Buffers_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_Buffers_bytes{node=\"$node\",pod=\"\"}[$__interval_sx3]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Buffered",


### PR DESCRIPTION
## Description
Filter out some duplicated metrics in our grafana dashboards that are created if [lens-hack](https://deckhouse.io/documentation/v1/modules/300-prometheus/faq.html#how-do-i-get-access-to-prometheus-metrics-from-lens) is applied. Filtering is implemented by checking that `pod` tag equals `null` for impacted metrics

## Why do we need it, and what problem does it solve?
If the [lens-hack](https://deckhouse.io/documentation/v1/modules/300-prometheus/faq.html#how-do-i-get-access-to-prometheus-metrics-from-lens) is applied in a cluster, duplicates of some metrics are created. `node` and `nodes` dashboards using these metrics break, showing double amount of RAM or storage or in some other way.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Minor grafana dashboards fix.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
