### PR TITLE
[user-authn] Fix CVEs

### DIFF
--- a/modules/150-user-authn/images/dex-authenticator/Dockerfile
+++ b/modules/150-user-authn/images/dex-authenticator/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /src
 
 # Download tools
 RUN apk add git patch
-RUN git clone --depth 1 --branch v7.2.0 ${SOURCE_REPO}/oauth2-proxy/oauth2-proxy.git .
+RUN git clone --depth 1 --branch v7.5.1 ${SOURCE_REPO}/oauth2-proxy/oauth2-proxy.git .
 ADD patches/cookie-refresh.patch patches/remove-groups.patch /
 RUN patch -p1 < /cookie-refresh.patch \
   && patch -p1 < /remove-groups.patch \

--- a/modules/150-user-authn/images/dex-authenticator/Dockerfile
+++ b/modules/150-user-authn/images/dex-authenticator/Dockerfile
@@ -17,6 +17,8 @@ RUN git clone --depth 1 --branch v7.5.1 ${SOURCE_REPO}/oauth2-proxy/oauth2-proxy
 ADD patches/cookie-refresh.patch patches/remove-groups.patch /
 RUN patch -p1 < /cookie-refresh.patch \
   && patch -p1 < /remove-groups.patch \
+  go get -u golang.org/x/net@v0.17.0 && \
+  go get -u google.golang.org/grpc@v1.56.3 && \
   && go build -ldflags '-s -w' -o oauth2-proxy github.com/oauth2-proxy/oauth2-proxy/v7
 
 RUN chown 64535:64535 oauth2-proxy

--- a/modules/150-user-authn/images/dex-authenticator/Dockerfile
+++ b/modules/150-user-authn/images/dex-authenticator/Dockerfile
@@ -15,11 +15,11 @@ WORKDIR /src
 RUN apk add git patch
 RUN git clone --depth 1 --branch v7.5.1 ${SOURCE_REPO}/oauth2-proxy/oauth2-proxy.git .
 ADD patches/cookie-refresh.patch patches/remove-groups.patch /
-RUN patch -p1 < /cookie-refresh.patch \
-  && patch -p1 < /remove-groups.patch \
+RUN patch -p1 < /cookie-refresh.patch && \
+  patch -p1 < /remove-groups.patch && \
   go get -u golang.org/x/net@v0.17.0 && \
   go get -u google.golang.org/grpc@v1.56.3 && \
-  && go build -ldflags '-s -w' -o oauth2-proxy github.com/oauth2-proxy/oauth2-proxy/v7
+  go build -ldflags '-s -w' -o oauth2-proxy github.com/oauth2-proxy/oauth2-proxy/v7
 
 RUN chown 64535:64535 oauth2-proxy
 RUN chmod 0700 oauth2-proxy

--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -17,7 +17,10 @@ RUN git clone --branch v2.35.3 --depth 1 ${SOURCE_REPO}/dexidp/dex.git . \
   && git apply /robots-txt.patch \
   && git apply /401-password-auth.patch
 
-RUN CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex
+RUN go get -u golang.org/x/net@v0.17.0 && \
+    go get -u google.golang.org/grpc@v1.56.3 && \
+    go get -u golang.org/x/text@v0.3.8 && \
+    CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex
 
 RUN chown 64535:64535 dex
 RUN chmod 0700 dex

--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -17,10 +17,9 @@ RUN git clone --branch v2.35.3 --depth 1 ${SOURCE_REPO}/dexidp/dex.git . \
   && git apply /robots-txt.patch \
   && git apply /401-password-auth.patch
 
-RUN go get -u golang.org/x/net@v0.17.0 && \
-    go get -u google.golang.org/grpc@v1.56.3 && \
-    go get -u golang.org/x/text@v0.3.8 && \
+RUN go get -u google.golang.org/grpc@v1.56.3 && \
     go mod tidy && \
+    go mod vendor && \
     CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex
 
 RUN chown 64535:64535 dex

--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -20,6 +20,7 @@ RUN git clone --branch v2.35.3 --depth 1 ${SOURCE_REPO}/dexidp/dex.git . \
 RUN go get -u golang.org/x/net@v0.17.0 && \
     go get -u google.golang.org/grpc@v1.56.3 && \
     go get -u golang.org/x/text@v0.3.8 && \
+    go mod tidy && \
     CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex
 
 RUN chown 64535:64535 dex

