### PR TITLE
[node-local-dns] Remove hostPorts when hostNetwork=false

### DIFF
--- a/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
+++ b/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
@@ -14,13 +14,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
+++ b/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
@@ -66,6 +66,9 @@ func handleHostNetworkFalseWithHostPorts(input *go_hook.HookInput, dc dependency
 	if !ok {
 		return nil
 	}
+if len(snap) == 0 {
+		return nil
+	}
 
 	if !snap[0].(bool) {
 		return nil

--- a/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
+++ b/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+/*
+The problem described here https://github.com/kubernetes/kubernetes/issues/117689
+We can remove this hook after the minimum supported Kubernetes version will be 1.28.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:       "/modules/node-local-dns",
+	OnAfterHelm: &go_hook.OrderedConfig{},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "daemonset",
+			ApiVersion: "apps/v1",
+			Kind:       "DaemonSet",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"node-local-dns"},
+			},
+			FilterFunc: hostNetworkFalse,
+		},
+	},
+}, dependency.WithExternalDependencies(handleHostNetworkFalseWithHostPorts))
+
+func hostNetworkFalse(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	ds := &appsv1.DaemonSet{}
+
+	err := sdk.FromUnstructured(obj, ds)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ds.Spec.Template.Spec.HostNetwork {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func handleHostNetworkFalseWithHostPorts(input *go_hook.HookInput, dc dependency.Container) error {
+	snap, ok := input.Snapshots["daemonset"]
+
+	if !ok {
+		return nil
+	}
+
+	if !snap[0].(bool) {
+		return nil
+	}
+
+	k8sClient, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("can't init Kubernetes client: %v", err)
+	}
+
+	ds, err := k8sClient.AppsV1().DaemonSets("kube-system").Get(context.TODO(), "node-local-dns", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get latest version of node-local-dns DaemonSet: %v", err)
+	}
+
+	for containerIdx := range ds.Spec.Template.Spec.Containers {
+		for portIdx := range ds.Spec.Template.Spec.Containers[containerIdx].Ports {
+			ds.Spec.Template.Spec.Containers[containerIdx].Ports[portIdx].HostPort = 0
+		}
+	}
+
+	_, err = k8sClient.AppsV1().DaemonSets("kube-system").Update(context.TODO(), ds, metav1.UpdateOptions{})
+
+	return err
+}

--- a/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
+++ b/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports.go
@@ -66,7 +66,8 @@ func handleHostNetworkFalseWithHostPorts(input *go_hook.HookInput, dc dependency
 	if !ok {
 		return nil
 	}
-if len(snap) == 0 {
+
+	if len(snap) == 0 {
 		return nil
 	}
 

--- a/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports_test.go
+++ b/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports_test.go
@@ -8,13 +8,13 @@ package hooks
 import (
 	"context"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 

--- a/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports_test.go
+++ b/ee/modules/350-node-local-dns/hooks/cleanup_daemonset_hostports_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node local dns :: hooks :: cleanup daemonset hostports ::", func() {
+	const (
+		initValuesString       = `{"nodeLocalDns": {"internal": {}}}`
+		initConfigValuesString = `{}`
+		dsToBePatched          = `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-local-dns
+    heritage: deckhouse
+    module: node-local-dns
+  name: node-local-dns
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: node-local-dns
+  template:
+    metadata:
+      labels:
+        app: node-local-dns
+        k8s-app: node-local-dns
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -l
+        - -c
+        - /start.sh
+        image: coredns
+        name: coredns
+        ports:
+        - containerPort: 53
+          hostPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          hostPort: 53
+          name: dns-tcp
+          protocol: TCP
+      - args:
+        - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9254
+        - --v=2
+        - --logtostderr=true
+        - --stale-cache-interval=1h30m
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: kube-rbac-proxy
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9254
+          hostPort: 9254
+          name: https-metrics
+          protocol: TCP
+      dnsPolicy: Default
+`
+		dsToBeSkipped = `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-local-dns
+    heritage: deckhouse
+    module: node-local-dns
+  name: node-local-dns
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: node-local-dns
+  template:
+    metadata:
+      labels:
+        app: node-local-dns
+        k8s-app: node-local-dns
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -l
+        - -c
+        - /start.sh
+        env:
+        - name: SHOULD_SETUP_IPTABLES
+          value: "yes"
+        image: coredns
+        name: coredns
+        ports:
+        - containerPort: 53
+          hostPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          hostPort: 53
+          name: dns-tcp
+          protocol: TCP
+      - args:
+        - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9254
+        - --v=2
+        - --logtostderr=true
+        - --stale-cache-interval=1h30m
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: kube-rbac-proxy
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9254
+          hostPort: 9254
+          name: https-metrics
+          protocol: TCP
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+`
+		dsWithoutHostPorts = `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-local-dns
+    heritage: deckhouse
+    module: node-local-dns
+  name: node-local-dns
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: node-local-dns
+  template:
+    metadata:
+      labels:
+        app: node-local-dns
+        k8s-app: node-local-dns
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -l
+        - -c
+        - /start.sh
+        image: coredns
+        name: coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+      - args:
+        - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9254
+        - --v=2
+        - --logtostderr=true
+        - --stale-cache-interval=1h30m
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: kube-rbac-proxy
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9254
+          name: https-metrics
+          protocol: TCP
+      dnsPolicy: Default
+`
+	)
+
+	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+	Context("Without DaemonSet", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+
+		It("Should do nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ds, _ := dependency.TestDC.MustGetK8sClient().AppsV1().DaemonSets("kube-system").Get(context.TODO(), "node-local-dns", metav1.GetOptions{})
+			Expect(ds).To(BeNil())
+		})
+	})
+
+	Context("With hostNetwork=false (null) and hostPorts", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(dsToBePatched))
+			var ds appsv1.DaemonSet
+			_ = yaml.Unmarshal([]byte(dsToBePatched), &ds)
+			_, err := dependency.TestDC.MustGetK8sClient().
+				AppsV1().
+				DaemonSets("kube-system").
+				Create(context.TODO(), &ds, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			f.RunHook()
+		})
+
+		It("Should remove hostPorts from manifest", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ds, _ := dependency.TestDC.MustGetK8sClient().AppsV1().DaemonSets("kube-system").Get(context.TODO(), "node-local-dns", metav1.GetOptions{})
+			Expect(ds.Spec.Template.Spec.HostNetwork).To(BeFalse())
+			Expect(ds.Spec.Template.Spec.Containers[0].Ports[0].HostPort).To(BeZero())
+			Expect(ds.Spec.Template.Spec.Containers[0].Ports[1].HostPort).To(BeZero())
+			Expect(ds.Spec.Template.Spec.Containers[1].Ports[0].HostPort).To(BeZero())
+		})
+	})
+
+	Context("With hostNetwork=false (null) and without hostPorts", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(dsWithoutHostPorts))
+			var ds appsv1.DaemonSet
+			_ = yaml.Unmarshal([]byte(dsWithoutHostPorts), &ds)
+			_, err := dependency.TestDC.MustGetK8sClient().
+				AppsV1().
+				DaemonSets("kube-system").
+				Create(context.TODO(), &ds, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			f.RunHook()
+		})
+
+		It("Shouldn't change anything", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ds, _ := dependency.TestDC.MustGetK8sClient().AppsV1().DaemonSets("kube-system").Get(context.TODO(), "node-local-dns", metav1.GetOptions{})
+			Expect(ds.Spec.Template.Spec.HostNetwork).To(BeFalse())
+			Expect(ds.Spec.Template.Spec.Containers[0].Ports[0].HostPort).To(BeZero())
+			Expect(ds.Spec.Template.Spec.Containers[0].Ports[1].HostPort).To(BeZero())
+			Expect(ds.Spec.Template.Spec.Containers[1].Ports[0].HostPort).To(BeZero())
+		})
+	})
+
+	Context("With hostNetwork=true", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(dsToBeSkipped))
+			var ds appsv1.DaemonSet
+			_ = yaml.Unmarshal([]byte(dsToBeSkipped), &ds)
+			_, err := dependency.TestDC.MustGetK8sClient().
+				AppsV1().
+				DaemonSets("kube-system").
+				Create(context.TODO(), &ds, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			f.RunHook()
+		})
+
+		It("Should do nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ds, _ := dependency.TestDC.MustGetK8sClient().AppsV1().DaemonSets("kube-system").Get(context.TODO(), "node-local-dns", metav1.GetOptions{})
+			Expect(ds.Spec.Template.Spec.HostNetwork).To(BeTrue())
+			Expect(ds.Spec.Template.Spec.Containers[0].Ports[0].HostPort).NotTo(BeZero())
+			Expect(ds.Spec.Template.Spec.Containers[0].Ports[1].HostPort).NotTo(BeZero())
+			Expect(ds.Spec.Template.Spec.Containers[1].Ports[0].HostPort).NotTo(BeZero())
+		})
+	})
+})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove `hostPorts` from manifest when `hostNetwork=false`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We don't use `hostNetwork` if `cni-cilium` is used and use it otherwise. If you migrate, e.g. from `cni-flannel` to `cni-cilium`, the `hostPorts` added by the controller when `hostNetwork` was true will remain in the DaemonSet manifest. In some cases, this can break resolving on nodes in the cluster because the `hostPort` bind port 53 on the host and then `systemd-resolved` (which works on port 53) stops working.
The problem described here https://github.com/kubernetes/kubernetes/issues/117689

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We don't

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Hook MUST remove `hostPorts` from the DaemonSet manifest if `hostNetwork=false`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: feature
summary: Remove `hostPorts` from manifest when `hostNetwork=false`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
