### PR TITLE
[dhctl] Fix mirror command is not available in container

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -59,14 +59,12 @@ func main() {
 		return
 	}
 
+	commands.DefineMirrorCommand(kpApp)
 	if !runningInContainer {
 		// We only allow mirror functions to be used outside of container environments.
-		commands.DefineMirrorCommand(kpApp)
 		runApplication(kpApp)
 		return
 	}
-
-	commands.DefineMirrorCommand(kpApp)
 
 	bootstrap.DefineBootstrapCommand(kpApp)
 	bootstrapPhaseCmd := kpApp.Command("bootstrap-phase", "Commands to run a single phase of the bootstrap process.")

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -66,6 +66,8 @@ func main() {
 		return
 	}
 
+	commands.DefineMirrorCommand(kpApp)
+
 	bootstrap.DefineBootstrapCommand(kpApp)
 	bootstrapPhaseCmd := kpApp.Command("bootstrap-phase", "Commands to run a single phase of the bootstrap process.")
 	{

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -386,13 +386,13 @@ Thus, Deckhouse images will be available at `https://your-harbor.com/d8s/deckhou
 1. If necessary, log in to the container registry `registry.deckhouse.io` using your license key.
 
    ```shell
-   docker login -u "<DECKHOUSE_LICENSE_KEY>" registry.deckhouse.io
+   docker login -u license-token registry.deckhouse.io
    ```
 
-1. Run the Deckhouse installer version 1.54.2 or higher.
+1. Run the Deckhouse installer version 1.54.3 or higher.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:v1.54.2 bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:v1.54.3 bash
    ```
 
    Note that the directory on the host will be mounted in the installer container. This directory will contain the pulled Deckhouse tarball.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -387,13 +387,13 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. При необходимости авторизуйтесь в container registry `registry.deckhouse.io` с помощью вашего лицензионного ключа.
 
    ```shell
-   docker login -u "<DECKHOUSE_LICENSE_KEY>" registry.deckhouse.io
+   docker login -u license-token registry.deckhouse.io
    ```
 
-1. Запустите установщик Deckhouse версии 1.54.2 или выше.
+1. Запустите установщик Deckhouse версии 1.54.3 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:v1.54.2 bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:v1.54.3 bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы Deckhouse.


### PR DESCRIPTION
## Description
Fix mirror command is not available in container
## Why do we need it, and what problem does it solve?
Command is not available

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Out of container mirror only available
![image](https://github.com/deckhouse/deckhouse/assets/30695496/9414f033-7687-47f2-b29a-2c85fbf34353)

All work in container
![image](https://github.com/deckhouse/deckhouse/assets/30695496/c597608c-8afc-4206-96d5-436b80e7df22)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix mirror command is not available in container
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
