### PR TITLE
[log-shipper] Add CEF encoder

### DIFF
--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -108,6 +108,18 @@ type CommonTLSSpec struct {
 	VerifyCertificate   *bool  `json:"verifyCertificate,omitempty"`
 }
 
+type EncodingCodec string
+
+const (
+	EncodingCodecText EncodingCodec = "TEXT"
+	EncodingCodecCEF  EncodingCodec = "CEF"
+	EncodingCodecJSON EncodingCodec = "JSON"
+)
+
+type CommonEncoding struct {
+	Codec EncodingCodec `json:"codec"`
+}
+
 type LokiSpec struct {
 	// TenantID is used only for GrafanaCloud. When running Loki locally, a tenant ID is not required.
 	TenantID string `json:"tenantID,omitempty"`
@@ -127,6 +139,8 @@ type KafkaSpec struct {
 	TLS CommonTLSSpec `json:"tls,omitempty"`
 
 	SASL KafkaSASL `json:"sasl,omitempty"`
+
+	Encoding CommonEncoding `json:"encoding,omitempty"`
 }
 
 type KafkaSASLMechanism string

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -371,6 +371,14 @@ spec:
                       items:
                         type: string
                         pattern: '^(.+)\:\d{1,5}$'
+                    encoding:
+                      type: object
+                      description: |
+                        How to encode the message.
+                      properties:
+                        codec:
+                          type: string
+                          enum: ["JSON", "CEF"]
                     sasl:
                       type: object
                       description: Configuration for SASL authentication when interacting with Kafka.

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -379,6 +379,7 @@ spec:
                         codec:
                           type: string
                           enum: ["JSON", "CEF"]
+                          default: "JSON"
                     sasl:
                       type: object
                       description: Configuration for SASL authentication when interacting with Kafka.

--- a/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
@@ -25,7 +25,6 @@ spec:
                         user:
                           description: Имя пользователя, используемое при Basic-аутентификации.
                     tenantID:
-                      type: string
                       description: |
                         ID тенанта.
 
@@ -148,16 +147,16 @@ spec:
                 kafka:
                   properties:
                     topic:
-                      type: string
                       description: |
                         Имя топика в Kafka для записи событий.
                         Этот параметр поддерживает синтаксис шаблонов, что дает возможность динамического создания топиков.
                     bootstrapServers:
-                      type: array
                       description: |
                         Список пар адресов (хост:порт) Kafka-брокеров в кластере Kafka, к которым должны подключиться клиенты для получения метаданных (топиков и партиций).
+                    encoding:
+                      description: |
+                        В каком формате закодировать сообщение.
                     sasl:
-                      type: object
                       description: Конфигурация аутентификации SASL для взаимодействия с Kafka.
                       properties:
                         mechanism:
@@ -195,7 +194,6 @@ spec:
                     endpoint:
                       description: Базовый URL для экземпляра Splunk.
                     token:
-                      type: string
                       description: Токен по умолчанию для Splunk HEC. Если токен не был передан через metadata, будет использовано значение из этого поля.
                     index:
                       description: Имя индекса, куда будут сохранены данные. Это поле можно задать динамически.
@@ -305,7 +303,6 @@ spec:
                   description: Параметры буфера.
                   properties:
                     type:
-                      type: string
                       description: Тип буфера для использования.
                     disk:
                       description:

--- a/modules/460-log-shipper/hooks/internal/vector/destination/common.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/common.go
@@ -52,10 +52,22 @@ type Healthcheck struct {
 	Enabled bool `json:"enabled"`
 }
 type Encoding struct {
-	ExceptFields    []string `json:"except_fields,omitempty"`
-	OnlyFields      []string `json:"only_fields,omitempty"`
-	Codec           string   `json:"codec,omitempty"`
-	TimestampFormat string   `json:"timestamp_format,omitempty"`
+	ExceptFields    []string    `json:"except_fields,omitempty"`
+	OnlyFields      []string    `json:"only_fields,omitempty"`
+	Codec           string      `json:"codec,omitempty"`
+	TimestampFormat string      `json:"timestamp_format,omitempty"`
+	CEF             CEFEncoding `json:"cef,omitempty"`
+}
+
+type CEFEncoding struct {
+	DeviceVendor       string            `json:"device_vendor,omitempty"`
+	DeviceProduct      string            `json:"device_product,omitempty"`
+	DeviceVersion      string            `json:"device_version,omitempty"`
+	DeviceEventClassID string            `json:"device_event_class_id,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	Severity           string            `json:"severity,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	Extensions         map[string]string `json:"extensions,omitempty"`
 }
 
 type CommonTLS struct {

--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -98,11 +98,11 @@ func NewKafka(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Kafka {
 				"node":      "node",
 				"host":      "host",
 				"pod":       "pod",
-				"pod_ip":    "pod_ip",
+				"podip":     "pod_ip",
 				"namespace": "namespace",
 				"image":     "image",
 				"container": "container",
-				"pod_owner": "pod_owner",
+				"podowner":  "pod_owner",
 			},
 		}
 	}

--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -85,7 +85,7 @@ func NewKafka(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Kafka {
 	if spec.Encoding.Codec == v1alpha1.EncodingCodecCEF {
 		encoding.Codec = "cef"
 		encoding.CEF = CEFEncoding{
-			Version:            "1",
+			Version:            "V1",
 			DeviceVendor:       "Deckhouse",
 			DeviceProduct:      "log-shipper-agent",
 			DeviceVersion:      "1",

--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -90,6 +90,8 @@ func NewKafka(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Kafka {
 			DeviceProduct:      "log-shipper-agent",
 			DeviceVersion:      "1",
 			DeviceEventClassID: "Log event",
+			Name:               "cef.name",
+			Severity:           "cef.severity",
 			Extensions: map[string]string{
 				"message":   "message",
 				"timestamp": "timestamp",

--- a/modules/460-log-shipper/hooks/internal/vector/transform/cef.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/cef.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transform
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/set"
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vrl"
+)
+
+func CEFNameAndSeverity() *DynamicTransform {
+	return &DynamicTransform{
+		CommonTransform: CommonTransform{
+			Name:   "cef_values",
+			Type:   "remap",
+			Inputs: set.New(),
+		},
+		DynamicArgsMap: map[string]interface{}{
+			"source":        vrl.CEFNameAndSeverity.String(),
+			"drop_on_abort": false,
+		},
+	}
+}

--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -31,11 +31,11 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 		transforms = append(transforms, DeDotTransform())
 		fallthrough
 	case v1alpha1.DestVector, v1alpha1.DestKafka:
-		if dest.Spec.Kafka.Encoding.Codec == v1alpha1.EncodingCodecCEF {
-			transforms = append(transforms, CEFNameAndSeverity())
-		}
 		if len(dest.Spec.ExtraLabels) > 0 {
 			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))
+		}
+		if dest.Spec.Kafka.Encoding.Codec == v1alpha1.EncodingCodecCEF {
+			transforms = append(transforms, CEFNameAndSeverity())
 		}
 	}
 

--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -34,6 +34,9 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 		if len(dest.Spec.ExtraLabels) > 0 {
 			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))
 		}
+		if dest.Spec.Kafka.Encoding.Codec == v1alpha1.EncodingCodecCEF {
+			transforms = append(transforms, CEFNameAndSeverity())
+		}
 	}
 
 	if dest.Spec.Type == v1alpha1.DestSplunk {

--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -31,11 +31,11 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 		transforms = append(transforms, DeDotTransform())
 		fallthrough
 	case v1alpha1.DestVector, v1alpha1.DestKafka:
-		if len(dest.Spec.ExtraLabels) > 0 {
-			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))
-		}
 		if dest.Spec.Kafka.Encoding.Codec == v1alpha1.EncodingCodecCEF {
 			transforms = append(transforms, CEFNameAndSeverity())
+		}
+		if len(dest.Spec.ExtraLabels) > 0 {
+			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))
 		}
 	}
 

--- a/modules/460-log-shipper/hooks/internal/vrl/cef.go
+++ b/modules/460-log-shipper/hooks/internal/vrl/cef.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vrl
 
 // CEFNameAndSeverity sets default values for cef encoding.
+// If also maps falco priority values to severity to make it possible to use for cef.
 const CEFNameAndSeverity Rule = `
 if !exists(.cef) {
   .cef = {};

--- a/modules/460-log-shipper/hooks/internal/vrl/cef.go
+++ b/modules/460-log-shipper/hooks/internal/vrl/cef.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vrl
+
+// CEFNameAndSeverity sets default values for cef encoding.
+const CEFNameAndSeverity Rule = `
+.cef = {
+  "name": "Deckhouse Event",
+  "severity": "5",
+}
+`

--- a/modules/460-log-shipper/hooks/internal/vrl/cef.go
+++ b/modules/460-log-shipper/hooks/internal/vrl/cef.go
@@ -18,8 +18,38 @@ package vrl
 
 // CEFNameAndSeverity sets default values for cef encoding.
 const CEFNameAndSeverity Rule = `
