### PR TITLE
[dhctl] Pushed images count in dhctl mirror during push to registry

### DIFF
--- a/dhctl/pkg/operations/mirror.go
+++ b/dhctl/pkg/operations/mirror.go
@@ -139,11 +139,12 @@ func PushMirrorToRegistry(mirrorCtx *mirror.Context) error {
 			return err
 		}
 
+		pushCount := 1
 		for _, manifest := range indexManifest.Manifests {
 			repo := mirrorCtx.RegistryHost + registryURL.Path
 			tag := manifest.Annotations["io.deckhouse.image.short_tag"]
 
-			log.InfoF("Pushing image %s...\t", repo+":"+tag)
+			log.InfoF("[%d / %d] Pushing image %s...\t", pushCount, len(indexManifest.Manifests), repo+":"+tag)
 			img, err := index.Image(manifest.Digest)
 			if err != nil {
 				log.InfoLn("❌")
@@ -169,6 +170,7 @@ func PushMirrorToRegistry(mirrorCtx *mirror.Context) error {
 				return fmt.Errorf("write %s to registry: %w", ref.String(), err)
 			}
 			log.InfoLn("✅")
+			pushCount++
 		}
 		log.InfoF("Repo %s is mirrored ✅\n", originalRepo)
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added number of pushed vs total images count to log output during push to registry

<img width="1179" alt="image" src="https://github.com/deckhouse/deckhouse/assets/5184586/600d6bf1-5351-47da-8476-d020b875aef2">


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Pull operation already has this, so push should have it too

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Added pushed images count in dhctl mirror log during push to registry
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
