### PR TITLE
[dhctl] Static build

### DIFF
--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -51,7 +51,7 @@ bin/gofumpt:
 	@chmod +x "./bin/gofumpt"
 
 build:
-	GOOS="$(OS)" GOARCH="$(GOARCH)" go build -ldflags="-s -w" -o $(DHCTL_BIN_NAME) ./cmd/dhctl
+	GOOS="$(OS)" GOARCH="$(GOARCH)" CGO_ENABLED=0 go build -ldflags="-s -w -extldflags '-static'"  -o $(DHCTL_BIN_NAME) ./cmd/dhctl
 
 build-test:
 	CGO_ENABLED=0 GOOS="linux" GOARCH="$(GOARCH)" go build -ldflags="-s -w" -o "bin/dhctl-linux-amd64-test" ./cmd/dhctl

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -69,7 +69,7 @@ func CreateOCIImageLayouts(
 		}
 		*layoutPtr, err = layout.FromPath(fsPath)
 		if err != nil {
-			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
+			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", fsPath, err)
 		}
 	}
 
@@ -80,7 +80,7 @@ func CreateOCIImageLayouts(
 		}
 		moduleLayout, err := layout.FromPath(path)
 		if err != nil {
-			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
+			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", path, err)
 		}
 
 		path = filepath.Join(rootFolder, registryRepo, "modules", module.Name, "release")
@@ -89,7 +89,7 @@ func CreateOCIImageLayouts(
 		}
 		moduleReleasesLayout, err := layout.FromPath(path)
 		if err != nil {
-			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", err)
+			return nil, fmt.Errorf("get OCI Image Layout from %s: %w", path, err)
 		}
 
 		layouts.Modules[module.Name] = ModuleImageLayout{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Static build of dhctl

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We want to be able to use dhctl outside of installer container for mirroring, so we need to bundle all of it's dependencies

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Build dhctl as static binary
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
