### PR TITLE
[common] Fix build csi-external-* images

### DIFF
--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -9,8 +9,6 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-attacher
     to: /csi-attacher
-    includePaths:
-      - csi-attacher
     before: setup
 docker:
   ENTRYPOINT: ["/csi-attacher"]

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -9,8 +9,6 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-provisioner
     to: /csi-provisioner
-    includePaths:
-      - csi-provisioner
     before: setup
 docker:
   ENTRYPOINT: ["/csi-provisioner"]

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -9,8 +9,6 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-resizer
     to: /csi-resizer
-    includePaths:
-      - csi-resizer
     before: setup
 docker:
   ENTRYPOINT: ["/csi-resizer"]

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -9,8 +9,6 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-snapshotter
     to: /csi-snapshotter
-    includePaths:
-      - csi-snapshotter
     before: setup
 docker:
   ENTRYPOINT: ["/csi-snapshotter"]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed build csi-external-* images

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Info

<details>

before
```shell
Status: Image is up to date for registry.deckhouse.io/deckhouse/fe/install:stable
[deckhouse] root@04f534d56612 / # cat /deckhouse/candi/images_digests.json | grep csiE | sort -V
    "csiExternalAttacher123": "sha256:635e7eb58d71d692f29c5dfa832631adb60c4b546bbca3deb8eb21627b6d7c5a",
    "csiExternalAttacher124": "sha256:635e7eb58d71d692f29c5dfa832631adb60c4b546bbca3deb8eb21627b6d7c5a",
    "csiExternalAttacher125": "sha256:635e7eb58d71d692f29c5dfa832631adb60c4b546bbca3deb8eb21627b6d7c5a",
    "csiExternalAttacher126": "sha256:635e7eb58d71d692f29c5dfa832631adb60c4b546bbca3deb8eb21627b6d7c5a",
    "csiExternalAttacher127": "sha256:635e7eb58d71d692f29c5dfa832631adb60c4b546bbca3deb8eb21627b6d7c5a",
    "csiExternalProvisioner123": "sha256:c83ee44239d77a77f382064b55cba5c7101f74d366cc6b2f613fcd2f70e3cb92",
    "csiExternalProvisioner124": "sha256:c83ee44239d77a77f382064b55cba5c7101f74d366cc6b2f613fcd2f70e3cb92",
    "csiExternalProvisioner125": "sha256:c83ee44239d77a77f382064b55cba5c7101f74d366cc6b2f613fcd2f70e3cb92",
    "csiExternalProvisioner126": "sha256:c83ee44239d77a77f382064b55cba5c7101f74d366cc6b2f613fcd2f70e3cb92",
    "csiExternalProvisioner127": "sha256:c83ee44239d77a77f382064b55cba5c7101f74d366cc6b2f613fcd2f70e3cb92",
    "csiExternalResizer123": "sha256:da412007b219d38bf09507fa673c5d104d60ae55e6151e9c933334f2a1f24953",
    "csiExternalResizer124": "sha256:da412007b219d38bf09507fa673c5d104d60ae55e6151e9c933334f2a1f24953",
    "csiExternalResizer125": "sha256:da412007b219d38bf09507fa673c5d104d60ae55e6151e9c933334f2a1f24953",
    "csiExternalResizer126": "sha256:da412007b219d38bf09507fa673c5d104d60ae55e6151e9c933334f2a1f24953",
    "csiExternalResizer127": "sha256:da412007b219d38bf09507fa673c5d104d60ae55e6151e9c933334f2a1f24953",
    "csiExternalSnapshotter123": "sha256:3d1ed8fbe086881a546f0caaeaf862d254caf7dc0bd18976f6ffdf697d5dc389",
    "csiExternalSnapshotter124": "sha256:3d1ed8fbe086881a546f0caaeaf862d254caf7dc0bd18976f6ffdf697d5dc389",
    "csiExternalSnapshotter125": "sha256:3d1ed8fbe086881a546f0caaeaf862d254caf7dc0bd18976f6ffdf697d5dc389",
    "csiExternalSnapshotter126": "sha256:3d1ed8fbe086881a546f0caaeaf862d254caf7dc0bd18976f6ffdf697d5dc389",
    "csiExternalSnapshotter127": "sha256:3d1ed8fbe086881a546f0caaeaf862d254caf7dc0bd18976f6ffdf697d5dc389",
```

after
```shell
Status: Image is up to date for dev-registry.deckhouse.io/sys/deckhouse-oss/install:pr6378
[deckhouse] root@f23179ac7692 / # cat /deckhouse/candi/images_digests.json | grep csiE | sort -V
    "csiExternalAttacher124": "sha256:793ad7a88134fb4a847eacf055ed0ef376cdca1efcae3039e70547ef3f11f3c7",
    "csiExternalAttacher125": "sha256:793ad7a88134fb4a847eacf055ed0ef376cdca1efcae3039e70547ef3f11f3c7",
    "csiExternalAttacher126": "sha256:793ad7a88134fb4a847eacf055ed0ef376cdca1efcae3039e70547ef3f11f3c7",
    "csiExternalAttacher127": "sha256:6b6f2cc3ce4d175208c51f03499f87df7d74c9e2153b7978df043c34bcce9a6a",
    "csiExternalAttacher128": "sha256:8ff8cc34f5e31dc13c09e60021ff7d5b663914b017ff527ceeda31d46e01d71b",
    "csiExternalProvisioner124": "sha256:8bc3e46fcb09c7c72b0d5561b442ebb23958eb575da93281f82d578e1792f2a6",
    "csiExternalProvisioner125": "sha256:8bc3e46fcb09c7c72b0d5561b442ebb23958eb575da93281f82d578e1792f2a6",
    "csiExternalProvisioner126": "sha256:8bc3e46fcb09c7c72b0d5561b442ebb23958eb575da93281f82d578e1792f2a6",
    "csiExternalProvisioner127": "sha256:9f34028f5ff745a52193a58f20d3540a42cfa38f2e97bcff88c735ba83fcf49d",
    "csiExternalProvisioner128": "sha256:5f84179c4f07b4334766c2ed82aaaf20cb9109bc45899899204a11252eac0c1d",
    "csiExternalResizer124": "sha256:e2af494ee8a61c5479716b7fd7b2c0bbc4c6625b99e3e8635d9397010f1efdf4",
    "csiExternalResizer125": "sha256:e2af494ee8a61c5479716b7fd7b2c0bbc4c6625b99e3e8635d9397010f1efdf4",
    "csiExternalResizer126": "sha256:e2af494ee8a61c5479716b7fd7b2c0bbc4c6625b99e3e8635d9397010f1efdf4",
    "csiExternalResizer127": "sha256:29d248d48ef1c085aa9d5257f8761cf1b411449e4e890b757e4d01fc110b3214",
    "csiExternalResizer128": "sha256:d8f44bda299fe80fd984dfab2beae8aa61a40421906a31a06eae2e4d9241814e",
    "csiExternalSnapshotter124": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter125": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter126": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter127": "sha256:cf04a41c8d039da9005bb8f6f7b1e3146928811baafa8e921d4c83d18b0d2959",
    "csiExternalSnapshotter128": "sha256:f5419dcc39d61df0538ae3177564884cebc9e843315281503b3040fa818766b8",
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed build csi-external-* images
impact: The csi-controller pod will be restarted
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
