### PR TITLE
[control-plane-manager] Use minimal kubernetes version for minimal support k8s version Deckhouse requirement

### DIFF
--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -63,6 +65,8 @@ Description:
 	and if effectiveKubernetesVersion >= maxUsedControlPlaneVersion:
 		update maxUsedControlPlaneKubernetesVersion in Secret: d8-cluster-configuration
 */
+
+const minK8sVersionRequirementKey = "controlPlaneManager:minUsedControlPlaneKubernetesVersion"
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue:        moduleQueue,
@@ -191,6 +195,8 @@ func handleEffectiveK8sVersion(input *go_hook.HookInput, dc dependency.Container
 	if err != nil {
 		return err
 	}
+
+	requirements.SaveValue(minK8sVersionRequirementKey, minNodeVersion.String())
 
 	// process secret snapshot
 	maxUsedControlPlaneVersion := ekvProcessSecretSnapshot(input)

--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
@@ -23,8 +23,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -34,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 )
 
 /*

--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
@@ -63,6 +63,8 @@ Description:
 	then save effectiveKubernetesVersion to Values (`global.clusterConfiguration.kubernetesVersion`)
 	and if effectiveKubernetesVersion >= maxUsedControlPlaneVersion:
 		update maxUsedControlPlaneKubernetesVersion in Secret: d8-cluster-configuration
+
+     For deckhouse upgrade requirements we are using minimal version of whole cluster.
 */
 
 const minK8sVersionRequirementKey = "controlPlaneManager:minUsedControlPlaneKubernetesVersion"

--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version_test.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version_test.go
@@ -28,12 +28,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 

--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version_test.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version_test.go
@@ -28,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -45,6 +47,7 @@ type input struct {
 type output struct {
 	maxUsedControlPlaneVersion string
 	effectiveVersion           string
+	minUsedVersion             string
 }
 
 func setStateFromTestCase(hec *HookExecutionConfig, caseInput input) {
@@ -186,6 +189,10 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				Expect(string(decodedMaxUsedKubernetesVersion)).To(Equal(out.maxUsedControlPlaneVersion))
 
 				Expect(f.ValuesGet("controlPlaneManager.internal.effectiveKubernetesVersion").String()).To(Equal(out.effectiveVersion))
+
+				minVer, ok := requirements.GetValue(minK8sVersionRequirementKey)
+				Expect(ok).To(BeTrue())
+				Expect(minVer.(string)).To(Equal(out.minUsedVersion))
 			},
 			Entry("upgrade: Node version lower than control plane, do not allow to bump effective version and max used version",
 				input{
@@ -197,6 +204,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.25",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.24.1",
 				},
 			),
 			Entry("upgrade: control plane and nodes are on the same version, allow bumping effective version and max used version", input{
@@ -208,6 +216,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.26",
 					effectiveVersion:           "1.26",
+					minUsedVersion:             "1.25.2",
 				},
 			),
 			Entry("upgrade: control plane and nodes are on the same version (but kube-scheduler is on a lower version), do not bump effective version and max used version",
@@ -220,6 +229,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.25",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.25.2",
 				},
 			),
 			Entry("downgrade: control plane and nodes are on the same version, do not lower effective version",
@@ -232,6 +242,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.25",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.25.2",
 				},
 			),
 			Entry("downgrade: nodes are downgraded already, lower effective version",
@@ -244,6 +255,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.26",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.25.2",
 				},
 			),
 			Entry("downgrade: nodes are downgraded already, but configVersion is 2 minor versions lower, lower effective version by one",
@@ -256,6 +268,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.26",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.25.2",
 				},
 			),
 			Entry("downgrade: nodes are downgraded already, but maxUsedControlPlaneVersion does not allow us to downgrade by more than 1",
@@ -268,6 +281,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.26",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.24.2",
 				},
 			),
 			Entry("downgrade: nodes are downgraded already, maxUsedControlPlaneVersion does not allow us to downgrade by more than 1, but we already violating maxUsedControlPlaneVersion",
@@ -280,6 +294,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: get_pki_checksum 
 				output{
 					maxUsedControlPlaneVersion: "1.27",
 					effectiveVersion:           "1.25",
+					minUsedVersion:             "1.24.2",
 				},
 			),
 		)

