### PR TITLE
[linstor] add ghost res files cleaner

### DIFF
--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -212,5 +212,9 @@ RUN curl -Lfo /usr/bin/piraeus-entry.sh ${PIRAEUS_GITREPO}/raw/${PIRAEUS_COMMIT_
 COPY liveness.sh /liveness.sh
 RUN chmod 755 /liveness.sh
 
+# Script for cleaner sidecar
+COPY cleaner.py /cleaner.py
+RUN chmod 755 /cleaner.py
+
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/modules/041-linstor/images/linstor-server/cleaner.py
+++ b/modules/041-linstor/images/linstor-server/cleaner.py
@@ -70,8 +70,8 @@ class LinstorConnection:
         return result
 
 def get_res_files() -> List[str]:
-    files_iter = Path(BASE_RES_PATH).glob("RES_FILES_MASK")
-    return [f.name for f in files_iter]
+    files_iter = Path(BASE_RES_PATH).glob(RES_FILES_MASK)
+    return list(files_iter)
    
 def process_res_files(log_level):
     logger = logging.getLogger()

--- a/modules/041-linstor/images/linstor-server/cleaner.py
+++ b/modules/041-linstor/images/linstor-server/cleaner.py
@@ -1,0 +1,79 @@
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import linstor
+import argparse
+import pathlib
+import sched, time
+import logging
+
+def singleton(class_):
+    instances = {}
+
+    def get_instance(*args, **kwargs):
+        if class_ not in instances:
+            instances[class_] = class_(*args, **kwargs)
+        return instances[class_]
+
+    return get_instance
+
+@singleton
+class LinstorConnection:
+    def __init__(self) -> None:
+        # In pod hardcoded.
+        self.__conn = linstor.Linstor("linstor+ssl://linstor.d8-linstor.svc:3371")
+        self.__conn.keyfile = '/etc/linstor/client/tls.key'
+        self.__conn.cafile = '/etc/linstor/client/ca.crt'
+        self.__conn.certfile =  '/etc/linstor/client/tls.crt'
+
+    def get_resource_list(self, retries=5):
+        logger = logging.getLogger()
+        self.__conn.connect()
+        for i in range(retries):
+            try:
+                result = self.__conn.resource_list()
+            except Exception:
+                logger.debug(f"try retrive list resource from Linstor {i} time")
+                continue
+            else:
+                break
+        else:
+            logger.error("couldnor request resource list from linstor")
+            result = None
+        self.__conn.disconnect()
+        return result
+
+
+def process_res_files():
+    pass
+
+def main(interval: int, debug: bool):
+    log_level = logging.INFO
+    if debug:
+        log_level = logging.DEBUG
+    logging.basicConfig(stream=sys.stdout, level=log_level)
+
+    scheduler = sched.scheduler(time.time, time.sleep)
+    scheduler.enter(interval, 1, process_res_files)
+    scheduler.run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--interval", type=int, help="Interval in seconds", default=20, required=False)
+    parser.add_argument("--debug", type=bool, action="store_true", help="Enable debug logging", required=False)
+    args = parser.parse_args()
+
+    main(args.interval, args.debug)

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -98,14 +98,10 @@ spec:
   volumeMounts:
     - name: res-files
       mountPath: /var/lib/linstor.d
-    - name: etc-configs
-      mountPath: /etc/linstor
   extraVolumes:
   - name: spaas-certs
     secret:
       secretName: spaas-certs
-  - name: res-files
-    readOnly: false
   - name: etc-configs
     readOnly: false
   logLevel: info
@@ -116,8 +112,8 @@ spec:
     volumeMounts:
       - name: res-files
         mountPath: /var/lib/linstor.d
-      - name: etc-configs
-        mountPath: /etc/linstor
+      - name: linstor-client
+        mountPath: /etc/linstor/client
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}
     image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -98,15 +98,15 @@ spec:
   volumeMounts:
     - name: res-files
       mountPath: /var/lib/linstor.d
-    - name: cert-for-client
-      mountPath: /etc/linstor/client
+    - name: etc-configs
+      mountPath: /etc/linstor
   extraVolumes:
   - name: spaas-certs
     secret:
       secretName: spaas-certs
   - name: res-files
     readOnly: false
-  - name: cert-for-client
+  - name: etc-configs
     readOnly: false
   logLevel: info
   sidecars:
@@ -116,8 +116,8 @@ spec:
     volumeMounts:
       - name: res-files
         mountPath: /var/lib/linstor.d
-      - name: cert-for-client
-        mountPath: /etc/linstor/client
+      - name: etc-configs
+        mountPath: /etc/linstor
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}
     image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -112,7 +112,7 @@ spec:
   sidecars:
   - name: res-file-cleaner
     image: {{ include "helm_lib_module_image" (list . "linstorServer") }}
-    command: "python3 /cleaner.py"
+    command: ["python3", "/cleaner.py"]
     volumeMounts:
       - name: res-files
         mountPath: /var/lib/linstor.d

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -95,12 +95,29 @@ spec:
     value: "https://spaas.d8-linstor.svc:2020"
   - name: LB_SELINUX_AS
     value: "modules_object_t"
+  volumeMounts:
+    - name: res-files
+      mountPath: /var/lib/linstor.d
+    - name: cert-for-client
+      mountPath: /etc/linstor/client
   extraVolumes:
   - name: spaas-certs
     secret:
       secretName: spaas-certs
+  - name: res-files
+    readOnly: false
+  - name: cert-for-client
+    readOnly: false
   logLevel: info
   sidecars:
+  - name: res-file-cleaner
+    image: {{ include "helm_lib_module_image" (list . "linstorServer") }}
+    command: "python3 /cleaner.py"
+    volumeMounts:
+      - name: res-files
+        mountPath: /var/lib/linstor.d
+      - name: cert-for-client
+        mountPath: /etc/linstor/client
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}
     image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -102,6 +102,8 @@ spec:
   - name: spaas-certs
     secret:
       secretName: spaas-certs
+  - name: res-files
+    readOnly: false
   - name: etc-configs
     readOnly: false
   logLevel: info


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add sidecar cleaner for stucked res files

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: storage
type: fix
summary: Add sidecar cleaner for stucked res files
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
