### PR TITLE
[cni-cilium][agent] Fixing resourceManagement for Static mode

### DIFF
--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "agent" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
 spec:
   {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "DaemonSet" "agent" "cilium-agent" .Values.cniCilium.resourcesManagement ) | nindent 2}}
-  {{- if .Values.cniCilium.resourcesManagement.vpa }}
+  {{- if (eq .Values.cniCilium.resourcesManagement.mode "VPA") }}
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Fixing resourceManagement in Static mode

## Why do we need it, and what problem does it solve?
It was impossible to configure Static resource management for agents.
Fixes https://github.com/deckhouse/deckhouse/issues/6559.

## Why do we need it in the patch release (if we do)?

There is a customer who can't configure resource management now.

## What is the expected result?
Resorce management works both in Static and VPA mode.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary:  Fixed `resourceManagement` in the Static mode.
impact_level: default
```