-.cef = {
-  "name": "Deckhouse Event",
-  "severity": "5",
-}
+if !exists(.cef) {
+  .cef = {};
+};
+
+if !exists(.cef.name) {
+  .cef.name = "Deckhouse Event";
+};
+
+if !exists(.cef.severity) {
+  .cef.severity = "5";
+} else if is_string(.cef.severity) {
+  if .cef.severity == "Debug" {
+    .cef.severity = "0";
+  };
+  if .cef.severity == "Informational" {
+    .cef.severity = "3";
+  };
+  if .cef.severity == "Notice" {
+    .cef.severity = "4";
+  };
+  if .cef.severity == "Warning" {
+    .cef.severity = "6";
+  };
+  if .cef.severity == "Error" {
+    .cef.severity = "7";
+  };
+  if .cef.severity == "Critical" {
+    .cef.severity = "8";
+  };
+  if .cef.severity == "Emergency" {
+    .cef.severity = "10";
+  };
+};
+
 `

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/manifests.yaml
@@ -19,6 +19,8 @@ spec:
   kafka:
     bootstrapServers:
     - "192.168.1.1:9200"
+    encoding:
+      codec: CEF
     topic: "logs"
     tls:
       clientCrt:

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
@@ -8,6 +8,14 @@
     }
   },
   "transforms": {
+    "transform/destination/test-kafka-dest/00_cef_values": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_local_timezone"
+      ],
+      "source": ".cef = {\n  \"name\": \"Deckhouse Event\",\n  \"severity\": \"5\",\n}",
+      "type": "remap"
+    },
     "transform/source/test-source/00_clean_up": {
       "drop_on_abort": false,
       "inputs": [
@@ -29,15 +37,34 @@
     "destination/cluster/test-kafka-dest": {
       "type": "kafka",
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/destination/test-kafka-dest/00_cef_values"
       ],
       "healthcheck": {
         "enabled": false
       },
       "bootstrap_servers": "192.168.1.1:9200",
       "encoding": {
-        "codec": "json",
-        "timestamp_format": "rfc3339"
+        "codec": "cef",
+        "timestamp_format": "rfc3339",
+        "cef": {
+          "device_vendor": "Deckhouse",
+          "device_product": "log-shipper-agent",
+          "device_version": "1",
+          "device_event_class_id": "Log event",
+          "version": "1",
+          "extensions": {
+            "container": "container",
+            "host": "host",
+            "image": "image",
+            "message": "message",
+            "namespace": "namespace",
+            "node": "node",
+            "pod": "pod",
+            "pod_ip": "pod_ip",
+            "pod_owner": "pod_owner",
+            "timestamp": "timestamp"
+          }
+        }
       },
       "topic": "logs",
       "compression": "gzip",

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
@@ -13,7 +13,7 @@
       "inputs": [
         "transform/source/test-source/01_local_timezone"
       ],
-      "source": ".cef = {\n  \"name\": \"Deckhouse Event\",\n  \"severity\": \"5\",\n}",
+      "source": "if !exists(.cef) {\n  .cef = {};\n};\n\nif !exists(.cef.name) {\n  .cef.name = \"Deckhouse Event\";\n};\n\nif !exists(.cef.severity) {\n  .cef.severity = \"5\";\n} else if is_string(.cef.severity) {\n  if .cef.severity == \"Debug\" {\n    .cef.severity = \"0\";\n  };\n  if .cef.severity == \"Informational\" {\n    .cef.severity = \"3\";\n  };\n  if .cef.severity == \"Notice\" {\n    .cef.severity = \"4\";\n  };\n  if .cef.severity == \"Warning\" {\n    .cef.severity = \"6\";\n  };\n  if .cef.severity == \"Error\" {\n    .cef.severity = \"7\";\n  };\n  if .cef.severity == \"Critical\" {\n    .cef.severity = \"8\";\n  };\n  if .cef.severity == \"Emergency\" {\n    .cef.severity = \"10\";\n  };\n};",
       "type": "remap"
     },
     "transform/source/test-source/00_clean_up": {
@@ -51,7 +51,9 @@
           "device_product": "log-shipper-agent",
           "device_version": "1",
           "device_event_class_id": "Log event",
-          "version": "1",
+          "name": "cef.name",
+          "severity": "cef.severity",
+          "version": "V1",
           "extensions": {
             "container": "container",
             "host": "host",
@@ -60,8 +62,8 @@
             "namespace": "namespace",
             "node": "node",
             "pod": "pod",
-            "pod_ip": "pod_ip",
-            "pod_owner": "pod_owner",
+            "podip": "pod_ip",
+            "podowner": "pod_owner",
             "timestamp": "timestamp"
           }
         }

--- a/modules/460-log-shipper/images/vector/Dockerfile
+++ b/modules/460-log-shipper/images/vector/Dockerfile
@@ -24,9 +24,11 @@ RUN git clone --depth 1 --branch v2.0.2 ${SOURCE_REPO}/confluentinc/librdkafka.g
     && make \
     && make install
 
+COPY patches/cef-encoder.patch /
 WORKDIR /vector
 RUN git clone --depth 1 --branch v0.31.0 ${SOURCE_REPO}/vectordotdev/vector.git \
-    && cd vector
+    && cd vector \
+    && git apply /cef-encoder.patch
 
 # Download and cache dependencies
 WORKDIR /vector/vector

--- a/modules/460-log-shipper/images/vector/patches/README.md
+++ b/modules/460-log-shipper/images/vector/patches/README.md
@@ -1,3 +1,7 @@
 ## Patches
 
-There are no patches at the current time.
+#### CEF Codec
+
+Add CEF encoder to the vector.
+
+Upstream PR - https://github.com/vectordotdev/vector/pull/17389

--- a/modules/460-log-shipper/images/vector/patches/cef-encoder.patch
+++ b/modules/460-log-shipper/images/vector/patches/cef-encoder.patch
@@ -1,6 +1,6 @@
 diff --git a/lib/codecs/src/encoding/format/cef.rs b/lib/codecs/src/encoding/format/cef.rs
 new file mode 100644
-index 0000000000000..b808b059948da
+index 000000000..b808b0599
 --- /dev/null
 +++ b/lib/codecs/src/encoding/format/cef.rs
 @@ -0,0 +1,483 @@
@@ -488,7 +488,7 @@ index 0000000000000..b808b059948da
 +    }
 +}
 diff --git a/lib/codecs/src/encoding/format/mod.rs b/lib/codecs/src/encoding/format/mod.rs
-index 1d4e008380516..63e4c86d51171 100644
+index 1d4e00838..63e4c86d5 100644
 --- a/lib/codecs/src/encoding/format/mod.rs
 +++ b/lib/codecs/src/encoding/format/mod.rs
 @@ -4,6 +4,7 @@
@@ -508,7 +508,7 @@ index 1d4e008380516..63e4c86d51171 100644
  pub use gelf::{GelfSerializer, GelfSerializerConfig};
  pub use json::{JsonSerializer, JsonSerializerConfig};
 diff --git a/lib/codecs/src/encoding/mod.rs b/lib/codecs/src/encoding/mod.rs
-index d798e8d7bf9d9..237f83d95ef1e 100644
+index f95164117..eadbc9fa7 100644
 --- a/lib/codecs/src/encoding/mod.rs
 +++ b/lib/codecs/src/encoding/mod.rs
 @@ -8,11 +8,11 @@ use std::fmt::Debug;
@@ -528,7 +528,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
  };
  pub use framing::{
      BoxedFramer, BoxedFramingError, BytesEncoder, BytesEncoderConfig, CharacterDelimitedEncoder,
-@@ -197,6 +197,13 @@ pub enum SerializerConfig {
+@@ -185,6 +185,13 @@ pub enum SerializerConfig {
          avro: AvroSerializerOptions,
      },
 
@@ -542,7 +542,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
      /// Encodes an event as a CSV message.
      ///
      /// This codec must be configured with fields to encode.
-@@ -269,6 +276,12 @@ impl From<AvroSerializerConfig> for SerializerConfig {
+@@ -248,6 +255,12 @@ impl From<AvroSerializerConfig> for SerializerConfig {
      }
  }
 
@@ -555,7 +555,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
  impl From<CsvSerializerConfig> for SerializerConfig {
      fn from(config: CsvSerializerConfig) -> Self {
          Self::Csv(config)
-@@ -324,6 +337,7 @@ impl SerializerConfig {
+@@ -303,6 +316,7 @@ impl SerializerConfig {
              SerializerConfig::Avro { avro } => Ok(Serializer::Avro(
                  AvroSerializerConfig::new(avro.schema.clone()).build()?,
              )),
@@ -563,7 +563,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              SerializerConfig::Csv(config) => Ok(Serializer::Csv(config.build()?)),
              SerializerConfig::Gelf => Ok(Serializer::Gelf(GelfSerializerConfig::new().build())),
              SerializerConfig::Json(config) => Ok(Serializer::Json(config.build())),
-@@ -356,7 +370,8 @@ impl SerializerConfig {
+@@ -335,7 +349,8 @@ impl SerializerConfig {
              SerializerConfig::Avro { .. } | SerializerConfig::Native => {
                  FramingConfig::LengthDelimited
              }
@@ -573,7 +573,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              | SerializerConfig::Gelf
              | SerializerConfig::Json(_)
              | SerializerConfig::Logfmt
-@@ -372,6 +387,7 @@ impl SerializerConfig {
+@@ -351,6 +366,7 @@ impl SerializerConfig {
              SerializerConfig::Avro { avro } => {
                  AvroSerializerConfig::new(avro.schema.clone()).input_type()
              }
@@ -581,7 +581,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              SerializerConfig::Csv(config) => config.input_type(),
              SerializerConfig::Gelf { .. } => GelfSerializerConfig::input_type(),
              SerializerConfig::Json(config) => config.input_type(),
-@@ -389,6 +405,7 @@ impl SerializerConfig {
+@@ -368,6 +384,7 @@ impl SerializerConfig {
              SerializerConfig::Avro { avro } => {
                  AvroSerializerConfig::new(avro.schema.clone()).schema_requirement()
              }
@@ -589,7 +589,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              SerializerConfig::Csv(config) => config.schema_requirement(),
              SerializerConfig::Gelf { .. } => GelfSerializerConfig::schema_requirement(),
              SerializerConfig::Json(config) => config.schema_requirement(),
-@@ -406,6 +423,8 @@ impl SerializerConfig {
+@@ -385,6 +402,8 @@ impl SerializerConfig {
  pub enum Serializer {
      /// Uses an `AvroSerializer` for serialization.
      Avro(AvroSerializer),
@@ -598,7 +598,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
      /// Uses a `CsvSerializer` for serialization.
      Csv(CsvSerializer),
      /// Uses a `GelfSerializer` for serialization.
-@@ -430,6 +449,7 @@ impl Serializer {
+@@ -409,6 +428,7 @@ impl Serializer {
          match self {
              Serializer::Json(_) | Serializer::NativeJson(_) | Serializer::Gelf(_) => true,
              Serializer::Avro(_)
@@ -606,7 +606,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              | Serializer::Csv(_)
              | Serializer::Logfmt(_)
              | Serializer::Text(_)
-@@ -450,6 +470,7 @@ impl Serializer {
+@@ -429,6 +449,7 @@ impl Serializer {
              Serializer::Json(serializer) => serializer.to_json_value(event),
              Serializer::NativeJson(serializer) => serializer.to_json_value(event),
              Serializer::Avro(_)
@@ -614,7 +614,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              | Serializer::Csv(_)
              | Serializer::Logfmt(_)
              | Serializer::Text(_)
-@@ -467,6 +488,12 @@ impl From<AvroSerializer> for Serializer {
+@@ -446,6 +467,12 @@ impl From<AvroSerializer> for Serializer {
      }
  }
 
@@ -627,7 +627,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
  impl From<CsvSerializer> for Serializer {
      fn from(serializer: CsvSerializer) -> Self {
          Self::Csv(serializer)
-@@ -521,6 +548,7 @@ impl tokio_util::codec::Encoder<Event> for Serializer {
+@@ -500,6 +527,7 @@ impl tokio_util::codec::Encoder<Event> for Serializer {
      fn encode(&mut self, event: Event, buffer: &mut BytesMut) -> Result<(), Self::Error> {
          match self {
              Serializer::Avro(serializer) => serializer.encode(event, buffer),
@@ -636,7 +636,7 @@ index d798e8d7bf9d9..237f83d95ef1e 100644
              Serializer::Gelf(serializer) => serializer.encode(event, buffer),
              Serializer::Json(serializer) => serializer.encode(event, buffer),
 diff --git a/src/codecs/encoding/config.rs b/src/codecs/encoding/config.rs
-index 97096de1e0f3d..b1d970e8e1d26 100644
+index 97096de1e..b1d970e8e 100644
 --- a/src/codecs/encoding/config.rs
 +++ b/src/codecs/encoding/config.rs
 @@ -109,7 +109,8 @@ impl EncodingConfigWithFraming {
@@ -650,7 +650,7 @@ index 97096de1e0f3d..b1d970e8e1d26 100644
                  | Serializer::Logfmt(_)
                  | Serializer::NativeJson(_)
 diff --git a/src/codecs/encoding/encoder.rs b/src/codecs/encoding/encoder.rs
-index 3f9970fb961a2..09b8241999297 100644
+index 3f9970fb9..09b824199 100644
 --- a/src/codecs/encoding/encoder.rs
 +++ b/src/codecs/encoding/encoder.rs
 @@ -116,6 +116,7 @@ impl Encoder<Framer> {
@@ -662,19 +662,19 @@ index 3f9970fb961a2..09b8241999297 100644
                  | Serializer::Gelf(_)
                  | Serializer::Json(_)
 diff --git a/src/components/validation/resources/mod.rs b/src/components/validation/resources/mod.rs
-index b6427bd7f6ab5..961e19385da6f 100644
+index 2b9fc3c54..f8ab26834 100644
 --- a/src/components/validation/resources/mod.rs
 +++ b/src/components/validation/resources/mod.rs
-@@ -182,6 +182,7 @@ fn decoder_framing_to_encoding_framer(framing: &decoding::FramingConfig) -> enco
+@@ -180,6 +180,7 @@ fn decoder_framing_to_encoding_framer(framing: &decoding::FramingConfig) -> enco
  fn serializer_config_to_deserializer(config: &SerializerConfig) -> decoding::Deserializer {
      let deserializer_config = match config {
          SerializerConfig::Avro { .. } => todo!(),
 +        SerializerConfig::Cef { .. } => todo!(),
          SerializerConfig::Csv { .. } => todo!(),
-         SerializerConfig::Gelf => DeserializerConfig::Gelf,
-         SerializerConfig::Json(_) => DeserializerConfig::Json,
+         SerializerConfig::Gelf => DeserializerConfig::Gelf(Default::default()),
+         SerializerConfig::Json(_) => DeserializerConfig::Json(Default::default()),
 diff --git a/website/cue/reference/components/sinks/base/amqp.cue b/website/cue/reference/components/sinks/base/amqp.cue
-index cd201bb517f08..4ea9e0b87b8cd 100644
+index cd201bb51..4ea9e0b87 100644
 --- a/website/cue/reference/components/sinks/base/amqp.cue
 +++ b/website/cue/reference/components/sinks/base/amqp.cue
 @@ -57,6 +57,91 @@ base: components: sinks: amqp: configuration: {
@@ -778,10 +778,10 @@ index cd201bb517f08..4ea9e0b87b8cd 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
-index 91f6204765875..d4e2da9c79511 100644
+index e5ea22305..68adbc7c0 100644
 --- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
 +++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
-@@ -214,6 +214,91 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
+@@ -219,6 +219,91 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -873,7 +873,7 @@ index 91f6204765875..d4e2da9c79511 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -223,6 +308,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
+@@ -228,6 +313,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -882,10 +882,10 @@ index 91f6204765875..d4e2da9c79511 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
-index 966082ca84f99..902546c9ef179 100644
+index 19a708606..03f26bd96 100644
 --- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
 +++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
-@@ -193,6 +193,91 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
+@@ -198,6 +198,91 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -977,7 +977,7 @@ index 966082ca84f99..902546c9ef179 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -202,6 +287,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
+@@ -207,6 +292,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -986,10 +986,10 @@ index 966082ca84f99..902546c9ef179 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
-index 50a8a22d90a4f..5613e082e8d93 100644
+index 40164b9d0..5d7cfc2ee 100644
 --- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
 +++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
-@@ -193,6 +193,91 @@ base: components: sinks: aws_kinesis_streams: configuration: {
+@@ -198,6 +198,91 @@ base: components: sinks: aws_kinesis_streams: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -1081,7 +1081,7 @@ index 50a8a22d90a4f..5613e082e8d93 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -202,6 +287,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
+@@ -207,6 +292,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -1090,10 +1090,10 @@ index 50a8a22d90a4f..5613e082e8d93 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/aws_s3.cue b/website/cue/reference/components/sinks/base/aws_s3.cue
-index 542f8c0ceab1e..3ead76bad8081 100644
+index 11265897c..f5f6a74ed 100644
 --- a/website/cue/reference/components/sinks/base/aws_s3.cue
 +++ b/website/cue/reference/components/sinks/base/aws_s3.cue
-@@ -302,6 +302,91 @@ base: components: sinks: aws_s3: configuration: {
+@@ -307,6 +307,91 @@ base: components: sinks: aws_s3: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -1185,7 +1185,7 @@ index 542f8c0ceab1e..3ead76bad8081 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -311,6 +396,7 @@ base: components: sinks: aws_s3: configuration: {
+@@ -316,6 +401,7 @@ base: components: sinks: aws_s3: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -1194,7 +1194,7 @@ index 542f8c0ceab1e..3ead76bad8081 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/aws_sqs.cue b/website/cue/reference/components/sinks/base/aws_sqs.cue
-index 403beb674ba3e..a7f57cc28fbf9 100644
+index 403beb674..a7f57cc28 100644
 --- a/website/cue/reference/components/sinks/base/aws_sqs.cue
 +++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
 @@ -134,6 +134,91 @@ base: components: sinks: aws_sqs: configuration: {
@@ -1298,10 +1298,10 @@ index 403beb674ba3e..a7f57cc28fbf9 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/azure_blob.cue b/website/cue/reference/components/sinks/base/azure_blob.cue
-index 9046389be1a57..eade9d8c463b1 100644
+index 5c2568145..05b998055 100644
 --- a/website/cue/reference/components/sinks/base/azure_blob.cue
 +++ b/website/cue/reference/components/sinks/base/azure_blob.cue
-@@ -165,6 +165,91 @@ base: components: sinks: azure_blob: configuration: {
+@@ -170,6 +170,91 @@ base: components: sinks: azure_blob: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -1393,7 +1393,7 @@ index 9046389be1a57..eade9d8c463b1 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -174,6 +259,7 @@ base: components: sinks: azure_blob: configuration: {
+@@ -179,6 +264,7 @@ base: components: sinks: azure_blob: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -1402,7 +1402,7 @@ index 9046389be1a57..eade9d8c463b1 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/console.cue b/website/cue/reference/components/sinks/base/console.cue
-index c4deb39c4ce1d..693ebc0dea837 100644
+index c4deb39c4..693ebc0de 100644
 --- a/website/cue/reference/components/sinks/base/console.cue
 +++ b/website/cue/reference/components/sinks/base/console.cue
 @@ -41,6 +41,91 @@ base: components: sinks: console: configuration: {
@@ -1506,7 +1506,7 @@ index c4deb39c4ce1d..693ebc0dea837 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/file.cue b/website/cue/reference/components/sinks/base/file.cue
-index 383b9d2086f37..5aa831dbecb0e 100644
+index 383b9d208..5aa831dbe 100644
 --- a/website/cue/reference/components/sinks/base/file.cue
 +++ b/website/cue/reference/components/sinks/base/file.cue
 @@ -61,6 +61,91 @@ base: components: sinks: file: configuration: {
@@ -1610,7 +1610,7 @@ index 383b9d2086f37..5aa831dbecb0e 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
-index 82d963fc5da3a..aa50423601fc5 100644
+index 82d963fc5..aa5042360 100644
 --- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
 +++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
 @@ -110,6 +110,91 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
@@ -1714,10 +1714,10 @@ index 82d963fc5da3a..aa50423601fc5 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
-index 3b636da3f16ab..b6c0710c1284e 100644
+index 89b2f3761..f50a7ec06 100644
 --- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
 +++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
-@@ -189,6 +189,91 @@ base: components: sinks: gcp_cloud_storage: configuration: {
+@@ -194,6 +194,91 @@ base: components: sinks: gcp_cloud_storage: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -1809,7 +1809,7 @@ index 3b636da3f16ab..b6c0710c1284e 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -198,6 +283,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
+@@ -203,6 +288,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -1818,7 +1818,7 @@ index 3b636da3f16ab..b6c0710c1284e 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/gcp_pubsub.cue b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
-index 9c45e6195401c..8219f4c6da2a4 100644
+index 9c45e6195..8219f4c6d 100644
 --- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
 +++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
 @@ -108,6 +108,91 @@ base: components: sinks: gcp_pubsub: configuration: {
@@ -1922,10 +1922,10 @@ index 9c45e6195401c..8219f4c6da2a4 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/http.cue b/website/cue/reference/components/sinks/base/http.cue
-index 7eefce772c920..55dd53c275dbc 100644
+index c737b39f5..354535237 100644
 --- a/website/cue/reference/components/sinks/base/http.cue
 +++ b/website/cue/reference/components/sinks/base/http.cue
-@@ -144,6 +144,91 @@ base: components: sinks: http: configuration: {
+@@ -149,6 +149,91 @@ base: components: sinks: http: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -2017,7 +2017,7 @@ index 7eefce772c920..55dd53c275dbc 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -153,6 +238,7 @@ base: components: sinks: http: configuration: {
+@@ -158,6 +243,7 @@ base: components: sinks: http: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -2026,10 +2026,10 @@ index 7eefce772c920..55dd53c275dbc 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/humio_logs.cue b/website/cue/reference/components/sinks/base/humio_logs.cue
-index e7967257dc81e..d69421658bf70 100644
+index 8d8253417..566c4c99d 100644
 --- a/website/cue/reference/components/sinks/base/humio_logs.cue
 +++ b/website/cue/reference/components/sinks/base/humio_logs.cue
-@@ -97,6 +97,91 @@ base: components: sinks: humio_logs: configuration: {
+@@ -102,6 +102,91 @@ base: components: sinks: humio_logs: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -2121,7 +2121,7 @@ index e7967257dc81e..d69421658bf70 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -106,6 +191,7 @@ base: components: sinks: humio_logs: configuration: {
+@@ -111,6 +196,7 @@ base: components: sinks: humio_logs: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -2130,7 +2130,7 @@ index e7967257dc81e..d69421658bf70 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/kafka.cue b/website/cue/reference/components/sinks/base/kafka.cue
-index 97de9c94750e9..994fc76c73138 100644
+index 97de9c947..994fc76c7 100644
 --- a/website/cue/reference/components/sinks/base/kafka.cue
 +++ b/website/cue/reference/components/sinks/base/kafka.cue
 @@ -96,6 +96,91 @@ base: components: sinks: kafka: configuration: {
@@ -2234,10 +2234,10 @@ index 97de9c94750e9..994fc76c73138 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/loki.cue b/website/cue/reference/components/sinks/base/loki.cue
-index 829bad773dd74..befc1ad04d37e 100644
+index 0071c5b2a..9317f72f2 100644
 --- a/website/cue/reference/components/sinks/base/loki.cue
 +++ b/website/cue/reference/components/sinks/base/loki.cue
-@@ -148,6 +148,91 @@ base: components: sinks: loki: configuration: {
+@@ -153,6 +153,91 @@ base: components: sinks: loki: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -2329,7 +2329,7 @@ index 829bad773dd74..befc1ad04d37e 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -157,6 +242,7 @@ base: components: sinks: loki: configuration: {
+@@ -162,6 +247,7 @@ base: components: sinks: loki: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -2338,7 +2338,7 @@ index 829bad773dd74..befc1ad04d37e 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/nats.cue b/website/cue/reference/components/sinks/base/nats.cue
-index 2708c111c08cc..d128faa1c3ec7 100644
+index 2708c111c..d128faa1c 100644
 --- a/website/cue/reference/components/sinks/base/nats.cue
 +++ b/website/cue/reference/components/sinks/base/nats.cue
 @@ -141,6 +141,91 @@ base: components: sinks: nats: configuration: {
@@ -2442,7 +2442,7 @@ index 2708c111c08cc..d128faa1c3ec7 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/papertrail.cue b/website/cue/reference/components/sinks/base/papertrail.cue
-index 8b4cce6d5c019..d782f06d25b62 100644
+index 8b4cce6d5..d782f06d2 100644
 --- a/website/cue/reference/components/sinks/base/papertrail.cue
 +++ b/website/cue/reference/components/sinks/base/papertrail.cue
 @@ -41,6 +41,91 @@ base: components: sinks: papertrail: configuration: {
@@ -2546,10 +2546,10 @@ index 8b4cce6d5c019..d782f06d25b62 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/pulsar.cue b/website/cue/reference/components/sinks/base/pulsar.cue
-index cd55deaf6093c..5c2369125e188 100644
+index cc62959b4..69a4b1b28 100644
 --- a/website/cue/reference/components/sinks/base/pulsar.cue
 +++ b/website/cue/reference/components/sinks/base/pulsar.cue
-@@ -128,6 +128,91 @@ base: components: sinks: pulsar: configuration: {
+@@ -135,6 +135,91 @@ base: components: sinks: pulsar: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -2641,7 +2641,7 @@ index cd55deaf6093c..5c2369125e188 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -137,6 +222,7 @@ base: components: sinks: pulsar: configuration: {
+@@ -144,6 +229,7 @@ base: components: sinks: pulsar: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -2650,7 +2650,7 @@ index cd55deaf6093c..5c2369125e188 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/redis.cue b/website/cue/reference/components/sinks/base/redis.cue
-index 774370ce58a00..03d7c52220bbf 100644
+index 774370ce5..03d7c5222 100644
 --- a/website/cue/reference/components/sinks/base/redis.cue
 +++ b/website/cue/reference/components/sinks/base/redis.cue
 @@ -94,6 +94,91 @@ base: components: sinks: redis: configuration: {
@@ -2754,7 +2754,7 @@ index 774370ce58a00..03d7c52220bbf 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/socket.cue b/website/cue/reference/components/sinks/base/socket.cue
-index c0b0c62ad106e..07d65c1d7a63f 100644
+index c0b0c62ad..07d65c1d7 100644
 --- a/website/cue/reference/components/sinks/base/socket.cue
 +++ b/website/cue/reference/components/sinks/base/socket.cue
 @@ -53,6 +53,91 @@ base: components: sinks: socket: configuration: {
@@ -2858,10 +2858,10 @@ index c0b0c62ad106e..07d65c1d7a63f 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
-index 00872c584d409..47f827aeb2d0e 100644
+index 184db1386..1e7c6e417 100644
 --- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
 +++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
-@@ -147,6 +147,91 @@ base: components: sinks: splunk_hec_logs: configuration: {
+@@ -152,6 +152,91 @@ base: components: sinks: splunk_hec_logs: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -2953,7 +2953,7 @@ index 00872c584d409..47f827aeb2d0e 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -156,6 +241,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
+@@ -161,6 +246,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -2962,10 +2962,10 @@ index 00872c584d409..47f827aeb2d0e 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/webhdfs.cue b/website/cue/reference/components/sinks/base/webhdfs.cue
-index 006b33156564b..bf03814c5205a 100644
+index b07f00ae7..0373e26ee 100644
 --- a/website/cue/reference/components/sinks/base/webhdfs.cue
 +++ b/website/cue/reference/components/sinks/base/webhdfs.cue
-@@ -97,6 +97,91 @@ base: components: sinks: webhdfs: configuration: {
+@@ -102,6 +102,91 @@ base: components: sinks: webhdfs: configuration: {
  					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
  				}
  			}
@@ -3057,7 +3057,7 @@ index 006b33156564b..bf03814c5205a 100644
  			codec: {
  				description: "The codec to use for encoding events."
  				required:    true
-@@ -106,6 +191,7 @@ base: components: sinks: webhdfs: configuration: {
+@@ -111,6 +196,7 @@ base: components: sinks: webhdfs: configuration: {
 
  						[apache_avro]: https://avro.apache.org/
  						"""
@@ -3066,7 +3066,7 @@ index 006b33156564b..bf03814c5205a 100644
  						Encodes an event as a CSV message.
 
 diff --git a/website/cue/reference/components/sinks/base/websocket.cue b/website/cue/reference/components/sinks/base/websocket.cue
-index ad51d78f9a46f..4358337af0c51 100644
+index ad51d78f9..4358337af 100644
 --- a/website/cue/reference/components/sinks/base/websocket.cue
 +++ b/website/cue/reference/components/sinks/base/websocket.cue
 @@ -88,6 +88,91 @@ base: components: sinks: websocket: configuration: {
@@ -3169,29 +3169,3 @@ index ad51d78f9a46f..4358337af0c51 100644
  					csv: """
  						Encodes an event as a CSV message.
 
-diff --git a/website/cue/reference/components/transforms/base/sample.cue b/website/cue/reference/components/transforms/base/sample.cue
-index 3e0d7aaba7f06..16b7fe370dff5 100644
---- a/website/cue/reference/components/transforms/base/sample.cue
-+++ b/website/cue/reference/components/transforms/base/sample.cue
-@@ -12,7 +12,7 @@ base: components: transforms: sample: configuration: {
- 			sampled.
-
- 			Each unique value for the key creates a bucket of related events to be sampled together
--			and the rate is applied to the buckets themselves to sample `1/N` buckets. Overall rate
-+			and the rate is applied to the buckets themselves to sample `1/N` buckets.  The overall rate
- 			of sampling may differ from the configured one if values in the field are not uniformly
- 			distributed. If left unspecified, or if the event doesn’t have `key_field`, then the
- 			event is sampled independently.
-diff --git a/website/cue/reference/components/transforms/base/throttle.cue b/website/cue/reference/components/transforms/base/throttle.cue
-index 710aeeb858ec7..608b43cef1c8c 100644
---- a/website/cue/reference/components/transforms/base/throttle.cue
-+++ b/website/cue/reference/components/transforms/base/throttle.cue
-@@ -8,7 +8,7 @@ base: components: transforms: throttle: configuration: {
- 	}
- 	key_field: {
- 		description: """
--			The value to group events into a separate buckets to be rate limited independently.
-+			The value to group events into separate buckets to be rate limited independently.
-
- 			If left unspecified, or if the event doesn't have `key_field`, then the event is not rate
- 			limited separately.

--- a/modules/460-log-shipper/images/vector/patches/cef-encoder.patch
+++ b/modules/460-log-shipper/images/vector/patches/cef-encoder.patch
@@ -1,0 +1,3197 @@
+diff --git a/lib/codecs/src/encoding/format/cef.rs b/lib/codecs/src/encoding/format/cef.rs
+new file mode 100644
+index 0000000000000..b808b059948da
+--- /dev/null
++++ b/lib/codecs/src/encoding/format/cef.rs
+@@ -0,0 +1,483 @@
++use std::{collections::HashMap, fmt::Write};
++
++use crate::encoding::BuildError;
++use bytes::BytesMut;
++use chrono::SecondsFormat;
++use lookup::lookup_v2::ConfigTargetPath;
++use tokio_util::codec::Encoder;
++use vector_core::{
++    config::DataType,
++    event::{Event, LogEvent, Value},
++    schema,
++};
++
++/// Device event identity.
++#[derive(Debug, Clone)]
++pub struct DeviceSettings {
++    pub vendor: String,
++    pub product: String,
++    pub version: String,
++    pub event_class_id: String,
++}
++
++impl DeviceSettings {
++    /// Creates a new `DeviceSettings`.
++    pub const fn new(
++        vendor: String,
++        product: String,
++        version: String,
++        event_class_id: String,
++    ) -> Self {
++        Self {
++            vendor,
++            product,
++            version,
++            event_class_id,
++        }
++    }
++}
++
++/// Config used to build a `CefSerializer`.
++#[crate::configurable_component]
++#[derive(Debug, Clone)]
++pub struct CefSerializerConfig {
++    /// The CEF Serializer Options.
++    pub cef: CefSerializerOptions,
++}
++
++impl CefSerializerConfig {
++    /// Creates a new `CefSerializerConfig`.
++    pub const fn new(cef: CefSerializerOptions) -> Self {
++        Self { cef }
++    }
++
++    /// Build the `CefSerializer` from this configuration.
++    pub fn build(&self) -> Result<CefSerializer, BuildError> {
++        let device_vendor = if let Some(device_vendor) = self.cef.device_vendor.clone() {
++            escape_header(device_vendor)
++        } else {
++            String::from("Datadog")
++        };
++        if device_vendor.len() > 63 {
++            return Err(format!(
++                "device_vendor exceed 63 characters limit: actual {}",
++                device_vendor.len()
++            )
++            .into());
++        };
++
++        let device_product = if let Some(device_product) = self.cef.device_product.clone() {
++            escape_header(device_product)
++        } else {
++            String::from("Vector")
++        };
++        if device_product.len() > 63 {
++            return Err(format!(
++                "device_product exceed 63 characters limit: actual {}",
++                device_product.len()
++            )
++            .into());
++        };
++
++        let device_version = if let Some(device_version) = self.cef.device_version.clone() {
++            device_version
++        } else {
++            String::from("0") // Major version. TODO(nabokihms): find a way to get the actual vector version.
++        };
++        if device_version.len() > 31 {
++            return Err(format!(
++                "device_version exceed 31 characters limit: actual {}",
++                device_version.len()
++            )
++            .into());
++        };
++
++        let device_event_class_id =
++            if let Some(device_event_class_id) = self.cef.device_event_class_id.clone() {
++                escape_header(device_event_class_id)
++            } else {
++                String::from("Telemetry Event")
++            };
++        if device_event_class_id.len() > 1023 {
++            return Err(format!(
++                "device_event_class_id exceed 1023 characters limit: actual {}",
++                device_event_class_id.len()
++            )
++            .into());
++        };
++
++        for key in self.cef.extensions.keys() {
++            if !key.chars().all(|c| c.is_ascii_alphabetic()) {
++                // TODO (nabokihms): Output all invalid keys
++                return Err(format!("extension keys can only contain ascii alphabetical characters: invalid key '{}'", key).into());
++            }
++        }
++
++        let device = DeviceSettings::new(
++            device_vendor,
++            device_product,
++            device_version,
++            device_event_class_id,
++        );
++
++        Ok(CefSerializer::new(
++            self.cef.version.clone(),
++            device,
++            self.cef.severity.clone(),
++            self.cef.name.clone(),
++            self.cef.extensions.clone(),
++        ))
++    }
++
++    /// The data type of events that are accepted by `CefSerializer`.
++    pub fn input_type(&self) -> DataType {
++        DataType::Log
++    }
++
++    /// The schema required by the serializer.
++    pub fn schema_requirement(&self) -> schema::Requirement {
++        // While technically we support `Value` variants that can't be losslessly serialized to
++        // CEF, we don't want to enforce that limitation to users yet.
++        schema::Requirement::empty()
++    }
++}
++
++/// CEF version.
++#[crate::configurable_component]
++#[derive(Debug, Default, Clone)]
++pub enum Version {
++    #[default]
++    /// CEF specification version 0.1.
++    V0,
++    /// CEF specification version 1.x.
++    V1,
++}
++
++impl Version {
++    fn as_str(&self) -> &'static str {
++        match self {
++            Version::V0 => "0",
++            Version::V1 => "1",
++        }
++    }
++}
++
++/// Config used to build a `CefSerializer`.
++#[crate::configurable_component]
++#[derive(Debug, Clone)]
++pub struct CefSerializerOptions {
++    /// CEF Version. Can be either 0 or 1.
++    /// Equals to "0" by default.
++    pub version: Version,
++
++    /// Identifies the vendor of the product.
++    /// The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++    /// The value length must be lower or equal to 63.
++    pub device_vendor: Option<String>,
++
++    /// Identifies the product of a vendor.
++    /// The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++    /// The value length must be lower or equal to 63.
++    pub device_product: Option<String>,
++
++    /// Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++    /// The value length must be lower or equal to 31.
++    pub device_version: Option<String>,
++
++    /// Unique identifier for each event-type. Identifies the type of event reported.
++    /// The value length must be lower or equal to 1023.
++    pub device_event_class_id: Option<String>,
++
++    /// This is a path that points to filed of a log event that reflects importance of the event.
++    /// Reflects importance of the event.
++    ///
++    /// It must point to a number from 0 to 10.
++    /// 0 = Lowest, 10 = Highest.
++    /// Equals to "cef.severity" by default.
++    pub severity: ConfigTargetPath,
++
++    /// This is a path that points to the human-readable description of a log event.
++    /// The value length must be lower or equal to 512.
++    /// Equals to "cef.name" by default.
++    pub name: ConfigTargetPath,
++
++    /// The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++    /// The event can have any number of key-value pairs in any order.
++    #[configurable(metadata(
++        docs::additional_props_description = "This is a path that points to the extension value of a log event."
++    ))]
++    pub extensions: HashMap<String, ConfigTargetPath>,
++    // TODO(nabokihms): use Template instead of ConfigTargetPath.
++    // Templates are in the src/ package, and codes are in the lib/codecs.
++}
++
++impl Default for CefSerializerOptions {
++    fn default() -> Self {
++        Self {
++            version: Version::default(),
++            device_vendor: None,
++            device_product: None,
++            device_version: None,
++            device_event_class_id: None,
++            severity: ConfigTargetPath::try_from("cef.severity".to_string()).unwrap(),
++            name: ConfigTargetPath::try_from("cef.name".to_string()).unwrap(),
++            extensions: HashMap::new(),
++        }
++    }
++}
++
++/// Serializer that converts an `Event` to bytes using the CEF format.
++/// CEF:<version>|<device_vendor>|<device_product>|<device_version>|<device_event_class>|<name>|<severity>|<encoded_fields>
++#[derive(Debug, Clone)]
++pub struct CefSerializer {
++    version: Version,
++    device: DeviceSettings,
++    severity: ConfigTargetPath,
++    name: ConfigTargetPath,
++    extensions: HashMap<String, ConfigTargetPath>,
++}
++
++impl CefSerializer {
++    /// Creates a new `CefSerializer`.
++    pub const fn new(
++        version: Version,
++        device: DeviceSettings,
++        severity: ConfigTargetPath,
++        name: ConfigTargetPath,
++        extensions: HashMap<String, ConfigTargetPath>,
++    ) -> Self {
++        Self {
++            version,
++            device,
++            severity,
++            name,
++            extensions,
++        }
++    }
++}
++
++impl Encoder<Event> for CefSerializer {
++    type Error = vector_common::Error;
++
++    fn encode(&mut self, event: Event, buffer: &mut BytesMut) -> Result<(), Self::Error> {
++        let log = event.into_log();
++
++        let severity: u8 = match get_log_event_value(&log, &self.severity).parse() {
++            Err(err) => {
++                return Err(format!("severity must be a number: {}", err).into());
++            }
++            Ok(severity) => {
++                if severity > 10 {
++                    return Err(format!(
++                        "severity must be a number from 0 to 10: actual {}",
++                        severity
++                    )
++                    .into());
++                };
++                severity
++            }
++        };
++
++        let name: String = escape_header(get_log_event_value(&log, &self.name));
++        if name.len() > 512 {
++            return Err(format!("name exceed 512 characters limit: actual {}", name.len()).into());
++        };
++
++        let mut formatted_extensions = Vec::new();
++        for (extension, field) in &self.extensions {
++            let value = get_log_event_value(&log, field);
++            if value.is_empty() {
++                continue;
++            }
++            let value = escape_extension(value);
++            formatted_extensions.push(format!("{}={}", extension, value));
++        }
++
++        buffer.write_fmt(format_args!(
++            "CEF:{}|{}|{}|{}|{}|{}|{}",
++            &self.version.as_str(),
++            &self.device.vendor,
++            &self.device.product,
++            &self.device.version,
++            &self.device.event_class_id,
++            severity,
++            name,
++        ))?;
++        if !formatted_extensions.is_empty() {
++            formatted_extensions.sort();
++
++            buffer.write_char('|')?;
++            buffer.write_str(formatted_extensions.join(" ").as_str())?;
++        }
++
++        Ok(())
++    }
++}
++
++fn get_log_event_value(log: &LogEvent, field: &ConfigTargetPath) -> String {
++    match log.get(field) {
++        Some(Value::Bytes(bytes)) => String::from_utf8_lossy(bytes).to_string(),
++        Some(Value::Integer(int)) => int.to_string(),
++        Some(Value::Float(float)) => float.to_string(),
++        Some(Value::Boolean(bool)) => bool.to_string(),
++        // TODO(nabokihms): support other timestamp options.
++        Some(Value::Timestamp(timestamp)) => timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, true),
++        Some(Value::Null) => String::from(""),
++        // Other value types: Array, Regex, Object are not supported by the CEF format.
++        Some(_) => String::from(""),
++        None => String::from(""),
++    }
++}
++
++fn escape_header(mut s: String) -> String {
++    s = s.replace('\\', r#"\\"#);
++    s = s.replace('|', r#"\|"#);
++    String::from_utf8_lossy(s.as_bytes()).to_string()
++}
++
++fn escape_extension(mut s: String) -> String {
++    s = s.replace('\\', r#"\\"#);
++    s = s.replace('=', r#"\="#);
++    String::from_utf8_lossy(s.as_bytes()).to_string()
++}
++
++#[cfg(test)]
++mod tests {
++    use bytes::BytesMut;
++    use chrono::DateTime;
++    use ordered_float::NotNan;
++    use vector_common::btreemap;
++    use vector_core::event::{Event, LogEvent, Value};
++
++    use super::*;
++
++    #[test]
++    fn build_error_on_invalid_extension() {
++        let extensions = HashMap::from([(
++            String::from("foo.test"),
++            ConfigTargetPath::try_from("foo".to_string()).unwrap(),
++        )]);
++        let opts: CefSerializerOptions = CefSerializerOptions {
++            extensions,
++            ..CefSerializerOptions::default()
++        };
++        let config = CefSerializerConfig::new(opts);
++        let err = config.build().unwrap_err();
++        assert_eq!(
++            err.to_string(),
++            "extension keys can only contain ascii alphabetical characters: invalid key 'foo.test'"
++        );
++    }
++
++    #[test]
++    fn try_escape_header() {
++        let s1 = String::from(r#"Test | test"#);
++        let s2 = String::from(r#"Test \ test"#);
++        let s3 = String::from(r#"Test test"#);
++        let s4 = String::from(r#"Test \| \| test"#);
++
++        let s1 = escape_header(s1);
++        let s2 = escape_header(s2);
++        let s3: String = escape_header(s3);
++        let s4: String = escape_header(s4);
++
++        assert_eq!(s1, r#"Test \| test"#);
++        assert_eq!(s2, r#"Test \\ test"#);
++        assert_eq!(s3, r#"Test test"#);
++        assert_eq!(s4, r#"Test \\\| \\\| test"#);
++    }
++
++    #[test]
++    fn try_escape_extension() {
++        let s1 = String::from(r#"Test=test"#);
++        let s2 = String::from(r#"Test = test"#);
++        let s3 = String::from(r#"Test test"#);
++        let s4 = String::from(r#"Test \| \| test"#);
++
++        let s1 = escape_extension(s1);
++        let s2 = escape_extension(s2);
++        let s3: String = escape_extension(s3);
++        let s4: String = escape_extension(s4);
++
++        assert_eq!(s1, r#"Test\=test"#);
++        assert_eq!(s2, r#"Test \= test"#);
++        assert_eq!(s3, r#"Test test"#);
++        assert_eq!(s4, r#"Test \\| \\| test"#);
++    }
++
++    // TODO(nabokihms): more tests for edge cases.
++
++    #[test]
++    fn serialize_extensions() {
++        let event = Event::Log(LogEvent::from(btreemap! {
++            "cef" => Value::from(btreemap! {
++                "severity" => Value::from(1),
++                "name" => Value::from("Event name"),
++            }),
++            "foo" => Value::from("bar"),
++            "int" => Value::from(123),
++            "comma" => Value::from("abc,bcd"),
++            "float" => Value::Float(NotNan::new(3.1415925).unwrap()),
++            "space" => Value::from("sp ace"),
++            "time" => Value::Timestamp(DateTime::parse_from_rfc3339("2023-02-27T15:04:49.363+08:00").unwrap().into()),
++            "quote" => Value::from("the \"quote\" should be escaped"),
++            "bool" => Value::from(true),
++            "other" => Value::from("data"),
++        }));
++
++        let extensions = HashMap::from([
++            (
++                String::from("foo"),
++                ConfigTargetPath::try_from("foo".to_string()).unwrap(),
++            ),
++            (
++                String::from("int"),
++                ConfigTargetPath::try_from("int".to_string()).unwrap(),
++            ),
++            (
++                String::from("comma"),
++                ConfigTargetPath::try_from("comma".to_string()).unwrap(),
++            ),
++            (
++                String::from("float"),
++                ConfigTargetPath::try_from("float".to_string()).unwrap(),
++            ),
++            (
++                String::from("missing"),
++                ConfigTargetPath::try_from("missing".to_string()).unwrap(),
++            ),
++            (
++                String::from("space"),
++                ConfigTargetPath::try_from("space".to_string()).unwrap(),
++            ),
++            (
++                String::from("time"),
++                ConfigTargetPath::try_from("time".to_string()).unwrap(),
++            ),
++            (
++                String::from("quote"),
++                ConfigTargetPath::try_from("quote".to_string()).unwrap(),
++            ),
++            (
++                String::from("bool"),
++                ConfigTargetPath::try_from("bool".to_string()).unwrap(),
++            ),
++        ]);
++
++        let opts: CefSerializerOptions = CefSerializerOptions {
++            extensions,
++            ..CefSerializerOptions::default()
++        };
++
++        let config = CefSerializerConfig::new(opts);
++        let mut serializer = config.build().unwrap();
++        let mut bytes = BytesMut::new();
++
++        serializer.encode(event, &mut bytes).unwrap();
++
++        assert_eq!(
++            bytes.freeze(),
++            b"CEF:0|Datadog|Vector|0|Telemetry Event|1|Event name|bool=true comma=abc,bcd float=3.1415925 foo=bar int=123 quote=the \"quote\" should be escaped space=sp ace time=2023-02-27T07:04:49.363Z".as_slice()
++        );
++    }
++}
+diff --git a/lib/codecs/src/encoding/format/mod.rs b/lib/codecs/src/encoding/format/mod.rs
+index 1d4e008380516..63e4c86d51171 100644
+--- a/lib/codecs/src/encoding/format/mod.rs
++++ b/lib/codecs/src/encoding/format/mod.rs
+@@ -4,6 +4,7 @@
+ #![deny(missing_docs)]
+
+ mod avro;
++mod cef;
+ mod csv;
+ mod gelf;
+ mod json;
+@@ -17,6 +18,7 @@ use std::fmt::Debug;
+
+ pub use self::csv::{CsvSerializer, CsvSerializerConfig};
+ pub use avro::{AvroSerializer, AvroSerializerConfig, AvroSerializerOptions};
++pub use cef::{CefSerializer, CefSerializerConfig};
+ use dyn_clone::DynClone;
+ pub use gelf::{GelfSerializer, GelfSerializerConfig};
+ pub use json::{JsonSerializer, JsonSerializerConfig};
+diff --git a/lib/codecs/src/encoding/mod.rs b/lib/codecs/src/encoding/mod.rs
+index d798e8d7bf9d9..237f83d95ef1e 100644
+--- a/lib/codecs/src/encoding/mod.rs
++++ b/lib/codecs/src/encoding/mod.rs
+@@ -8,11 +8,11 @@ use std::fmt::Debug;
+
+ use bytes::BytesMut;
+ pub use format::{
+-    AvroSerializer, AvroSerializerConfig, AvroSerializerOptions, CsvSerializer,
+-    CsvSerializerConfig, GelfSerializer, GelfSerializerConfig, JsonSerializer,
+-    JsonSerializerConfig, LogfmtSerializer, LogfmtSerializerConfig, NativeJsonSerializer,
+-    NativeJsonSerializerConfig, NativeSerializer, NativeSerializerConfig, RawMessageSerializer,
+-    RawMessageSerializerConfig, TextSerializer, TextSerializerConfig,
++    AvroSerializer, AvroSerializerConfig, AvroSerializerOptions, CefSerializer,
++    CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfSerializer, GelfSerializerConfig,
++    JsonSerializer, JsonSerializerConfig, LogfmtSerializer, LogfmtSerializerConfig,
++    NativeJsonSerializer, NativeJsonSerializerConfig, NativeSerializer, NativeSerializerConfig,
++    RawMessageSerializer, RawMessageSerializerConfig, TextSerializer, TextSerializerConfig,
+ };
+ pub use framing::{
+     BoxedFramer, BoxedFramingError, BytesEncoder, BytesEncoderConfig, CharacterDelimitedEncoder,
+@@ -197,6 +197,13 @@ pub enum SerializerConfig {
+         avro: AvroSerializerOptions,
+     },
+
++    /// Encodes an event as a CEF (Common Event Format) formatted message.
++    ///
++    Cef(
++        /// Options for the CEF encoder.
++        CefSerializerConfig,
++    ),
++
+     /// Encodes an event as a CSV message.
+     ///
+     /// This codec must be configured with fields to encode.
+@@ -269,6 +276,12 @@ impl From<AvroSerializerConfig> for SerializerConfig {
+     }
+ }
+
++impl From<CefSerializerConfig> for SerializerConfig {
++    fn from(config: CefSerializerConfig) -> Self {
++        Self::Cef(config)
++    }
++}
++
+ impl From<CsvSerializerConfig> for SerializerConfig {
+     fn from(config: CsvSerializerConfig) -> Self {
+         Self::Csv(config)
+@@ -324,6 +337,7 @@ impl SerializerConfig {
+             SerializerConfig::Avro { avro } => Ok(Serializer::Avro(
+                 AvroSerializerConfig::new(avro.schema.clone()).build()?,
+             )),
++            SerializerConfig::Cef(config) => Ok(Serializer::Cef(config.build()?)),
+             SerializerConfig::Csv(config) => Ok(Serializer::Csv(config.build()?)),
+             SerializerConfig::Gelf => Ok(Serializer::Gelf(GelfSerializerConfig::new().build())),
+             SerializerConfig::Json(config) => Ok(Serializer::Json(config.build())),
+@@ -356,7 +370,8 @@ impl SerializerConfig {
+             SerializerConfig::Avro { .. } | SerializerConfig::Native => {
+                 FramingConfig::LengthDelimited
+             }
+-            SerializerConfig::Csv(_)
++            SerializerConfig::Cef(_)
++            | SerializerConfig::Csv(_)
+             | SerializerConfig::Gelf
+             | SerializerConfig::Json(_)
+             | SerializerConfig::Logfmt
+@@ -372,6 +387,7 @@ impl SerializerConfig {
+             SerializerConfig::Avro { avro } => {
+                 AvroSerializerConfig::new(avro.schema.clone()).input_type()
+             }
++            SerializerConfig::Cef(config) => config.input_type(),
+             SerializerConfig::Csv(config) => config.input_type(),
+             SerializerConfig::Gelf { .. } => GelfSerializerConfig::input_type(),
+             SerializerConfig::Json(config) => config.input_type(),
+@@ -389,6 +405,7 @@ impl SerializerConfig {
+             SerializerConfig::Avro { avro } => {
+                 AvroSerializerConfig::new(avro.schema.clone()).schema_requirement()
+             }
++            SerializerConfig::Cef(config) => config.schema_requirement(),
+             SerializerConfig::Csv(config) => config.schema_requirement(),
+             SerializerConfig::Gelf { .. } => GelfSerializerConfig::schema_requirement(),
+             SerializerConfig::Json(config) => config.schema_requirement(),
+@@ -406,6 +423,8 @@ impl SerializerConfig {
+ pub enum Serializer {
+     /// Uses an `AvroSerializer` for serialization.
+     Avro(AvroSerializer),
++    /// Uses a `CefSerializer` for serialization.
++    Cef(CefSerializer),
+     /// Uses a `CsvSerializer` for serialization.
+     Csv(CsvSerializer),
+     /// Uses a `GelfSerializer` for serialization.
+@@ -430,6 +449,7 @@ impl Serializer {
+         match self {
+             Serializer::Json(_) | Serializer::NativeJson(_) | Serializer::Gelf(_) => true,
+             Serializer::Avro(_)
++            | Serializer::Cef(_)
+             | Serializer::Csv(_)
+             | Serializer::Logfmt(_)
+             | Serializer::Text(_)
+@@ -450,6 +470,7 @@ impl Serializer {
+             Serializer::Json(serializer) => serializer.to_json_value(event),
+             Serializer::NativeJson(serializer) => serializer.to_json_value(event),
+             Serializer::Avro(_)
++            | Serializer::Cef(_)
+             | Serializer::Csv(_)
+             | Serializer::Logfmt(_)
+             | Serializer::Text(_)
+@@ -467,6 +488,12 @@ impl From<AvroSerializer> for Serializer {
+     }
+ }
+
++impl From<CefSerializer> for Serializer {
++    fn from(serializer: CefSerializer) -> Self {
++        Self::Cef(serializer)
++    }
++}
++
+ impl From<CsvSerializer> for Serializer {
+     fn from(serializer: CsvSerializer) -> Self {
+         Self::Csv(serializer)
+@@ -521,6 +548,7 @@ impl tokio_util::codec::Encoder<Event> for Serializer {
+     fn encode(&mut self, event: Event, buffer: &mut BytesMut) -> Result<(), Self::Error> {
+         match self {
+             Serializer::Avro(serializer) => serializer.encode(event, buffer),
++            Serializer::Cef(serializer) => serializer.encode(event, buffer),
+             Serializer::Csv(serializer) => serializer.encode(event, buffer),
+             Serializer::Gelf(serializer) => serializer.encode(event, buffer),
+             Serializer::Json(serializer) => serializer.encode(event, buffer),
+diff --git a/src/codecs/encoding/config.rs b/src/codecs/encoding/config.rs
+index 97096de1e0f3d..b1d970e8e1d26 100644
+--- a/src/codecs/encoding/config.rs
++++ b/src/codecs/encoding/config.rs
+@@ -109,7 +109,8 @@ impl EncodingConfigWithFraming {
+             }
+             (
+                 None,
+-                Serializer::Csv(_)
++                Serializer::Cef(_)
++                | Serializer::Csv(_)
+                 | Serializer::Gelf(_)
+                 | Serializer::Logfmt(_)
+                 | Serializer::NativeJson(_)
+diff --git a/src/codecs/encoding/encoder.rs b/src/codecs/encoding/encoder.rs
+index 3f9970fb961a2..09b8241999297 100644
+--- a/src/codecs/encoding/encoder.rs
++++ b/src/codecs/encoding/encoder.rs
+@@ -116,6 +116,7 @@ impl Encoder<Framer> {
+             (Serializer::Native(_), _) => "application/octet-stream",
+             (
+                 Serializer::Avro(_)
++                | Serializer::Cef(_)
+                 | Serializer::Csv(_)
+                 | Serializer::Gelf(_)
+                 | Serializer::Json(_)
+diff --git a/src/components/validation/resources/mod.rs b/src/components/validation/resources/mod.rs
+index b6427bd7f6ab5..961e19385da6f 100644
+--- a/src/components/validation/resources/mod.rs
++++ b/src/components/validation/resources/mod.rs
+@@ -182,6 +182,7 @@ fn decoder_framing_to_encoding_framer(framing: &decoding::FramingConfig) -> enco
+ fn serializer_config_to_deserializer(config: &SerializerConfig) -> decoding::Deserializer {
+     let deserializer_config = match config {
+         SerializerConfig::Avro { .. } => todo!(),
++        SerializerConfig::Cef { .. } => todo!(),
+         SerializerConfig::Csv { .. } => todo!(),
+         SerializerConfig::Gelf => DeserializerConfig::Gelf,
+         SerializerConfig::Json(_) => DeserializerConfig::Json,
+diff --git a/website/cue/reference/components/sinks/base/amqp.cue b/website/cue/reference/components/sinks/base/amqp.cue
+index cd201bb517f08..4ea9e0b87b8cd 100644
+--- a/website/cue/reference/components/sinks/base/amqp.cue
++++ b/website/cue/reference/components/sinks/base/amqp.cue
+@@ -57,6 +57,91 @@ base: components: sinks: amqp: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -66,6 +151,7 @@ base: components: sinks: amqp: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+index 91f6204765875..d4e2da9c79511 100644
+--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
++++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+@@ -214,6 +214,91 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -223,6 +308,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+index 966082ca84f99..902546c9ef179 100644
+--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
++++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+@@ -193,6 +193,91 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -202,6 +287,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+index 50a8a22d90a4f..5613e082e8d93 100644
+--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
++++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+@@ -193,6 +193,91 @@ base: components: sinks: aws_kinesis_streams: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -202,6 +287,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/aws_s3.cue b/website/cue/reference/components/sinks/base/aws_s3.cue
+index 542f8c0ceab1e..3ead76bad8081 100644
+--- a/website/cue/reference/components/sinks/base/aws_s3.cue
++++ b/website/cue/reference/components/sinks/base/aws_s3.cue
+@@ -302,6 +302,91 @@ base: components: sinks: aws_s3: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -311,6 +396,7 @@ base: components: sinks: aws_s3: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/aws_sqs.cue b/website/cue/reference/components/sinks/base/aws_sqs.cue
+index 403beb674ba3e..a7f57cc28fbf9 100644
+--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
++++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
+@@ -134,6 +134,91 @@ base: components: sinks: aws_sqs: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -143,6 +228,7 @@ base: components: sinks: aws_sqs: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/azure_blob.cue b/website/cue/reference/components/sinks/base/azure_blob.cue
+index 9046389be1a57..eade9d8c463b1 100644
+--- a/website/cue/reference/components/sinks/base/azure_blob.cue
++++ b/website/cue/reference/components/sinks/base/azure_blob.cue
+@@ -165,6 +165,91 @@ base: components: sinks: azure_blob: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -174,6 +259,7 @@ base: components: sinks: azure_blob: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/console.cue b/website/cue/reference/components/sinks/base/console.cue
+index c4deb39c4ce1d..693ebc0dea837 100644
+--- a/website/cue/reference/components/sinks/base/console.cue
++++ b/website/cue/reference/components/sinks/base/console.cue
+@@ -41,6 +41,91 @@ base: components: sinks: console: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -50,6 +135,7 @@ base: components: sinks: console: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/file.cue b/website/cue/reference/components/sinks/base/file.cue
+index 383b9d2086f37..5aa831dbecb0e 100644
+--- a/website/cue/reference/components/sinks/base/file.cue
++++ b/website/cue/reference/components/sinks/base/file.cue
+@@ -61,6 +61,91 @@ base: components: sinks: file: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -70,6 +155,7 @@ base: components: sinks: file: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+index 82d963fc5da3a..aa50423601fc5 100644
+--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
++++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+@@ -110,6 +110,91 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -119,6 +204,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+index 3b636da3f16ab..b6c0710c1284e 100644
+--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
++++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+@@ -189,6 +189,91 @@ base: components: sinks: gcp_cloud_storage: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -198,6 +283,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/gcp_pubsub.cue b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+index 9c45e6195401c..8219f4c6da2a4 100644
+--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
++++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+@@ -108,6 +108,91 @@ base: components: sinks: gcp_pubsub: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -117,6 +202,7 @@ base: components: sinks: gcp_pubsub: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/http.cue b/website/cue/reference/components/sinks/base/http.cue
+index 7eefce772c920..55dd53c275dbc 100644
+--- a/website/cue/reference/components/sinks/base/http.cue
++++ b/website/cue/reference/components/sinks/base/http.cue
+@@ -144,6 +144,91 @@ base: components: sinks: http: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -153,6 +238,7 @@ base: components: sinks: http: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/humio_logs.cue b/website/cue/reference/components/sinks/base/humio_logs.cue
+index e7967257dc81e..d69421658bf70 100644
+--- a/website/cue/reference/components/sinks/base/humio_logs.cue
++++ b/website/cue/reference/components/sinks/base/humio_logs.cue
+@@ -97,6 +97,91 @@ base: components: sinks: humio_logs: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -106,6 +191,7 @@ base: components: sinks: humio_logs: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/kafka.cue b/website/cue/reference/components/sinks/base/kafka.cue
+index 97de9c94750e9..994fc76c73138 100644
+--- a/website/cue/reference/components/sinks/base/kafka.cue
++++ b/website/cue/reference/components/sinks/base/kafka.cue
+@@ -96,6 +96,91 @@ base: components: sinks: kafka: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -105,6 +190,7 @@ base: components: sinks: kafka: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/loki.cue b/website/cue/reference/components/sinks/base/loki.cue
+index 829bad773dd74..befc1ad04d37e 100644
+--- a/website/cue/reference/components/sinks/base/loki.cue
++++ b/website/cue/reference/components/sinks/base/loki.cue
+@@ -148,6 +148,91 @@ base: components: sinks: loki: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -157,6 +242,7 @@ base: components: sinks: loki: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/nats.cue b/website/cue/reference/components/sinks/base/nats.cue
+index 2708c111c08cc..d128faa1c3ec7 100644
+--- a/website/cue/reference/components/sinks/base/nats.cue
++++ b/website/cue/reference/components/sinks/base/nats.cue
+@@ -141,6 +141,91 @@ base: components: sinks: nats: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -150,6 +235,7 @@ base: components: sinks: nats: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/papertrail.cue b/website/cue/reference/components/sinks/base/papertrail.cue
+index 8b4cce6d5c019..d782f06d25b62 100644
+--- a/website/cue/reference/components/sinks/base/papertrail.cue
++++ b/website/cue/reference/components/sinks/base/papertrail.cue
+@@ -41,6 +41,91 @@ base: components: sinks: papertrail: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -50,6 +135,7 @@ base: components: sinks: papertrail: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/pulsar.cue b/website/cue/reference/components/sinks/base/pulsar.cue
+index cd55deaf6093c..5c2369125e188 100644
+--- a/website/cue/reference/components/sinks/base/pulsar.cue
++++ b/website/cue/reference/components/sinks/base/pulsar.cue
+@@ -128,6 +128,91 @@ base: components: sinks: pulsar: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -137,6 +222,7 @@ base: components: sinks: pulsar: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/redis.cue b/website/cue/reference/components/sinks/base/redis.cue
+index 774370ce58a00..03d7c52220bbf 100644
+--- a/website/cue/reference/components/sinks/base/redis.cue
++++ b/website/cue/reference/components/sinks/base/redis.cue
+@@ -94,6 +94,91 @@ base: components: sinks: redis: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -103,6 +188,7 @@ base: components: sinks: redis: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/socket.cue b/website/cue/reference/components/sinks/base/socket.cue
+index c0b0c62ad106e..07d65c1d7a63f 100644
+--- a/website/cue/reference/components/sinks/base/socket.cue
++++ b/website/cue/reference/components/sinks/base/socket.cue
+@@ -53,6 +53,91 @@ base: components: sinks: socket: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -62,6 +147,7 @@ base: components: sinks: socket: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+index 00872c584d409..47f827aeb2d0e 100644
+--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
++++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+@@ -147,6 +147,91 @@ base: components: sinks: splunk_hec_logs: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -156,6 +241,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/webhdfs.cue b/website/cue/reference/components/sinks/base/webhdfs.cue
+index 006b33156564b..bf03814c5205a 100644
+--- a/website/cue/reference/components/sinks/base/webhdfs.cue
++++ b/website/cue/reference/components/sinks/base/webhdfs.cue
+@@ -97,6 +97,91 @@ base: components: sinks: webhdfs: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -106,6 +191,7 @@ base: components: sinks: webhdfs: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/sinks/base/websocket.cue b/website/cue/reference/components/sinks/base/websocket.cue
+index ad51d78f9a46f..4358337af0c51 100644
+--- a/website/cue/reference/components/sinks/base/websocket.cue
++++ b/website/cue/reference/components/sinks/base/websocket.cue
+@@ -88,6 +88,91 @@ base: components: sinks: websocket: configuration: {
+ 					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+ 				}
+ 			}
++			cef: {
++				description:   "The CEF Serializer Options."
++				relevant_when: "codec = \"cef\""
++				required:      true
++				type: object: options: {
++					device_event_class_id: {
++						description: """
++																Unique identifier for each event-type. Identifies the type of event reported.
++																The value length must be lower or equal to 1023.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_product: {
++						description: """
++																Identifies the product of a vendor.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_vendor: {
++						description: """
++																Identifies the vendor of the product.
++																The part of a unique device identifier. No two products can use the same pair of devide vendor and device product combination.
++																The value length must be lower or equal to 63.
++																"""
++						required: false
++						type: string: {}
++					}
++					device_version: {
++						description: """
++																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of device that sends messages.
++																The value length must be lower or equal to 31.
++																"""
++						required: false
++						type: string: {}
++					}
++					extensions: {
++						description: """
++																The collection fo key-value pairs. Keys are the keys of the extensions, and values are path that point to the extension values of a log event.
++																The event can have any number of key-value pairs in any order.
++																"""
++						required: false
++						type: object: options: "*": {
++							description: "This is a path that points to the extension value of a log event."
++							required:    true
++							type: string: {}
++						}
++					}
++					name: {
++						description: """
++																This is a path that points to the human-readable description of a log event.
++																The value length must be lower or equal to 512.
++																Equals to "cef.name" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					severity: {
++						description: """
++																This is a path that points to filed of a log event that reflects importance of the event.
++																Reflects importance of the event.
++
++																It must point to a number from 0 to 10.
++																0 = Lowest, 10 = Highest.
++																Equals to "cef.severity" by default.
++																"""
++						required: true
++						type: string: {}
++					}
++					version: {
++						description: """
++																CEF Version. Can be either 0 or 1.
++																Equals to "0" by default.
++																"""
++						required: true
++						type: string: enum: {
++							V0: "CEF specification version 0.1."
++							V1: "CEF specification version 1.x."
++						}
++					}
++				}
++			}
+ 			codec: {
+ 				description: "The codec to use for encoding events."
+ 				required:    true
+@@ -97,6 +182,7 @@ base: components: sinks: websocket: configuration: {
+
+ 						[apache_avro]: https://avro.apache.org/
+ 						"""
++					cef: "Encodes an event as a CEF (Common Event Format) formatted message."
+ 					csv: """
+ 						Encodes an event as a CSV message.
+
+diff --git a/website/cue/reference/components/transforms/base/sample.cue b/website/cue/reference/components/transforms/base/sample.cue
+index 3e0d7aaba7f06..16b7fe370dff5 100644
+--- a/website/cue/reference/components/transforms/base/sample.cue
++++ b/website/cue/reference/components/transforms/base/sample.cue
+@@ -12,7 +12,7 @@ base: components: transforms: sample: configuration: {
+ 			sampled.
+
+ 			Each unique value for the key creates a bucket of related events to be sampled together
+-			and the rate is applied to the buckets themselves to sample `1/N` buckets. Overall rate
++			and the rate is applied to the buckets themselves to sample `1/N` buckets.  The overall rate
+ 			of sampling may differ from the configured one if values in the field are not uniformly
+ 			distributed. If left unspecified, or if the event doesn’t have `key_field`, then the
+ 			event is sampled independently.
+diff --git a/website/cue/reference/components/transforms/base/throttle.cue b/website/cue/reference/components/transforms/base/throttle.cue
+index 710aeeb858ec7..608b43cef1c8c 100644
+--- a/website/cue/reference/components/transforms/base/throttle.cue
++++ b/website/cue/reference/components/transforms/base/throttle.cue
+@@ -8,7 +8,7 @@ base: components: transforms: throttle: configuration: {
+ 	}
+ 	key_field: {
+ 		description: """
+-			The value to group events into a separate buckets to be rate limited independently.
++			The value to group events into separate buckets to be rate limited independently.
+
+ 			If left unspecified, or if the event doesn't have `key_field`, then the event is not rate
+ 			limited separately.


### PR DESCRIPTION
## Description
This PR adds an option to encode messages to CEF format (often accepted by SIEM systems, such as KUMA (Kaspersky Unified Monitoring and Analysis Platform).

> The Common Event Format (CEF) is a standardized logging format developed by ArcSight (now part of Micro Focus), a security information and event management (SIEM) solution provider. CEF is designed to simplify the process of logging security-related events and making it easier to integrate logs from different sources into a single system. CEF is based on the syslog format, which is a standard for message logging that is supported by most network devices and operating systems.

As of today, only Kafka is supported, but the feature is generic enough and can be exposed to other destinations in the future.

## Why do we need it, and what problem does it solve?
Deckhouse has security events provided by the `runtime-audit-engine` module. However, the messages are encoded in the JSON format.

To be able to send these messages (or any other messages) to SIEM systems, the following config can be used:
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ClusterLogDestination
metadata:
  name: siem-kafka
spec:
  extraLabels:
    cef.name: '{{ rule }}'
    cef.severity: '{{ priority }}'
    message: '{{ output }}'
  type: Kafka
  kafka:
    bootstrapServers:
    - my-cluster-kafka-brokers.kafka:9092
    encoding:
      codec: CEF
    tls:
      verifyCertificate: false
      verifyHostname: true
    topic: logs
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: feature
summary: Add an option to encode messages to CEF format (often accepted by SIEM systems, such as KUMA (Kaspersky Unified Monitoring and Analysis Platform).
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
