### PR TITLE
[deckhouse] Send clusterUUID when checking for deckhouse release

### DIFF
--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -88,6 +88,7 @@ func (r *client) Image(tag string) (v1.Image, error) {
 	}
 
 	imageOptions := make([]remote.Option, 0)
+	imageOptions = append(imageOptions, remote.WithUserAgent(r.options.userAgent))
 	if !r.options.withoutAuth {
 		imageOptions = append(imageOptions, remote.WithAuth(authn.FromConfig(r.authConfig)))
 	}
@@ -195,6 +196,7 @@ type registryOptions struct {
 	useHTTP     bool
 	withoutAuth bool
 	dockerCfg   string
+	userAgent   string
 }
 
 type Option func(options *registryOptions)
@@ -224,6 +226,13 @@ func WithDisabledAuth() Option {
 func WithAuth(dockerCfg string) Option {
 	return func(options *registryOptions) {
 		options.dockerCfg = dockerCfg
+	}
+}
+
+// WithUserAgent adds ua string to the User-Agent header
+func WithUserAgent(ua string) Option {
+	return func(options *registryOptions) {
+		options.userAgent = ua
 	}
 }
 

--- a/modules/002-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release.go
@@ -574,8 +574,9 @@ func (dcr *DeckhouseReleaseChecker) nextVersion(actual, target *semver.Version) 
 func NewDeckhouseReleaseChecker(input *go_hook.HookInput, dc dependency.Container, releaseChannel string) (*DeckhouseReleaseChecker, error) {
 	repo := input.Values.Get("global.modulesImages.registry.base").String() // host/ns/repo
 	dockerCfg := input.Values.Get("global.modulesImages.registry.dockercfg").String()
+	clusterUUID := input.Values.Get("global.discovery.clusterUUID").String()
 	// registry.deckhouse.io/deckhouse/ce/release-channel:$release-channel
-	regCli, err := dc.GetRegistryClient(path.Join(repo, "release-channel"), cr.WithAuth(dockerCfg), cr.WithCA(getCA(input)), cr.WithInsecureSchema(isHTTP(input)))
+	regCli, err := dc.GetRegistryClient(path.Join(repo, "release-channel"), cr.WithAuth(dockerCfg), cr.WithCA(getCA(input)), cr.WithInsecureSchema(isHTTP(input)), cr.WithUserAgent(clusterUUID))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Send clusterUUID when checking for deckhouse release

## Why do we need it, and what problem does it solve?
We want to know cluster uuid when registry is accessed.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Before
```
http.request.useragent="go-containerregistry/v0.5.1"
```
After
```
http.request.useragent="bb6781c1-b38c-4ba8-9f8a-ff0feac51a66 go-containerregistry/v0.5.1"
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Send clusterUUID when checking for deckhouse release
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
