### PR TITLE
[dhctl] Fix delete unnecessary obsolescence image preflight check

### DIFF
--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -79,13 +79,7 @@ func (pc *Checker) Cloud() error {
 }
 
 func (pc *Checker) Global() error {
-	return pc.do("Global preflight checks", []checkStep{
-		{
-			fun:            pc.CheckDhctlVersionObsolescence,
-			successMessage: "installer and deckhouse-controller version compatibility",
-			skipFlag:       app.DeckhouseVersionCheckArgName,
-		},
-	})
+	return nil
 }
 
 func (pc *Checker) do(title string, checks []checkStep) error {


### PR DESCRIPTION
## Description

Delete unnecessary obsolescence image preflight check.

## Why do we need it, and what problem does it solve?
Now we always use version from file in image.

## Why do we need it in the patch release (if we do)?

Cluster bootstrap fails with panic.

```
unknown - [info] - panic: You are probably using a development image. please use devBranch
unknown - [info] - goroutine 9 [running]:
unknown - [info] - github.com/deckhouse/deckhouse/dhctl/pkg/config.(*DeckhouseInstaller).GetImage(0xc000cad080, 0x40?)
unknown - [info] - 	/dhctl/pkg/config/deckhouse_config.go:116 +0x118
unknown - [info] - github.com/deckhouse/deckhouse/dhctl/pkg/preflight.(*Checker).fetchAndValidateDeckhouseImageHashFromReleaseChannel(0xc0002f04c0, {0x1f06b28?, 0xc000dc6540})
unknown - [info] - 	/dhctl/pkg/preflight/dhctl_obsolescence.go:125 +0xc8
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix 
summary: Delete unnecessary obsolescence image preflight check.
impact_level: default
```
