### PR TITLE
[node-manager] Fix node group validation webhook if global mc does not exists

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -131,7 +131,7 @@ EOF
   has_missing_taints=0
   taints=$(context::jq -r '.review.request.object.spec.nodeTemplate.taints // []')
   if [[ "$taints" != "[]" ]]; then
-    customTolerationKeys=$(context::jq -e -r '.snapshots.deckhouse_config[0].filterResult' | yq  e '.' -j - | jq -r '.modules.placement.customTolerationKeys | if . == null then empty else .[] end')
+    customTolerationKeys=$(context::jq -e -r 'if (.snapshots.deckhouse_config | length) > 0 then .snapshots.deckhouse_config[0].filterResult else {} end' | yq  e '.' -j - | jq -r '.modules.placement.customTolerationKeys | if . == null then empty else .[] end')
     for taint in $(jq -e -r '.[].key' <<< "$taints"); do
       # Skip 'standart' taints
       if [[ $taint = 'dedicated' || $taint = 'dedicated.deckhouse.io' || $taint = 'node-role.kubernetes.io/control-plane' || $taint = 'node-role.kubernetes.io/master' ]]; then

--- a/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
@@ -41,14 +41,3 @@ metadata:
   name: flant-integration
 spec:
   enabled: false
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: global
-spec:
-  enabled: true
-  settings:
-    modules:
-      publicDomainTemplate: "%s.k8s.smoke.flant.com"
-  version: 1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add guard for nodegroup validation  webhook in case when global module config is not exists.
Add test configuration for GCP cluster. 

## Why do we need it, and what problem does it solve?
Editing node group fail with message:
```
Execute hook"
"Traceback (most recent call last):"
"  File \"/hooks/040-node-manager/webhooks/validating/node_group\", line 191, in main"
"    hook::run \"$@\""
"  File \"/frameworks/shell/hook.sh\", line 17, in hook::run"
"    hook::_run_first_available_handler \"${HANDLERS}\""
"  File \"/frameworks/shell/hook.sh\", line 73, in hook::_run_first_available_handler"
"    ($handler) # brackets are to run handler as a subprocess"
"  File \"/hooks/040-node-manager/webhooks/validating/node_group\", line 134, in __main__"
"    customTolerationKeys=$(context::jq -e -r '.snapshots.deckhouse_config[0].filterResult' | yq  e '.' -j - | jq -r '.modules.placement.customTolerationKeys | if . == null then empty else .[] end')"
"  File \"/frameworks/shell/context.sh\", line 9, in context::jq"
"    context::global::jq '.['\"${BINDING_CONTEXT_CURRENT_INDEX}\"']' | jq \"$@\""
"Exiting with status 1"

```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/deckhouse/deckhouse/assets/30695496/2a370ab9-55cf-427f-8026-80d26ddb5a79)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-group
type: fix
summary: Fix node group validation webhook if global mc does not exists
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
