### PR TITLE
[runtime-audit-engine] Fix CVEs

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $falcoVersion := "0.36.2" }}
+{{- $falcoVersion := "0.35.1" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_UBUNTU }}

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $falcoVersion := "0.35.1" }}
+{{- $falcoVersion := "0.36.2" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_UBUNTU }}

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -14,7 +14,7 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src
 RUN apk add --no-cache make git bash && \
-    git clone --branch 2.26.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
+    git clone --branch 2.28.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
     make falcosidekick && \
     chown -R 64535:64535 /src/falcosidekick && \
     chmod 0755 /src/falcosidekick

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -1,8 +1,8 @@
 # Based on https://github.com/falcosecurity/falcosidekick/blob/41d530807f1a0294c0276e4cb42af68c8b26a659/Dockerfile
-ARG BASE_GOLANG_18_ALPINE
+ARG BASE_GOLANG_20_ALPINE
 ARG BASE_DISTROLESS
 
-FROM $BASE_GOLANG_18_ALPINE as artifact
+FROM $BASE_GOLANG_20_ALPINE as artifact
 ARG GOPROXY
 ARG SOURCE_REPO
 

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -14,7 +14,10 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src
 RUN apk add --no-cache make git bash && \
-    git clone --branch 2.28.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
+    git clone -c advice.detachedHead=false --branch 2.28.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
+    go get -u github.com/nats-io/nkeys@v0.4.6 && \
+    go get -u golang.org/x/net@v0.17.0 && \
+    go get -u google.golang.org/grpc@v1.56.3 && \
     make falcosidekick && \
     chown -R 64535:64535 /src/falcosidekick && \
     chmod 0755 /src/falcosidekick

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $falcoVersion := "0.36.2" }}
+{{- $falcoVersion := "0.35.1" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_UBUNTU }}

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- $falcoVersion := "0.36.2" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_UBUNTU }}
@@ -48,9 +49,9 @@ shell:
   beforeInstall:
   - apt update -y
   - apt install -yq curl python3='3.10.6-1~22.04' python3-pip
-  - curl -sSfL https://download.falco.org/packages/bin/x86_64/falco-0.35.1-x86_64.tar.gz | tar -C /tmp -xzvf -
-  - cp -f /tmp/falco-0.35.1-x86_64/usr/bin/falco /usr/bin/falco
-  - cp -rf /tmp/falco-0.35.1-x86_64/usr/share/falco /usr/share/falco
+  - curl -sSfL https://download.falco.org/packages/bin/x86_64/falco-{{ $falcoVersion }}-x86_64.tar.gz | tar -C /tmp -xzvf -
+  - cp -f /tmp/falco-{{ $falcoVersion }}-x86_64/usr/bin/falco /usr/bin/falco
+  - cp -rf /tmp/falco-{{ $falcoVersion }}-x86_64/usr/share/falco /usr/share/falco
   # cleanup
   - apt-get clean autoclean
   - apt-get autoremove -y


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed vulnerabilities: GHSA-62mh-w5cv-p88c, CVE-2021-3127, GHSA-j756-f273-xhp4, CVE-2022-21698, CVE-2020-29652, CVE-2021-43565, CVE-2022-27191, CVE-2021-33194, CVE-2022-27664, CVE-2022-41723, CVE-2023-39325, CVE-2021-38561, CVE-2022-32149, GHSA-m425-mq94-257g, CVE-2022-28948

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checks

<details><summary>before</summary>