--- a/modules/150-user-authn/images/kubeconfig-generator/Dockerfile
+++ b/modules/150-user-authn/images/kubeconfig-generator/Dockerfile
@@ -19,7 +19,12 @@ ADD already_logged.patch /
 RUN git clone ${SOURCE_REPO}/mintel/dex-k8s-authenticator.git . && \
   git checkout 378a39dd93bed9f56a5a1b1a799a208c61ead83f && \
   git apply --whitespace=fix /already_logged.patch && \
-  go mod download && \
+  go mod edit -go=1.20 && \
+  go mod tidy && \
+  go get -u golang.org/x/crypto@v0.15.0 && \
+  go get -u golang.org/x/net@v0.17.0 && \
+  go get -u golang.org/x/text@v0.14.0 && \
+  go get -u gopkg.in/yaml.v2@v2.4.0 && \
   mkdir -p /app/app/bin && \
   go build -ldflags '-s -w' -o /app/app/bin/dex-k8s-authenticator .
 


### PR DESCRIPTION
## Description
Fix vulnerabilities: 
- CVE-2022-41721
- CVE-2022-41723
- CVE-2023-39325
- CVE-2022-32149
- GHSA-m425-mq94-257g
- CVE-2021-33194
- CVE-2022-27664
- CVE-2022-21698
- CVE-2021-43565
- CVE-2022-27191
- CVE-2021-38561
- CVE-2020-29652
- CVE-2020-7919
- CVE-2020-9283
- CVE-2019-9512
- CVE-2019-9514
- CVE-2022-3064.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checks

<details><summary>in cluster</summary>

```shell
root@dev-master-0:~# kubectl -n d8-user-authn get po
NAME                                    READY   STATUS    RESTARTS   AGE
dex-d9f9cb54b-sk5xn                     2/2     Running   0          23m
kubeconfig-generator-55c88d5fd9-5xrjd   1/1     Running   0          4m30s
root@dev-master-0:~# kubectl -n d8-user-authn logs dex-d9f9cb54b-sk5xn -c dex | head -n3
{"level":"info","msg":"Dex Version: DEV, Go Version: go1.20.5, Go OS/ARCH: linux amd64","time":"2023-11-10T12:27:24Z"}
{"level":"info","msg":"config using log level: info","time":"2023-11-10T12:27:24Z"}
{"level":"info","msg":"config issuer: https://dex.dev.v-snurnitsin.hf.flant.com/","time":"2023-11-10T12:27:24Z"}
root@dev-master-0:~# kubectl -n d8-user-authn logs kubeconfig-generator-55c88d5fd9-5xrjd | head -n3
2023/11/10 12:46:22 Using config file: /app/config.yaml
2023/11/10 12:46:22 Creating new provider https://dex.dev.v-snurnitsin.hf.flant.com/
2023/11/10 12:46:22 Verifying client kubeconfig-generator
root@dev-master-0:~# kubectl -n d8-monitoring logs grafana-dex-authenticator-5bb96bdfdd-lbvdx | head -n3
Defaulted container "dex-authenticator" out of: dex-authenticator, redis, self-signed-generator (init)
[2023/11/10 12:28:31] [proxy.go:83] mapping path "/dev/null" => file system "/dev/null"
[2023/11/10 12:28:31] [oauthproxy.go:166] OAuthProxy configured for OpenID Connect Client ID: grafana-d8-monitoring-dex-authenticator
[2023/11/10 12:28:31] [oauthproxy.go:172] Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:168h0m0s domains: path:/ samesite: refresh:after 10m0s

```

</details>

<details><summary>before</summary>

