### PR TITLE
[deckhouse-controller] Fix flags for logging and kube-client qps

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -59,6 +59,13 @@ const (
 func main() {
 	sh_app.Version = ShellOperatorVersion
 	ad_app.Version = AddonOperatorVersion
+	// Set default log type as json
+	sh_app.LogType = DefaultLogType
+	sh_app.KubeClientQpsDefault = DefaultKubeClientQPS
+	sh_app.KubeClientBurstDefault = DefaultKubeClientBurst
+	fmt.Println("FLAGS SET", sh_app.LogType)
+	fmt.Println("FLAGS SET2", sh_app.KubeClientQpsDefault)
+
 	FileName := filepath.Base(os.Args[0])
 
 	kpApp := kingpin.New(FileName, fmt.Sprintf("%s %s: %s", AppName, DeckhouseVersion, AppDescription))
@@ -83,10 +90,6 @@ func main() {
 		Command("start", "Start deckhouse.").
 		Action(start)
 
-	// Set default log type as json
-	sh_app.LogType = DefaultLogType
-	sh_app.KubeClientQpsDefault = DefaultKubeClientQPS
-	sh_app.KubeClientBurstDefault = DefaultKubeClientBurst
 	ad_app.DefineStartCommandFlags(kpApp, startCmd)
 
 	// Add debug commands from shell-operator and addon-operator

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -50,21 +50,11 @@ func version() string {
 const (
 	AppName        = "deckhouse"
 	AppDescription = "controller for Kubernetes platform from Flant"
-
-	DefaultLogType         = "json"
-	DefaultKubeClientQPS   = "20"
-	DefaultKubeClientBurst = "40"
 )
 
 func main() {
 	sh_app.Version = ShellOperatorVersion
 	ad_app.Version = AddonOperatorVersion
-	// Set default log type as json
-	sh_app.LogType = DefaultLogType
-	sh_app.KubeClientQpsDefault = DefaultKubeClientQPS
-	sh_app.KubeClientBurstDefault = DefaultKubeClientBurst
-	fmt.Println("FLAGS SET", sh_app.LogType)
-	fmt.Println("FLAGS SET2", sh_app.KubeClientQpsDefault)
 
 	FileName := filepath.Base(os.Args[0])
 

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -373,6 +373,10 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			Value: params.LogLevel,
 		},
 		{
+			Name:  "LOG_TYPE",
+			Value: "json",
+		},
+		{
 			Name:  "DECKHOUSE_BUNDLE",
 			Value: params.Bundle,
 		},

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5
+	github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026
 	github.com/flant/kube-client v1.0.1
 	github.com/flant/shell-operator v1.4.1
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026
+	github.com/flant/addon-operator v1.3.2-0.20231030110333-9aa956bff433
 	github.com/flant/kube-client v1.0.1
 	github.com/flant/shell-operator v1.4.1
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.1
+	github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5
 	github.com/flant/kube-client v1.0.1
 	github.com/flant/shell-operator v1.4.1
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026 h1:2QNO79vNMJoNPlW2xBvJY2swr7202Scuv/HW0TiwL/E=
-github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
+github.com/flant/addon-operator v1.3.2-0.20231030110333-9aa956bff433 h1:3t99l4/4IkIG/WtKt5buWac4YiLJv1FJ+ZHH7Rx/fKs=
+github.com/flant/addon-operator v1.3.2-0.20231030110333-9aa956bff433/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.0.1 h1:W2cUtu07VF8eWpdv49FomTJzREBHprkFzZgz/UbVp5A=

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5 h1:ULSvFWo7YuWTkyNxe/RXz7CdkZCUKwdcqJPZv8oCbwg=
-github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
+github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026 h1:2QNO79vNMJoNPlW2xBvJY2swr7202Scuv/HW0TiwL/E=
+github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.0.1 h1:W2cUtu07VF8eWpdv49FomTJzREBHprkFzZgz/UbVp5A=

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.1 h1:pLlyJYX6RY2+ZsGdg7fMwzE5/lyKrIcu5lr/OD4xCYs=
-github.com/flant/addon-operator v1.3.1/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
+github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5 h1:ULSvFWo7YuWTkyNxe/RXz7CdkZCUKwdcqJPZv8oCbwg=
+github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.0.1 h1:W2cUtu07VF8eWpdv49FomTJzREBHprkFzZgz/UbVp5A=

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
 {{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.deckhouse.logLevel }}
+            - name: LOG_TYPE
+              value: "json"
             - name: DECKHOUSE_BUNDLE
               value: {{ .Values.deckhouse.bundle }}
             - name: DECKHOUSE_POD
@@ -143,6 +145,10 @@ spec:
               value: "30"
             - name: OBJECT_PATCHER_KUBE_CLIENT_BURST
               value: "60"
+            - name: KUBE_CLIENT_QPS
+              value: "20"
+            - name: KUBE_CLIENT_BURST
+              value: "40"
             - name: ADDON_OPERATOR_PROMETHEUS_METRICS_PREFIX
               value: deckhouse_
             - name: ADDON_OPERATOR_NAMESPACE

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1063,7 +1063,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
+github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
 github.com/flant/kube-client v1.0.1/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1063,7 +1063,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.1/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
+github.com/flant/addon-operator v1.3.2-0.20231030100235-e5868bdc98e5/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
 github.com/flant/kube-client v1.0.1/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1063,7 +1063,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.2-0.20231030102441-bc1f8930b026/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
+github.com/flant/addon-operator v1.3.2-0.20231030110333-9aa956bff433/go.mod h1:gs2O9pvkHgatAPUA4gr2sPgGSdAaBI0U8Dz9Xax5XCw=
 github.com/flant/kube-client v1.0.1/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=


### PR DESCRIPTION
## Description
Update addon-operator and explicitly set run flags

## What is the expected result?
Starts with JSON logs:
```
{"msg": "-- Starting Deckhouse using bundle Default --"}
{"level":"info", "msg": "New deckhouse PID 14"}
{"level":"info","msg":"Create metric histogram deckhouse_kubernetes_client_request_latency_seconds","operator.component":"metricsStorage","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Create metric counter deckhouse_kubernetes_client_request_result_total","operator.component":"metricStorage","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Kubernetes client is configured successfully with 'out-of-cluster' config","operator.component":"KubernetesAPIClient","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Kubernetes client is configured successfully with 'out-of-cluster' config","operator.component":"KubernetesAPIClient","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Create metric histogram deckhouse_kubernetes_client_rate_limiter_latency_seconds","operator.component":"metricsStorage","time":"2023-10-30T10:38:35Z"}
{"backend":{},"component":"KubeConfigManager","level":"info","msg":"Setup KubeConfigManager backend","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Helm3Lib detected. Use builtin Helm.","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Helm 3 version: v3.10","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Kubernetes client is configured successfully with 'out-of-cluster' config","operator.component":"KubernetesAPIClient","time":"2023-10-30T10:38:35Z"}
{"level":"info","msg":"Global hooks directory: /deckhouse/global-hooks","time":"2023-10-30T10:38:35Z"}
```


qps:
```
{"level":"info","msg":"I1030 10:50:56.027512      14 request.go:690] Waited for 1.062077426s due to client-side throttling, not priority and fairness, request: GET:https://10.222.0.1:443/apis/autoscaling.k8s.io/v1/namespaces/d8-monitoring/verticalpodautoscalers?resourceVersion=0\u0026resourceVersionMatch=NotOlderThan\n","source":"klog","time":"2023-10-30T10:50:56Z"}
{"level":"info","msg":"I1030 10:54:02.114811      14 request.go:690] Waited for 1.126538506s due to client-side throttling, not priority and fairness, request: GET:https://10.222.0.1:443/apis/deckhouse.io/v1/grafanadashboarddefinitions?resourceVersion=0\u0026resourceVersionMatch=NotOlderThan\n","source":"klog","time":"2023-10-30T10:54:02Z"}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix deckhouse logging and qps settings.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
