### PR TITLE
[prometheus-metrics-adapter] fix cve in k8sPrometheusAdapter image

### DIFF
--- a/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
@@ -11,6 +11,9 @@ RUN apk add --update --no-cache git
 RUN git clone --depth 1 --branch v0.9.1 ${SOURCE_REPO}/kubernetes-sigs/prometheus-adapter.git .
 
 RUN go get -u golang.org/x/net@v0.17.0 \
+    && go get -u github.com/prometheus/client_golang@v1.11.1 \
+    && go get -u gopkg.in/yaml.v3@v3.0.1 \
+    && go get -u github.com/emicklei/go-restful@v2.16.0 \
     && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o adapter ./cmd/adapter/adapter.go
 

--- a/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /src
 RUN apk add --update --no-cache git
 RUN git clone --depth 1 --branch v0.9.1 ${SOURCE_REPO}/kubernetes-sigs/prometheus-adapter.git .
 
+RUN go get -u golang.org/x/net@v0.17.0
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o adapter ./cmd/adapter/adapter.go
 
 RUN chown 64535:64535 adapter

--- a/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /src
 RUN apk add --update --no-cache git
 RUN git clone --depth 1 --branch v0.9.1 ${SOURCE_REPO}/kubernetes-sigs/prometheus-adapter.git .
 
-RUN go get -u golang.org/x/net@v0.17.0
+RUN go get -u golang.org/x/net@v0.17.0 \
+    && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o adapter ./cmd/adapter/adapter.go
 
 RUN chown 64535:64535 adapter


### PR DESCRIPTION
## Description
Fixed CVE issues:

- [CVE-2022-1996](https://access.redhat.com/security/cve/CVE-2022-1996)
- [CVE-2022-21698](https://access.redhat.com/errata/RHSA-2022:7529)
- [CVE-2021-43565](https://access.redhat.com/security/cve/CVE-2021-43565)
- [CVE-2022-27191](https://access.redhat.com/errata/RHSA-2022:7469)
- [CVE-2022-27664](https://access.redhat.com/errata/RHSA-2023:2802)
- [CVE-2022-41723](https://access.redhat.com/security/cve/CVE-2022-41723)
- [CVE-2023-39325](https://github.com/deckhouse/deckhouse/pull/golang.org/x/net)
- [CVE-2021-38561](https://access.redhat.com/security/cve/CVE-2021-38561)
- [CVE-2022-32149](https://access.redhat.com/security/cve/CVE-2022-32149)
- [CVE-2022-28948](https://access.redhat.com/security/cve/CVE-2022-28948)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixed HIGH CVE issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus-metrics-adapter
type: fix
summary: fix cve issues in k8sPrometheusAdapter image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
