### PR TITLE
[external-module-manager] add support for hardlinks and symlinks to the module

### DIFF
--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -457,6 +457,16 @@ func copyLayersToFS(rootPath string, rc io.ReadCloser) error {
 			if err != nil {
 				return fmt.Errorf("chmod: %w", err)
 			}
+		case tar.TypeSymlink:
+			link := path.Join(rootPath, hdr.Name)
+			if err := os.Symlink(hdr.Linkname, link); err != nil {
+				return fmt.Errorf("create symlink: %w", err)
+			}
+		case tar.TypeLink:
+			err := os.Link(path.Join(rootPath, hdr.Linkname), path.Join(rootPath, hdr.Name))
+			if err != nil {
+				return fmt.Errorf("create hardlink: %w", err)
+			}
 
 		default:
 			return errors.New("unknown tar type")


### PR DESCRIPTION
## Description
Adds support for unpacking images with modules containing links.

## Why do we need it, and what problem does it solve?
Currently, when unpacking an image containing a module, only files and directories are unpacked.
If your module has other types of files, you will see a "unknown tar type" error.

## Why do we need it in the patch release (if we do)?
## What is the expected result?
It will create links if they exist.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: external-module-manager
type: fix
summary: add support for hardlinks and symlinks to the module
impact_level: default 
```