### PR TITLE
[node-manager](caps) fix NodeGroup deletion

### DIFF
--- a/modules/040-node-manager/hooks/cluster_api_deployment_required.go
+++ b/modules/040-node-manager/hooks/cluster_api_deployment_required.go
@@ -19,6 +19,8 @@ package hooks
 import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
@@ -33,6 +35,38 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Kind:       "NodeGroup",
 			FilterFunc: staticInstancesNodeGroupFilter,
 		},
+		{
+			Name:       "machine_deployment",
+			ApiVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "MachineDeployment",
+			FilterFunc: clusterAPIMachineDeploymentFilter,
+		},
+		{
+			Name:       "machine_set",
+			ApiVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "MachineSet",
+			FilterFunc: clusterAPIMachineSetFilter,
+		},
+		{
+			Name:       "machine",
+			ApiVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Machine",
+			FilterFunc: clusterAPIMachineFilter,
+		},
+		{
+			Name:       "cluster",
+			ApiVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Cluster",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{clusterAPIStaticClusterName},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{clusterAPINamespace},
+				},
+			},
+			FilterFunc: clusterAPIClusterFilter,
+		},
 	},
 }, handleClusterAPIDeploymentRequired)
 
@@ -44,7 +78,33 @@ func staticInstancesNodeGroupFilter(obj *unstructured.Unstructured) (go_hook.Fil
 		return nil, err
 	}
 
