### PR TITLE
[dhctl] Support for uploading mirrored Deckhouse images to custom repo path

### DIFF
--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -36,7 +36,7 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	app.DefineMirrorFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		if app.MirrorRegistryHost != "" {
+		if app.MirrorRegistry != "" {
 			return log.Process("mirror", "Push mirrored Deckhouse images from local filesystem to private registry", func() error {
 				return mirrorPushDeckhouseToPrivateRegistry()
 			})
@@ -52,12 +52,13 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 
 func mirrorPushDeckhouseToPrivateRegistry() error {
 	mirrorCtx := &mirror.Context{
-		Insecure:           app.MirrorInsecure,
-		RegistryHost:       app.MirrorRegistryHost,
-		RegistryRepo:       app.MirrorDeckhouseRegistryRepo,
-		TarBundlePath:      app.MirrorTarBundle,
-		UnpackedImagesPath: filepath.Join(app.TmpDirName, time.Now().Format("mirror_tmp_02-01-2006_15-04-05")),
-		ValidationMode:     mirror.ValidationMode(app.MirrorValidationMode),
+		Insecure:              app.MirrorInsecure,
+		RegistryHost:          app.MirrorRegistryHost,
+		RegistryPath:          app.MirrorRegistryPath,
+		DeckhouseRegistryRepo: app.MirrorDeckhouseRegistryRepo,
+		TarBundlePath:         app.MirrorTarBundle,
+		UnpackedImagesPath:    filepath.Join(app.TmpDirName, time.Now().Format("mirror_tmp_02-01-2006_15-04-05")),
+		ValidationMode:        mirror.ValidationMode(app.MirrorValidationMode),
 	}
 
 	if app.MirrorRegistryUsername != "" {
@@ -88,10 +89,10 @@ func mirrorPushDeckhouseToPrivateRegistry() error {
 
 func mirrorPullDeckhouseToLocalFilesystem() error {
 	mirrorCtx := &mirror.Context{
-		Insecure:        app.MirrorInsecure,
-		SkipGOSTDigests: app.MirrorSkipGOSTHashing,
-		RegistryHost:    app.MirrorRegistryHost,
-		RegistryRepo:    app.MirrorDeckhouseRegistryRepo,
+		Insecure:              app.MirrorInsecure,
+		SkipGOSTDigests:       app.MirrorSkipGOSTHashing,
+		RegistryHost:          app.MirrorRegistryHost,
+		DeckhouseRegistryRepo: app.MirrorDeckhouseRegistryRepo,
 		RegistryAuth: authn.FromConfig(authn.AuthConfig{
 			Username: "license-token",
 			Password: app.MirrorDHLicenseToken,

--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -26,8 +27,12 @@ import (
 )
 
 const (
-	enterpriseEditionRepo = "registry.deckhouse.io/deckhouse/ee"
-	flantEditionRepo      = "registry.deckhouse.io/deckhouse/fe"
+	deckhouseRegistryHost     = "registry.deckhouse.io"
+	enterpriseEditionRepoPath = "/deckhouse/ee"
+	flantEditionRepoPath      = "/deckhouse/fe"
+
+	enterpriseEditionRepo = deckhouseRegistryHost + enterpriseEditionRepoPath
+	flantEditionRepo      = deckhouseRegistryHost + flantEditionRepoPath
 )
 
 const (
@@ -37,12 +42,15 @@ const (
 )
 
 var (
+	MirrorRegistry         = ""
 	MirrorRegistryHost     = ""
+	MirrorRegistryPath     = ""
 	MirrorRegistryUsername = ""
 	MirrorRegistryPassword = ""
-	MirrorInsecure         = false
-	MirrorDHLicenseToken   = ""
-	MirrorTarBundle        = ""
+
+	MirrorInsecure       = false
+	MirrorDHLicenseToken = ""
+	MirrorTarBundle      = ""
 
 	mirrorMinVersionString                 = ""
 	MirrorMinVersion       *semver.Version = nil
@@ -61,10 +69,10 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 		PlaceHolder("TOKEN").
 		Envar(configEnvName("MIRROR_LICENSE")).
 		StringVar(&MirrorDHLicenseToken)
-	cmd.Flag("registry", "Push Deckhouse images to your private registry, specified as registry-host[:port]. Conflicts with --license.").
+	cmd.Flag("registry", "Push Deckhouse images to your private registry, specified as registry-host[:port][/path]. Conflicts with --license.").
 		Short('r').
 		Envar(configEnvName("MIRROR_PRIVATE_REGISTRY")).
-		StringVar(&MirrorRegistryHost)
+		StringVar(&MirrorRegistry)
 	cmd.Flag("registry-login", "Username to log into your registry.").
 		Short('u').
 		PlaceHolder("LOGIN").
@@ -103,43 +111,92 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 
 	cmd.PreAction(func(c *kingpin.ParseContext) error {
 		var err error
-
-		if MirrorRegistryHost == "" && MirrorDHLicenseToken == "" {
-			return errors.New("One of --license or --registry is required.")
+		if err = validateRegistryAndTokenFlagsUsage(); err != nil {
+			return err
 		}
-
-		if MirrorRegistryHost != "" && MirrorDHLicenseToken != "" {
-			return errors.New("You have specified both --license and --registry flags. This is not how it works.\n\n" +
-				"Leave only --license if you want to pull Deckhouse images from public registry.\n" +
-				"Leave only --registry if you already pulled Deckhouse images and want to push it to your private registry.")
+		if err = parseAndValidateMinVersionFlag(); err != nil {
+			return err
 		}
-
-		if mirrorMinVersionString != "" {
-			MirrorMinVersion, err = semver.NewVersion(mirrorMinVersionString)
-			if err != nil {
-				return fmt.Errorf("Minimal deckhouse version: %w", err)
-			}
+		if err = parseAndValidateRegistryURLFlag(); err != nil {
+			return err
 		}
-
-		if MirrorRegistryPassword != "" && MirrorRegistryUsername == "" {
-			return errors.New("Registry username not specified")
+		if err = validateRegistryCredentials(); err != nil {
+			return err
+		}
+		if err = validateImagesBundlePathFlag(); err != nil {
+			return err
 		}
 
 		if mirrorFlantEdition {
 			MirrorDeckhouseRegistryRepo = flantEditionRepo
 		}
 
-		MirrorTarBundle = filepath.Clean(MirrorTarBundle)
-		stats, err := os.Stat(MirrorTarBundle)
-		switch {
-		case errors.Is(err, fs.ErrNotExist):
-			break
-		case err != nil && !errors.Is(err, fs.ErrNotExist):
-			return fmt.Errorf("stat %s: %w", MirrorTarBundle, err)
-		case stats.IsDir() || filepath.Ext(MirrorTarBundle) != ".tar":
-			return fmt.Errorf("%s should be a tar archive", MirrorTarBundle)
-		}
-
 		return nil
 	})
+}
+
+func validateImagesBundlePathFlag() error {
+	MirrorTarBundle = filepath.Clean(MirrorTarBundle)
+	stats, err := os.Stat(MirrorTarBundle)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		break
+	case err != nil && !errors.Is(err, fs.ErrNotExist):
+		return fmt.Errorf("stat %s: %w", MirrorTarBundle, err)
+	case stats.IsDir() || filepath.Ext(MirrorTarBundle) != ".tar":
+		return fmt.Errorf("%s should be a tar archive", MirrorTarBundle)
+	}
+	return nil
+}
+
+func validateRegistryCredentials() error {
+	if MirrorRegistryPassword != "" && MirrorRegistryUsername == "" {
+		return errors.New("Registry username not specified")
+	}
+	return nil
+}
+
+func parseAndValidateRegistryURLFlag() error {
+	if MirrorRegistry != "" {
+		registryUrl, err := url.Parse("docker://" + MirrorRegistry)
+		if err != nil {
+			return fmt.Errorf("Validate registry address: %w", err)
+		}
+		MirrorRegistryHost = registryUrl.Host
+		MirrorRegistryPath = registryUrl.Path
+		if MirrorRegistryHost == "" {
+			return errors.New("Please specify registry address correctly")
+		}
+		if MirrorRegistryPath == "" {
+			MirrorRegistryPath = enterpriseEditionRepoPath
+			if mirrorFlantEdition {
+				MirrorRegistryPath = flantEditionRepoPath
+			}
+		}
+	}
+	return nil
+}
+
+func parseAndValidateMinVersionFlag() error {
+	var err error
+	if mirrorMinVersionString != "" {
+		MirrorMinVersion, err = semver.NewVersion(mirrorMinVersionString)
+		if err != nil {
+			return fmt.Errorf("Minimal deckhouse version: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateRegistryAndTokenFlagsUsage() error {
+	if MirrorRegistry == "" && MirrorDHLicenseToken == "" {
+		return errors.New("One of --license or --registry is required.")
+	}
+
+	if MirrorRegistry != "" && MirrorDHLicenseToken != "" {
+		return errors.New("You have specified both --license and --registry flags. This is not how it works.\n\n" +
+			"Leave only --license if you want to pull Deckhouse images from public registry.\n" +
+			"Leave only --registry if you already pulled Deckhouse images and want to push it to your private registry.")
+	}
+	return nil
 }

--- a/dhctl/pkg/operations/mirror/context.go
+++ b/dhctl/pkg/operations/mirror/context.go
@@ -25,8 +25,10 @@ type Context struct {
 	SkipGOSTDigests bool // --skip-gost-digests
 
 	RegistryAuth authn.Authenticator // --registry-login + --registry-password (can be nil in this case) or --license depending on the operation requested
-	RegistryHost string              // --registry
-	RegistryRepo string
+	RegistryHost string              // --registry (FQDN with port, if one is provided)
+	RegistryPath string              // --registry (path)
+
+	DeckhouseRegistryRepo string // points to the registry.deckhouse.io with path to required edition repo, see --fe flag
 
 	TarBundlePath      string // --images
 	UnpackedImagesPath string

--- a/dhctl/pkg/operations/mirror/digests.go
+++ b/dhctl/pkg/operations/mirror/digests.go
@@ -53,7 +53,7 @@ func ExtractImageDigestsFromDeckhouseInstaller(
 	}
 
 	digests := map[string]struct{}{}
-	if err = parseDigestsFromImagesDigestsJSON(mirrorCtx.RegistryRepo, imagesDigestsJSON, digests); err != nil {
+	if err = parseDigestsFromImagesDigestsJSON(mirrorCtx.DeckhouseRegistryRepo, imagesDigestsJSON, digests); err != nil {
 		return nil, fmt.Errorf("cannot parse images_digests.json: %w", err)
 	}
 

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -153,33 +153,33 @@ type ociLayout struct {
 
 func FillLayoutsImages(mirrorCtx *Context, layouts *ImageLayouts, deckhouseVersions []*semver.Version) {
 	layouts.DeckhouseImages = map[string]struct{}{
-		mirrorCtx.RegistryRepo + ":alpha":        {},
-		mirrorCtx.RegistryRepo + ":beta":         {},
-		mirrorCtx.RegistryRepo + ":early-access": {},
-		mirrorCtx.RegistryRepo + ":stable":       {},
-		mirrorCtx.RegistryRepo + ":rock-solid":   {},
+		mirrorCtx.DeckhouseRegistryRepo + ":alpha":        {},
+		mirrorCtx.DeckhouseRegistryRepo + ":beta":         {},
+		mirrorCtx.DeckhouseRegistryRepo + ":early-access": {},
+		mirrorCtx.DeckhouseRegistryRepo + ":stable":       {},
+		mirrorCtx.DeckhouseRegistryRepo + ":rock-solid":   {},
 	}
 
 	layouts.InstallImages = map[string]struct{}{
-		mirrorCtx.RegistryRepo + "/install:alpha":        {},
-		mirrorCtx.RegistryRepo + "/install:beta":         {},
-		mirrorCtx.RegistryRepo + "/install:early-access": {},
-		mirrorCtx.RegistryRepo + "/install:stable":       {},
-		mirrorCtx.RegistryRepo + "/install:rock-solid":   {},
+		mirrorCtx.DeckhouseRegistryRepo + "/install:alpha":        {},
+		mirrorCtx.DeckhouseRegistryRepo + "/install:beta":         {},
+		mirrorCtx.DeckhouseRegistryRepo + "/install:early-access": {},
+		mirrorCtx.DeckhouseRegistryRepo + "/install:stable":       {},
+		mirrorCtx.DeckhouseRegistryRepo + "/install:rock-solid":   {},
 	}
 
 	layouts.ReleaseChannelImages = map[string]struct{}{
-		mirrorCtx.RegistryRepo + "/release-channel:alpha":        {},
-		mirrorCtx.RegistryRepo + "/release-channel:beta":         {},
-		mirrorCtx.RegistryRepo + "/release-channel:early-access": {},
-		mirrorCtx.RegistryRepo + "/release-channel:stable":       {},
-		mirrorCtx.RegistryRepo + "/release-channel:rock-solid":   {},
+		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:alpha":        {},
+		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:beta":         {},
+		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:early-access": {},
+		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:stable":       {},
+		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:rock-solid":   {},
 	}
 
 	for _, version := range deckhouseVersions {
-		layouts.DeckhouseImages[fmt.Sprintf("%s:v%s", mirrorCtx.RegistryRepo, version.String())] = struct{}{}
-		layouts.InstallImages[fmt.Sprintf("%s/install:v%s", mirrorCtx.RegistryRepo, version.String())] = struct{}{}
-		layouts.ReleaseChannelImages[fmt.Sprintf("%s/release-channel:v%s", mirrorCtx.RegistryRepo, version.String())] = struct{}{}
+		layouts.DeckhouseImages[fmt.Sprintf("%s:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+		layouts.InstallImages[fmt.Sprintf("%s/install:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+		layouts.ReleaseChannelImages[fmt.Sprintf("%s/release-channel:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
 	}
 }
 
@@ -190,11 +190,11 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 	for _, moduleName := range modulesNames {
 		moduleData := layouts.Modules[moduleName]
 		moduleData.ReleaseImages = map[string]struct{}{
-			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:alpha":        {},
-			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:beta":         {},
-			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:early-access": {},
-			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:stable":       {},
-			mirrorCtx.RegistryRepo + "/modules/" + moduleName + "/release:rock-solid":   {},
+			mirrorCtx.DeckhouseRegistryRepo + "/modules/" + moduleName + "/release:alpha":        {},
+			mirrorCtx.DeckhouseRegistryRepo + "/modules/" + moduleName + "/release:beta":         {},
+			mirrorCtx.DeckhouseRegistryRepo + "/modules/" + moduleName + "/release:early-access": {},
+			mirrorCtx.DeckhouseRegistryRepo + "/modules/" + moduleName + "/release:stable":       {},
+			mirrorCtx.DeckhouseRegistryRepo + "/modules/" + moduleName + "/release:rock-solid":   {},
 		}
 
 		channelVersions, err := fetchVersionsFromModuleReleaseChannels(mirrorCtx, moduleData.ReleaseImages)
@@ -203,8 +203,8 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 		}
 
 		for _, moduleVersion := range channelVersions {
-			moduleData.ModuleImages[mirrorCtx.RegistryRepo+"/modules/"+moduleName+":"+moduleVersion] = struct{}{}
-			moduleData.ReleaseImages[mirrorCtx.RegistryRepo+"/modules/"+moduleName+"/release:"+moduleVersion] = struct{}{}
+			moduleData.ModuleImages[mirrorCtx.DeckhouseRegistryRepo+"/modules/"+moduleName+":"+moduleVersion] = struct{}{}
+			moduleData.ReleaseImages[mirrorCtx.DeckhouseRegistryRepo+"/modules/"+moduleName+"/release:"+moduleVersion] = struct{}{}
 		}
 
 		fetchDigestsFrom := maputil.Clone(moduleData.ModuleImages)
@@ -235,7 +235,7 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 
 			digests := digestRegex.FindAllString(imagesDigestsJSON.String(), -1)
 			for _, digest := range digests {
-				moduleData.ModuleImages[mirrorCtx.RegistryRepo+"/modules/"+moduleName+"@"+digest] = struct{}{}
+				moduleData.ModuleImages[mirrorCtx.DeckhouseRegistryRepo+"/modules/"+moduleName+"@"+digest] = struct{}{}
 			}
 		}
 

--- a/dhctl/pkg/operations/mirror/modules.go
+++ b/dhctl/pkg/operations/mirror/modules.go
@@ -37,7 +37,7 @@ func GetExternalModules(mirrorCtx *Context) ([]Module, error) {
 		remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
 	}
 
-	modulesRepo, err := name.NewRepository(mirrorCtx.RegistryRepo+"/modules", nameOpts...)
+	modulesRepo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/modules", nameOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing modules repo: %v", err)
 	}
@@ -51,7 +51,7 @@ func GetExternalModules(mirrorCtx *Context) ([]Module, error) {
 	for _, module := range modules {
 		m := Module{
 			Name:         module,
-			RegistryPath: fmt.Sprintf("%s/modules/%s", mirrorCtx.RegistryRepo, module),
+			RegistryPath: fmt.Sprintf("%s/modules/%s", mirrorCtx.DeckhouseRegistryRepo, module),
 			Releases:     []string{},
 		}
 

--- a/dhctl/pkg/operations/mirror/versions.go
+++ b/dhctl/pkg/operations/mirror/versions.go
@@ -57,7 +57,7 @@ func getTagsFromRegistry(mirrorCtx *Context) ([]string, error) {
 		remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
 	}
 
-	repo, err := name.NewRepository(mirrorCtx.RegistryRepo+"/release-channel", nameOpts...)
+	repo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/release-channel", nameOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing repo: %v", err)
 	}
@@ -104,7 +104,7 @@ func getRockSolidVersionFromRegistry(mirrorCtx *Context) (*semver.Version, error
 		refOpts = append(refOpts, name.Insecure)
 	}
 
-	ref, err := name.ParseReference(mirrorCtx.RegistryRepo+"/release-channel:rock-solid", refOpts...)
+	ref, err := name.ParseReference(mirrorCtx.DeckhouseRegistryRepo+"/release-channel:rock-solid", refOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("parse rock solid release ref: %w", err)
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`dhctl mirror` subcommand's `--registry` flag now supports use of full paths of registry repository to specify where to upload Deckhouse images. 

If only the FQDN or `host:port` is provided, it falls back to default of `/deckhouse/ee` or `/deckhouse/fe` paths for EE and FE respectfully

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: dhctl now supports uploading mirrored Deckhouse images to custom repo paths
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
