### PR TITLE
[dhctl] Support destroy command for static clusters

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -277,6 +277,7 @@ func DeleteMCMMachineDeployments(kubeCl *client.KubernetesClient) error {
 
 		for _, machine := range allMachines.Items {
 			labels := machine.GetLabels()
+			// it needs for force delete machine (without drain)
 			labels["force-deletion"] = "True"
 			machine.SetLabels(labels)
 
@@ -416,6 +417,7 @@ func DeleteCAPIMachineDeployments(kubeCl *client.KubernetesClient) error {
 
 		for _, machine := range allMachines.Items {
 			m := machine
+			// we delete cluster anyway and we can force delete machine (without drain)
 			unstructured.SetNestedField(m.Object, "10s", "spec", "nodeDrainTimeout")
 
 			_, err = kubeCl.Dynamic().Resource(capiMachinesSchema).Namespace(machine.GetNamespace()).Update(context.TODO(), &m, metav1.UpdateOptions{})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete_test.go
@@ -33,7 +33,7 @@ func TestDeleteMachinesIfResourcesExist(t *testing.T) {
 	t.Run("Without sap API registration", func(t *testing.T) {
 		fakeClient := client.NewFakeKubernetesClient()
 
-		err := checkMachinesAPI(fakeClient)
+		err := checkMCMMachinesAPI(fakeClient)
 		require.EqualError(t, err, "the server could not find the requested resource, GroupVersion \"machine.sapcloud.io/v1alpha1\" not found")
 	})
 
@@ -46,7 +46,7 @@ func TestDeleteMachinesIfResourcesExist(t *testing.T) {
 			APIResources: []metav1.APIResource{},
 		})
 
-		err := checkMachinesAPI(fakeClient)
+		err := checkMCMMachinesAPI(fakeClient)
 		require.EqualError(t, err, "0 of 2 resources found in the cluster")
 	})
 
@@ -68,7 +68,7 @@ func TestDeleteMachinesIfResourcesExist(t *testing.T) {
 			},
 		})
 
-		err := checkMachinesAPI(fakeClient)
+		err := checkMCMMachinesAPI(fakeClient)
 		require.EqualError(t, err, "1 of 2 resources found in the cluster")
 	})
 
@@ -98,7 +98,7 @@ func TestDeleteMachinesIfResourcesExist(t *testing.T) {
 			},
 		})
 
-		err := checkMachinesAPI(fakeClient)
+		err := checkMCMMachinesAPI(fakeClient)
 		require.NoError(t, err)
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -43,10 +43,6 @@ func (b *ClusterBootstrapper) Abort(forceAbortFromCache bool) error {
 	return log.Process("bootstrap", "Abort", func() error { return b.doRunBootstrapAbort(forceAbortFromCache) })
 }
 