```shell
[deckhouse] root@bc5f4c33c3d7 / # cat /deckhouse/candi/images_digests.json | grep userAuthn -A7
  "userAuthn": {
    "dexAuthenticatorRedis": "sha256:f019b69c613171b585d5a4b64f274fd4d7595c6175dcc8f3cacbb3fd02d38194",
    "dexAuthenticator": "sha256:d55761659af34f789eab758dbd16fbba1fb23ae32503483f220d80d8d1cb6579",
    "selfSignedGenerator": "sha256:9ae9ee9125005cb18db2c17e4548589d4439a77707149e238b0eb35e31c0be5f",
    "crowdBasicAuthProxy": "sha256:cf12d49909daa089f7b6a9f6475c2419c2d80ca7bb10e9522554a0ea81eea63f",
    "kubeconfigGenerator": "sha256:914f75c1d17eab3d6bae5a55ff6966c4eb5543483488cc89b631a94d4806bc3b",
    "dex": "sha256:6b60ba33bb827a06428cfc33a4ba211a8e16bb3ff10d78a4886510d6108a911d"
  },

dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6b60ba33bb827a06428cfc33a4ba211a8e16bb3ff10d78a4886510d6108a911d
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6b60ba33bb827a06428cfc33a4ba211a8e16bb3ff10d78a4886510d6108a911d
2023-11-10T09:20:38.041+0300    INFO    Vulnerability scanning is enabled
2023-11-10T09:20:38.041+0300    INFO    Secret scanning is enabled
2023-11-10T09:20:38.041+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T09:20:38.041+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T09:20:38.043+0300    INFO    Number of language-specific files: 1
2023-11-10T09:20:38.043+0300    INFO    Detecting gobinary vulnerabilities...

usr/local/bin/dex (gobinary)

Total: 5 (HIGH: 5, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬─────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │         Installed Version          │            Fixed Version            │                            Title                             │
├────────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2022-41721      │ HIGH     │ v0.0.0-20220927171203-f486391704dc │ 0.1.1-0.20221104162952-702349b0e862 │ request smuggling                                            │
│                        │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-41721                   │
│                        ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2022-41723      │          │                                    │ 0.7.0                               │ net/http, golang.org/x/net/http2: avoid quadratic complexity │
│                        │                     │          │                                    │                                     │ in HPACK decoding                                            │
│                        │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-41723                   │
│                        ├─────────────────────┤          │                                    ├─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-39325      │          │                                    │ 0.17.0                              │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                        │                     │          │                                    │                                     │ excessive work (CVE-2023-44487)                              │
│                        │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
├────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/text      │ CVE-2022-32149      │          │ v0.3.7                             │ 0.3.8                               │ ParseAcceptLanguage takes a long time to parse complex tags  │
│                        │                     │          │                                    │                                     │ https://avd.aquasec.com/nvd/cve-2022-32149                   │
├────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.49.0                            │ 1.56.3, 1.57.1, 1.58.3              │ gRPC-Go HTTP/2 Rapid Reset vulnerability                     │
│                        │                     │          │                                    │                                     │ https://github.com/advisories/GHSA-m425-mq94-257g            │
└────────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴─────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:d55761659af34f789eab758dbd16fbba1fb23ae32503483f220d80d8d1cb6579
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:d55761659af34f789eab758dbd16fbba1fb23ae32503483f220d80d8d1cb6579
2023-11-10T09:21:38.504+0300    INFO    Vulnerability scanning is enabled
2023-11-10T09:21:38.504+0300    INFO    Secret scanning is enabled
2023-11-10T09:21:38.504+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T09:21:38.504+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T09:21:38.506+0300    INFO    Number of language-specific files: 1
2023-11-10T09:21:38.506+0300    INFO    Detecting gobinary vulnerabilities...

bin/oauth2_proxy (gobinary)

Total: 10 (HIGH: 10, CRITICAL: 0)

┌─────────────────────────────────────┬─────────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│               Library               │    Vulnerability    │ Severity │         Installed Version          │           Fixed Version           │                            Title                             │
├─────────────────────────────────────┼─────────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/prometheus/client_golang │ CVE-2022-21698      │ HIGH     │ v1.9.0                             │ 1.11.1                            │ Denial of service using InstrumentHandlerCounter             │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-21698                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto                 │ CVE-2021-43565      │          │ v0.0.0-20210711020723-a769d52b0f97 │ 0.0.0-20211202192323-5770296d904e │ empty plaintext packet causes panic                          │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-43565                   │
│                                     ├─────────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27191      │          │                                    │ 0.0.0-20220314234659-1baeb1ce4c0b │ crash in a golang.org/x/crypto/ssh server                    │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net                    │ CVE-2021-33194      │          │ v0.0.0-20210226172049-e18ecbb05110 │ 0.0.0-20210520170846-37e1c6afe023 │ infinite loop in ParseFragment                               │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-33194                   │
│                                     ├─────────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27664      │          │                                    │ 0.0.0-20220906165146-f3363e06e74c │ golang: net/http: handle server errors after sending GOAWAY  │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27664                   │
│                                     ├─────────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-41723      │          │                                    │ 0.7.0                             │ net/http, golang.org/x/net/http2: avoid quadratic complexity │
│                                     │                     │          │                                    │                                   │ in HPACK decoding                                            │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-41723                   │
│                                     ├─────────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2023-39325      │          │                                    │ 0.17.0                            │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                                     │                     │          │                                    │                                   │ excessive work (CVE-2023-44487)                              │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/text                   │ CVE-2021-38561      │          │ v0.3.3                             │ 0.3.7                             │ out-of-bounds read in golang.org/x/text/language leads to    │
│                                     │                     │          │                                    │                                   │ DoS                                                          │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-38561                   │
│                                     ├─────────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-32149      │          │                                    │ 0.3.8                             │ ParseAcceptLanguage takes a long time to parse complex tags  │
│                                     │                     │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-32149                   │
├─────────────────────────────────────┼─────────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc              │ GHSA-m425-mq94-257g │          │ v1.27.0                            │ 1.56.3, 1.57.1, 1.58.3            │ gRPC-Go HTTP/2 Rapid Reset vulnerability                     │
│                                     │                     │          │                                    │                                   │ https://github.com/advisories/GHSA-m425-mq94-257g            │
└─────────────────────────────────────┴─────────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴──────────────────────────────────────────────────────────────┘

dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:914f75c1d17eab3d6bae5a55ff6966c4eb5543483488cc89b631a94d4806bc3b
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:914f75c1d17eab3d6bae5a55ff6966c4eb5543483488cc89b631a94d4806bc3b
2023-11-10T09:22:22.486+0300    INFO    Vulnerability scanning is enabled
2023-11-10T09:22:22.486+0300    INFO    Secret scanning is enabled
2023-11-10T09:22:22.486+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T09:22:22.486+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T09:22:23.114+0300    INFO    Number of language-specific files: 1
2023-11-10T09:22:23.114+0300    INFO    Detecting gobinary vulnerabilities...

app/bin/dex-k8s-authenticator (gobinary)

Total: 14 (HIGH: 14, CRITICAL: 0)

┌─────────────────────┬────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│       Library       │ Vulnerability  │ Severity │         Installed Version          │           Fixed Version           │                            Title                             │
├─────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2020-29652 │ HIGH     │ v0.0.0-20190308221718-c2843e01d9a2 │ 0.0.0-20201216223049-8b5274cf687f │ crafted authentication request can lead to nil pointer       │
│                     │                │          │                                    │                                   │ dereference                                                  │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2020-29652                   │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2020-7919  │          │                                    │ 0.0.0-20200124225646-8b5121be2f68 │ golang: Integer overflow on 32bit architectures via crafted  │
│                     │                │          │                                    │                                   │ certificate allows for denial...                             │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2020-7919                    │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2020-9283  │          │                                    │ 0.0.0-20200220183623-bac4c82f6975 │ golang.org/x/crypto: Processing of crafted ssh-ed25519       │
│                     │                │          │                                    │                                   │ public keys allows for panic                                 │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2020-9283                    │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2021-43565 │          │                                    │ 0.0.0-20211202192323-5770296d904e │ empty plaintext packet causes panic                          │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-43565                   │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2022-27191 │          │                                    │ 0.0.0-20220314234659-1baeb1ce4c0b │ crash in a golang.org/x/crypto/ssh server                    │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27191                   │
├─────────────────────┼────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net    │ CVE-2019-9512  │          │ v0.0.0-20190522155817-f3200d17e092 │ 0.0.0-20190813141303-74dc4d7220e7 │ flood using PING frames results in unbounded memory growth   │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2019-9512                    │
│                     ├────────────────┤          │                                    │                                   ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2019-9514  │          │                                    │                                   │ flood using HEADERS frames results in unbounded memory       │
│                     │                │          │                                    │                                   │ growth                                                       │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2019-9514                    │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2021-33194 │          │                                    │ 0.0.0-20210520170846-37e1c6afe023 │ infinite loop in ParseFragment                               │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-33194                   │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2022-27664 │          │                                    │ 0.0.0-20220906165146-f3363e06e74c │ golang: net/http: handle server errors after sending GOAWAY  │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27664                   │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2022-41723 │          │                                    │ 0.7.0                             │ net/http, golang.org/x/net/http2: avoid quadratic complexity │
│                     │                │          │                                    │                                   │ in HPACK decoding                                            │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-41723                   │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2023-39325 │          │                                    │ 0.17.0                            │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                     │                │          │                                    │                                   │ excessive work (CVE-2023-44487)                              │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
├─────────────────────┼────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/text   │ CVE-2021-38561 │          │ v0.3.0                             │ 0.3.7                             │ out-of-bounds read in golang.org/x/text/language leads to    │
│                     │                │          │                                    │                                   │ DoS                                                          │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-38561                   │
│                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2022-32149 │          │                                    │ 0.3.8                             │ ParseAcceptLanguage takes a long time to parse complex tags  │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-32149                   │
├─────────────────────┼────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ gopkg.in/yaml.v2    │ CVE-2022-3064  │          │ v2.2.2                             │ 2.2.4                             │ Improve heuristics preventing CPU/memory abuse by parsing    │
│                     │                │          │                                    │                                   │ malicious or large YAML documents...                         │
│                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-3064                    │
└─────────────────────┴────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

</details>

<details><summary>after</summary>

```shell
[deckhouse] root@c19db746fcc6 / # cat /deckhouse/candi/images_digests.json | grep userAuthn -A7
  "userAuthn": {
    "dexAuthenticatorRedis": "sha256:f019b69c613171b585d5a4b64f274fd4d7595c6175dcc8f3cacbb3fd02d38194",
    "dexAuthenticator": "sha256:86a05dc693a16345195b83d569c53bcfe76c3f1822a716b4e84570b645d1d46d",
    "selfSignedGenerator": "sha256:9ae9ee9125005cb18db2c17e4548589d4439a77707149e238b0eb35e31c0be5f",
    "crowdBasicAuthProxy": "sha256:cf12d49909daa089f7b6a9f6475c2419c2d80ca7bb10e9522554a0ea81eea63f",
    "kubeconfigGenerator": "sha256:5570d4f8277f9fc3744417eb528bbbdb23bda6017bb33d327edffbf7f3296bea",
    "dex": "sha256:1658ec349c3e3515b77700817ca8ec0f699fe016ef350403448fd90d033be6de"
  },
  
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:1658ec349c3e3515b77700817ca8ec0f699fe016ef350403448fd90d033be6de
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:1658ec349c3e3515b77700817ca8ec0f699fe016ef350403448fd90d033be6de
2023-11-10T14:57:44.301+0300    INFO    Vulnerability scanning is enabled
2023-11-10T14:57:44.301+0300    INFO    Secret scanning is enabled
2023-11-10T14:57:44.301+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T14:57:44.301+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T14:57:44.304+0300    INFO    Number of language-specific files: 1
2023-11-10T14:57:44.304+0300    INFO    Detecting gobinary vulnerabilities...

dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:5570d4f8277f9fc3744417eb528bbbdb23bda6017bb33d327edffbf7f3296bea
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:5570d4f8277f9fc3744417eb528bbbdb23bda6017bb33d327edffbf7f3296bea
2023-11-10T14:56:55.568+0300    INFO    Vulnerability scanning is enabled
2023-11-10T14:56:55.568+0300    INFO    Secret scanning is enabled
2023-11-10T14:56:55.568+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T14:56:55.568+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T14:56:55.571+0300    INFO    Number of language-specific files: 1
2023-11-10T14:56:55.571+0300    INFO    Detecting gobinary vulnerabilities...

dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:86a05dc693a16345195b83d569c53bcfe76c3f1822a716b4e84570b645d1d46d
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:86a05dc693a16345195b83d569c53bcfe76c3f1822a716b4e84570b645d1d46d
2023-11-10T14:56:48.538+0300    INFO    Vulnerability scanning is enabled
2023-11-10T14:56:48.538+0300    INFO    Secret scanning is enabled
2023-11-10T14:56:48.538+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-10T14:56:48.538+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-11-10T14:56:48.541+0300    INFO    Number of language-specific files: 1
2023-11-10T14:56:48.541+0300    INFO    Detecting gobinary vulnerabilities...
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: |
   Fix vulnerabilities: CVE-2022-41721, CVE-2022-41723, CVE-2023-39325, CVE-2022-32149, GHSA-m425-mq94-257g, CVE-2021-33194, CVE-2022-27664, CVE-2022-21698, CVE-2021-43565, CVE-2022-27191, CVE-2021-38561, CVE-2020-29652, CVE-2020-7919, CVE-2020-9283, CVE-2019-9512, CVE-2019-9514, CVE-2022-3064.
impact: dex and kubeconfig-generator pods will restart.
impact_level: default
```
