### PR TITLE
[local-path-provisioner] fix cve issues in local-path-provisioner image

### DIFF
--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -31,6 +31,12 @@ shell:
     - git clone --depth 1 --branch v{{$localPathProvisionerVersion}} {{ $.SOURCE_REPO }}/rancher/local-path-provisioner.git /src
     - cd /src
     - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
+    - go mod edit -go 1.20
+    - go get -u golang.org/x/crypto@v0.14.0
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u github.com/prometheus/client_golang@v1.17.0
+    - go mod tidy
+    - go mod vendor
     - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner
     - chown -R 64535:64535 /local-path-provisioner
     - chmod 0700 /local-path-provisioner

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -13,7 +13,6 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
-fromCacheVersion: "2023-10-16.0"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -12,7 +12,7 @@ docker:
   ENTRYPOINT: ["/usr/bin/local-path-provisioner"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 fromCacheVersion: "2023-10-16.0"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -31,6 +31,11 @@ shell:
     - git clone --depth 1 --branch v{{$localPathProvisionerVersion}} {{ $.SOURCE_REPO }}/rancher/local-path-provisioner.git /src
     - cd /src
     - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
+    - go mod edit -go 1.20
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u github.com/prometheus/client_golang@v1.17.0
+    - go get -u golang.org/x/crypto@v0.14.0
+    - go mod tidy
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner
     - chown -R 64535:64535 /local-path-provisioner
     - chmod 0700 /local-path-provisioner

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -1,9 +1,9 @@
-{{- $localPathProvisionerVersion := "0.0.21"}}
+{{- $localPathProvisionerVersion := "0.0.24"}}
 
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2023-10-30.1"
+fromCacheVersion: "2023-10-31.1"
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /local-path-provisioner
@@ -14,7 +14,7 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
-fromCacheVersion: "2023-10-30.1"
+fromCacheVersion: "2023-10-31.1"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches
@@ -31,12 +31,6 @@ shell:
     - git clone --depth 1 --branch v{{$localPathProvisionerVersion}} {{ $.SOURCE_REPO }}/rancher/local-path-provisioner.git /src
     - cd /src
     - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
-    - go mod edit -go 1.20
-    - go get -u golang.org/x/crypto@v0.14.0
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u github.com/prometheus/client_golang@v1.17.0
-    - go mod tidy
-    - go mod vendor
     - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner
     - chown -R 64535:64535 /local-path-provisioner
     - chmod 0700 /local-path-provisioner

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -13,6 +13,7 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+fromCacheVersion: "2023-10-16.0"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches
@@ -25,17 +26,16 @@ mount:
 shell:
   install:
     - apk add --no-cache git
-    - export GOPROXY={{ $.GOPROXY }}
     - mkdir /src
     - git clone --depth 1 --branch v{{$localPathProvisionerVersion}} {{ $.SOURCE_REPO }}/rancher/local-path-provisioner.git /src
     - cd /src
     - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
     - go mod edit -go 1.20
+    - go get -u golang.org/x/crypto@v0.14.0
     - go get -u golang.org/x/net@v0.17.0
     - go get -u github.com/prometheus/client_golang@v1.17.0
-    - go get -u golang.org/x/crypto@v0.14.0
     - go mod tidy
     - go mod vendor
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner
+    - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner
     - chown -R 64535:64535 /local-path-provisioner
     - chmod 0700 /local-path-provisioner

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -3,6 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
+fromCacheVersion: "2023-10-30.1"
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /local-path-provisioner

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -7,7 +7,7 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /local-path-provisioner
     to: /usr/bin/local-path-provisioner
-    before: setup
+    after: install
 docker:
   ENTRYPOINT: ["/usr/bin/local-path-provisioner"]
 ---

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -13,7 +13,7 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
-fromCacheVersion: "2023-10-16.0"
+fromCacheVersion: "2023-10-30.0"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -1,9 +1,9 @@
-{{- $localPathProvisionerVersion := "0.0.24"}}
+{{- $localPathProvisionerVersion := "0.0.21"}}
 
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2023-10-31.1"
+fromCacheVersion: "2023-10-30.1"
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /local-path-provisioner
@@ -14,7 +14,7 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
-fromCacheVersion: "2023-10-31.1"
+fromCacheVersion: "2023-10-30.1"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -32,6 +32,7 @@ shell:
     - cd /src
     - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
     - go mod edit -go 1.20
+    - go mod edit -dropreplace golang.org/x/crypto
     - go get -u golang.org/x/crypto@v0.14.0
     - go get -u golang.org/x/net@v0.17.0
     - go get -u github.com/prometheus/client_golang@v1.17.0

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -13,6 +13,7 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+fromCacheVersion: "2023-10-16.0"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -13,7 +13,7 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
-fromCacheVersion: "2023-10-30.0"
+fromCacheVersion: "2023-10-30.1"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -13,7 +13,6 @@ docker:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
-fromCacheVersion: "2023-10-30.0"
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
     to: /patches

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -36,6 +36,7 @@ shell:
     - go get -u github.com/prometheus/client_golang@v1.17.0
     - go get -u golang.org/x/crypto@v0.14.0
     - go mod tidy
+    - go mod vendor
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner
     - chown -R 64535:64535 /local-path-provisioner
     - chmod 0700 /local-path-provisioner


### PR DESCRIPTION
## Description
Fixed CVE issues:

- [CVE-2022-21698](https://avd.aquasec.com/nvd/cve-2022-21698)
- [CVE-2021-43565](https://avd.aquasec.com/nvd/cve-2021-43565)
- [CVE-2022-27191](https://avd.aquasec.com/nvd/cve-2022-27191)
- [CVE-2021-33194](https://avd.aquasec.com/nvd/cve-2021-33194)
- [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)
- [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)
- [CVE-2021-38561](https://avd.aquasec.com/nvd/cve-2021-38561)
- [CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixed HIGH CVE issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: local-path-provisioner
type: fix
summary: fix cve issues in local-path-provisioner image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
