### PR TITLE
[candi] send bootstrap logs to console in case of manual bootstrap

### DIFF
--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -89,27 +89,27 @@ bb-rp-install() {
     local DIGESTS=""
     DIGESTS="$(bb-rp-get-digests "${DIGEST}")"
 
-    local TMPDIR=""
-    TMPDIR="$(mktemp -d)"
+    local TMP_DIR=""
+    TMP_DIR="$(mktemp -d)"
 
     # Get digests
-    for TMPDIGEST in ${DIGESTS}; do
-      local TMPFILE=""
-      TMPFILE="$(mktemp -u)"
-      bb-rp-fetch-digest "${TMPDIGEST}" "${TMPFILE}"
-      tar -xf "${TMPFILE}" -C "${TMPDIR}"
-      rm -f "${TMPFILE}"
+    for TMP_DIGEST in ${DIGESTS}; do
+      local TMP_FILE=""
+      TMP_FILE="$(mktemp -u)"
+      bb-rp-fetch-digest "${TMP_DIGEST}" "${TMP_FILE}"
+      tar -xf "${TMP_FILE}" -C "${TMP_DIR}"
+      rm -f "${TMP_FILE}"
     done
 
     bb-log-info "Installing package '${PACKAGE}'"
     # run install script
     # shellcheck disable=SC2164
-    pushd "${TMPDIR}" >/dev/null
+    pushd "${TMP_DIR}" >/dev/null
     ./install
     if bb-error?
     then
         popd >/dev/null
-        rm -rf "${TMPDIR}"
+        rm -rf "${TMP_DIR}"
         bb-log-error "Failed to install package '${PACKAGE}'"
         return $BB_ERROR
     fi
@@ -119,9 +119,9 @@ bb-rp-install() {
     mkdir -p "${BB_RP_INSTALLED_PACKAGES_STORE}/${PACKAGE}"
     echo "${DIGEST}" > "${BB_RP_INSTALLED_PACKAGES_STORE}/${PACKAGE}/digest"
     # copy install/uninstall scripts to hold dir
-    cp "${TMPDIR}/install" "${TMPDIR}/uninstall" "${BB_RP_INSTALLED_PACKAGES_STORE}/${PACKAGE}"
+    cp "${TMP_DIR}/install" "${TMP_DIR}/uninstall" "${BB_RP_INSTALLED_PACKAGES_STORE}/${PACKAGE}"
     # cleanup
-    rm -rf "${TMPDIR}"
+    rm -rf "${TMP_DIR}"
 
     bb-event-fire "bb-package-installed" "${PACKAGE}"
     trap - ERR

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -15,7 +15,9 @@ set -Eeuo pipefail
 BOOTSTRAP_DIR="/var/lib/bashible"
 TMPDIR="/opt/deckhouse/tmp"
 mkdir -p "${BOOTSTRAP_DIR}" "${TMPDIR}"
+  {{- if or (eq $ng.nodeType "CloudEphemeral") (hasKey $ng "staticInstances") }}
 exec >"${TMPDIR}/bootstrap.log" 2>&1
+  {{- end }}
 
 function detect_bundle() {
   {{- $context.Files.Get "candi/bashible/detect_bundle.sh" | nindent 2 }}
@@ -123,6 +125,7 @@ EOF
   fi
 }
 
+  {{- if or (eq $ng.nodeType "CloudEphemeral") (hasKey $ng "staticInstances") }}
 function run_log_output() {
   {{- /*
   # Start output bootstrap logs
@@ -132,15 +135,20 @@ function run_log_output() {
     bootstrap_job_log_pid=$!
   fi
 }
+ {{- end }}
 BUNDLE="$(detect_bundle)"
 run_cloud_network_setup
+  {{- if or (eq $ng.nodeType "CloudEphemeral") (hasKey $ng "staticInstances") }}
 run_log_output
+  {{- end }}
 get_phase2 | bash
 
   {{- /*
 # Stop output bootstrap logs
   */}}
+  {{- if or (eq $ng.nodeType "CloudEphemeral") (hasKey $ng "staticInstances") }}
 if [ -n "${bootstrap_job_log_pid}" ]; then
   kill -9 "${bootstrap_job_log_pid}"
 fi
+  {{- end }}
 {{- end }}

--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -10,6 +10,8 @@ clusterDomain: "cluster.local"
 proxy:
   httpProxy: http://192.168.199.254:8888
   httpsProxy: http://192.168.199.254:8888
+  noProxy:
+  - 192.168.199.0/24
 ---
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -480,7 +480,7 @@ function bootstrap_static() {
     if $ssh_command -i "$ssh_private_key_path" "$ssh_user@$bastion_ip" sudo su -c /bin/bash <<ENDSSH; then
        apt-get update
        apt-get install -y docker.io
-       docker run -d --network host vimagick/tinyproxy
+       docker run -d --network host ajoergensen/tinyproxy -e "ALLOWED=192.168.199.0/24"
 ENDSSH
       initial_setup_failed=""
       break

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -480,7 +480,7 @@ function bootstrap_static() {
     if $ssh_command -i "$ssh_private_key_path" "$ssh_user@$bastion_ip" sudo su -c /bin/bash <<ENDSSH; then
        apt-get update
        apt-get install -y docker.io
-       docker run -d --network host ajoergensen/tinyproxy -e "ALLOWED=192.168.199.0/24"
+       docker run -d --network host -e "ALLOWED=192.168.199.0/24" ajoergensen/tinyproxy
 ENDSSH
       initial_setup_failed=""
       break

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -480,7 +480,7 @@ function bootstrap_static() {
     if $ssh_command -i "$ssh_private_key_path" "$ssh_user@$bastion_ip" sudo su -c /bin/bash <<ENDSSH; then
        apt-get update
        apt-get install -y docker.io
-       docker run -d --network host -e "ALLOWED=192.168.199.0/24" ajoergensen/tinyproxy
+       docker run -d --network host -e "ALLOWED=192.168.199.0/24" -e "CONNECT_PORTS=443 5001" ajoergensen/tinyproxy
 ENDSSH
       initial_setup_failed=""
       break

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -480,7 +480,7 @@ function bootstrap_static() {
     if $ssh_command -i "$ssh_private_key_path" "$ssh_user@$bastion_ip" sudo su -c /bin/bash <<ENDSSH; then
        apt-get update
        apt-get install -y docker.io
-       docker run -d --network host -e "ALLOWED=192.168.199.0/24" -e "CONNECT_PORTS=443 5001" ajoergensen/tinyproxy
+       docker run -d --name='tinyproxy' -p 8888:8888 monokal/tinyproxy:latest ANY
 ENDSSH
       initial_setup_failed=""
       break


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. Send bootstrap logs to console in case of manual bootstrap insead of sending to /opt/deckhouse/tmp/bootstrap.log.

2. Change tinyproxy image in static e2e tests.

3. Change TMP* variables in bashbooster to TMP_*.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

1. When we manually bootstraps the node, we need to see any possible problems. It's inconvenient to look logs at the file. 

2. Sometimes e2e static tests fail due to improper work of tinyproxy image (container started, but not work).

3. Bashbootser uses TMPDIR variable which intersects with system TMPDIR variable.
 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: send bootstrap logs to console in case of manual bootstrap
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
