### PR TITLE
[control-plane-manager] updated the documentation on backing up etcd

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -470,18 +470,12 @@ spec:
 ```bash
 #!/usr/bin/env bash
 
-for pod in $(kubectl get pod -n kube-system -l component=etcd,tier=control-plane -o name); do
-  if kubectl -n kube-system exec "$pod" -- sh -c "ETCDCTL_API=3 /usr/bin/etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ snapshot save /tmp/${pod##*/}.snapshot" && \
-  kubectl -n kube-system exec "$pod" -- gzip -c /tmp/${pod##*/}.snapshot | zcat > "${pod##*/}.snapshot" && \
-  kubectl -n kube-system exec "$pod" -- sh -c "cd /tmp && sha256sum ${pod##*/}.snapshot" | sha256sum -c && \
-  kubectl -n kube-system exec "$pod" -- rm "/tmp/${pod##*/}.snapshot"; then
-    mv "${pod##*/}.snapshot" etcd-backup.snapshot
-    break
-  fi
-done
-cp -r /etc/kubernetes/ ./
+pod=`crictl ps | grep " etcd " | awk '{print $NF}'`
+kubectl -n kube-system exec "$pod" -- /usr/bin/etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ snapshot save /var/lib/etcd/${pod##*/}.snapshot && \
+mv /var/lib/etcd/"${pod##*/}.snapshot" etcd-backup.snapshot && \
+cp -r /etc/kubernetes/ ./ && \
 tar -cvzf kube-backup.tar.gz ./etcd-backup.snapshot ./kubernetes/
-rm -r ./kubernetes
+rm -r ./kubernetes ./etcd-backup.snapshot
 ```
 
 В текущей директории будет создан файл `etcd-backup.snapshot` со снимком базы etcd одного из членов etcd-кластера.


### PR DESCRIPTION
## Description
Update the documentation on backing up etcd.

## Why do we need it, and what problem does it solve?
The current option in the documentation does not work.

## Why do we need it in the patch release (if we do)?
1.54 already uses an distroless image for etcd so this fix should be included in that version.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: control-plane-manager
type: fix
summary: Update the documentation on backing up etcd.
impact_level: low
```
