### PR TITLE
[external-module-manager] Store checksums in memory

### DIFF
--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -79,17 +79,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, createDeckhouseModuleSource)
 
 func createDeckhouseModuleSource(input *go_hook.HookInput) error {
-	if input.Values.Get("global.modulesImages.registry.address").String() != "registry.deckhouse.io" {
-		// For now, modules are only stored in the base deckhouse registry,
-		// for other registries deploying this resource by default will only cause an error.
-		return nil
-	}
-
-	if input.Values.Get("global.modulesImages.registry.path").String() == "/deckhouse/ce" {
-		// For CE, there are no modules for now, but will be some in the future!
-		return nil
-	}
-
 	deckhouseRepo := input.Values.Get("global.modulesImages.registry.base").String() + "/modules"
 	deckhouseDockerCfg := input.Values.Get("global.modulesImages.registry.dockercfg").String()
 	deckhouseCA := input.Values.Get("global.modulesImages.registry.CA").String()
@@ -105,7 +94,7 @@ func createDeckhouseModuleSource(input *go_hook.HookInput) error {
 		releaseChannel = ms.Spec.ReleaseChannel
 
 		if moduleSourceUpToDate(&ms, deckhouseRepo, deckhouseDockerCfg, deckhouseCA) {
-			// return if ModuleSource deckhouse already exists and all param are equal
+			// return if ModuleSource deckhouse already exists and all params are equal
 			return nil
 		}
 	}

--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source_test.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source_test.go
@@ -97,11 +97,11 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should not deploy the module source", func() {
+		It("Should deploy the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
-			Expect(ms.Exists()).To(BeFalse())
+			Expect(ms.Exists()).To(BeTrue())
 		})
 	})
 
@@ -112,11 +112,11 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should not deploy the module source", func() {
+		It("Should deploy the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
-			Expect(ms.Exists()).To(BeFalse())
+			Expect(ms.Exists()).To(BeTrue())
 		})
 	})
 

--- a/modules/005-external-module-manager/openapi/values.yaml
+++ b/modules/005-external-module-manager/openapi/values.yaml
@@ -5,4 +5,11 @@ properties:
   internal:
     type: object
     default: {}
-
+    properties:
+      modulesChecksums:
+        type: object
+        default: {}
+        additionalProperties:
+          type: object
+          additionalProperties:
+            type: string


### PR DESCRIPTION
## Description
* Reconcile all modules sources on startup. This affects client's registry load, but is more error pron.
* Always deploy the module source for deckhouse modules (since as of today dhctl mirror command copies the module source to private registries by default).

In the module values, checksum map looks like
```
externalModuleManager:
  internal:
    modulesChecksums:
      inspektor-gadget:
        inspektor-gadget: sha256:155628253a07fd119c179ec175658b7ce5012c5bfa9512b28323e2f24d9228b8
```
an it is dropped on restarts.

## Why do we need it, and what problem does it solve?
The first fix is applied to survive the situation when dechkouse the problem that module was downloaded but there is no module release in the cluster. The assumption is that the situation occurs when deckhouse is restarted in the middle of downloading the module, or hook simply fails.  With the current approaches, modules will be downloaded on deckhouse restart and checksums will only be saved if the hook executed successfully. 

The second fix is applied to make default module sources work in air-gapped environments. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: feat
summary: Store checksums in memory.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
