### PR TITLE
[common] Fix CVEs in csi-external-* images

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -35,7 +35,7 @@ k8s:
       attacher: v4.2.0
       resizer: v1.7.0
       registrar: v2.7.0
-      snapshotter: v6.2.1
+      snapshotter: v6.3.1
       livenessprobe: v2.9.0
   '1.25':
     status: available
@@ -55,7 +55,7 @@ k8s:
       attacher: v4.2.0
       resizer: v1.7.0
       registrar: v2.7.0
-      snapshotter: v6.2.1
+      snapshotter: v6.3.1
       livenessprobe: v2.9.0
   '1.26':
     status: available
@@ -75,7 +75,7 @@ k8s:
       attacher: v4.2.0
       resizer: v1.7.0
       registrar: v2.7.0
-      snapshotter: v6.2.1
+      snapshotter: v6.3.1
       livenessprobe: v2.9.0
   '1.27':
     status: available
@@ -95,7 +95,7 @@ k8s:
       attacher: v4.3.0
       resizer: v1.8.0
       registrar: v2.8.0
-      snapshotter: v6.2.1
+      snapshotter: v6.3.1
       livenessprobe: v2.10.0
   '1.28':
     status: preview
@@ -115,5 +115,5 @@ k8s:
       attacher: v4.4.0
       resizer: v1.9.0
       registrar: v2.9.0
-      snapshotter: v6.3.0
+      snapshotter: v6.3.1
       livenessprobe: v2.11.0

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -23,6 +23,9 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u google.golang.org/grpc@v1.57.2
+    - go mod vendor
     - make build
     - cp bin/csi-attacher /csi-attacher
     - chown 64535:64535 /csi-attacher

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -23,6 +23,11 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u google.golang.org/grpc@v1.56.3
+    - go mod tidy
+    - go mod vendor
+    - go mod edit -dropreplace google.golang.org/grpc
     - make build
     - cp bin/csi-provisioner /csi-provisioner
     - chown 64535:64535 /csi-provisioner

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -23,6 +23,9 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u google.golang.org/grpc@v1.56.3
+    - go mod vendor
     - make build
     - cp bin/csi-resizer /csi-resizer
     - chown 64535:64535 /csi-resizer

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -23,6 +23,11 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u google.golang.org/grpc@v1.56.3
+    - go mod tidy
+    - go mod vendor
+    - go mod edit -dropreplace golang.org/x/net
     - make build
     - cp bin/csi-snapshotter /csi-snapshotter
     - chown 64535:64535 /csi-snapshotter

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -23,13 +23,8 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u google.golang.org/grpc@v1.56.3
-    - go mod tidy
-    {{- if semverCompare ">=1.27" $version }}
-    - go mod edit -dropreplace golang.org/x/net
-    {{- end }}
-    - go mod vendor
+    - go get -u google.golang.org/grpc@v1.56.3 && \
+    - go mod vendor && \
     - make build
     - cp bin/csi-snapshotter /csi-snapshotter
     - chown 64535:64535 /csi-snapshotter

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -26,7 +26,9 @@ shell:
     - go get -u golang.org/x/net@v0.17.0
     - go get -u google.golang.org/grpc@v1.56.3
     - go mod tidy
+    {{- if semverCompare ">=1.27" $version }}
     - go mod edit -dropreplace golang.org/x/net
+    {{- end }}
     - go mod vendor
     - make build
     - cp bin/csi-snapshotter /csi-snapshotter

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -26,8 +26,8 @@ shell:
     - go get -u golang.org/x/net@v0.17.0
     - go get -u google.golang.org/grpc@v1.56.3
     - go mod tidy
-    - go mod vendor
     - go mod edit -dropreplace golang.org/x/net
+    - go mod vendor
     - make build
     - cp bin/csi-snapshotter /csi-snapshotter
     - chown 64535:64535 /csi-snapshotter


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed vulnerabilities: CVE-2023-44487, CVE-2022-41723, GHSA-m425-mq94-257g

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Info

<details><summary>trivy report</summary>

