### PR TITLE
[node-manager] Alert about yandex ru-central-c zone deprecation

### DIFF
--- a/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone.go
+++ b/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+)
+
+const yandexDeprecatedZoneNodesKey = "node_groups_with_deprecated_region"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       yandexDeprecatedZoneNodesKey,
+			ApiVersion: "v1",
+			Kind:       "Node",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"topology.kubernetes.io/zone": "ru-central1-c",
+				},
+			},
+			FilterFunc: filterYandexDeprecatedZoneNodes,
+		},
+	},
+}, alertOnNodesInDeprecatedAvailabilityZones)
+
+func filterYandexDeprecatedZoneNodes(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	node := &v1.Node{}
+	if err := sdk.FromUnstructured(obj, node); err != nil {
+		return nil, err
+	}
+
+	providerID, err := url.Parse(node.Spec.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("Parse Node's .spec.providerID: %w", err)
+	}
+	if providerID.Scheme != "yandex" {
+		return nil, nil
+	}
+
+	return node.Labels["node.deckhouse.io/group"], nil
+}
+
+func alertOnNodesInDeprecatedAvailabilityZones(input *go_hook.HookInput) error {
+	nodeGroupsWithDeprecatedZones := set.NewFromSnapshot(input.Snapshots[yandexDeprecatedZoneNodesKey])
+
+	for _, nodeGroupName := range nodeGroupsWithDeprecatedZones.Slice() {
+		input.MetricsCollector.Set("d8_node_group_node_with_deprecated_availability_zone", 1, map[string]string{
+			"node_group": nodeGroupName,
+		})
+	}
+
+	return nil
+}

--- a/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/shell-operator/pkg/metric_storage/operation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: alert_on_deprecated_availability_zone ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	initialKubeState := `
+apiVersion: v1
+kind: Node
+metadata:
+  name: yandex-central1-a
+  labels:
+    node.deckhouse.io/group: master
+    topology.kubernetes.io/region: ru-central1
+    topology.kubernetes.io/zone: ru-central1-a
+spec:
+  providerID: yandex://9cgf2kcqvi50mn5hqmhf`
+
+	Context("With no Nodes on deprecated zones", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(initialKubeState))
+			f.RunHook()
+		})
+
+		It("Should succeed with no collected metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(BeEmpty())
+		})
+	})
+
+	nodeOnDeprecatedAvailabilityZone := `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: yandex-central1-c
+  labels:
+    node.deckhouse.io/group: system-c
+    topology.kubernetes.io/region: ru-central1
+    topology.kubernetes.io/zone: ru-central1-c
+spec:
+  providerID: yandex://fhmqh5nm05ivqck2fgc9`
+
+	expectedMetric := operation.MetricOperation{
+		Name:   "d8_node_group_node_with_deprecated_availability_zone",
+		Value:  pointer.Float64(1.0),
+		Labels: map[string]string{"node_group": "system-c"},
+		Action: "set",
+	}
+
+	Context("With Nodes on deprecated ru-central1-c zone", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(initialKubeState + nodeOnDeprecatedAvailabilityZone))
+			f.RunHook()
+		})
+
+		It("Should collect metrics with node groups", func() {
+			collectedMetrics := f.MetricsCollector.CollectedMetrics()
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(collectedMetrics).To(ContainElement(expectedMetric))
+			Expect(len(collectedMetrics)).Should(Equal(1))
+		})
+	})
+})

--- a/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
+++ b/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
@@ -15,5 +15,5 @@
         summary: NodeGroup {{ $labels.node_group }} contains Nodes with deprecated availability zone.
         description: |
           Availability zone `ru-central1-c` is deprecated by Yandex.Cloud.
-          You should migrate your Nodes to the new `ru‑central1‑d` zone.
+          You should migrate your Nodes to `ru‑central1‑a` or `ru‑central1‑b` zone.
           To check which Nodes should be migrated, use `kubectl get node -l "topology.kubernetes.io/zone=ru-central1-c"` command.

--- a/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
+++ b/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
@@ -1,0 +1,19 @@
+- name: d8.node-group-node-with-deprecated-availability-zone
+  rules:
+    - alert: NodeGroupNodeWithDeprecatedAvailabilityZone
+      expr: |
+        max by (node_group) (d8_node_group_node_with_deprecated_availability_zone) > 0
+      for: 1m
+      labels:
+        tier: cluster
+        severity_level: "9"
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__cluster_has_node_groups_deprecation_alerts: "AvailabilityZonesDeprecationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__cluster_has_node_groups_deprecation_alerts: "AvailabilityZonesDeprecationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: NodeGroup {{ $labels.node_group }} contains Nodes with deprecated availability zone.
+        description: |
+          Availability zone `ru-central1-c` is deprecated by Yandex.Cloud.
+          You should migrate your Nodes to the new `ru‑central1‑d` zone.
+          To check which Nodes should be migrated, use `kubectl get node -l "topology.kubernetes.io/zone=ru-central1-c"` command.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

If cluster has nodes on Yandex.Cloud availability zone `ru-central1-c`, alert will be fired asking user to migrate to zone `ru-centra1-d`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Yandex.Cloud [deprecated](https://cloud.yandex.com/en-ru/docs/overview/concepts/ru-central1-c-deprecation) `ru-central1-c` availability zone, users are encouraged to migrate to `ru-central1-d`

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Alert about yandex ru-central-c zone deprecation
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
