### PR TITLE
[loki] fix cve in loki image

### DIFF
--- a/modules/462-loki/images/loki/Dockerfile
+++ b/modules/462-loki/images/loki/Dockerfile
@@ -15,6 +15,9 @@ ENV GOPROXY=${GOPROXY} \
 RUN apk add --no-cache make git
 RUN git clone --depth 1 --branch v2.7.7 ${SOURCE_REPO}/grafana/loki.git /loki
 WORKDIR /loki/
+
+RUN go get -u golang.org/x/net@v0.17.0 \
+    && go mod tidy
 RUN go build -ldflags="-s -w" -o loki cmd/loki/main.go && \
     chown -R 64535:64535 /loki/ && \
     chmod 0700 /loki/loki

--- a/modules/462-loki/images/loki/Dockerfile
+++ b/modules/462-loki/images/loki/Dockerfile
@@ -17,7 +17,8 @@ RUN git clone --depth 1 --branch v2.7.7 ${SOURCE_REPO}/grafana/loki.git /loki
 WORKDIR /loki/
 
 RUN go get -u golang.org/x/net@v0.17.0 \
-    && go mod tidy
+    && go mod tidy \
+    && go mod vendor
 RUN go build -ldflags="-s -w" -o loki cmd/loki/main.go && \
     chown -R 64535:64535 /loki/ && \
     chmod 0700 /loki/loki

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -98,7 +98,7 @@ function prepareImageArgs() {
 
 function trivyGetCVEListForImage() (
   prepareImageArgs "$@"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" --timeout 30m | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
 )
 
 function htmlReportHeader() (
@@ -108,7 +108,7 @@ function htmlReportHeader() (
 function trivyGetHTMLReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS" --timeout 30m
+  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
   echo -n "    <br/>"
 )
 

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -98,7 +98,7 @@ function prepareImageArgs() {
 
 function trivyGetCVEListForImage() (
   prepareImageArgs "$@"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" --timeout 30m | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
 )
 
 function htmlReportHeader() (
@@ -108,7 +108,7 @@ function htmlReportHeader() (
 function trivyGetHTMLReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
+  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS" --timeout 30m
   echo -n "    <br/>"
 )
 


### PR DESCRIPTION
## Description
Fixed CVE issues:
[CVE-2023-39325](https://github.com/deckhouse/deckhouse/pull/golang.org/x/net)
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixed HIGH CVE issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: loki
type: fix
summary: fix cve issues in loki image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
