### PR TITLE
[node-manager] Use bearer token from in-cluster config in caps

### DIFF
--- a/modules/040-node-manager/images/capi-controller-manager/patches/k8s_bearer_token_for_in-cluster_operation.patch
+++ b/modules/040-node-manager/images/capi-controller-manager/patches/k8s_bearer_token_for_in-cluster_operation.patch
@@ -1,0 +1,32 @@
+Subject: [PATCH] Use k8s-provided bearer token for in-cluster operation
+---
+Index: cluster-api/controllers/remote/cluster_cache_tracker.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-api/controllers/remote/cluster_cache_tracker.go b/cluster-api/controllers/remote/cluster_cache_tracker.go
+--- a/cluster-api/controllers/remote/cluster_cache_tracker.go	(revision e55c6bfad66bb7c39d95037b7334c795e6201b23)
++++ b/cluster-api/controllers/remote/cluster_cache_tracker.go	(revision 0c58bf16930fc4ccb0ca0edd57c6833726e6a45a)
+@@ -316,17 +316,19 @@
+ 			return nil, errors.Wrapf(err, "error creating client for self-hosted cluster %q", cluster.String())
+ 		}
+ 
+-		// Use CA and Host from in-cluster config.
++		// Use CA, Host and Bearer token from in-cluster config.
+ 		config.CAData = nil
+ 		config.CAFile = inClusterConfig.CAFile
+ 		config.Host = inClusterConfig.Host
++		config.BearerToken = inClusterConfig.BearerToken
+ 
+ 		// Create a new client and overwrite the previously created client.
+ 		c, _, cache, err = t.createClient(ctx, config, cluster, indexes)
+ 		if err != nil {
+ 			return nil, errors.Wrap(err, "error creating client for self-hosted cluster")
+ 		}
+-		log.Info(fmt.Sprintf("Creating cluster accessor for cluster %q with in-cluster service %q", cluster.String(), config.Host))
++		// fixme remove token after tests
++		log.Info(fmt.Sprintf("Creating cluster accessor for cluster %q with in-cluster service %q BEARER TOKEN %q", cluster.String(), config.Host, config.BearerToken))
+ 	} else {
+ 		log.Info(fmt.Sprintf("Creating cluster accessor for cluster %q with the regular apiserver endpoint %q", cluster.String(), config.Host))
+ 	}

--- a/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
@@ -10,6 +10,12 @@ import:
 ---
 artifact: {{ $.ModuleName }}/capi-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+git:
+  - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+    to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -17,11 +23,12 @@ shell:
   beforeInstall:
   - apk add --no-cache make git bash
   install:
-  - mkdir /src
+  - mkdir /cluster-api
   - export GOPROXY={{ $.GOPROXY }}
-  - git clone --depth 1 --branch v{{ $version }} {{ $.SOURCE_REPO }}/kubernetes-sigs/cluster-api.git /src
-  - cd /src
+  - git clone --depth 1 --branch v{{ $version }} {{ $.SOURCE_REPO }}/kubernetes-sigs/cluster-api.git /cluster-api
+  - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
+  - cd /cluster-api
   - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make managers LDFLAGS="-s -w -extldflags \"-static\""
-  - mv /src/bin/manager /capi-controller-manager
+  - mv /cluster-api/bin/manager /capi-controller-manager
   - chown 64535:64535 /capi-controller-manager
   - chmod 0700 /capi-controller-manager


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
