### PR TITLE
[node-manager] fix ng update loop

### DIFF
--- a/modules/040-node-manager/hooks/update_node_group_status.go
+++ b/modules/040-node-manager/hooks/update_node_group_status.go
@@ -203,7 +203,6 @@ func updStatusFilterNodeGroup(obj *unstructured.Unstructured) (go_hook.FilterRes
 		Error:      ng.Status.Error,
 
 		UID:             ng.UID,
-		ResourceVersion: ng.ResourceVersion,
 		Conditions:      ng.Status.Conditions,
 	}, nil
 }
@@ -460,7 +459,6 @@ func buildEventV1(nodeGroup statusNodeGroup, eventType, reason, msg string, now 
 			Name:            nodeGroup.Name,
 			UID:             nodeGroup.UID,
 			APIVersion:      "deckhouse.io/v1",
-			ResourceVersion: nodeGroup.ResourceVersion,
 		},
 		Reason:              reason,
 		Note:                msg,
@@ -484,7 +482,6 @@ type statusNodeGroup struct {
 
 	// for event generation
 	UID             apimtypes.UID
-	ResourceVersion string
 }
 
 type statusNode struct {

--- a/modules/040-node-manager/hooks/update_node_group_status.go
+++ b/modules/040-node-manager/hooks/update_node_group_status.go
@@ -202,8 +202,8 @@ func updStatusFilterNodeGroup(obj *unstructured.Unstructured) (go_hook.FilterRes
 		ZonesNum:   int32(zonesNum),
 		Error:      ng.Status.Error,
 
-		UID:             ng.UID,
-		Conditions:      ng.Status.Conditions,
+		UID:        ng.UID,
+		Conditions: ng.Status.Conditions,
 	}, nil
 }
 
@@ -455,10 +455,10 @@ func buildEventV1(nodeGroup statusNodeGroup, eventType, reason, msg string, now 
 			GenerateName: "ng-" + nodeGroup.Name + "-",
 		},
 		Regarding: corev1.ObjectReference{
-			Kind:            "NodeGroup",
-			Name:            nodeGroup.Name,
-			UID:             nodeGroup.UID,
-			APIVersion:      "deckhouse.io/v1",
+			Kind:       "NodeGroup",
+			Name:       nodeGroup.Name,
+			UID:        nodeGroup.UID,
+			APIVersion: "deckhouse.io/v1",
 		},
 		Reason:              reason,
 		Note:                msg,
@@ -481,7 +481,7 @@ type statusNodeGroup struct {
 	Conditions []ngv1.NodeGroupCondition
 
 	// for event generation
-	UID             apimtypes.UID
+	UID apimtypes.UID
 }
 
 type statusNode struct {


### PR DESCRIPTION
## Description
Removes `ResourceVersion` field from `statusNodeGroup` struct and snapshot of the `040-node-manager/hooks/update_node_group_status.go` go hook.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
There's a bug in `040-node-manager/hooks/update_node_group_status.go` go hook causing a looped process of updating node groups' statuses. The hook creates nodegroup snapshot including `metadata.ResourceVersion` field and that field's value is getting incremented each time any field of a nodegroup is updated (including `.status`). Also, the hook updates node groups's status fields `observed`/`processed` which results in incrementing `metatada.ResourceVersion` field, forming a loop.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Node groups' status updates aren't getting looped and node groups' events are still getting attached (referenced) in the `kubectl describe ng` output (was tested in 1.25,1.26,1.27) even though `resourceVersion` field isn't provided  on event creating.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: noge-manager
type: chore
summary: Fix node groups update loop.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