```shell
[deckhouse] root@2794dff5146e / # cat /deckhouse/candi/images_digests.json | grep runtimeAuditEngine -A4
  "runtimeAuditEngine": {
    "falcosidekick": "sha256:c0f4f9202ee991f9d47dea491efc70b36bd739fe804d14a9aa4c30c899c78cd9",
    "rulesLoader": "sha256:014252666b89a056778b820eab24dbce4beb1cb2a8c1c0b24935c70287237ffc",
    "falco": "sha256:296b85a3cdd42248f7b827cacc7ccea054b3d5f61ac8735c2a9ae0586216ed8c"
  },

dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:c0f4f9202ee991f9d47dea491efc70b36bd739fe804d14a9aa4c30c899c78cd9
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:c0f4f9202ee991f9d47dea491efc70b36bd739fe804d14a9aa4c30c899c78cd9
2023-11-10T09:07:43.131+0300    INFO    Vulnerability scanning is enabled
2023-11-10T09:07:43.131+0300    INFO    Secret scanning is enabled
2023-11-10T09:07:43.131+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T09:07:43.131+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T09:07:43.134+0300    INFO    Number of language-specific files: 1
2023-11-10T09:07:43.134+0300    INFO    Detecting gobinary vulnerabilities...

falcosidekick (gobinary)

Total: 15 (HIGH: 14, CRITICAL: 1)

┌─────────────────────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬─────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│               Library               │    Vulnerability    │ Severity │         Installed Version          │            Fixed Version            │                            Title                             │
├─────────────────────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/nats-io/jwt              │ GHSA-62mh-w5cv-p88c │ CRITICAL │ v1.1.0                             │ 2.0.1                               │ nats-io/jwt not enforcing checking of Import token           │
│                                     │                     │          │                                    │                                     │ permissions                                                  │
│                                     │                     │          │                                    │                                     │ https://github.com/advisories/GHSA-62mh-w5cv-p88c            │
│                                     ├─────────────────────┼──────────┤                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2021-3127       │ HIGH     │                                    │ 1.2.3-0.20210314221642-a826c77dc9d2 │ nats-server: mishandling Import Token bindings may lead to   │
│                                     │                     │          │                                    │                                     │ Incorrect Access Control                                     │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2021-3127                    │
│                                     ├─────────────────────┤          │                                    │                                     ├──────────────────────────────────────────────────────────────┤
│                                     │ GHSA-j756-f273-xhp4 │          │                                    │                                     │ github.com/nats-io/nats-server/ Import token permissions     │
│                                     │                     │          │                                    │                                     │ checking not enforced                                        │
│                                     │                     │          │                                    │                                     │ https://github.com/advisories/GHSA-j756-f273-xhp4            │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/prometheus/client_golang │ CVE-2022-21698      │          │ v1.9.0                             │ 1.11.1                              │ Denial of service using InstrumentHandlerCounter             │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-21698                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto                 │ CVE-2020-29652      │          │ v0.0.0-20201016220609-9e8e0b390897 │ 0.0.0-20201216223049-8b5274cf687f   │ crafted authentication request can lead to nil pointer       │
│                                     │                     │          │                                    │                                     │ dereference                                                  │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2020-29652                   │
│                                     ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2021-43565      │          │                                    │ 0.0.0-20211202192323-5770296d904e   │ empty plaintext packet causes panic                          │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2021-43565                   │
│                                     ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27191      │          │                                    │ 0.0.0-20220314234659-1baeb1ce4c0b   │ crash in a golang.org/x/crypto/ssh server                    │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-27191                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net                    │ CVE-2021-33194      │          │ v0.0.0-20201224014010-6772e930b67b │ 0.0.0-20210520170846-37e1c6afe023   │ infinite loop in ParseFragment                               │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2021-33194                   │
│                                     ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27664      │          │                                    │ 0.0.0-20220906165146-f3363e06e74c   │ golang: net/http: handle server errors after sending GOAWAY  │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-27664                   │
│                                     ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-41723      │          │                                    │ 0.7.0                               │ net/http, golang.org/x/net/http2: avoid quadratic complexity │
│                                     │                     │          │                                    │                                     │ in HPACK decoding                                            │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-41723                   │
│                                     ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2023-39325      │          │                                    │ 0.17.0                              │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                                     │                     │          │                                    │                                     │ excessive work (CVE-2023-44487)                              │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/text                   │ CVE-2021-38561      │          │ v0.3.4                             │ 0.3.7                               │ out-of-bounds read in golang.org/x/text/language leads to    │
│                                     │                     │          │                                    │                                     │ DoS                                                          │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2021-38561                   │
│                                     ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-32149      │          │                                    │ 0.3.8                               │ ParseAcceptLanguage takes a long time to parse complex tags  │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-32149                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc              │ GHSA-m425-mq94-257g │          │ v1.35.0                            │ 1.56.3, 1.57.1, 1.58.3              │ gRPC-Go HTTP/2 Rapid Reset vulnerability                     │
│                                     │                     │          │                                    │                                     │ https://github.com/advisories/GHSA-m425-mq94-257g            │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ gopkg.in/yaml.v3                    │ CVE-2022-28948      │          │ v3.0.0-20200615113413-eeeca48fe776 │ 3.0.0-20220521103104-8f96da9f5d5e   │ crash when attempting to deserialize invalid input           │
│                                     │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-28948                   │
└─────────────────────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴─────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

</details>

<details><summary>after</summary>

```shell
[deckhouse] root@f0d5198fbc23 / # cat /deckhouse/candi/images_digests.json | grep runtimeAuditEngine -A4
  "runtimeAuditEngine": {
    "falcosidekick": "sha256:22df88347f280a2f8fdfbe815b89200dc0d674f1dbbdef7d0105019d58d2251f",
    "rulesLoader": "sha256:fdbac35ea9c6109042eca7f5154e63ed82084b46d9410c5f2c2d2cc7d03d6364",
    "falco": "sha256:44e3030610250e315b17511ad7965924f1da9ec22f61ca365039be265d9f5880"
  },
  
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:22df88347f280a2f8fdfbe815b89200dc0d674f1dbbdef7d0105019d58d2251f
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:22df88347f280a2f8fdfbe815b89200dc0d674f1dbbdef7d0105019d58d2251f
2023-11-10T09:06:30.120+0300    INFO    Vulnerability scanning is enabled
2023-11-10T09:06:30.120+0300    INFO    Secret scanning is enabled
2023-11-10T09:06:30.120+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T09:06:30.120+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T09:06:30.123+0300    INFO    Number of language-specific files: 1
2023-11-10T09:06:30.123+0300    INFO    Detecting gobinary vulnerabilities...
```

</details>

<details><summary>d8-runtime-audit-engine</summary>

```shell
root@dev-master-0:~# kubectl -n d8-runtime-audit-engine get po
NAME                         READY   STATUS    RESTARTS      AGE
runtime-audit-engine-9p8rw   4/4     Running   0             117s
runtime-audit-engine-hhpbf   4/4     Running   2 (62s ago)   117s
runtime-audit-engine-hxnxf   4/4     Running   0             117s
root@dev-master-0:~# kubectl -n d8-runtime-audit-engine logs runtime-audit-engine-9p8rw falcosidekick | head -n3
2023/11/10 05:54:11 [INFO]  : Falco Sidekick version: 2.28.0-dirty
2023/11/10 05:54:11 [INFO]  : Enabled Outputs : []
2023/11/10 05:54:11 [INFO] : Falco Sidekick is up and listening on 127.0.0.1:2801
root@dev-master-0:~# kubectl -n d8-runtime-audit-engine logs runtime-audit-engine-9p8rw rules-loader | head -n3
{"level":"info","msg":"shell-operator v1.3.2","time":"2023-11-10T05:54:14Z"}
{"level":"info","msg":"Debug endpoint listen on /tmp/shell-operator-debug.socket","time":"2023-11-10T05:54:14Z"}
{"level":"info","msg":"Listen on 0.0.0.0:9115","time":"2023-11-10T05:54:14Z"}
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: Fixed vulnerabilities: GHSA-62mh-w5cv-p88c, CVE-2021-3127, GHSA-j756-f273-xhp4, CVE-2022-21698, CVE-2020-29652, CVE-2021-43565, CVE-2022-27191, CVE-2021-33194, CVE-2022-27664, CVE-2022-41723, CVE-2023-39325, CVE-2021-38561, CVE-2022-32149, GHSA-m425-mq94-257g, CVE-2022-28948
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
