### PR TITLE
[linstor-test] Add wrappers for lvs, vgs and lsblk commands

### DIFF
--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -212,5 +212,9 @@ RUN curl -Lfo /usr/bin/piraeus-entry.sh ${PIRAEUS_GITREPO}/raw/${PIRAEUS_COMMIT_
 COPY liveness.sh /liveness.sh
 RUN chmod 755 /liveness.sh
 
+COPY vgs lvs /usr/local/sbin/
+RUN chmod +x /usr/local/sbin/vgs && \
+  chmod +x /usr/local/sbin/lvs
+
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -212,9 +212,10 @@ RUN curl -Lfo /usr/bin/piraeus-entry.sh ${PIRAEUS_GITREPO}/raw/${PIRAEUS_COMMIT_
 COPY liveness.sh /liveness.sh
 RUN chmod 755 /liveness.sh
 
-COPY vgs lvs /usr/local/sbin/
+COPY vgs lvs lsblk /usr/local/sbin/
 RUN chmod +x /usr/local/sbin/vgs && \
-  chmod +x /usr/local/sbin/lvs
+  chmod +x /usr/local/sbin/lvs && \
+  chmod +x /usr/local/sbin/lsblk
 
 CMD ["startSatellite"]
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/usr/bin/piraeus-entry.sh"]

--- a/modules/041-linstor/images/linstor-server/lsblk
+++ b/modules/041-linstor/images/linstor-server/lsblk
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SLEEP_DURATION=${TEST_TIMEOUT_LSBLK:-5}
+sleep "$SLEEP_DURATION"
+/usr/bin/lsblk "$@"

--- a/modules/041-linstor/images/linstor-server/lsblk
+++ b/modules/041-linstor/images/linstor-server/lsblk
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-SLEEP_DURATION=${TEST_TIMEOUT_LSBLK:-5}
+SLEEP_DURATION=${TEST_TIMEOUT_LSBLK:-1}
 sleep "$SLEEP_DURATION"
 /usr/bin/lsblk "$@"

--- a/modules/041-linstor/images/linstor-server/lvs
+++ b/modules/041-linstor/images/linstor-server/lvs
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SLEEP_DURATION=${TEST_TIMEOUT:-0.5}
+sleep "$SLEEP_DURATION"
+/usr/sbin/lvs "$@"

--- a/modules/041-linstor/images/linstor-server/vgs
+++ b/modules/041-linstor/images/linstor-server/vgs
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SLEEP_DURATION=${TEST_TIMEOUT:-0.5}
+sleep "$SLEEP_DURATION"
+/usr/sbin/vgs "$@"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
