### PR TITLE
[monitoring-kubernetes] fix cve issues in kube-state-metrics image

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_GOLANG_17_ALPINE
+ARG BASE_GOLANG_20_ALPINE
 ARG BASE_DISTROLESS
-FROM $BASE_GOLANG_17_ALPINE as artifact
+FROM $BASE_GOLANG_20_ALPINE as artifact
 RUN apk add --no-cache make git patch
 
 ARG GOPROXY
@@ -16,7 +16,10 @@ ENV GOPROXY=${GOPROXY} \
 RUN mkdir -p /src/kube-state-metrics && \
   git clone --depth 1 --branch v2.6.0 ${SOURCE_REPO}/kubernetes/kube-state-metrics/ /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
-RUN make build-local && \
+RUN go mod edit -go 1.20 \
+    && go get -u golang.org/x/net@v0.17.0 \
+    && go get -u github.com/emicklei/go-restful@v2.16.0 \
+    && make build-local && \
     chown -R 64535:64535 /src/kube-state-metrics && \
     chmod 0700 /src/kube-state-metrics/kube-state-metrics
 


### PR DESCRIPTION
## Description
Fixed CVE issues:

- [CVE-2022-1996](https://access.redhat.com/security/cve/CVE-2022-1996)
- [CVE-2022-27664](https://access.redhat.com/errata/RHSA-2023:2357)
- [CVE-2022-41723](https://access.redhat.com/security/cve/CVE-2022-41723)
- [CVE-2022-32149](https://access.redhat.com/security/cve/CVE-2022-32149)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixed CRITICAL and HIGH CVE issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: fix cve issues in kube-state-metrics image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