-type Destroyer interface {
-	DestroyCluster(autoApprove bool) error
-}
-
 func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) error {
 	metaConfig, err := config.ParseConfig(app.ConfigPath)
 	if err != nil {
@@ -82,7 +78,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 		return err
 	}
 
-	var destroyer Destroyer
+	var destroyer destroy.Destroyer
 
 	err = log.Process("common", "Choice abort type", func() error {
 		ok, err := stateCache.InCache(ManifestCreatedInClusterCacheKey)

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -74,7 +74,7 @@ func (g *DeckhouseDestroyer) GetKubeClient() (*client.KubernetesClient, error) {
 	return kubeCl, err
 }
 
-func (g *DeckhouseDestroyer) DeleteResources() error {
+func (g *DeckhouseDestroyer) DeleteResources(cloudType string) error {
 	resourcesDestroyed, err := g.state.IsResourcesDestroyed()
 	if err != nil {
 		return err

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -15,12 +15,25 @@
 package destroy
 
 import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	infra "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	dhctlstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/frontend"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
+
+type Destroyer interface {
+	DestroyCluster(autoApprove bool) error
+}
 
 type Params struct {
 	SSHClient   *ssh.Client
@@ -35,8 +48,8 @@ type ClusterDestroyer struct {
 	stateCache      dhctlstate.Cache
 	terrStateLoader infra.StateLoader
 
-	d8Destroyer  *DeckhouseDestroyer
-	clusterInfra *infra.ClusterInfra
+	d8Destroyer       *DeckhouseDestroyer
+	cloudClusterInfra *infra.ClusterInfra
 
 	skipResources bool
 
@@ -55,8 +68,8 @@ func NewClusterDestroyer(params *Params) *ClusterDestroyer {
 		stateCache:      params.StateCache,
 		terrStateLoader: terraStateLoader,
 
-		d8Destroyer:  d8Destroyer,
-		clusterInfra: clusterInfra,
+		d8Destroyer:       d8Destroyer,
+		cloudClusterInfra: clusterInfra,
 
 		skipResources: params.SkipResources,
 
@@ -65,8 +78,6 @@ func NewClusterDestroyer(params *Params) *ClusterDestroyer {
 }
 
 func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
-	var err error
-
 	defer d.d8Destroyer.UnlockConverge(true)
 
 	if err := d.PhasedExecutionContext.Init(d.stateCache); err != nil {
@@ -74,13 +85,30 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 	}
 	defer d.PhasedExecutionContext.Finalize(d.stateCache)
 
+	// populate cluster state in cache
+	metaConfig, err := d.terrStateLoader.PopulateMetaConfig()
+	if err != nil {
+		return err
+	}
+
+	clusterType := metaConfig.ClusterType
+	var infraDestroyer Destroyer
+	switch clusterType {
+	case config.CloudClusterType:
+		infraDestroyer = d.cloudClusterInfra
+	case config.StaticClusterType:
+		infraDestroyer = newStaticMastersDestroyer()
+	default:
+		return fmt.Errorf("Unknown cluster type '%s'", clusterType)
+	}
+
 	if !d.skipResources {
 		if shouldStop, err := d.PhasedExecutionContext.StartPhase(phases.DeleteResourcesPhase, false); err != nil {
 			return err
 		} else if shouldStop {
 			return nil
 		}
-		if err := d.d8Destroyer.DeleteResources(); err != nil {
+		if err := d.d8Destroyer.DeleteResources(clusterType); err != nil {
 			return err
 		}
 		if err := d.PhasedExecutionContext.CommitState(d.stateCache); err != nil {
@@ -88,15 +116,11 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 		}
 	}
 
-	// populate cluster state in cache
-	_, err = d.terrStateLoader.PopulateMetaConfig()
-	if err != nil {
-		return err
-	}
-
-	_, _, err = d.terrStateLoader.PopulateClusterState()
-	if err != nil {
-		return err
+	if clusterType == config.CloudClusterType {
+		_, _, err = d.terrStateLoader.PopulateClusterState()
+		if err != nil {
+			return err
+		}
 	}
 
 	// only after load and save all states into cache
@@ -113,10 +137,59 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 	// Stop proxy because we have already got all info from kubernetes-api
 	d.d8Destroyer.StopProxy()
 
-	if err := d.clusterInfra.DestroyCluster(autoApprove); err != nil {
+	if err := infraDestroyer.DestroyCluster(autoApprove); err != nil {
 		return err
 	}
 
 	d.state.Clean()
 	return d.PhasedExecutionContext.Complete()
+}
+
+type StaticMastersDestroyer struct{}
+
+func newStaticMastersDestroyer() *StaticMastersDestroyer {
+	return &StaticMastersDestroyer{}
+}
+
+func (d *StaticMastersDestroyer) DestroyCluster(_ bool) error {
+	sshClient := ssh.NewClientFromFlags()
+
+	mastersHosts := sshClient.Settings.AvailableHosts()
+	stdOutErrHandler := func(l string) {
+		log.InfoLn(l)
+	}
+
+	cmd := "test -f /var/lib/bashible/cleanup_static_node.sh || exit 0 && bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing"
+	for _, host := range mastersHosts {
+		settings := sshClient.Settings.Copy()
+		settings.SetAvailableHosts([]string{host})
+		err := retry.NewLoop(fmt.Sprintf("Clear master %s", host), 5, 10*time.Second).Run(func() error {
+			err := frontend.NewCommand(settings, cmd).
+				Sudo().
+				WithTimeout(5 * time.Minute).
+				WithStdoutHandler(stdOutErrHandler).
+				WithStderrHandler(stdOutErrHandler).
+				Run()
+
+			if err != nil {
+				var ee *exec.ExitError
+				if errors.As(err, &ee) {
+					// script reboot node
+					if ee.ExitCode() == 255 {
+						return nil
+					}
+				}
+
+				return err
+			}
+
+			return err
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add destroy for static cluster with cleanup CAPS machines and clean up control-plane nodes passed with `ssh-host`.

## Why do we need it, and what problem does it solve?
We need to add it for support static clusters in Deckhouse commander.

## Why do we need it in the patch release (if we do)?
Needs for pilots.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

![image](https://github.com/deckhouse/deckhouse/assets/30695496/90a07364-1db0-46d5-b11a-2bdbd40581d6)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/e67aec06-b30d-41a6-84c9-c3a13c0c12e0)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/c1038d9e-0101-4728-9724-924dc17e7e59)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/59ebfaa1-bf4e-4240-bf17-86fcd216b430)

Also tested re bootstrap after clean up.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Support destroy command for static clusters
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
