### PR TITLE
[dhctl] Overhaul preflight checks error messages

### DIFF
--- a/candi/bashible/preflight/check_localhost.sh
+++ b/candi/bashible/preflight/check_localhost.sh
@@ -15,6 +15,6 @@
 */}}
 
 if ! getent ahosts localhost; then
-  echo "Localhost is unavailable. You should add record '127.0.0.1 localhost' to /etc/hosts file."
+  echo "localhost domain is not resolved. You should add a line '127.0.0.1 localhost' to this node's /etc/hosts file."
   exit 1
 fi

--- a/candi/bashible/preflight/check_ports.sh
+++ b/candi/bashible/preflight/check_ports.sh
@@ -52,17 +52,27 @@ function check_port() {
 
 has_error=false
 
-for port in 6443 2379 2380
-do
-    echo -n "Check port $port "
-    check_port $port
-    if [ $? -ne 0 ]; then
-        echo "Cannot open port $port. Probably control-plane node protected with firewall rules or another software (like antivirus) does not allow to open port."
-        has_error=true
-        continue
-    fi
-    echo "SUCCESS"
-done
+echo -n "Checking if kubernetes API port is open (6443) "
+check_port 6443
+if [ $? -ne 0 ]; then
+    echo "Port 6443 is closed, but required for Kubernetes API server to function. Probably control-plane node is protected by firewall rules or another software (like antivirus) and blocks connections."
+    has_error=true
+fi
+echo "SUCCESS"
+
+echo -n "Checking if Etcd ports are available (2379, 2380) "
+check_port 2379
+if [ $? -ne 0 ]; then
+    echo "Port 2379 is closed, but required for Etcd clients to communicate with it. Probably control-plane node is protected by firewall rules or another software (like antivirus) and blocks connections."
+    has_error=true
+fi
+
+check_port 2380
+if [ $? -ne 0 ]; then
+    echo "Port 2380 is closed, but required for Etcd database server peers communications. Probably control-plane node is protected by firewall rules or another software (like antivirus) and blocks connections."
+    has_error=true
+fi
+echo "SUCCESS"
 
 if [ "$has_error" == true ]; then
   exit 1

--- a/dhctl/pkg/preflight/dhctl_obsolescence.go
+++ b/dhctl/pkg/preflight/dhctl_obsolescence.go
@@ -35,7 +35,7 @@ import (
 
 const dhctlVersionMismatchError = "" +
 	"%w\nThere is a possibility that you will not be able to install latest versions of Deckhouse correctly with this image.\n" +
-	`To fix this add "--pull=always" flag to your "docker run" cmdline`
+	`To fix this add "--pull=always" flag to your "docker run" cmdline using release channel tag or use --preflight-skip-deckhouse-version-check flag`
 
 var (
 	ErrInstallerVersionMismatch                      = errors.New("Your installer image is outdated")

--- a/dhctl/pkg/preflight/domain.go
+++ b/dhctl/pkg/preflight/domain.go
@@ -30,7 +30,7 @@ func (pc *Checker) CheckLocalhostDomain() error {
 		return nil
 	}
 
-	log.DebugLn("Checking resolving the localhost domain")
+	log.DebugLn("Checking if localhost domain resolves correctly")
 
 	file, err := template.RenderAndSavePreflightCheckLocalhostScript()
 	if err != nil {
@@ -42,9 +42,9 @@ func (pc *Checker) CheckLocalhostDomain() error {
 	if err != nil {
 		log.ErrorLn(strings.Trim(string(out), "\n"))
 		if ee, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("check_localhost.sh: %w, %s", err, string(ee.Stderr))
+			return fmt.Errorf("Localhost domain resolving check failed: %w, %s", err, string(ee.Stderr))
 		}
-		return fmt.Errorf("check_localhost.sh: %w", err)
+		return fmt.Errorf("Could not execute a script to check for localhost domain resolution: %w", err)
 	}
 
 	log.DebugLn(string(out))

--- a/dhctl/pkg/preflight/ports.go
+++ b/dhctl/pkg/preflight/ports.go
@@ -42,9 +42,9 @@ func (pc *Checker) CheckAvailabilityPorts() error {
 	if err != nil {
 		log.ErrorLn(strings.Trim(string(out), "\n"))
 		if ee, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("check_ports.sh: %w, %s", err, string(ee.Stderr))
+			return fmt.Errorf("Required ports check failed: %w, %s", err, string(ee.Stderr))
 		}
-		return fmt.Errorf("check_ports.sh: %w", err)
+		return fmt.Errorf("Could not execute a script to check if all necessary ports are open on the node: %w", err)
 	}
 
 	log.DebugLn(string(out))

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -52,7 +52,7 @@ func NewChecker(sshClient *ssh.Client, config *config.DeckhouseInstaller, metaCo
 func (pc *Checker) Static() error {
 	return pc.do("Preflight checks for static-cluster", []checkStep{
 		{
-			fun:            pc.CheckSSHTunel,
+			fun:            pc.CheckSSHTunnel,
 			successMessage: "ssh tunnel will up",
 			skipFlag:       app.SSHForwardArgName,
 		},

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -28,7 +28,7 @@ const (
 	DefaultTunnelRemotePort = 22322
 )
 
-func (pc *Checker) CheckSSHTunel() error {
+func (pc *Checker) CheckSSHTunnel() error {
 	if app.PreflightSkipSSHForword {
 		log.InfoLn("SSH forward preflight check was skipped")
 		return nil
@@ -45,8 +45,7 @@ func (pc *Checker) CheckSSHTunel() error {
 	err := tun.Up()
 	if err != nil {
 		return fmt.Errorf(`Cannot setup tunnel to control-plane host: %w.
-Please check connectivity to control-plane host or
-check that sshd config 'AllowTcpForwarding' set to 'yes' on control-plane node.`, err)
+Please check connectivity to control-plane host and that the sshd config parameter 'AllowTcpForwarding' set to 'yes' on control-plane node.`, err)
 	}
 
 	tun.Stop()


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Edited error texts for preflight checks.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We want to make sure it's clear what is wrong with the node and how to fix it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Clarified dhctl's preflight checks error messages
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
