### PR TITLE
[candi] Fix containerd deckhouse start

### DIFF
--- a/modules/040-node-manager/templates/fix-containerd-start.yaml
+++ b/modules/040-node-manager/templates/fix-containerd-start.yaml
@@ -3,6 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: NodeGroupConfiguration
 metadata:
   name: fix-start-containerd-deckhouse.sh
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
   weight: 32
   bundles:

--- a/modules/040-node-manager/templates/fix-containerd-start.yaml
+++ b/modules/040-node-manager/templates/fix-containerd-start.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: NodeGroupConfiguration
+metadata:
+  name: fix-start-containerd-deckhouse.sh
+spec:
+  weight: 32
+  bundles:
+    - "*"
+  nodeGroups:
+    - "*"
+  content: |
+    #!/bin/bash
+    if ! systemctl -q is-enabled containerd-deckhouse.service; then
+      exit 0
+    fi
+
+    if systemctl -q is-active containerd-deckhouse.service; then
+      exit 0
+    fi
+    bb-log-info "Trying to start containerd-deckhouse service."
+    systemctl start containerd-deckhouse.service


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix containerd deckhouse start after install new containerd-deckhouse package (now new containerd-deckhouse starts later, in 050_ step, which leads to possibly problems with node notReady for large amount of time)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

When we updates from release 1.51 to 1.52, we've got a problem:
Containerd package is replaced with containerd-deckhouse package in 031_ step.
After that kubeletpackage downloads and install.
After that containerd config updated and containerd-deckhouse is started.

When downloading of kubelet takes significant amount of time, we get node notReady due to all this time containerd does not work.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix deckhouse containerd start after installing new containerd-deckhouse package.
```
