### PR TITLE
[docs][getting-started] Fix incorrect StorageClass for the Longterm Prometheus

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -160,7 +160,7 @@ metadata:
 spec:
   enabled: true
   settings:
-    longtermStorageClass: localpath-system
+    longtermStorageClass: localpath-monitoring
     storageClass: localpath-monitoring
   version: 2
 EOF

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -160,7 +160,7 @@ metadata:
 spec:
   enabled: true
   settings:
-    longtermStorageClass: localpath-system
+    longtermStorageClass: localpath-monitoring
     storageClass: localpath-monitoring
   version: 2
 EOF


### PR DESCRIPTION
## Description
Fix incorrect StorageClass for the Longterm Prometheus in the Getting Started for bare metal.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix incorrect StorageClass for the Longterm Prometheus in the Getting Started for bare metal.
impact_level: low
```