--- a/modules/040-control-plane-manager/openapi/values.yaml
+++ b/modules/040-control-plane-manager/openapi/values.yaml
@@ -10,9 +10,6 @@ properties:
     - pkiChecksum
     - rolloutEpoch
     properties:
-      minUsedControlPlaneKubernetesVersion:
-        type: string
-        x-examples: [ "1.27.2" ]
       audit:
         type: object
         default: {}

--- a/modules/040-control-plane-manager/openapi/values.yaml
+++ b/modules/040-control-plane-manager/openapi/values.yaml
@@ -10,6 +10,9 @@ properties:
     - pkiChecksum
     - rolloutEpoch
     properties:
+      minUsedControlPlaneKubernetesVersion:
+        type: string
+        x-examples: [ "1.27.2" ]
       audit:
         type: object
         default: {}

--- a/modules/040-control-plane-manager/requirements/check.go
+++ b/modules/040-control-plane-manager/requirements/check.go
@@ -24,13 +24,15 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 )
 
+const minK8sVersionRequirementKey = "controlPlaneManager:minUsedControlPlaneKubernetesVersion"
+
 func init() {
 	f := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
 		desiredVersion, err := semver.NewVersion(requirementValue)
 		if err != nil {
 			return false, err
 		}
-		currentVersionStr, exists := getter.Get("global.discovery.kubernetesVersion")
+		currentVersionStr, exists := getter.Get(minK8sVersionRequirementKey)
 		if !exists {
 			return true, nil
 		}

--- a/modules/040-control-plane-manager/requirements/check_test.go
+++ b/modules/040-control-plane-manager/requirements/check_test.go
@@ -27,14 +27,14 @@ import (
 
 func TestKubernetesVersionRequirement(t *testing.T) {
 	t.Run("requirement met", func(t *testing.T) {
-		requirements.SaveValue("global.discovery.kubernetesVersion", "1.19.16")
+		requirements.SaveValue(minK8sVersionRequirementKey, "1.19.16")
 		ok, err := requirements.CheckRequirement("k8s", "1.19")
 		assert.True(t, ok)
 		require.NoError(t, err)
 	})
 
 	t.Run("requirement failed", func(t *testing.T) {
-		requirements.SaveValue("global.discovery.kubernetesVersion", "1.18.3")
+		requirements.SaveValue(minK8sVersionRequirementKey, "1.18.3")
 		ok, err := requirements.CheckRequirement("k8s", "1.19")
 		assert.False(t, ok)
 		require.Error(t, err)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Previously we used a minimal version of control-plane to restrict Deckhouse updates. Now we take the minimum version in the whole cluster.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.
  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to wait until the cluster is fully upgraded to the target version of k8s before upgrading Deckhouse. This will reduce the number of possible problems when updating k8s and Deckhouse at the same time

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Running without requirements is ok
![image](https://github.com/deckhouse/deckhouse/assets/30695496/fddcdad2-7b54-4f28-a2a2-c8f0b2a812c9)

Add release with requirements is blocking release

![Untitled](https://github.com/deckhouse/deckhouse/assets/30695496/62c400cf-454d-439c-88e2-42002e398bcc)

Upgrade 1.25 -> 1.26 is ok, with requirements exist

![image](https://github.com/deckhouse/deckhouse/assets/30695496/ed387358-4910-4fd8-a486-fd837a21b0fd)

block updating one node group for checking blocking update
![image](https://github.com/deckhouse/deckhouse/assets/30695496/b3b35149-d156-4440-a997-9ab4570b6fa4)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/5232ad9b-ae48-45aa-8a5f-42b2dd56b0e6)

One node was updated one was not. Requirements still exist and its target behavior.
![image](https://github.com/deckhouse/deckhouse/assets/30695496/d8a0608d-59bb-4da9-8ebd-9e306497904b)
 
Second node was updated. All cluster was updated to desired version and requirements was gone
![image](https://github.com/deckhouse/deckhouse/assets/30695496/763a57cb-9ff0-4fae-960b-275d3a7985cb)


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Use minimal kubernetes version for minimal support k8s version Deckhouse requirement
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
