### PR TITLE
[operator-prometheus] Fix rbac for alertmanager

### DIFF
--- a/modules/200-operator-prometheus/templates/rbac-for-us.yaml
+++ b/modules/200-operator-prometheus/templates/rbac-for-us.yaml
@@ -17,6 +17,7 @@ rules:
   resources:
   - alertmanagers
   - alertmanagers/finalizers
+  - alertmanagers/status
   - alertmanagerconfigs
   - prometheuses
   - prometheuses/status


### PR DESCRIPTION
## Description
Fix RBAC for updating alertmanager status.

## Why do we need it, and what problem does it solve?
Without this we can see in logs:
```
level=error ts=2023-11-08T10:09:33.267498071Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="status \"d8-monitoring/sre\" failed: failed to update status subresource: alertmanagers.monitoring.coreos.com \"sre\" is forbidden: User \"system:serviceaccount:d8-operator-prometheus:operator-prometheus\" cannot update resource \"alertmanagers/status\" in API group \"monitoring.coreos.com\" in the namespace \"d8-monitoring\""
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-prometheus
type: fix
summary: Fix RBAC for updating alertmanager status.
```
