### PR TITLE
[metallb] fix error with preserving controller internal state after reboot

### DIFF
--- a/ee/modules/380-metallb/images/artifact/werf.inc.yaml
+++ b/ee/modules/380-metallb/images/artifact/werf.inc.yaml
@@ -7,6 +7,7 @@ shell:
     - mkdir -p /src
     - cd /src
     - git clone -b v0.13.12 {{ $.SOURCE_REPO }}/metallb/metallb.git .
+    - git config --global user.email "builder@deckhouse.io"
     # https://github.com/metallb/metallb/pull/2004
     # Remove cherry-pick when this commit is included in the release
     - git cherry-pick 667ab7e93d1e6465d5b6d343b73b3c7b1edd5015

--- a/ee/modules/380-metallb/images/artifact/werf.inc.yaml
+++ b/ee/modules/380-metallb/images/artifact/werf.inc.yaml
@@ -20,4 +20,4 @@ shell:
     - cd ../speaker
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /speaker
     - chown 64535:64535 /speaker
-    - chmod 0700 /speaker
+    - chmod 0755 /speaker

--- a/ee/modules/380-metallb/images/artifact/werf.inc.yaml
+++ b/ee/modules/380-metallb/images/artifact/werf.inc.yaml
@@ -6,12 +6,10 @@ shell:
     - apk add --no-cache git
     - mkdir -p /src
     - cd /src
-    - git clone --depth 1 -b v0.13.12 {{ $.SOURCE_REPO }}/metallb/metallb.git .
+    - git clone -b v0.13.12 {{ $.SOURCE_REPO }}/metallb/metallb.git .
     # https://github.com/metallb/metallb/pull/2004
-    # Remove cherry-pick when this commits is included in the release
+    # Remove cherry-pick when this commit is included in the release
     - git cherry-pick 667ab7e93d1e6465d5b6d343b73b3c7b1edd5015
-    - git cherry-pick e6b5b40f00da6b86e8bda67198a46f341527761d
-    - git cherry-pick adf1274346d28996fe36253b3e4f7127fd0bfa98
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd controller

--- a/ee/modules/380-metallb/images/artifact/werf.inc.yaml
+++ b/ee/modules/380-metallb/images/artifact/werf.inc.yaml
@@ -6,7 +6,12 @@ shell:
     - apk add --no-cache git
     - mkdir -p /src
     - cd /src
-    - git clone --depth 1 -b v0.13.11 {{ $.SOURCE_REPO }}/metallb/metallb.git .
+    - git clone --depth 1 -b v0.13.12 {{ $.SOURCE_REPO }}/metallb/metallb.git .
+    # https://github.com/metallb/metallb/pull/2004
+    # Remove cherry-pick when this commits is included in the release
+    - git cherry-pick 667ab7e93d1e6465d5b6d343b73b3c7b1edd5015
+    - git cherry-pick e6b5b40f00da6b86e8bda67198a46f341527761d
+    - git cherry-pick adf1274346d28996fe36253b3e4f7127fd0bfa98
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd controller

--- a/ee/modules/380-metallb/images/artifact/werf.inc.yaml
+++ b/ee/modules/380-metallb/images/artifact/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: {{ .ModuleName }}/metallb-artifact
-from: {{ .Images.BASE_GOLANG_19_ALPINE }}
+from: {{ .Images.BASE_GOLANG_20_ALPINE }}
 shell:
   install:
     - apk add --no-cache git

--- a/ee/modules/380-metallb/templates/controller/deployment.yaml
+++ b/ee/modules/380-metallb/templates/controller/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       imagePullSecrets:
         - name: deckhouse-registry
       containers:


### PR DESCRIPTION
## Description
Fix error with preserving controller internal state after reboot.

## Why do we need it in the patch release (if we do)?
There is an LB service with a specific IP (annotated) assigned to it.
Also there are other LB services in the cluster on "pending".
MetalLB's controller resets and when it goes back up again,
it loops over the services, sees first the "pending" LB service,
and assigns it the IP that was assigned to the annotated service.

Upstream PR - https://github.com/metallb/metallb/pull/2004
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Tests

<details><summary>before</summary>

```shell
main-load-balancer-01   LoadBalancer   10.222.13.26     10.220.212.17   80:30829/TCP   2m5s
main-load-balancer-02   LoadBalancer   10.222.215.6     10.220.212.18   80:30959/TCP   53s
main-load-balancer-03   LoadBalancer   10.222.178.136   10.220.212.19   80:31481/TCP   53s
main-load-balancer-04   LoadBalancer   10.222.162.16    10.220.212.20   80:31467/TCP   53s
main-load-balancer-05   LoadBalancer   10.222.213.119   10.220.212.21   80:30713/TCP   53s
main-load-balancer-06   LoadBalancer   10.222.207.141   10.220.212.22   80:32636/TCP   53s
main-load-balancer-07   LoadBalancer   10.222.127.172   10.220.212.23   80:30242/TCP   53s
main-load-balancer-08   LoadBalancer   10.222.45.14     <pending>       80:32321/TCP   7s
main-load-balancer-09   LoadBalancer   10.222.170.251   <pending>       80:32140/TCP   7s
metallb controller restart
main-load-balancer-01   LoadBalancer   10.222.13.26     <pending>       80:30829/TCP   3m4s
main-load-balancer-02   LoadBalancer   10.222.215.6     <pending>       80:30959/TCP   112s
main-load-balancer-03   LoadBalancer   10.222.178.136   10.220.212.19   80:31481/TCP   112s
main-load-balancer-04   LoadBalancer   10.222.162.16    10.220.212.20   80:31467/TCP   112s
main-load-balancer-05   LoadBalancer   10.222.213.119   10.220.212.21   80:30713/TCP   112s
main-load-balancer-06   LoadBalancer   10.222.207.141   10.220.212.22   80:32636/TCP   112s
main-load-balancer-07   LoadBalancer   10.222.127.172   10.220.212.23   80:30242/TCP   112s
main-load-balancer-08   LoadBalancer   10.222.45.14     10.220.212.16   80:32321/TCP   66s
main-load-balancer-09   LoadBalancer   10.222.170.251   10.220.212.18   80:32140/TCP   66s
```

