### PR TITLE
[user-authn] revert deletion of userID from dex.password template

### DIFF
--- a/modules/150-user-authn/template_tests/user_test.go
+++ b/modules/150-user-authn/template_tests/user_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(userPassword.Exists()).To(BeTrue())
 			Expect(userPassword.Field("email").String()).To(Equal("user@example.com"))
 			Expect(userPassword.Field("username").String()).To(Equal("userName"))
+			Expect(userPassword.Field("userID").String()).To(Equal("userName"))
 			Expect(userPassword.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(userPassword.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -81,6 +82,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(base64Password.Exists()).To(BeTrue())
 			Expect(base64Password.Field("email").String()).To(Equal("base64@example.com"))
 			Expect(base64Password.Field("username").String()).To(Equal("base64UserName"))
+			Expect(base64Password.Field("userID").String()).To(Equal("base64UserName"))
 			Expect(base64Password.Field("hash").String()).To(Equal("JDJhJDEwJDdyeGN3aDhyMlJjbndjM2pEeXNxaE9yYnNrTEJqdHgxenZ6V2FRVlBGTzc4RERBTVpIaExD"))
 			Expect(base64Password.Field("groups").String()).To(MatchJSON(`["Everyone"]`))
 
@@ -88,6 +90,7 @@ var _ = Describe("Module :: user-authn :: helm template :: user", func() {
 			Expect(adminPassword.Exists()).To(BeTrue())
 			Expect(adminPassword.Field("email").String()).To(Equal("admintest@example.com"))
 			Expect(adminPassword.Field("username").String()).To(Equal("adminName"))
+			Expect(adminPassword.Field("userID").String()).To(Equal("adminName"))
 			Expect(adminPassword.Field("hash").String()).To(Equal("JDJhJDEwJEUvTWp5ekZpNkdaa3RhOUdIZDh6Q2V1WWlnYkxlblh2MThqa3hPWjZ2aG9Xc0tuYXhOSm91"))
 			Expect(adminPassword.Field("groups").String()).To(MatchJSON(`["Everyone","Admins"]`))
 		})

--- a/modules/150-user-authn/templates/dex/passwords.yaml
+++ b/modules/150-user-authn/templates/dex/passwords.yaml
@@ -14,6 +14,7 @@ metadata:
 email: {{ $crd.spec.email | lower | quote }}
 hash: {{ $pass | quote }}
 username: {{ $crd.name | quote }}
+userID: {{ $crd.name }}
   {{- if $crd.spec.groups }}
 groups:
 {{- range $group := $crd.spec.groups }}


### PR DESCRIPTION
## Description
Adds userID field to dex Password manifest.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
userID field was removed from dex password definition, but it's value is taken into account during JWT generation and not having userID set results in all JWT's having the same SUB field, breaking auth process.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It fixes JWT-based authentication.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
dex password custom resources are created with userID field set to userName. It should fix the aforementioned JWT generation problem.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Provide userID field for correct JWT generation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
