### PR TITLE
[ingress-nginx] add default .spec.replicas value

### DIFF
--- a/modules/402-ingress-nginx/crds/kruise/crd_daemonsets.yaml
+++ b/modules/402-ingress-nginx/crds/kruise/crd_daemonsets.yaml
@@ -80,6 +80,7 @@ spec:
                 replicas:
                   type: integer
                   description: Replicas value equals to the number of desired pods and is set by the controller for compatibility with PDB requirements.
+                  default: 1
                 burstReplicas:
                   anyOf:
                     - type: integer

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -62,7 +62,7 @@ kind: PodDisruptionBudget
 metadata:
   name: controller-{{ $name }}
   namespace: d8-ingress-nginx
-  {{ include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name )) | nindent 2 }}
+  {{ include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name "init" {{ now | date "20060102150405" }})) | nindent 2 }}
 spec:
   maxUnavailable: 1
   selector:

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -75,7 +75,7 @@ kind: DaemonSet
 metadata:
   name: controller-{{ $name }}
   namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name)) | nindent 2 }}
   {{- if eq $crd.spec.inlet "HostWithFailover" }}
     {{- if $failover }}
     ingress-nginx-failover: ""

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -62,7 +62,7 @@ kind: PodDisruptionBudget
 metadata:
   name: controller-{{ $name }}
   namespace: d8-ingress-nginx
-  {{ include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name "init" {{ now | date "20060102150405" }})) | nindent 2 }}
+  {{ include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name "init" (now | date "20060102150405"))) | nindent 2 }}
 spec:
   maxUnavailable: 1
   selector:

--- a/modules/402-ingress-nginx/templates/failover/daemonset.yaml
+++ b/modules/402-ingress-nginx/templates/failover/daemonset.yaml
@@ -9,7 +9,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: proxy-{{ $crd.name }}-failover
   namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name)) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
@@ -24,7 +24,7 @@ kind: PodDisruptionBudget
 metadata:
   name: proxy-{{ $crd.name }}-failover
   namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name "init" {{ now | date "20060102150405" }})) | nindent 2 }}
 spec:
   maxUnavailable: 1
   selector:

--- a/modules/402-ingress-nginx/templates/failover/daemonset.yaml
+++ b/modules/402-ingress-nginx/templates/failover/daemonset.yaml
@@ -24,7 +24,7 @@ kind: PodDisruptionBudget
 metadata:
   name: proxy-{{ $crd.name }}-failover
   namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name "init" {{ now | date "20060102150405" }})) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name "init" (now | date "20060102150405"))) | nindent 2 }}
 spec:
   maxUnavailable: 1
   selector:


### PR DESCRIPTION
## Description
Add default value of `1` to  the .`spec.replicas` field of the kruise daemonset CRD.
Add some extra labels to ingress-nginx PDBs to make them recalculate their state.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It fixes a migration problem when we update kruise controller to the revision where PDB support is enabled, but `.spec.replicas` isn't set yet so the controller can't get it with `GetScale` method.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Advanced daemonsets get initial value of `.spec.replicas` set to 1 and further updates are performed by open kruise controller according to its logic.
To check: `kubectl get ads -n d8-ingress-nginx -o yaml | grep relicas`
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: Ingress-nginx
type: chore
summary: Update kruise daemonsets' specs with default .spec.replicas value.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
