### PR TITLE
[dhctl] Fix `edit provider-cluster-configuration` command remove discovery-data.json from `kube-system/d8-provider-cluster-configuration` secret

### DIFF
--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	v1 "k8s.io/api/core/v1"
-
 	"gopkg.in/alecthomas/kingpin.v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -165,7 +165,10 @@ func runApplication(kpApp *kingpin.Application) {
 
 func isRunningInContainer() (bool, error) {
 	_, err := os.Stat("/deckhouse/version")
+	_, inClusterEnvExists := os.LookupEnv("DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER")
 	switch {
+	case inClusterEnvExists:
+		return true, nil
 	case errors.Is(err, fs.ErrNotExist):
 		return false, nil
 	case err != nil:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix edit `provider-cluster-configuration` command. Update only one field expect replace whole secret
Also fix not creating terraform auto-converger and terraform exporter pods

## Why do we need it, and what problem does it solve?
`edit provider-cluster-configuration` command remove discovery-data.json from `kube-system/d8-provider-cluster-configuration` secret

## Why do we need it in the patch release (if we do)?

`edit provider-cluster-configuration` command remove discovery-data.json from kube-system/d8-provider-cluster-configuration secret

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Terrafrm autoconverger  and terraform-exporter are running now.
![image](https://github.com/deckhouse/deckhouse/assets/30695496/0deb83f3-ddbe-4e11-9831-597967a05811)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/72809e53-8fbe-4d55-912f-033e374d47a9)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/c5eed63b-6a5d-448c-a302-aa426f0340cf)

Cluster configuration was edited
![image](https://github.com/deckhouse/deckhouse/assets/30695496/30a1921e-d8fe-42ba-bdaa-4afdd55d93ec)

Provider cluster configuration
![image](https://github.com/deckhouse/deckhouse/assets/30695496/c39e5877-9801-4978-91dc-c2c64086349d)

discovery data json kept

![image](https://github.com/deckhouse/deckhouse/assets/30695496/6278eb36-58c6-4aba-8c6d-7bcc1eecf887)

DHCTL work in container and static cluster config edited

![image](https://github.com/deckhouse/deckhouse/assets/30695496/2fea974d-e7ce-4bcf-9d35-e2baad4b0a31)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/bde27e38-c605-4e38-9beb-d2632281de47)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix 
summary:Fix edit provider-cluster-configuration command remove discovery-data.json from kube-system/d8-provider-cluster-configuration secret
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
