### PR TITLE
[node-manager](caps) fix static-kubeconfig generation

### DIFF
--- a/go_lib/hooks/tls_certificate/order_certificate.go
+++ b/go_lib/hooks/tls_certificate/order_certificate.go
@@ -65,6 +65,8 @@ type OrderCertificateRequest struct {
 	ValueName   string
 	ModuleName  string
 	WaitTimeout time.Duration
+
+	ExpirationSeconds *int32
 }
 
 func (r *OrderCertificateRequest) DeepCopy() OrderCertificateRequest {
@@ -247,9 +249,10 @@ func IssueCertificate(input *go_hook.HookInput, dc dependency.Container, request
 			Name: request.CommonName,
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
-			Request:    csrPEM,
-			Usages:     request.Usages,
-			SignerName: request.SignerName,
+			Request:           csrPEM,
+			Usages:            request.Usages,
+			SignerName:        request.SignerName,
+			ExpirationSeconds: request.ExpirationSeconds,
 		},
 	}
 

--- a/modules/040-node-manager/hooks/internal/kubeconfig/kubeconfig.go
+++ b/modules/040-node-manager/hooks/internal/kubeconfig/kubeconfig.go
@@ -25,8 +25,8 @@ import (
 )
 
 // New creates a new Kubeconfig using the cluster name and specified endpoint.
-func New(clusterName string, endpoint string, caCert []byte, token string) (*api.Config, error) {
-	userName := fmt.Sprintf("%s-admin", clusterName)
+func New(clusterName, endpoint string, caCert []byte, clientKey []byte, clientCert []byte) (*api.Config, error) {
+	userName := "capi-controller-manager"
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
 
 	return &api.Config{
@@ -44,7 +44,8 @@ func New(clusterName string, endpoint string, caCert []byte, token string) (*api
 		},
 		AuthInfos: map[string]*api.AuthInfo{
 			userName: {
-				Token: token,
+				ClientKeyData:         clientKey,
+				ClientCertificateData: clientCert,
 			},
 		},
 		CurrentContext: contextName,
@@ -69,25 +70,5 @@ func GenerateSecret(clusterName string, namespace string, data []byte) *corev1.S
 			"value": data,
 		},
 		Type: "cluster.x-k8s.io/secret",
-	}
-}
-
-func GenerateSecretForServiceAccountToken(clusterName string, namespace string, serviceAccountName string) *corev1.Secret {
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-kubeconfig-token", clusterName),
-			Namespace: namespace,
-			Labels: map[string]string{
-				"cluster.x-k8s.io/cluster-name": clusterName,
-			},
-			Annotations: map[string]string{
-				"kubernetes.io/service-account.name": serviceAccountName,
-			},
-		},
-		Type: "kubernetes.io/service-account-token",
 	}
 }

--- a/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"k8s.io/component-base/logs"
 	v1 "k8s.io/component-base/logs/api/v1"
@@ -64,11 +65,14 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var syncPeriod time.Duration
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute, "The minimum interval at which watched resources are reconciled (e.g. 15m).")
 	flag.Parse()
 
 	if err := v1.ValidateAndApply(logOptions, nil); err != nil {
@@ -95,6 +99,7 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		SyncPeriod: &syncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/modules/040-node-manager/templates/capi-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/rbac-for-us.yaml
@@ -429,4 +429,6 @@ subjects:
   - kind: ServiceAccount
     name: capi-controller-manager
     namespace: d8-cloud-instance-manager
+  - kind: User
+    name: capi-controller-manager
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Generate a `static-kubeconfig` with X.509 certificates for the Cluster API controller.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When we generate kubeconfig, we need to avoid using a token that never expires.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Generate a `static-kubeconfig` with X.509 certificates for the Cluster API controller.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
