### PR TITLE
[prometheus][alertmanager] Ignore unnecessary alerts in Alertmanager examples update

### DIFF
--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -438,16 +438,16 @@ Receive all alerts with labels `service: foo|bar|baz`:
 
 ```yaml
 receivers:
-  # the parameterless receiver is similar to "/dev/null".
+  # The parameterless receiver is similar to "/dev/null".
   - name: blackhole
-  # your valid receiver
+  # Your valid receiver.
   - name: some-other-receiver
     # ...
 route:
-  # default receiver
+  # Default receiver.
   receiver: blackhole
   routes:
-    # child receiver
+    # Child receiver.
     - matchers:
         - matchType: =~
           name: service
@@ -459,16 +459,16 @@ Receive all alerts except for `DeadMansSwitch`:
 
 ```yaml
 receivers:
-  # the parameterless receiver is similar to "/dev/null".
+  # The parameterless receiver is similar to "/dev/null".
   - name: blackhole
-  # your valid receiver
+  # Your valid receiver.
   - name: some-other-receiver
     # ...
 route:
   # default receiver
   receiver: some-other-receiver
   routes:
-    # child receiver
+    # Child receiver.
     - matchers:
         - matchType: =
           name: alertname

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -432,28 +432,48 @@ You will need to:
 1. Create a parameterless receiver.
 1. Route unwanted alerts to this receiver.
 
-Below is the sample `alertmanager.yaml` for this kind of a situation:
+Below are samples for configuring `CustomAlertmanager`.
+
+Receive all alerts with labels `service: foo|bar|baz`:
 
 ```yaml
 receivers:
-- name: blackhole
   # the parameterless receiver is similar to "/dev/null".
-- name: some-other-receiver
-  # ...
+  - name: blackhole
+  # your valid receiver
+  - name: some-other-receiver
+    # ...
 route:
   # default receiver
-  receiver: some-other-receiver
+  receiver: blackhole
   routes:
-    - matchers:
-        - matchType: =
-          name: alertname
-          value: DeadMansSwitch
-      receiver: blackhole
+    # child receiver
     - matchers:
         - matchType: =~
           name: service
           value: ^(foo|bar|baz)$
       receiver: some-other-receiver
+```
+
+Receive all alerts except for `DeadMansSwitch`:
+
+```yaml
+receivers:
+  # the parameterless receiver is similar to "/dev/null".
+  - name: blackhole
+  # your valid receiver
+  - name: some-other-receiver
+    # ...
+route:
+  # default receiver
+  receiver: some-other-receiver
+  routes:
+    # child receiver
+    - matchers:
+        - matchType: =
+          name: alertname
+          value: DeadMansSwitch
+      receiver: blackhole
 ```
 
 A detailed description of all parameters can be found in the [official documentation](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file).

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -429,7 +429,7 @@ spec:
 1. Завести получателя без параметров.
 1. Смаршрутизировать лишние алерты в этого получателя.
 
-Ниже примеры настройки `CustomAlertmanager`.
+Ниже приведены примеры настройки `CustomAlertmanager`.
 
 Чтобы получать только алерты с лейблами `service: foo|bar|baz`:
 
@@ -458,14 +458,14 @@ route:
 receivers:
   # Получатель, определенный без параметров, будет работать как "/dev/null".
   - name: blackhole
-  # Действующий получатель
+  # Действующий получатель.
   - name: some-other-receiver
   # ...
 route:
   # receiver по умолчанию.
   receiver: some-other-receiver
   routes:
-    # Дочерний маршрут
+    # Дочерний маршрут.
     - matchers:
         - matchType: =
           name: alertname

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -429,28 +429,48 @@ spec:
 1. Завести получателя без параметров.
 1. Смаршрутизировать лишние алерты в этого получателя.
 
-В `alertmanager.yaml` это будет выглядеть так:
+Ниже примеры настройки `CustomAlertmanager`.
+
+Чтобы получать только алерты с лейблами `service: foo|bar|baz`:
 
 ```yaml
 receivers:
-- name: blackhole
   # Получатель, определенный без параметров, будет работать как "/dev/null".
-- name: some-other-receiver
-  # ...
+  - name: blackhole
+  # Действующий получатель  
+  - name: some-other-receiver
+    # ...
 route:
   # receiver по умолчанию.
-  receiver: some-other-receiver
+  receiver: blackhole
   routes:
-    - matchers:
-        - matchType: =
-          name: alertname
-          value: DeadMansSwitch
-      receiver: blackhole
+    # Дочерний маршрут
     - matchers:
         - matchType: =~
           name: service
           value: ^(foo|bar|baz)$
       receiver: some-other-receiver
+```
+
+Чтобы получать все алерты, кроме `DeadMansSwitch`:
+
+```yaml
+receivers:
+  # Получатель, определенный без параметров, будет работать как "/dev/null".
+  - name: blackhole
+  # Действующий получатель
+  - name: some-other-receiver
+  # ...
+route:
+  # receiver по умолчанию.
+  receiver: some-other-receiver
+  routes:
+    # Дочерний маршрут
+    - matchers:
+        - matchType: =
+          name: alertname
+          value: DeadMansSwitch
+      receiver: blackhole
 ```
 
 С подробным описанием всех параметров можно ознакомиться [в официальной документации](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file).


### PR DESCRIPTION
## Description
Updated FAQ entry by adding two tested examples.

## Why do we need it, and what problem does it solve?
The current example wasn't entirely valid, as the root route had a valid receiver set instead of a blackhole. Because of that, the explicit child route was redundant and misleading.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: chore
summary: Minor documentation change.
impact_level: low
```
