### PR TITLE
[common] fix cve issues in kube-rbac-proxy image

### DIFF
--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
   - go mod edit -go 1.20
   - go get -u golang.org/x/net@v0.17.0
   - go get -u github.com/prometheus/client_golang@v1.17.0
-  - go get -u github.com/gogo/protobuf@1.3.2
+  - go get -u github.com/gogo/protobuf@v1.3.2
   - go mod tidy
   - make build
   - cp /src/_output/kube-rbac-proxy-linux-$(go env GOARCH) /kube-rbac-proxy

--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -11,7 +11,7 @@ docker:
   EXPOSE: "8080"
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ .Images.BASE_GOLANG_16_ALPINE }}
+from: {{ .Images.BASE_GOLANG_20_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -29,6 +29,8 @@ shell:
   - cd /src
   - test -d /patches && for patchfile in /patches/*.patch ; do patch -p1 < ${patchfile}; done
   - export GOPROXY={{ .GOPROXY }} GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  - go mod edit -go 1.20
+  - go get -u golang.org/x/net@v0.17.0
   - make build
   - cp /src/_output/kube-rbac-proxy-linux-$(go env GOARCH) /kube-rbac-proxy
   - chown 64535:64535 /kube-rbac-proxy

--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -31,6 +31,7 @@ shell:
   - export GOPROXY={{ .GOPROXY }} GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - go mod edit -go 1.20
   - go get -u golang.org/x/net@v0.17.0
+  - go mod tidy
   - make build
   - cp /src/_output/kube-rbac-proxy-linux-$(go env GOARCH) /kube-rbac-proxy
   - chown 64535:64535 /kube-rbac-proxy

--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -31,6 +31,8 @@ shell:
   - export GOPROXY={{ .GOPROXY }} GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - go mod edit -go 1.20
   - go get -u golang.org/x/net@v0.17.0
+  - go get -u github.com/prometheus/client_golang@v1.17.0
+  - go get -u github.com/gogo/protobuf@1.3.2
   - go mod tidy
   - make build
   - cp /src/_output/kube-rbac-proxy-linux-$(go env GOARCH) /kube-rbac-proxy


### PR DESCRIPTION
## Description
Fixed CVE issues:

- [CVE-2021-3121](https://access.redhat.com/security/cve/CVE-2021-3121)
- [CVE-2022-21698](https://access.redhat.com/errata/RHSA-2022:8057)
- [CVE-2020-29652](https://access.redhat.com/security/cve/CVE-2020-29652)
- [CVE-2021-43565](https://access.redhat.com/security/cve/CVE-2021-43565)
- [CVE-2022-27191](https://access.redhat.com/errata/RHSA-2022:8008)
- [CVE-2021-33194](https://access.redhat.com/security/cve/CVE-2021-33194)
- [CVE-2022-27664](https://access.redhat.com/errata/RHSA-2023:2357)
- [CVE-2022-41723](https://access.redhat.com/security/cve/CVE-2022-41723)
- [CVE-2021-38561](https://access.redhat.com/security/cve/CVE-2021-38561)
- [CVE-2022-32149](https://access.redhat.com/security/cve/CVE-2022-32149)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixed HIGH CVE issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: fix cve issues in kube-rbac-proxy image
impact:  check the pods that are behind the kube-rbac-proxy
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
