### PR TITLE
[linstor] ToggleDisk: Set resolved StorPoolName property

### DIFF
--- a/modules/041-linstor/images/linstor-server/patches/0001-ToggleDisk-Set-resolved-StorPoolName-property.patch
+++ b/modules/041-linstor/images/linstor-server/patches/0001-ToggleDisk-Set-resolved-StorPoolName-property.patch
@@ -1,0 +1,95 @@
+From 92652166583f406ed4ce470f31e88a687e5ad33f Mon Sep 17 00:00:00 2001
+From: Alexandr Ohrimenko <alexandr.ohrimenko@flant.com>
+Date: Mon, 20 Nov 2023 16:43:43 +0300
+Subject: [PATCH] ToggleDisk: Set resolved StorPoolName property
+
+---
+ .../CtrlRscToggleDiskApiCallHandler.java      | 25 ++++++++++++++++---
+ 1 file changed, 22 insertions(+), 3 deletions(-)
+
+diff --git a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscToggleDiskApiCallHandler.java b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscToggleDiskApiCallHandler.java
+index eacdda04b..d819ebec2 100644
+--- a/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscToggleDiskApiCallHandler.java
++++ b/controller/src/main/java/com/linbit/linstor/core/apicallhandler/controller/CtrlRscToggleDiskApiCallHandler.java
+@@ -26,6 +26,7 @@ import com.linbit.linstor.core.apicallhandler.response.ResponseUtils;
+ import com.linbit.linstor.core.identifier.NodeName;
+ import com.linbit.linstor.core.identifier.ResourceName;
+ import com.linbit.linstor.core.identifier.SharedStorPoolName;
++import com.linbit.linstor.core.identifier.StorPoolName;
+ import com.linbit.linstor.core.objects.Node;
+ import com.linbit.linstor.core.objects.Resource;
+ import com.linbit.linstor.core.objects.Resource.DiskfulBy;
+@@ -77,6 +78,7 @@ import javax.inject.Singleton;
+ import java.util.ArrayList;
+ import java.util.Collection;
+ import java.util.Collections;
++import java.util.HashSet;
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Set;
+@@ -389,7 +391,9 @@ public class CtrlRscToggleDiskApiCallHandler implements CtrlSatelliteConnectionL
+         {
+             payload.drbdRsc.needsNewNodeId = true;
+         }
++
+         // Resolve storage pool now so that nothing is committed if the storage pool configuration is invalid
++        Set<StorPoolName> storPoolNames = new HashSet<>();
+         Iterator<Volume> vlmIter = rsc.iterateVolumes();
+         while (vlmIter.hasNext())
+         {
+@@ -399,12 +403,27 @@ public class CtrlRscToggleDiskApiCallHandler implements CtrlSatelliteConnectionL
+             StorPool sp = ctrlStorPoolResolveHelper
+                 .resolveStorPool(rsc, vlmDfn, removeDisk)
+                 .extractApiCallRc(responses);
++            storPoolNames.add(sp.getName());
+             if (isSharedSpAlreadyUsed(rsc, sp))
+             {
+                 needsDeactivate = true;
+                 payload.drbdRsc.needsNewNodeId = true;
+             }
+         }
++        if (storPoolNames.size() == 1)
++        {
++            /*
++             * Since we also set the StorPoolName property when going diskless, we should also set it then going diskful
++             * (and this property makes sense to be set on resource-level)
++             */
++            ctrlPropsHelper.fillProperties(
++                responses,
++                LinStorObject.RESOURCE,
++                Collections.singletonMap(ApiConsts.KEY_STOR_POOL_NAME, storPoolNames.iterator().next().displayValue),
++                rscProps,
++                ApiConsts.FAIL_ACC_DENIED_RSC
++            );
++        }
+ 
+         if (removeDisk)
+         {
+@@ -420,7 +439,7 @@ public class CtrlRscToggleDiskApiCallHandler implements CtrlSatelliteConnectionL
+         else
+         {
+             // diskless -> diskful
+-//            ctrlLayerStackHelper.resetStoragePools(rsc);
++            // ctrlLayerStackHelper.resetStoragePools(rsc);
+ 
+             markDiskAddRequested(rsc);
+ 
+@@ -702,7 +721,7 @@ public class CtrlRscToggleDiskApiCallHandler implements CtrlSatelliteConnectionL
+         }
+ 
+         // Don't start the operation if any of the required nodes are offline
+-        if (!offlineWarnings.getEntries().isEmpty())
++        if (!offlineWarnings.isEmpty())
+         {
+             responses = Flux.just(offlineWarnings);
+         }
+@@ -1336,4 +1355,4 @@ public class CtrlRscToggleDiskApiCallHandler implements CtrlSatelliteConnectionL
+     {
+         return lockGuardFactory.buildDeferred(LockType.WRITE, LockObj.NODES_MAP, LockObj.RSC_DFN_MAP);
+     }
+-}
++}
+\ No newline at end of file
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
