### PR TITLE
[getting-started][docs] Fix main config in private envinronment

### DIFF
--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -43,6 +43,9 @@ deckhouse:
             # [<en>] Use self-signed certificates for Deckhouse modules.
             # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
             clusterIssuerName: selfsigned
+      # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
+      # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
+      storageClass: localpath-deckhouse-system
     certManager:
       disableLetsencrypt: true
     userAuthn:

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -44,10 +44,6 @@ deckhouse:
             # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
             clusterIssuerName: selfsigned
     certManager:
-      # [<en>] Disable letsencrypt and letsencrypt-staging ClusterIssuer objects (if set to true).
-      # [<en>] It is necessary to prevent attempts to access outside to Let's Encrypt.
-      # [<ru>] Не создавать ClusterIssuer letsencrypt и letsencrypt-staging в кластере.
-      # [<ru>] Необходимо для предовтвращения попыток доступа наружу к Let's Encrypt.
       disableLetsencrypt: true
     userAuthn:
       controlPlaneConfigurator:

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -51,12 +51,6 @@ deckhouse:
       disableLetsencrypt: true
     userAuthn:
       controlPlaneConfigurator:
-        # [<en>] How to determine the CA that will be used when configuring kube-apiserver.
-        # [<en>] Extract the CA of certificate from the Secret that is used in the Ingress.
-        # [<en>] Used with self-signed certificates in Ingress resources.
-        # [<ru>] Способ определения CA, который будет использован при настройке kube-apiserver.
-        # [<ru>] Извлекает CA или сам сертификат из Secret’а, который используется в Ingress-ресурсе.
-        # [<ru>] Используется с самоподписанными сертификатами в Ingress-ресурсах.
         dexCAMode: FromIngressSecret
     # [<en>] Enable the cni-flannel module.
     # [<ru>] Включить модуль cni-flannel.

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -40,10 +40,8 @@ deckhouse:
         # [<ru>] Способ реализации протокола HTTPS, используемый модулями Deckhouse.
         https:
           certManager:
-            # [<en>] Name of a ClusterIssuer to use for Deckhouse modules.
-            # [<en>] For a closed environment, self-signed certificates are set.
-            # [<ru>] Имя ClusterIssuer, используемого модулями Deckhouse.
-            # [<ru>] Для закрытого окружения задаются самоподписанные сертификаты.
+            # [<en>] Use self-signed certificates for Deckhouse modules.
+            # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
             clusterIssuerName: selfsigned
     certManager:
       # [<en>] Disable letsencrypt and letsencrypt-staging ClusterIssuer objects (if set to true).

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -36,6 +36,30 @@ deckhouse:
         # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
         # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
         publicDomainTemplate: "%s.example.com"
+        # [<en>] The HTTPS implementation used by the Deckhouse modules.
+        # [<ru>] Способ реализации протокола HTTPS, используемый модулями Deckhouse.
+        https:
+          certManager:
+            # [<en>] Name of a ClusterIssuer to use for Deckhouse modules.
+            # [<en>] For a closed environment, self-signed certificates are set.
+            # [<ru>] Имя ClusterIssuer, используемого модулями Deckhouse.
+            # [<ru>] Для закрытого окружения задаются самоподписанные сертификаты.
+            clusterIssuerName: selfsigned
+    certManager:
+      # [<en>] Disable letsencrypt and letsencrypt-staging ClusterIssuer objects (if set to true).
+      # [<en>] It is necessary to prevent attempts to access outside to Let's Encrypt.
+      # [<ru>] Не создавать ClusterIssuer letsencrypt и letsencrypt-staging в кластере.
+      # [<ru>] Необходимо для предовтвращения попыток доступа наружу к Let's Encrypt.
+      disableLetsencrypt: true
+    userAuthn:
+      controlPlaneConfigurator:
+        # [<en>] How to determine the CA that will be used when configuring kube-apiserver.
+        # [<en>] Extract the CA of certificate from the Secret that is used in the Ingress.
+        # [<en>] Used with self-signed certificates in Ingress resources.
+        # [<ru>] Способ определения CA, который будет использован при настройке kube-apiserver.
+        # [<ru>] Извлекает CA или сам сертификат из Secret’а, который используется в Ingress-ресурсе.
+        # [<ru>] Используется с самоподписанными сертификатами в Ingress-ресурсах.
+        dexCAMode: FromIngressSecret
     # [<en>] Enable the cni-flannel module.
     # [<ru>] Включить модуль cni-flannel.
     # [<en>] You might consider changing this.

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -137,7 +137,7 @@ sudo /opt/deckhouse/bin/kubectl create -f - << EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: LocalPathProvisioner
 metadata:
-  name: localpath-monitoring
+  name: localpath-deckhouse-system
 spec:
   nodeGroups:
   - worker
