### PR TITLE
[go_lib] Fix EnsureCRDs hook

### DIFF
--- a/go_lib/hooks/ensure_crds/hook.go
+++ b/go_lib/hooks/ensure_crds/hook.go
@@ -160,8 +160,14 @@ func (cp *crdsProcessor) putCRDToCluster(crdReader io.Reader, bufferSize int) er
 	if err != nil {
 		return err
 	}
-	if crd == nil || crd.APIVersion != v1.SchemeGroupVersion.String() {
-		return fmt.Errorf("invalid CRD: %v", crd)
+
+	// it could be a comment or some other peace of yaml file, skip it
+	if crd == nil {
+		return nil
+	}
+
+	if crd.APIVersion != v1.SchemeGroupVersion.String() && crd.Kind != "CustomResourceDefinition" {
+		return fmt.Errorf("invalid CRD document apiversion/kind: '%s/%s'", crd.APIVersion, crd.Kind)
 	}
 
 	cp.k8sTasks.Go(func() error {

--- a/go_lib/hooks/ensure_crds/hook_test.go
+++ b/go_lib/hooks/ensure_crds/hook_test.go
@@ -34,7 +34,8 @@ func TestEnsureCRDs(t *testing.T) {
 	dependency.TestDC.K8sClient = cluster.Client
 
 	merr := EnsureCRDs("./test_data/**", dependency.TestDC)
-	require.NoError(t, merr.ErrorOrNil())
+	require.Equal(t, 1, merr.Len())
+	assert.Errorf(t, merr.Errors[0], "invalid CRD document apiversion/kind: 'v1/Pod'")
 
 	//
 	list, err := cluster.Client.Dynamic().Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})

--- a/go_lib/hooks/ensure_crds/test_data/huge.crd
+++ b/go_lib/hooks/ensure_crds/test_data/huge.crd
@@ -1,3 +1,4 @@
+# comment should not ruin anything
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/go_lib/hooks/ensure_crds/test_data/invalid.crd
+++ b/go_lib/hooks/ensure_crds/test_data/invalid.crd
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: invalid


### PR DESCRIPTION
## Description
Fix hook logic

## Why do we need it, and what problem does it solve?
If yaml document has only comment it was rendered as CRD and through an error. We can ignore such situations

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: go_lib
type: fix 
summary: Fix EnsureCRDs hook - reading an empty yaml document should't trigger an error.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