-	return ng.Spec.StaticInstances != nil, nil
+	return nodeGroupWithStaticInstances{
+		Name:               ng.Name,
+		HasStaticInstances: ng.Spec.StaticInstances != nil,
+		DeletionTimestamp:  obj.GetDeletionTimestamp(),
+	}, nil
+}
+
+func clusterAPIMachineDeploymentFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return clusterAPIResourceForNodeGroup{
+		NodeGroup: obj.GetLabels()["node-group"],
+	}, nil
+}
+
+func clusterAPIMachineSetFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return clusterAPIResourceForNodeGroup{
+		NodeGroup: obj.GetLabels()["cluster.x-k8s.io/deployment-name"],
+	}, nil
+}
+
+func clusterAPIMachineFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return clusterAPIResourceForNodeGroup{
+		NodeGroup: obj.GetLabels()["node-group"],
+	}, nil
+}
+
+func clusterAPIClusterFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return struct{}{}, nil
 }
 
 func handleClusterAPIDeploymentRequired(input *go_hook.HookInput) error {
@@ -52,19 +112,100 @@ func handleClusterAPIDeploymentRequired(input *go_hook.HookInput) error {
 
 	nodeGroupSnapshots := input.Snapshots["node_group"]
 	for _, nodeGroupSnapshot := range nodeGroupSnapshots {
-		hasStaticInstancesField = nodeGroupSnapshot.(bool)
+		hasStaticInstancesField = nodeGroupSnapshot.(nodeGroupWithStaticInstances).HasStaticInstances
 		if hasStaticInstancesField {
 			break // we need at least one NodeGroup with staticInstances field
 		}
 	}
 
+	//nodeGroupSnapshots := input.Snapshots["node_group"]
+	//for _, nodeGroupSnapshot := range nodeGroupSnapshots {
+	//	nodeGroup := nodeGroupSnapshot.(nodeGroupWithStaticInstances)
+	//
+	//	if nodeGroup.HasStaticInstances {
+	//		if nodeGroup.DeletionTimestamp != nil && !nodeGroup.DeletionTimestamp.IsZero() {
+	//
+	//			if clusterAPIHasMachineDeploymentForNodeGroup(nodeGroup.Name, input) {
+	//				patch := map[string]interface{}{
+	//					"spec": map[string]interface{}{
+	//						"replicas": 0,
+	//					},
+	//				}
+	//
+	//				input.PatchCollector.MergePatch(patch, "cluster.x-k8s.io/v1beta1", "MachineDeployment", clusterAPINamespace, nodeGroup.Name)
+	//			}
+	//
+	//			//patch := map[string]interface{}{
+	//			//	"spec": map[string]interface{}{
+	//			//		"staticInstances": map[string]interface{}{
+	//			//			"count": 0,
+	//			//		},
+	//			//	},
+	//			//}
+	//
+	//			//input.PatchCollector.MergePatch(patch, "deckhouse.io/v1", "NodeGroup", "", "static-worker")
+	//
+	//			//if clusterAPIHasResourcesForNodeGroup(nodeGroup.NodeGroup, input) {
+	//			//	hasStaticInstancesField = true
+	//			//
+	//			//	break
+	//			//}
+	//		}
+	//	}
+	//}
+
 	if hasStaticInstancesField {
-		input.Values.Set("nodeManager.internal.capsControllerManagerEnabled", true)
 		input.Values.Set("nodeManager.internal.capiControllerManagerEnabled", true)
-	} else {
-		input.Values.Remove("nodeManager.internal.capsControllerManagerEnabled")
-		input.Values.Remove("nodeManager.internal.capiControllerManagerEnabled")
+		input.Values.Set("nodeManager.internal.capsControllerManagerEnabled", true)
+		input.Values.Set("nodeManager.internal.capsControllerManagerClusterEnabled", true)
+	} else if len(input.Snapshots["machine"]) == 0 {
+		input.Values.Remove("nodeManager.internal.capsControllerManagerClusterEnabled")
+
+		if len(input.Snapshots["cluster"]) == 0 {
+			input.Values.Remove("nodeManager.internal.capiControllerManagerEnabled")
+			input.Values.Remove("nodeManager.internal.capsControllerManagerEnabled")
+		}
 	}
 
 	return nil
+}
+
+type clusterAPIResourceForNodeGroup struct {
+	NodeGroup string
+}
+
+type nodeGroupWithStaticInstances struct {
+	Name               string
+	HasStaticInstances bool
+	DeletionTimestamp  *metav1.Time
+}
+
+func clusterAPIHasResourcesForNodeGroup(nodeGroupName string, input *go_hook.HookInput) bool {
+	//snapshots := input.Snapshots["machine_deployment"]
+	snapshots := input.Snapshots["machine_set"]
+	snapshots = append(snapshots, input.Snapshots["machine"]...)
+
+	for _, snapshot := range snapshots {
+		resource := snapshot.(clusterAPIResourceForNodeGroup)
+
+		if resource.NodeGroup == nodeGroupName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func clusterAPIHasMachineDeploymentForNodeGroup(nodeGroupName string, input *go_hook.HookInput) bool {
+	snapshots := input.Snapshots["machine_deployment"]
+
+	for _, snapshot := range snapshots {
+		resource := snapshot.(clusterAPIResourceForNodeGroup)
+
+		if resource.NodeGroup == nodeGroupName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/modules/040-node-manager/hooks/generate_capi_static_kubeconfig_secret.go
+++ b/modules/040-node-manager/hooks/generate_capi_static_kubeconfig_secret.go
@@ -65,7 +65,7 @@ func generateStaticKubeconfigSecret(input *go_hook.HookInput, dc dependency.Cont
 
 	nodeGroupSnapshots := input.Snapshots["node_group"]
 	for _, nodeGroupSnapshot := range nodeGroupSnapshots {
-		hasStaticInstancesField = nodeGroupSnapshot.(bool)
+		hasStaticInstancesField = nodeGroupSnapshot.(nodeGroupWithStaticInstances).HasStaticInstances
 		if hasStaticInstancesField {
 			break // we need at least one NodeGroup with staticInstances field
 		}

--- a/modules/040-node-manager/openapi/values.yaml
+++ b/modules/040-node-manager/openapi/values.yaml
@@ -48,6 +48,8 @@ properties:
         type: boolean
       capsControllerManagerEnabled:
         type: boolean
+      capsControllerManagerClusterEnabled:
+        type: boolean
 
       clusterMasterAddresses:
         type: array

--- a/modules/040-node-manager/templates/caps-controller-manager/static-cluster.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/static-cluster.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.nodeManager.internal.capsControllerManagerEnabled }}
 {{- $prefix := "static" }}
 {{- $provider := "static" }}
+  {{- if .Values.nodeManager.internal.capsControllerManagerClusterEnabled }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -8,11 +9,6 @@ metadata:
   name: {{ $prefix }}
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager")) | nindent 2 }}
-#  annotations:
-#    cluster.x-k8s.io/paused: "true"
-# A finalizer has been added to prevent cascading removing of all capi resources after deleting the cluster resource.
-  finalizers:
-    - deckhouse.io/capi-controller-manager
 spec:
   clusterNetwork:
     pods:
@@ -32,6 +28,7 @@ spec:
     kind: StaticControlPlane
     namespace: d8-cloud-instance-manager
     name: {{ $prefix }}-control-plane
+  {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: StaticCluster


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
