### PR TITLE
[docs] update documentation for integration user-authn with Gitlab ver16+

### DIFF
--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -74,6 +74,7 @@ Create a new application in the GitLab project.
 To do this, you need to:
 * **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
 * **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`.
+* When using Gitlab version 16 and higher, when creating an application, you also need to check the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` option.
 
 Paste the generated `Application ID` and `Secret` into the [DexProvider](cr.html#dexprovider) custom resource.
 

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -74,7 +74,7 @@ Create a new application in the GitLab project.
 To do this, you need to:
 * **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
 * **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`;
-* When using GitLab version 16 and higher, when creating an application, you also need to enable the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` checkbox.
+* (for GitLab version starting with 16) enable the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` checkbox  when creating an application.
 
 Paste the generated `Application ID` and `Secret` into the [DexProvider](cr.html#dexprovider) custom resource.
 

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -74,7 +74,7 @@ Create a new application in the GitLab project.
 To do this, you need to:
 * **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
 * **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`.
-* When using Gitlab version 16 and higher, when creating an application, you also need to check the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` option.
+* When using Gitlab version 16 and higher, when creating an application, you also need to enable the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` checkbox.
 
 Paste the generated `Application ID` and `Secret` into the [DexProvider](cr.html#dexprovider) custom resource.
 

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -74,7 +74,7 @@ Create a new application in the GitLab project.
 To do this, you need to:
 * **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
 * **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`.
-* When using Gitlab version 16 and higher, when creating an application, you also need to enable the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` checkbox.
+* When using GitLab version 16 and higher, when creating an application, you also need to enable the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` checkbox.
 
 Paste the generated `Application ID` and `Secret` into the [DexProvider](cr.html#dexprovider) custom resource.
 

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -73,7 +73,7 @@ Create a new application in the GitLab project.
 
 To do this, you need to:
 * **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
-* **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`.
+* **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`;
 * When using GitLab version 16 and higher, when creating an application, you also need to enable the `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` checkbox.
 
 Paste the generated `Application ID` and `Secret` into the [DexProvider](cr.html#dexprovider) custom resource.

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -74,6 +74,7 @@ spec:
 Для этого необходимо:
 * **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
 * **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`.
+* При использовании Gitlab версии 16 и выше - при создании приложения также требуется отметить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
 
 Полученные `Application ID` и `Secret` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -74,7 +74,7 @@ spec:
 Для этого необходимо:
 * **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
 * **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
-* При использовании GitLab версии 16 и выше, при создании приложения также требуется включить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
+* (для GitLab версии 16 и выше) включить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow` при создании приложения.
 
 Полученные `Application ID` и `Secret` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -73,7 +73,7 @@ spec:
 
 Для этого необходимо:
 * **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
-* **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`.
+* **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
 * При использовании GitLab версии 16 и выше, при создании приложения также требуется включить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
 
 Полученные `Application ID` и `Secret` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -74,7 +74,7 @@ spec:
 Для этого необходимо:
 * **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
 * **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`.
-* При использовании Gitlab версии 16 и выше - при создании приложения также требуется отметить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
+* При использовании Gitlab версии 16 и выше - при создании приложения также требуется включить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
 
 Полученные `Application ID` и `Secret` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -74,7 +74,7 @@ spec:
 Для этого необходимо:
 * **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
 * **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`.
-* При использовании Gitlab версии 16 и выше - при создании приложения также требуется включить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
+* При использовании GitLab версии 16 и выше, при создании приложения также требуется включить опцию `Trusted`/`Trusted applications are automatically authorized on Gitlab OAuth flow`.
 
 Полученные `Application ID` и `Secret` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 


### PR DESCRIPTION
## Description
A new option has been added to the GitLab integration setup in version 16; users are faced with difficulties during authorization if it is not configured. The documentation has been updated with a method for enabling this option.

```changes
section: docs
type: chore
summary: Update documentation for integration user-authn with Gitlab ver16+.
impact_level: low
```

