### PR TITLE
[extended-monitoring] Fix NodeDiskInodesUsage alert threshold values according to kubelet default

### DIFF
--- a/modules/340-extended-monitoring/docs/CONFIGURATION.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION.md
@@ -38,8 +38,8 @@ Non-namespaced Kubernetes objects do not need labels on the namespace, and monit
 |-----------------------------------------|---------------|----------------|
 | disk-bytes-warning                      | int (percent) | 70             |
 | disk-bytes-critical                     | int (percent) | 80             |
-| disk-inodes-warning                     | int (percent) | 85             |
-| disk-inodes-critical                    | int (percent) | 90             |
+| disk-inodes-warning                     | int (percent) | 90             |
+| disk-inodes-critical                    | int (percent) | 95             |
 | load-average-per-core-warning           | int           | 3              |
 | load-average-per-core-critical          | int           | 10             |
 

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -38,8 +38,8 @@ Non-namespaced Kubernetes-объекты не нуждаются в лейбла
 |-----------------------------------------|---------------|----------------|
 | disk-bytes-warning                      | int (percent) | 70             |
 | disk-bytes-critical                     | int (percent) | 80             |
-| disk-inodes-warning                     | int (percent) | 85             |
-| disk-inodes-critical                    | int (percent) | 90             |
+| disk-inodes-warning                     | int (percent) | 90             |
+| disk-inodes-critical                    | int (percent) | 95             |
 | load-average-per-core-warning           | int           | 3              |
 | load-average-per-core-critical          | int           | 10             |
 

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -222,8 +222,8 @@ class AnnotatedNode(Annotated):
     default_thresholds = {
         "disk-bytes-warning": 70,
         "disk-bytes-critical": 80,
-        "disk-inodes-warning": 85,
-        "disk-inodes-critical": 90,
+        "disk-inodes-warning": 90,
+        "disk-inodes-critical": 95,
         "load-average-per-core-warning": 3,
         "load-average-per-core-critical": 10,
     }


### PR DESCRIPTION
## Description
The NodeDiskInodesUsage alert had a value lower than the corresponding eviction threshold parameter from kubelet, which led to premature alerts (without the ability to fix the problem directly - releasing inodes in the kubelet occurs automatically when the soft eviction threshold is reached).

The solution is to set the default threshold values corresponding to the system ones, so that the alert notifies when a problem really exists.

Kubelet soft eviction values hardcoded here: https://github.com/deckhouse/deckhouse/blob/2af949365a368dabe2e09d7936f6827fa1bef6dd/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl#L94

```changes
section: extended-monitoring
type: chore
summary: Fix `NodeDiskInodesUsage` alert threshold values.
impact_level: low
```
