### PR TITLE
[dhctl] Add config map with install version

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -164,7 +164,7 @@ func runApplication(kpApp *kingpin.Application) {
 }
 
 func isRunningInContainer() (bool, error) {
-	_, err := os.Stat("/deckhouse/version")
+	_, err := os.Stat(app.VersionFile)
 	_, inClusterEnvExists := os.LookupEnv("DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER")
 	switch {
 	case inClusterEnvExists:

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -58,7 +58,12 @@ func LoadConfigFromFile(path string) (*MetaConfig, error) {
 		return nil, err
 	}
 
-	err = metaConfig.LoadimagesDigests(imagesDigestsJSON)
+	err = metaConfig.LoadImagesDigests(imagesDigestsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	err = metaConfig.LoadInstallerVersion()
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -99,7 +99,8 @@ type DeckhouseInstaller struct {
 	KubeadmBootstrap   bool
 	MasterNodeSelector bool
 
-	ReleaseChannel string
+	ReleaseChannel   string
+	InstallerVersion string
 }
 
 func (c *DeckhouseInstaller) GetImage(forceVersionTag bool) string {
@@ -255,6 +256,7 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 		ClusterConfig:         clusterConfig,
 		ModuleConfigs:         metaConfig.ModuleConfigs,
 		ReleaseChannel:        releaseChannel,
+		InstallerVersion:      metaConfig.InstallerVersion,
 	}
 
 	return &installConfig, nil

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -27,6 +27,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"sigs.k8s.io/yaml"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
@@ -48,10 +49,11 @@ type MetaConfig struct {
 	ProviderClusterConfig map[string]json.RawMessage `json:"providerClusterConfiguration,omitempty"`
 	StaticClusterConfig   map[string]json.RawMessage `json:"staticClusterConfiguration,omitempty"`
 
-	VersionMap map[string]interface{} `json:"-"`
-	Images     imagesDigests          `json:"-"`
-	Registry   RegistryData           `json:"-"`
-	UUID       string                 `json:"clusterUUID,omitempty"`
+	VersionMap       map[string]interface{} `json:"-"`
+	Images           imagesDigests          `json:"-"`
+	Registry         RegistryData           `json:"-"`
+	UUID             string                 `json:"clusterUUID,omitempty"`
+	InstallerVersion string                 `json:"-"`
 }
 
 type imagesDigests map[string]map[string]interface{}
@@ -598,7 +600,7 @@ func (m *MetaConfig) EnrichProxyData() (map[string]interface{}, error) {
 	return ret, nil
 }
 
-func (m *MetaConfig) LoadimagesDigests(filename string) error {
+func (m *MetaConfig) LoadImagesDigests(filename string) error {
 	var imagesDigests imagesDigests
 
 	imagesDigestsJSONFile, err := os.ReadFile(filename)
@@ -612,6 +614,17 @@ func (m *MetaConfig) LoadimagesDigests(filename string) error {
 	}
 
 	m.Images = imagesDigests
+
+	return nil
+}
+
+func (m *MetaConfig) LoadInstallerVersion() error {
+	rawFile, err := os.ReadFile(app.VersionFile)
+	if err != nil {
+		return err
+	}
+
+	m.InstallerVersion = strings.TrimSpace(string(rawFile))
 
 	return nil
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -196,6 +196,36 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				return nil
 			},
 		},
+		{
+			Name: `ConfigMap "install-version"`,
+			Manifest: func() interface{} {
+				return &apiv1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "install-version",
+						Namespace: "d8-system",
+					},
+					Data: map[string]string{
+						"version": cfg.InstallerVersion,
+					},
+				}
+			},
+			CreateFunc: func(manifest interface{}) error {
+				cm := manifest.(*apiv1.ConfigMap)
+				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+					Create(context.TODO(), cm, metav1.CreateOptions{})
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				cm := manifest.(*apiv1.ConfigMap)
+				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+					Update(context.TODO(), cm, metav1.UpdateOptions{})
+				return err
+			},
+		},
 	}
 
 	if cfg.IsRegistryAccessRequired() {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -197,7 +197,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			},
 		},
 		{
-			Name: `ConfigMap "install-version"`,
+			Name: `ConfigMap "install-data"`,
 			Manifest: func() interface{} {
 				return &apiv1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
@@ -205,7 +205,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "install-version",
+						Name:      "install-data",
 						Namespace: "d8-system",
 					},
 					Data: map[string]string{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Create d8-system/install-data config map with Deckhouse version at install time.

## Why do we need it, and what problem does it solve?
We need to enable some features only new cluster with needed version.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:dhctl
type: feature
impact: Add config map with install version
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