```shell
[deckhouse] root@b948a088bb62 / # cat /deckhouse/candi/images_digests.json | grep csiE | sort -V
    "csiExternalAttacher124": "sha256:793ad7a88134fb4a847eacf055ed0ef376cdca1efcae3039e70547ef3f11f3c7",
    "csiExternalAttacher125": "sha256:793ad7a88134fb4a847eacf055ed0ef376cdca1efcae3039e70547ef3f11f3c7",
    "csiExternalAttacher126": "sha256:793ad7a88134fb4a847eacf055ed0ef376cdca1efcae3039e70547ef3f11f3c7",
    "csiExternalAttacher127": "sha256:6b6f2cc3ce4d175208c51f03499f87df7d74c9e2153b7978df043c34bcce9a6a",
    "csiExternalAttacher128": "sha256:8ff8cc34f5e31dc13c09e60021ff7d5b663914b017ff527ceeda31d46e01d71b",
    "csiExternalProvisioner124": "sha256:8bc3e46fcb09c7c72b0d5561b442ebb23958eb575da93281f82d578e1792f2a6",
    "csiExternalProvisioner125": "sha256:8bc3e46fcb09c7c72b0d5561b442ebb23958eb575da93281f82d578e1792f2a6",
    "csiExternalProvisioner126": "sha256:8bc3e46fcb09c7c72b0d5561b442ebb23958eb575da93281f82d578e1792f2a6",
    "csiExternalProvisioner127": "sha256:9f34028f5ff745a52193a58f20d3540a42cfa38f2e97bcff88c735ba83fcf49d",
    "csiExternalProvisioner128": "sha256:5f84179c4f07b4334766c2ed82aaaf20cb9109bc45899899204a11252eac0c1d",
    "csiExternalResizer124": "sha256:e2af494ee8a61c5479716b7fd7b2c0bbc4c6625b99e3e8635d9397010f1efdf4",
    "csiExternalResizer125": "sha256:e2af494ee8a61c5479716b7fd7b2c0bbc4c6625b99e3e8635d9397010f1efdf4",
    "csiExternalResizer126": "sha256:e2af494ee8a61c5479716b7fd7b2c0bbc4c6625b99e3e8635d9397010f1efdf4",
    "csiExternalResizer127": "sha256:29d248d48ef1c085aa9d5257f8761cf1b411449e4e890b757e4d01fc110b3214",
    "csiExternalResizer128": "sha256:d8f44bda299fe80fd984dfab2beae8aa61a40421906a31a06eae2e4d9241814e",
    "csiExternalSnapshotter124": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter125": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter126": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter127": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter128": "sha256:f5419dcc39d61df0538ae3177564884cebc9e843315281503b3040fa818766b8",
```

```shell
csiExternalSnapshotter128
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.13.0           │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.58.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalSnapshotter127-124
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2022-41723      │ HIGH     │ v0.4.0            │ 0.7.0                  │ avoid quadratic complexity in HPACK decoding      │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-41723        │
│                        ├─────────────────────┤          │                   ├────────────────────────┼───────────────────────────────────────────────────┤
│                        │ CVE-2023-39325      │          │                   │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.50.1           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘

csiExternalResizer128
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.13.0           │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.54.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalResizer127
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.8.0            │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalResizer126-124
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2022-41723      │ HIGH     │ v0.4.0            │ 0.7.0                  │ avoid quadratic complexity in HPACK decoding      │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-41723        │
│                        ├─────────────────────┤          │                   ├────────────────────────┼───────────────────────────────────────────────────┤
│                        │ CVE-2023-39325      │          │                   │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalProvisioner128
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.14.0           │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.57.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalProvisioner127
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.8.0            │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.54.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalProvisioner126-124
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2022-41723      │ HIGH     │ v0.4.0            │ 0.7.0                  │ avoid quadratic complexity in HPACK decoding      │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-41723        │
│                        ├─────────────────────┤          │                   ├────────────────────────┼───────────────────────────────────────────────────┤
│                        │ CVE-2023-39325      │          │                   │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.51.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalAttacher128
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.13.0           │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.57.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalAttacher127
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.8.0            │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.54.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
csiExternalAttacher126-124
┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2022-41723      │ HIGH     │ v0.4.0            │ 0.7.0                  │ avoid quadratic complexity in HPACK decoding      │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-41723        │
│                        ├─────────────────────┤          │                   ├────────────────────────┼───────────────────────────────────────────────────┤
│                        │ CVE-2023-39325      │          │                   │ 0.17.0                 │ rapid stream resets can cause excessive work      │
│                        │                     │          │                   │                        │ (CVE-2023-44487)                                  │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325        │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.52.3           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘

```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed vulnerabilities in csi-external-* images: CVE-2023-44487, CVE-2022-41723, GHSA-m425-mq94-257g
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
