### PR TITLE
[monitoring-kubernetes] Bump kube-state-metrics 2.7.0

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -14,7 +14,7 @@ ENV GOPROXY=${GOPROXY} \
 
 # Build KSM from sources in case of future patching
 RUN mkdir -p /src/kube-state-metrics && \
-  git clone --depth 1 --branch v2.6.0 ${SOURCE_REPO}/kubernetes/kube-state-metrics/ /src/kube-state-metrics
+  git clone --depth 1 --branch v2.7.0 ${SOURCE_REPO}/kubernetes/kube-state-metrics/ /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
 RUN go mod edit -go 1.20 \
     && go get -u golang.org/x/net@v0.17.0 \

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - "--telemetry-host=127.0.0.1"
         - "--telemetry-port=8082"
         - "--resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,namespaces,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,verticalpodautoscalers"
-        - "--metric-labels-allowlist=cronjobs=[*],deployments=[*],daemonsets=[*],ingresses=[*],jobs=[*],namespaces=[*],nodes=[*],pods=[*],persistentvolumes=[*],secrets=[*],services=[*],statefulsets=[*],storageclasses=[*]"
+        - "--metric-labels-allowlist=cronjobs=[*],deployments=[*],daemonsets=[*],ingresses=[*],jobs=[*],namespaces=[*],nodes=[*],pods=[*],persistentvolumes=[*],secrets=[*],services=[*],statefulsets=[*],storageclasses=[*]" # TODO(nabokihms): try =*=[*] https://github.com/kubernetes/kube-state-metrics/pull/1823
         - "--metric-denylist=^.*_annotations" # reduce metrics quantity because we do not provide allowed annotations list
         - "--use-apiserver-cache"
         livenessProbe:


### PR DESCRIPTION
## Description
https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.7.0 

## Why do we need it, and what problem does it solve?
Interesting features from this release are:
- exit code metrics
- asterisk for the allowed list's keys

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: chore
summary: Bump kube-state-metrics 2.7.0
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
