### PR TITLE
[candi] move caps-controller image to distroless

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-from: {{ .Images.BASE_ALPINE }}
+fromImage: common/distroless
 docker:
   ENTRYPOINT: ["/caps-controller-manager"]
 import:
@@ -8,12 +8,12 @@ import:
   add: /caps-controller-manager
   to: /caps-controller-manager
   before: setup
-shell:
-  beforeInstall:
-  - echo "deckhouse:x:64535:64535:deckhouse:/:/sbin/nologin" >> /etc/passwd
-  - echo "deckhouse:x:64535:" >> /etc/group
-  - echo "deckhouse:!::0:::::" >> /etc/shadow
-  - apk add --no-cache openssh-client
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  add: /relocate
+  to: /
+  before: setup
+  includePaths:
+    - '**/*'
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
@@ -47,3 +47,14 @@ shell:
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /caps-controller-manager cmd/main.go
     - chown 64535:64535 /caps-controller-manager
     - chmod 0700 /caps-controller-manager
+---
+{{- $csiBinaries := "/usr/bin/ssh" }}
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+fromImage: common/alt
+shell:
+  beforeSetup:
+    - apt-get update
+    - |
+      apt-get install -y openssh-clients
+  setup:
+    - /binary_replace.sh -i "{{ $csiBinaries }}" -o /relocate

--- a/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
@@ -48,7 +48,7 @@ shell:
     - chown 64535:64535 /caps-controller-manager
     - chmod 0700 /caps-controller-manager
 ---
-{{- $csiBinaries := "/usr/bin/ssh" }}
+{{- $csiBinaries := "/usr/bin/ssh /lib64/libnss_*" }}
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 fromImage: common/alt
 shell:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Move caps-controller image to distroless.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Unification of the approach to the development of module images

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Move caps-controller image to distroless.
impact: caps-controller should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