@@ -145,29 +145,6 @@ spec:
 EOF
 ```
 {% endsnippetcut %}
-
-<li><p><strong>Configuring Prometheus</strong></p>
-
-Configure Prometheus to use the created StorageClass (this will prevent data loss if Prometheus gets restarted). Run the following command on the <strong>master node</strong>:
-
-{% snippetcut %}
-```shell
-sudo /opt/deckhouse/bin/kubectl create -f - << EOF
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: prometheus
-spec:
-  enabled: true
-  settings:
-    longtermStorageClass: localpath-monitoring
-    storageClass: localpath-monitoring
-  version: 2
-EOF
-```
-{% endsnippetcut %}
-</li>
-
 </li>
 <li><p><strong>Create a user</strong> to access the cluster web interfaces</p>
 <p>Create on the <strong>master node</strong> the <code>user.yml</code> file containing the user account data and access rights:</p>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -45,7 +45,7 @@ EOF
     Deckhouse will generate the script needed to configure the prospective node and include it in the cluster. Print its contents in Base64 format (you will need them at the next step):
     {% snippetcut %}
   ```bash
-kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
+sudo /opt/deckhouse/bin/kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
   ```
   {% endsnippetcut %}
   </li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -45,7 +45,7 @@ EOF
     Deckhouse подготовит скрипт, необходимый для настройки будущего узла и включения его в кластер. Выведите его содержимое в формате Base64 (оно понадобится на следующем шаге):
     {% snippetcut %}
   ```bash
-kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
+sudo /opt/deckhouse/bin/kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
   ```
   {% endsnippetcut %}
   </li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -137,7 +137,7 @@ sudo /opt/deckhouse/bin/kubectl create -f - << EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: LocalPathProvisioner
 metadata:
-  name: localpath-monitoring
+  name: localpath-deckhouse-system
 spec:
   nodeGroups:
   - worker
@@ -145,29 +145,6 @@ spec:
 EOF
 ```
 {% endsnippetcut %}
-
-<li><p><strong>Настройка Prometheus</strong></p>
-
-Настройте Prometheus на использование созданного StorageClass'а (это позволит не терять данные при перезапуске Prometheus). Выполните на <strong>master-узле</strong> следующую команду:
-
-{% snippetcut %}
-```shell
-sudo /opt/deckhouse/bin/kubectl create -f - << EOF
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: prometheus
-spec:
-  enabled: true
-  settings:
-    longtermStorageClass: localpath-monitoring
-    storageClass: localpath-monitoring
-  version: 2
-EOF
-```
-{% endsnippetcut %}
-</li>
-
 </li>
 <li><p><strong>Создание пользователя</strong> для доступа в веб-интерфейсы кластера</p>
 <p>Создайте на <strong>master-узле</strong> файл <code>user.yml</code> содержащий описание учетной записи пользователя и прав доступа:</p>

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
@@ -34,6 +34,9 @@ deckhouse:
         # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
         # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
         publicDomainTemplate: "%s.example.com"
+      # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
+      # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
+      storageClass: localpath-deckhouse-system
     userAuthn:
       controlPlaneConfigurator:
         dexCAMode: DoNotNeed

--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -93,7 +93,7 @@
 
   <div class="form__row">
     <label class="label" title="Specify the path prefix for Deckhouse container images">
-      The path prefix for Deckhouse container images (e.g., <code>registry.deckhouse.io/deckhouse/ce</code> for Deckhouse CE).
+      The path prefix for Deckhouse container images (e.g., <code>registry.deckhouse.io/deckhouse/ee</code> for Deckhouse EE).
     </label>
     <input
       class="textfield"
@@ -101,7 +101,7 @@
       name="registryImagesRepo" placeholder=""
       autocomplete="off" />
     <span class="info">
-       Note that Deckhouse container images of the corresponding edition (CE or EE) must be available at the specified address and path.
+       Note that Deckhouse container images must be available at the specified address and path.
     </span>
   </div>
 

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -93,7 +93,7 @@
 
   <div class="form__row">
     <label class="label" title="Укажите префикс имени образов контейнеров Deckhouse">
-      Префикс имени образов контейнеров Deckhouse (например, для публичных образов Deckhouse CE — <code>registry.deckhouse.io/deckhouse/ce</code>).
+      Префикс имени образов контейнеров Deckhouse (например, для публичных образов Deckhouse EE — <code>registry.deckhouse.io/deckhouse/ee</code>).
     </label>
     <input
       class="textfield"
@@ -101,7 +101,7 @@
       name="registryImagesRepo" placeholder=""
       autocomplete="off" />
     <span class="info">
-       По указанному адресу и пути должны быть доступны образы Deckhouse необходимой вам редакции (CE или EE).
+       По указанному адресу и пути должны быть доступны образы Deckhouse.
     </span>
   </div>
 


### PR DESCRIPTION
## Description

1. Updated the config for the private environment in GS.
Added parameters:
```
global: modules.https.certManager.clusterIssuerName: selfsigned
cert-manager: disableLetsencrypt
contol-plane-manager: controlPlaneConfigurator.dexCAMode: FromIngressSecret
```
2. Removed the creation of a separate Storage Class for Prometheus.
3. Added a global Storage Class for system components.
4. Fixed the text at the 3rd step of installation in a private environment.

## Why do we need it, and what problem does it solve?

This will help to improve the installation of the platform in a private environment.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Make the Getting Started more consistent.
impact_level: low
```
