### PR TITLE
[dependency] Ignore path for docker registry auths

### DIFF
--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -167,7 +167,7 @@ func readAuthConfig(repo, dockerCfgBase64 string) (authn.AuthConfig, error) {
 		}
 	}
 
-	return authn.AuthConfig{}, fmt.Errorf("no auth data")
+	return authn.AuthConfig{}, fmt.Errorf("%q credentials not found in the dockerCfg", repo)
 }
 
 func GetHTTPTransport(ca string) (transport http.RoundTripper) {

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -153,7 +153,12 @@ func readAuthConfig(repo, dockerCfgBase64 string) (authn.AuthConfig, error) {
 
 	// The config should have at least one .auths.* entry
 	for repoName, repoAuth := range auths {
-		if repoName == r.Host {
+		repoNameUrl, err := parse(repoName)
+		if err != nil {
+			return authn.AuthConfig{}, err
+		}
+
+		if repoNameUrl.Host == r.Host {
 			err := json.Unmarshal([]byte(repoAuth.Raw), &authConfig)
 			if err != nil {
 				return authn.AuthConfig{}, err

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -153,12 +153,12 @@ func readAuthConfig(repo, dockerCfgBase64 string) (authn.AuthConfig, error) {
 
 	// The config should have at least one .auths.* entry
 	for repoName, repoAuth := range auths {
-		repoNameUrl, err := parse(repoName)
+		repoNameURL, err := parse(repoName)
 		if err != nil {
 			return authn.AuthConfig{}, err
 		}
 
-		if repoNameUrl.Host == r.Host {
+		if repoNameURL.Host == r.Host {
 			err := json.Unmarshal([]byte(repoAuth.Raw), &authConfig)
 			if err != nil {
 				return authn.AuthConfig{}, err


### PR DESCRIPTION
## Description
We can ignore path for registry credentials

## Why do we need it, and what problem does it solve?
User can set auths like:
```
{
  "auths": {
      "registry.example.com:8032/modules": {
          "auth": "YTpiCg=="
	}
  }
}
```

and out auth check will fail with `no auth data` if you check auth for `registry.example.com:8032/modules` source
We can avoid this

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dependency
type: feature
summary: Ignore `/path` when checking registry credentials.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
