### PR TITLE
[distroless] chore: yandex-cloud-metrics-exporter to distroless

### DIFF
--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-from: {{ .Images.BASE_ALPINE }}
+from: common/distroless
 import:
 - artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/exporter
@@ -29,22 +29,35 @@ git:
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
-
-ansible:
+shell:
   beforeInstall:
-    - apk:
-        name: git
-        update_cache: yes
-    - command: rm -rf /var/cache/apk/*
+  - |
+    apk upgrade --available --no-cache && \
+    apk add --no-cache ca-certificates git make
   install:
-    - shell: go mod download
-      args:
-        chdir: /src
+  - cd /src
+  - go mod download
   setup:
-    - shell: go build -ldflags="-s -w" -o exporter .
-      args:
-        chdir: /src
-      environment:
-        GOOS: "linux"
-        GOARCH: "amd64"
-        CGO_ENABLED: "0"
+  - export GO_VERSION=${GOLANG_VERSION}
+  - export GOPROXY={{ $.GOPROXY }}
+  - cd /src
+  - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o exporter .
+
+# ansible:
+#   beforeInstall:
+#     - apk:
+#         name: git
+#         update_cache: yes
+#     - command: rm -rf /var/cache/apk/*
+#   install:
+#     - shell: go mod download
+#       args:
+#         chdir: /src
+#   setup:
+#     - shell: go build -ldflags="-s -w" -o exporter .
+#       args:
+#         chdir: /src
+#       environment:
+#         GOOS: "linux"
+#         GOARCH: "amd64"
+#         CGO_ENABLED: "0"

--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-from: common/distroless
+fromImage: common/distroless
 import:
 - artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/exporter

--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -42,22 +42,5 @@ shell:
   - export GOPROXY={{ $.GOPROXY }}
   - cd /src
   - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o exporter .
-
-# ansible:
-#   beforeInstall:
-#     - apk:
-#         name: git
-#         update_cache: yes
-#     - command: rm -rf /var/cache/apk/*
-#   install:
-#     - shell: go mod download
-#       args:
-#         chdir: /src
-#   setup:
-#     - shell: go build -ldflags="-s -w" -o exporter .
-#       args:
-#         chdir: /src
-#       environment:
-#         GOOS: "linux"
-#         GOARCH: "amd64"
-#         CGO_ENABLED: "0"
+  - chown 64535:64535 /src/exporter
+  - chmod 0755 /src/exporter

--- a/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       containers:
       - name: exporter
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- [x] yandex/cloud-metrics-exporter
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR is a part of moving Deckhouse to distroless.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex | cloud-metrics-exporter
type: chore
summary:"`cloud-metrics-exporter` use distroless based image."
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
