### PR TITLE
[dhctl] Fix panic on getting tag during bootstrap

### DIFF
--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -134,8 +134,8 @@ func readVersionTagFromInstallerContainer() (string, bool) {
 		return "", false
 	}
 
-	tag := string(rawFile)
-	if _, err = semver.NewVersion(tag); err != nil {
+	tag := strings.TrimSpace(string(rawFile))
+	if _, err = semver.NewVersion(strings.TrimPrefix(tag, "v")); err != nil {
 		return "", false
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix no parse version from version file as semantic version.

## Why do we need it, and what problem does it solve?
Panic during bootstrap
```
unknown - [info] - panic: You are probably using a development image. please use devBranch
unknown - [info] - goroutine 21 [running]:
unknown - [info] - github.com/deckhouse/deckhouse/dhctl/pkg/config.(*DeckhouseInstaller).GetImage(0xc0003fe000, 0x0?)
unknown - [info] - 	/dhctl/pkg/config/deckhouse_config.go:116 +0x118
unknown - [info] - github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse.deckhouseDeploymentParamsFromCfg(0xc0003fe000)
unknown - [info] - 	/dhctl/pkg/kubernetes/actions/deckhouse/install.go:453 +0x45
unknown - [info] - github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse.CreateDeckhouseDeploymentManifest(0x1c0c501?)
```

## Why do we need it in the patch release (if we do)?
Cannot bootstrap clusters

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix panic on getting tag during bootstrap.
impact_level: default
```
