### PR TITLE
[external-module-manager] fix deckhouse ModuleSource recreation

### DIFF
--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -102,8 +102,9 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 
 	if len(input.Snapshots["sources"]) > 0 {
 		ms := input.Snapshots["sources"][0].(v1alpha1.ModuleSource)
+		releaseChannel = ms.Spec.ReleaseChannel
 
-		if moduleSourceUpToDate(&ms, deckhouseRepo, deckhouseDockerCfg, deckhouseCA, releaseChannel) {
+		if moduleSourceUpToDate(&ms, deckhouseRepo, deckhouseDockerCfg, deckhouseCA) {
 			// return if ModuleSource deckhouse already exists and all param are equal
 			return nil
 		}
@@ -141,7 +142,7 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 	return nil
 }
 
-func moduleSourceUpToDate(ms *v1alpha1.ModuleSource, repo, cfg, ca, channel string) bool {
+func moduleSourceUpToDate(ms *v1alpha1.ModuleSource, repo, cfg, ca string) bool {
 	if ms.Spec.Registry.Repo != repo {
 		return false
 	}
@@ -151,10 +152,6 @@ func moduleSourceUpToDate(ms *v1alpha1.ModuleSource, repo, cfg, ca, channel stri
 	}
 
 	if ms.Spec.Registry.DockerCFG != cfg {
-		return false
-	}
-
-	if channel != "" && ms.Spec.ReleaseChannel != channel {
 		return false
 	}
 

--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -101,7 +101,7 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 	}
 
 	if len(input.Snapshots["sources"]) > 0 {
-		ms := input.Snapshots["sources"].(v1alpha1.ModuleSource)
+		ms := input.Snapshots["sources"][0].(v1alpha1.ModuleSource)
 
 		if moduleSourceUpToDate(&ms, deckhouseRepo, deckhouseDockerCfg, deckhouseCA, releaseChannel) {
 			// return if ModuleSource deckhouse already exists and all param are equal

--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -90,6 +90,25 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 		return nil
 	}
 
+	deckhouseRepo := input.Values.Get("global.modulesImages.registry.base").String() + "/modules"
+	deckhouseDockerCfg := input.Values.Get("global.modulesImages.registry.dockercfg").String()
+	deckhouseCA := input.Values.Get("global.modulesImages.registry.CA").String()
+	releaseChannel := ""
+
+	if len(input.Snapshots["deckhouse-secret"]) > 0 {
+		ds := input.Snapshots["deckhouse-secret"][0].(deckhouseSecret)
+		releaseChannel = strcase.ToKebab(ds.ReleaseChannel)
+	}
+
+	if len(input.Snapshots["sources"]) > 0 {
+		ms := input.Snapshots["sources"].(v1alpha1.ModuleSource)
+
+		if moduleSourceUpToDate(&ms, deckhouseRepo, deckhouseDockerCfg, deckhouseCA, releaseChannel) {
+			// return if ModuleSource deckhouse already exists and all param are equal
+			return nil
+		}
+	}
+
 	newms := v1alpha1.ModuleSource{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ModuleSource",
@@ -102,29 +121,14 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 			},
 		},
 		Spec: v1alpha1.ModuleSourceSpec{
+			ReleaseChannel: releaseChannel,
 			Registry: v1alpha1.ModuleSourceSpecRegistry{
-				Repo:      input.Values.Get("global.modulesImages.registry.base").String() + "/modules",
-				DockerCFG: input.Values.Get("global.modulesImages.registry.dockercfg").String(),
+				Scheme:    "HTTPS",
+				Repo:      deckhouseRepo,
+				DockerCFG: deckhouseDockerCfg,
+				CA:        deckhouseCA,
 			},
 		},
-	}
-
-	ca := input.Values.Get("global.modulesImages.registry.CA").String()
-	if ca != "" {
-		newms.Spec.Registry.CA = ca
-	}
-
-	if len(input.Snapshots["deckhouse-secret"]) > 0 {
-		ds := input.Snapshots["deckhouse-secret"][0].(deckhouseSecret)
-		newms.Spec.ReleaseChannel = strcase.ToKebab(ds.ReleaseChannel)
-	}
-
-	if len(input.Snapshots["sources"]) > 0 {
-		ms := input.Snapshots["sources"][0].(v1alpha1.ModuleSource)
-
-		// Keep some options that users configured manually to prevent overriding
-		// In the future, instead, it is possible to use the server-side apply instead of subscribing to the object.
-		newms.Spec.ReleaseChannel = ms.Spec.ReleaseChannel
 	}
 
 	o, err := sdk.ToUnstructured(&newms)
@@ -135,4 +139,24 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 	input.PatchCollector.Create(o, object_patch.UpdateIfExists())
 
 	return nil
+}
+
+func moduleSourceUpToDate(ms *v1alpha1.ModuleSource, repo, cfg, ca, channel string) bool {
+	if ms.Spec.Registry.Repo != repo {
+		return false
+	}
+
+	if ca != "" && ms.Spec.Registry.CA != ca {
+		return false
+	}
+
+	if ms.Spec.Registry.DockerCFG != cfg {
+		return false
+	}
+
+	if channel != "" && ms.Spec.ReleaseChannel != channel {
+		return false
+	}
+
+	return true
 }

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -42,7 +42,7 @@ type ModuleSourceSpec struct {
 }
 
 type ModuleSourceSpecRegistry struct {
-	Scheme    string `json:"scheme"`
+	Scheme    string `json:"scheme,omitempty"`
 	Repo      string `json:"repo"`
 	DockerCFG string `json:"dockerCfg"`
 	CA        string `json:"ca"`


### PR DESCRIPTION
## Description
Fix ModuleSource recreation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

Every time patching a ModuleSource can stuck the queue. Because it tries to purge schema

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix 
summary: Fix deckhouse ModuleSource recreation on startup.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
