### PR TITLE
[user-authn] add missing quotes

### DIFF
--- a/modules/150-user-authn/templates/dex/passwords.yaml
+++ b/modules/150-user-authn/templates/dex/passwords.yaml
@@ -14,7 +14,7 @@ metadata:
 email: {{ $crd.spec.email | lower | quote }}
 hash: {{ $pass | quote }}
 username: {{ $crd.name | quote }}
-userID: {{ $crd.name }}
+userID: {{ $crd.name | quote }}
   {{- if $crd.spec.groups }}
 groups:
 {{- range $group := $crd.spec.groups }}


### PR DESCRIPTION
## Description
Add missing quotes.

## Why do we need it, and what problem does it solve?
It's better to have all properties as strings.

## Why do we need it in the patch release (if we do)?
Add missing quotes.

## What is the expected result?
Have no missing quotes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: Add missing quotes.
impact_level: low
```
