### PR TITLE
[candi] Fixing disabling managing foreign ip rules by systemd-networkd

### DIFF
--- a/candi/bashible/common-steps/all/005_disable_manage_iprules.sh.tpl
+++ b/candi/bashible/common-steps/all/005_disable_manage_iprules.sh.tpl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Do nothing, if systemd-networkd is not enabled and active
-if ! systemctl is-enabled --quiet systemd-networkd && systemctl is-active --quiet systemd-networkd ; then
+if ! systemctl is-enabled --quiet systemd-networkd ; then
   exit 0
 fi
 


### PR DESCRIPTION
## Description

Fix disabling managing foreign IP rules by systemd-networkd.

## Why do we need it, and what problem does it solve?

If the systemd-networkd module did not exist in the operating system, the step would terminate with an error and the node installation could not proceed.

## What is the expected result?

If the systemd-networkd module did not exist in the operating system (e.g. CentOS 8+), the bashible step completes correctly and does not crash with an error

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: Fix disabling managing foreign IP rules by systemd-networkd.
impact_level: low
```
