### PR TITLE
[getting-started][docs] Add base64 encoding to GS pages and JS-scripts

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.minimal.inc
@@ -102,10 +102,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/azure/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/azure/partials/resources.yml.minimal.inc
@@ -88,10 +88,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/bm-private/partials/user.yml.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/user.yml.inc
@@ -33,10 +33,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the newly generated <GENERATED_PASSWORD> password.
   # [<en>] Generate your own or use it at your own risk (for testing purposes):
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас.
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования:
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/bm/partials/user.yml.inc
+++ b/docs/site/_includes/getting_started/bm/partials/user.yml.inc
@@ -29,10 +29,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
   # [<en>] generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
   # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/gcp/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/resources.yml.minimal.inc
@@ -90,10 +90,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/openstack/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/resources.yml.minimal.inc
@@ -95,10 +95,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/resources.yml.minimal.inc
@@ -95,10 +95,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/resources.yml.minimal.inc
@@ -95,10 +95,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/openstack_vk/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/resources.yml.minimal.inc
@@ -95,10 +95,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/vsphere/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/resources.yml.minimal.inc
@@ -99,10 +99,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/yandex/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/resources.yml.minimal.inc
@@ -96,10 +96,10 @@ spec:
   email: admin@deckhouse.io
   # [<en>] This is a hash of the password <GENERATED_PASSWORD>, generated when loading the page of the Getting Started.
   # [<en>] Generate your own or use it at your own risk (for testing purposes)
-  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<ru>] Это хэш пароля <GENERATED_PASSWORD>, сгенерированного при загрузке страницы "Быстрого Старта".
   # [<ru>] Сгенерируйте свой или используйте этот, но только для тестирования
-  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2 | base64 -w0
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/js/getting-started.js
+++ b/docs/site/js/getting-started.js
@@ -288,7 +288,8 @@ function generate_password(force = false) {
     var salt = bcrypt.genSaltSync(10);
     var password = Math.random().toString(36).slice(-10);
     var hash = bcrypt.hashSync(password, salt);
-    sessionStorage.setItem("dhctl-user-password-hash", hash);
+    var base64 = btoa(hash)
+    sessionStorage.setItem("dhctl-user-password-hash", base64);
     sessionStorage.setItem("dhctl-user-password", password);
   }
 }


### PR DESCRIPTION
## Description

In the listings on GS pages, password generation with base64 has been added in accordance with #6030

## Why do we need it, and what problem does it solve?

Close https://github.com/deckhouse/deckhouse/issues/5587 – update Getting Started.

## Why do we need it in the patch release (if we do)?

It will help to avoid problems when copying the password hash sum and executing the `sudo /opt/deckhouse/bin/kubectl create -f - << EOF...` command during GS execution.

## What is the expected result?

GS improvement .

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Make the Getting Started more consistent.
impact_level: low
```
