### PR TITLE
[user-authz] user-authz-webhook livenessProbe

### DIFF
--- a/ee/modules/140-user-authz/images/webhook/Dockerfile
+++ b/ee/modules/140-user-authz/images/webhook/Dockerfile
@@ -16,13 +16,16 @@ WORKDIR /src/user-authz-webhook
 COPY main.go go.mod go.sum /src/user-authz-webhook/
 COPY cache /src/user-authz-webhook/cache/
 COPY web /src/user-authz-webhook/web/
+COPY cmd /src/user-authz-webhook/cmd/
 
 RUN go test ./...
 RUN go build -ldflags="-s -w" -o user-authz-webhook main.go
+RUN go build -ldflags="-s -w" -o healthcheck ./cmd/healthcheck/main.go
 
-RUN chown 64535:64535 user-authz-webhook
-RUN chmod 0700 user-authz-webhook
+RUN chown 64535:64535 user-authz-webhook healthcheck
+RUN chmod 0700 user-authz-webhook healthcheck
 
 FROM $BASE_DISTROLESS
 COPY --from=artifact /src/user-authz-webhook/user-authz-webhook /user-authz-webhook
+COPY --from=artifact /src/user-authz-webhook/healthcheck /healthcheck
 ENTRYPOINT [ "/user-authz-webhook" ]

--- a/ee/modules/140-user-authz/images/webhook/cmd/healthcheck/main.go
+++ b/ee/modules/140-user-authz/images/webhook/cmd/healthcheck/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+
+	"user-authz-webhook/web"
+)
+
+func main() {
+	client, err := web.NewClient()
+	check(err)
+
+	addr := url.URL{
+		Scheme: "https",
+		Host:   web.ListenAddr,
+		Path:   "healthz",
+	}
+	response, err := client.Get(addr.String())
+	check(err)
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		io.Copy(log.Writer(), response.Body)
+		log.Fatalln()
+	}
+
+	io.Copy(io.Discard, response.Body)
+}
+
+func check(err error) {
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/ee/modules/140-user-authz/images/webhook/web/client.go
+++ b/ee/modules/140-user-authz/images/webhook/web/client.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package web
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+func NewClient() (*http.Client, error) {
+	clientTLSCert, err := tls.LoadX509KeyPair(sslListenCert, sslListenKey)
+	if err != nil {
+		return nil, fmt.Errorf("error loading certificate and key file: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{clientTLSCert},
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	client := &http.Client{Transport: tr}
+	return client, nil
+}

--- a/ee/modules/140-user-authz/images/webhook/web/server.go
+++ b/ee/modules/140-user-authz/images/webhook/web/server.go
@@ -28,7 +28,7 @@ const (
 	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers
 	authClientCA = "/etc/ssl/apiserver-authentication-requestheader-client-ca/ca.crt"
 
-	listenAddr = "127.0.0.1:40443"
+	ListenAddr = "127.0.0.1:40443"
 )
 
 func buildTLSConfig() (*tls.Config, error) {
@@ -92,7 +92,7 @@ func (s *Server) prepareHTTPServer() (*http.Server, error) {
 	}
 
 	srv := &http.Server{
-		Addr:         listenAddr,
+		Addr:         ListenAddr,
 		TLSConfig:    tlsCfg,
 		Handler:      router,
 		ErrorLog:     s.logger,
@@ -111,7 +111,7 @@ func (s *Server) Run() error {
 		return err
 	}
 
-	s.logger.Println("server is starting to listen on ", listenAddr, "...")
+	s.logger.Println("server is starting to listen on ", ListenAddr, "...")
 
 	// Register and stop config updater
 	stopCh := make(chan struct{})
@@ -122,7 +122,7 @@ func (s *Server) Run() error {
 	})
 
 	if err := httpServer.ListenAndServeTLS(sslListenCert, sslListenKey); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("could not listen on %s: %v", listenAddr, err)
+		return fmt.Errorf("could not listen on %s: %v", ListenAddr, err)
 	}
 
 	return nil

--- a/ee/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -68,13 +68,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - curl
-            - -ksS
-            - --cert
-            - /etc/ssl/user-authz-webhook/tls.crt
-            - --key
-            - /etc/ssl/user-authz-webhook/tls.key
-            - https://127.0.0.1:40443/healthz
+            - /healthcheck
           # Wait for one minute before restarting the container to avoid crashloopbackoofs in case if apiserver restarts
           initialDelaySeconds: 5
           periodSeconds: 10


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
An additional binary has been added to the image to replace the curl request with a client certificate

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
https://github.com/deckhouse/deckhouse/issues/6368


<!---
## Why do we need it in the patch release (if we do)?

Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Health check passes successfully

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: Fixed liveness probe for user-authz-webhook
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