</details>

<details><summary>after</summary>

```shell
root@s-metallb-test-ks-master-0:~# kubectl create -f svc-lb-test.yaml 
service/main-load-balancer-01 created
service/main-load-balancer-02 created
service/main-load-balancer-03 created
service/main-load-balancer-04 created
service/main-load-balancer-05 created
service/main-load-balancer-06 created
service/main-load-balancer-07 created
service/main-load-balancer-08 created
service/main-load-balancer-09 created
root@s-metallb-test-ks-master-0:~# kubectl get svc
NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)        AGE
kubernetes              ClusterIP      10.222.0.1       <none>          443/TCP        21d
main-load-balancer-01   LoadBalancer   10.222.244.179   10.220.212.17   80:30665/TCP   1s
main-load-balancer-02   LoadBalancer   10.222.155.250   10.220.212.18   80:30403/TCP   1s
main-load-balancer-03   LoadBalancer   10.222.240.157   10.220.212.19   80:32510/TCP   1s
main-load-balancer-04   LoadBalancer   10.222.217.208   10.220.212.20   80:30238/TCP   1s
main-load-balancer-05   LoadBalancer   10.222.248.94    10.220.212.21   80:30331/TCP   1s
main-load-balancer-06   LoadBalancer   10.222.135.99    10.220.212.22   80:32476/TCP   1s
main-load-balancer-07   LoadBalancer   10.222.137.206   10.220.212.23   80:31995/TCP   1s
main-load-balancer-08   LoadBalancer   10.222.254.138   <pending>       80:32754/TCP   1s
main-load-balancer-09   LoadBalancer   10.222.104.202   <pending>       80:31014/TCP   1s
root@s-metallb-test-ks-master-0:~# kubectl -n d8-metallb delete po controller-6ff9b9d49c-t4sgt 
pod "controller-6ff9b9d49c-t4sgt" deleted
root@s-metallb-test-ks-master-0:~# kubectl get svc
NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)        AGE
kubernetes              ClusterIP      10.222.0.1       <none>          443/TCP        21d
main-load-balancer-01   LoadBalancer   10.222.244.179   10.220.212.17   80:30665/TCP   35s
main-load-balancer-02   LoadBalancer   10.222.155.250   10.220.212.18   80:30403/TCP   35s
main-load-balancer-03   LoadBalancer   10.222.240.157   10.220.212.19   80:32510/TCP   35s
main-load-balancer-04   LoadBalancer   10.222.217.208   10.220.212.20   80:30238/TCP   35s
main-load-balancer-05   LoadBalancer   10.222.248.94    10.220.212.21   80:30331/TCP   35s
main-load-balancer-06   LoadBalancer   10.222.135.99    10.220.212.22   80:32476/TCP   35s
main-load-balancer-07   LoadBalancer   10.222.137.206   10.220.212.23   80:31995/TCP   35s
main-load-balancer-08   LoadBalancer   10.222.254.138   <pending>       80:32754/TCP   35s
main-load-balancer-09   LoadBalancer   10.222.104.202   <pending>       80:31014/TCP   35s
root@s-metallb-test-ks-master-0:~# kubectl -n d8-metallb delete po controller-6ff9b9d49c-5csrx 
pod "controller-6ff9b9d49c-5csrx" deleted
root@s-metallb-test-ks-master-0:~# kubectl get svc
NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)        AGE
kubernetes              ClusterIP      10.222.0.1       <none>          443/TCP        21d
main-load-balancer-01   LoadBalancer   10.222.244.179   10.220.212.17   80:30665/TCP   49s
main-load-balancer-02   LoadBalancer   10.222.155.250   10.220.212.18   80:30403/TCP   49s
main-load-balancer-03   LoadBalancer   10.222.240.157   10.220.212.19   80:32510/TCP   49s
main-load-balancer-04   LoadBalancer   10.222.217.208   10.220.212.20   80:30238/TCP   49s
main-load-balancer-05   LoadBalancer   10.222.248.94    10.220.212.21   80:30331/TCP   49s
main-load-balancer-06   LoadBalancer   10.222.135.99    10.220.212.22   80:32476/TCP   49s
main-load-balancer-07   LoadBalancer   10.222.137.206   10.220.212.23   80:31995/TCP   49s
main-load-balancer-08   LoadBalancer   10.222.254.138   <pending>       80:32754/TCP   49s
main-load-balancer-09   LoadBalancer   10.222.104.202   <pending>       80:31014/TCP   49s
```


</details>


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: metallb
type: fix
summary: Fix error with preserving controller internal state after reboot.
impact: Metallb pods will restart.
impact_level: default
```
