### PR TITLE
[dhctl] Validate passed credentials against registry prior to mirroring

### DIFF
--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -70,6 +70,14 @@ func mirrorPushDeckhouseToPrivateRegistry() error {
 
 	defer os.RemoveAll(app.TmpDirName)
 
+	if err := mirror.ValidateWriteAccessForRepo(
+		mirrorCtx.RegistryHost+mirrorCtx.RegistryPath,
+		mirrorCtx.RegistryAuth,
+		mirrorCtx.Insecure,
+	); err != nil {
+		return fmt.Errorf("Registry credentials validation failure: %w", err)
+	}
+
 	err := log.Process("mirror", "Unpacking Deckhouse bundle", func() error {
 		return mirror.UnpackBundle(mirrorCtx)
 	})
@@ -104,6 +112,10 @@ func mirrorPullDeckhouseToLocalFilesystem() error {
 	}
 
 	defer os.RemoveAll(mirrorCtx.UnpackedImagesPath)
+
+	if err := mirror.ValidateReadAccessForImage(mirrorCtx.DeckhouseRegistryRepo+":rock-solid", mirrorCtx.RegistryAuth, mirrorCtx.Insecure); err != nil {
+		return fmt.Errorf("License token validation failure: %w", err)
+	}
 
 	var versionsToMirror []*semver.Version
 	var err error

--- a/dhctl/pkg/operations/mirror.go
+++ b/dhctl/pkg/operations/mirror.go
@@ -138,15 +138,7 @@ func PushDeckhouseToRegistry(mirrorCtx *mirror.Context) error {
 				return fmt.Errorf("read image: %w", err)
 			}
 
-			refOpts := []name.Option{}
-			remoteOpts := []remote.Option{}
-			if mirrorCtx.Insecure {
-				refOpts = append(refOpts, name.Insecure)
-			}
-			if mirrorCtx.RegistryAuth != nil {
-				remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
-			}
-
+			refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
 			ref, err := name.ParseReference(imageRef, refOpts...)
 			if err != nil {
 				return fmt.Errorf("parse oci layout reference: %w", err)

--- a/dhctl/pkg/operations/mirror.go
+++ b/dhctl/pkg/operations/mirror.go
@@ -35,7 +35,7 @@ func MirrorDeckhouseToLocalFS(
 	versions []*semver.Version,
 ) error {
 	log.InfoF("Fetching Deckhouse modules list...\t")
-	modules, err := mirror.GetDeckhouseModules(mirrorCtx)
+	modules, err := mirror.GetDeckhouseExternalModules(mirrorCtx)
 	if err != nil {
 		return fmt.Errorf("get Deckhouse modules: %w", err)
 	}

--- a/dhctl/pkg/operations/mirror/auth.go
+++ b/dhctl/pkg/operations/mirror/auth.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func ValidateReadAccessForImage(imageTag string, authProvider authn.Authenticator, insecure bool) error {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+	ref, err := name.ParseReference(imageTag, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("Parse registry address: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	remoteOpts = append(remoteOpts, remote.WithContext(ctx))
+	_, err = remote.Head(ref, remoteOpts...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateWriteAccessForRepo(repo string, authProvider authn.Authenticator, insecure bool) error {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+	ref, err := name.NewTag(repo+":dhctlWriteCheck", nameOpts...)
+	if err != nil {
+		return err
+	}
+
+	if err = remote.Write(ref, empty.Image, remoteOpts...); err != nil {
+		return err
+	}
+
+	if err = remote.Delete(ref, remoteOpts...); err != nil {
+		return fmt.Errorf("Could not clean up after write-testing registry permissions: %w", err)
+	}
+
+	return nil
+}
+
+func MakeRemoteRegistryRequestOptions(authProvider authn.Authenticator, insecure bool) ([]name.Option, []remote.Option) {
+	n, r := make([]name.Option, 0), make([]remote.Option, 0)
+	if insecure {
+		n = append(n, name.Insecure)
+	}
+	if authProvider != nil && authProvider != authn.Anonymous {
+		r = append(r, remote.WithAuth(authProvider))
+	}
+
+	return n, r
+}
+
+func MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx *Context) ([]name.Option, []remote.Option) {
+	return MakeRemoteRegistryRequestOptions(mirrorCtx.RegistryAuth, mirrorCtx.Insecure)
+}

--- a/dhctl/pkg/operations/mirror/auth.go
+++ b/dhctl/pkg/operations/mirror/auth.go
@@ -55,7 +55,7 @@ func ValidateWriteAccessForRepo(repo string, authProvider authn.Authenticator, i
 	}
 
 	if err = remote.Delete(ref, remoteOpts...); err != nil {
-		return fmt.Errorf("Could not clean up after write-testing registry permissions: %w", err)
+		return fmt.Errorf("Could not clean up image %q after write-testing registry permissions: %w", ref.String(), err)
 	}
 
 	return nil

--- a/dhctl/pkg/operations/mirror/auth.go
+++ b/dhctl/pkg/operations/mirror/auth.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -50,14 +50,15 @@ func ValidateWriteAccessForRepo(repo string, authProvider authn.Authenticator, i
 		return err
 	}
 
-	if err = remote.Write(ref, empty.Image, remoteOpts...); err != nil {
+	syntheticImage, err := random.Image(512, 1)
+	if err != nil {
+		return fmt.Errorf("Generate random image: %w", err)
+	}
+
+	// We do not delete uploaded synthetic image, not all registries are set up to take DELETE requests kindly
+	if err = remote.Write(ref, syntheticImage, remoteOpts...); err != nil {
 		return err
 	}
-
-	if err = remote.Delete(ref, remoteOpts...); err != nil {
-		return fmt.Errorf("Could not clean up image %q after write-testing registry permissions: %w", ref.String(), err)
-	}
-
 	return nil
 }
 

--- a/dhctl/pkg/operations/mirror/auth.go
+++ b/dhctl/pkg/operations/mirror/auth.go
@@ -32,7 +32,7 @@ func ValidateReadAccessForImage(imageTag string, authProvider authn.Authenticato
 		return fmt.Errorf("Parse registry address: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	remoteOpts = append(remoteOpts, remote.WithContext(ctx))
 	_, err = remote.Head(ref, remoteOpts...)

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -235,7 +235,7 @@ func fetchVersionsFromModuleReleaseChannels(
 	authProvider authn.Authenticator,
 	insecure bool,
 ) (map[string]string, error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
 	channelVersions := map[string]string{}
 	for imageTag := range releaseChannelImages {
 

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -200,14 +200,7 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 			moduleData.ReleaseImages[mirrorCtx.DeckhouseRegistryRepo+"/modules/"+moduleName+"/release:"+moduleVersion] = struct{}{}
 		}
 
-		nameOpts := []name.Option{}
-		remoteOpts := []remote.Option{}
-		if mirrorCtx.Insecure {
-			nameOpts = append(nameOpts, name.Insecure)
-		}
-		if mirrorCtx.RegistryAuth != nil {
-			remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
-		}
+		nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
 		fetchDigestsFrom := maputil.Clone(moduleData.ModuleImages)
 		for imageTag := range fetchDigestsFrom {
 			ref, err := name.ParseReference(imageTag, nameOpts...)
@@ -242,15 +235,9 @@ func fetchVersionsFromModuleReleaseChannels(
 	authProvider authn.Authenticator,
 	insecure bool,
 ) (map[string]string, error) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
 	channelVersions := map[string]string{}
 	for imageTag := range releaseChannelImages {
-		nameOpts, remoteOpts := []name.Option{}, []remote.Option{}
-		if insecure {
-			nameOpts = append(nameOpts, name.Insecure)
-		}
-		if authProvider != nil {
-			remoteOpts = append(remoteOpts, remote.WithAuth(authProvider))
-		}
 
 		ref, err := name.ParseReference(imageTag, nameOpts...)
 		if err != nil {

--- a/dhctl/pkg/operations/mirror/modules.go
+++ b/dhctl/pkg/operations/mirror/modules.go
@@ -30,15 +30,9 @@ type Module struct {
 	Releases     []string
 }
 
-func GetDeckhouseModules(mirrorCtx *Context) ([]Module, error) {
-	nameOpts, remoteOpts := []name.Option{}, []remote.Option{}
-	if mirrorCtx.Insecure {
-		nameOpts = append(nameOpts, name.Insecure)
-	}
-	if mirrorCtx.RegistryAuth != nil {
-		remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
-	}
-
+func GetExternalModules(mirrorCtx *Context) ([]Module, error) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
+	modulesRepo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/modules", nameOpts...)
 	repoPathBuildFuncForDeckhouseModule := func(repo, moduleName string) string {
 		return fmt.Sprintf("%s/modules/%s", mirrorCtx.DeckhouseRegistryRepo, moduleName)
 	}

--- a/dhctl/pkg/operations/mirror/modules.go
+++ b/dhctl/pkg/operations/mirror/modules.go
@@ -30,9 +30,9 @@ type Module struct {
 	Releases     []string
 }
 
-func GetExternalModules(mirrorCtx *Context) ([]Module, error) {
+func GetDeckhouseExternalModules(mirrorCtx *Context) ([]Module, error) {
 	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
-	modulesRepo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/modules", nameOpts...)
+	// modulesRepo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/modules", nameOpts...)
 	repoPathBuildFuncForDeckhouseModule := func(repo, moduleName string) string {
 		return fmt.Sprintf("%s/modules/%s", mirrorCtx.DeckhouseRegistryRepo, moduleName)
 	}
@@ -51,14 +51,7 @@ func GetExternalModules(mirrorCtx *Context) ([]Module, error) {
 }
 
 func GetExternalModulesFromRepo(repo string, registryAuth authn.Authenticator, insecure bool) ([]Module, error) {
-	nameOpts, remoteOpts := []name.Option{}, []remote.Option{}
-	if insecure {
-		nameOpts = append(nameOpts, name.Insecure)
-	}
-	if registryAuth != nil {
-		remoteOpts = append(remoteOpts, remote.WithAuth(registryAuth))
-	}
-
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(registryAuth, insecure)
 	repoPathBuildFuncForExternalModule := func(repo, moduleName string) string {
 		return fmt.Sprintf("%s/%s", repo, moduleName)
 	}
@@ -109,13 +102,7 @@ func getModulesForRepo(
 }
 
 func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, insecure bool) (moduleImages, releaseImages map[string]struct{}, err error) {
-	nameOpts, remoteOpts := []name.Option{}, []remote.Option{}
-	if insecure {
-		nameOpts = append(nameOpts, name.Insecure)
-	}
-	if authProvider != nil {
-		remoteOpts = append(remoteOpts, remote.WithAuth(authProvider))
-	}
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
 
 	moduleImages = map[string]struct{}{}
 	releaseImages, err = getAvailableReleaseChannelsImagesForModule(mod, nameOpts, remoteOpts)

--- a/dhctl/pkg/operations/mirror/pull.go
+++ b/dhctl/pkg/operations/mirror/pull.go
@@ -65,15 +65,7 @@ func PullImageSet(
 	for imageTag := range imageSet {
 		log.InfoF("[%d / %d] Pulling %s...\t", pullCount, totalCount, imageTag)
 
-		pullOpts := []name.Option{}
-		remoteOpts := []remote.Option{}
-		if insecure {
-			pullOpts = append(pullOpts, name.Insecure)
-		}
-		if authProvider != nil {
-			remoteOpts = append(remoteOpts, remote.WithAuth(authProvider))
-		}
-
+		pullOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
 		ref, err := name.ParseReference(imageTag, pullOpts...)
 		if err != nil {
 			return fmt.Errorf("parse image reference %q: %w", imageTag, err)

--- a/dhctl/pkg/operations/mirror/versions.go
+++ b/dhctl/pkg/operations/mirror/versions.go
@@ -48,15 +48,7 @@ func VersionsToCopy(mirrorCtx *Context) ([]*semver.Version, error) {
 }
 
 func getTagsFromRegistry(mirrorCtx *Context) ([]string, error) {
-	nameOpts := []name.Option{}
-	remoteOpts := []remote.Option{}
-	if mirrorCtx.Insecure {
-		nameOpts = append(nameOpts, name.Insecure)
-	}
-	if mirrorCtx.RegistryAuth != nil {
-		remoteOpts = append(remoteOpts, remote.WithAuth(mirrorCtx.RegistryAuth))
-	}
-
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
 	repo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/release-channel", nameOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing repo: %v", err)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`dhctl mirror` will now validate passed credentials such as Deckhouse license tokens and registry logins/passwords prior to mirroring

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We got a feedback about dhctl taking long time to signal about bad registry credentials after push to the third-party registry is started due to the tar bundle unpack procedure taking a few minutes. Only after dhctl is done with it and started pushing, it will find out about bad creds and fail.

## Manual testing

https://github.com/deckhouse/deckhouse/pull/6629#issuecomment-1822893839

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Validate passed credentials against registry prior to mirroring
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
