### PR TITLE
[ingress-nginx] fix cve issues in kruise-state-metrics image

### DIFF
--- a/modules/402-ingress-nginx/images/kruise-state-metrics/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/kruise-state-metrics/werf.inc.yaml
@@ -15,7 +15,7 @@ shell:
     - go get -u golang.org/x/net@v0.17.0
     - go get -u gopkg.in/yaml.v3@v3.0.1
     - go get -u github.com/prometheus/client_golang@v1.17.0
-    - go get -u golang.org/x/crypto@0.14.0
+    - go get -u golang.org/x/crypto@v0.14.0
     - go mod tidy
     - go mod ventor
     - GOPROXY={{ $.GOPROXY }} go build -mod=vendor -a -o /tmp/kruise-state-metrics main.go

--- a/modules/402-ingress-nginx/images/kruise-state-metrics/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/kruise-state-metrics/werf.inc.yaml
@@ -17,7 +17,7 @@ shell:
     - go get -u github.com/prometheus/client_golang@v1.17.0
     - go get -u golang.org/x/crypto@v0.14.0
     - go mod tidy
-    - go mod ventor
+    - go mod vendor
     - GOPROXY={{ $.GOPROXY }} go build -mod=vendor -a -o /tmp/kruise-state-metrics main.go
     - chown -R 64535:64535 /tmp/kruise-state-metrics
     - chmod 0700 /tmp/kruise-state-metrics

--- a/modules/402-ingress-nginx/images/kruise-state-metrics/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/kruise-state-metrics/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $commit := "b081f2ae9e011fd92fd23f6efa209601f5a20a01" }}
 ---
 artifact: kruise-state-metrics
-from: {{ $.Images.BASE_GOLANG_19_BULLSEYE }}
+from: {{ $.Images.BASE_GOLANG_20_BULLSEYE }}
 shell:
   setup:
     - export "CGO_ENABLED=0"
@@ -11,6 +11,13 @@ shell:
     - git clone --depth 1 --branch {{ $branch }} {{ $.SOURCE_REPO }}/openkruise/kruise-state-metrics.git
     - cd kruise-state-metrics
     - git checkout {{ $commit }}
+    - go mod edit -go 1.20
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u gopkg.in/yaml.v3@v3.0.1
+    - go get -u github.com/prometheus/client_golang@v1.17.0
+    - go get -u golang.org/x/crypto@0.14.0
+    - go mod tidy
+    - go mod ventor
     - GOPROXY={{ $.GOPROXY }} go build -mod=vendor -a -o /tmp/kruise-state-metrics main.go
     - chown -R 64535:64535 /tmp/kruise-state-metrics
     - chmod 0700 /tmp/kruise-state-metrics


### PR DESCRIPTION
## Description
Fixed CVE issues:

- [CVE-2022-21698](https://access.redhat.com/errata/RHSA-2022:8057)
- [CVE-2021-43565](https://access.redhat.com/security/cve/CVE-2021-43565)
- [CVE-2022-27191](https://access.redhat.com/errata/RHSA-2022:8008)
- [CVE-2022-27664](https://access.redhat.com/errata/RHSA-2023:2357)
- [CVE-2022-41723](https://access.redhat.com/security/cve/CVE-2022-41723)
- [CVE-2022-32149](https://access.redhat.com/security/cve/CVE-2022-32149)
- [CVE-2022-28948](https://access.redhat.com/security/cve/CVE-2022-28948)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixed HIGH CVE issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: fix cve issues in kruise-state-metrics image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
