### PR TITLE
[external-module-manager] Support http scheme for a source registry

### DIFF
--- a/modules/005-external-module-manager/crds/doc-ru-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-module-source.yaml
@@ -13,6 +13,8 @@ spec:
                   description: Желаемый канал обновлений по-умолчанию для модулей данного container registry.
                 registry:
                   properties:
+                    scheme:
+                      description: Протокол для доступа к репозиторию контейнеров.
                     repo:
                       type: string
                       description: Адрес репозитория образов контейнеров.

--- a/modules/005-external-module-manager/crds/module-source.yaml
+++ b/modules/005-external-module-manager/crds/module-source.yaml
@@ -41,6 +41,13 @@ spec:
                   required:
                     - repo
                   properties:
+                    scheme:
+                      type: string
+                      default: "https"
+                      description: Protocol to access the registry.
+                      enum:
+                        - http
+                        - https
                     repo:
                       type: string
                       description: URL of the container registry.

--- a/modules/005-external-module-manager/crds/module-source.yaml
+++ b/modules/005-external-module-manager/crds/module-source.yaml
@@ -43,11 +43,11 @@ spec:
                   properties:
                     scheme:
                       type: string
-                      default: "https"
+                      default: "HTTPS"
                       description: Protocol to access the registry.
                       enum:
-                        - http
-                        - https
+                        - HTTP
+                        - HTTPS
                     repo:
                       type: string
                       description: URL of the container registry.

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -84,6 +84,11 @@ func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 		return nil, err
 	}
 
+	if ms.Spec.Registry.Scheme == "" {
+		// fallback to default https protocol
+		ms.Spec.Registry.Scheme = "https"
+	}
+
 	// remove unused fields
 	newms := v1alpha1.ModuleSource{
 		TypeMeta: ms.TypeMeta,
@@ -133,6 +138,10 @@ func handleSource(input *go_hook.HookInput, dc dependency.Container) error {
 
 		if ex.Spec.Registry.CA != "" {
 			opts = append(opts, cr.WithCA(ex.Spec.Registry.CA))
+		}
+
+		if ex.Spec.Registry.Scheme == "http" {
+			opts = append(opts, cr.WithInsecureSchema(true))
 		}
 
 		regCli, err := dc.GetRegistryClient(ex.Spec.Registry.Repo, opts...)

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -86,7 +86,7 @@ func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 
 	if ms.Spec.Registry.Scheme == "" {
 		// fallback to default https protocol
-		ms.Spec.Registry.Scheme = "https"
+		ms.Spec.Registry.Scheme = "HTTPS"
 	}
 
 	// remove unused fields
@@ -140,7 +140,7 @@ func handleSource(input *go_hook.HookInput, dc dependency.Container) error {
 			opts = append(opts, cr.WithCA(ex.Spec.Registry.CA))
 		}
 
-		if ex.Spec.Registry.Scheme == "http" {
+		if ex.Spec.Registry.Scheme == "HTTP" {
 			opts = append(opts, cr.WithInsecureSchema(true))
 		}
 

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -42,6 +42,7 @@ type ModuleSourceSpec struct {
 }
 
 type ModuleSourceSpecRegistry struct {
+	Scheme    string `json:"scheme"`
 	Repo      string `json:"repo"`
 	DockerCFG string `json:"dockerCfg"`
 	CA        string `json:"ca"`

--- a/testing/openapi_validation/validators/enum.go
+++ b/testing/openapi_validation/validators/enum.go
@@ -184,12 +184,6 @@ var (
 	}
 
 	arrayPathRegex = regexp.MustCompile(`\[\d+\]`)
-
-	// some keys, that must not be capitalized anywhere
-	enumKeyExcludes = map[string]struct{}{
-		"http":  {},
-		"https": {},
-	}
 )
 
 type EnumValidator struct {
@@ -258,10 +252,6 @@ func (en EnumValidator) validateEnumValues(enumKey string, values []string) *mul
 
 func (en EnumValidator) validateEnumValue(value string) error {
 	if len(value) == 0 {
-		return nil
-	}
-
-	if _, ok := enumKeyExcludes[value]; ok {
 		return nil
 	}
 

--- a/testing/openapi_validation/validators/enum.go
+++ b/testing/openapi_validation/validators/enum.go
@@ -64,6 +64,9 @@ var (
 			// http and https
 			"properties.modulesImages.properties.registry.properties.scheme",
 		},
+		//"modules/005-external-module-manager/crds/module-source.yaml": {
+		//// http and https should not be capitalized
+		//},
 		"modules/010-user-authn-crd/crds/dex-provider.yaml": {
 			// v1alpha1 migrated to v1
 			"spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.github.properties.teamNameField",
@@ -184,6 +187,12 @@ var (
 	}
 
 	arrayPathRegex = regexp.MustCompile(`\[\d+\]`)
+
+	// some keys, that must not be capitalized anywhere
+	enumKeyExcludes = map[string]struct{}{
+		"http":  {},
+		"https": {},
+	}
 )
 
 type EnumValidator struct {
@@ -252,6 +261,10 @@ func (en EnumValidator) validateEnumValues(enumKey string, values []string) *mul
 
 func (en EnumValidator) validateEnumValue(value string) error {
 	if len(value) == 0 {
+		return nil
+	}
+
+	if _, ok := enumKeyExcludes[value]; ok {
 		return nil
 	}
 

--- a/testing/openapi_validation/validators/enum.go
+++ b/testing/openapi_validation/validators/enum.go
@@ -64,9 +64,6 @@ var (
 			// http and https
 			"properties.modulesImages.properties.registry.properties.scheme",
 		},
-		//"modules/005-external-module-manager/crds/module-source.yaml": {
-		//// http and https should not be capitalized
-		//},
 		"modules/010-user-authn-crd/crds/dex-provider.yaml": {
 			// v1alpha1 migrated to v1
 			"spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.github.properties.teamNameField",


### PR DESCRIPTION
## Description
Support `http` scheme for registry with source modules

## Why do we need it, and what problem does it solve?
Some users can have insecure registry

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: feature
summary: Add support for module pull from insecure (http) registry.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
