### PR TITLE
[ingress-nginx] Add validation rule for httpsPort parameter

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -203,6 +203,9 @@ spec:
                   anyOf:
                   - {required: ["httpPort"]}
                   - {required: ["httpsPort"]}
+                  x-kubernetes-validations:
+                    - message: .spec.httpsPort shouldn't equal to 6443
+                      rule: 'self.httpsPort != 6443'
                   properties:
                     httpPort:
                       type: integer
@@ -222,9 +225,6 @@ spec:
 
                         This parameter is mandatory if `httpPort` is not set.
                       x-doc-examples: ['443']
-                      x-kubernetes-validations:
-                        - message: .spec.httpsPort shouldn't equal to 6443 for .spec.annotationValidationEnabled to make effect
-                          rule: 'self.annotationValidationEnabled == true ? self.httpsPort != 6443: true'
                     behindL7Proxy:
                       type: boolean
                       description: |

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -204,7 +204,7 @@ spec:
                   - {required: ["httpPort"]}
                   - {required: ["httpsPort"]}
                   x-kubernetes-validations:
-                    - message: .spec.httpsPort shouldn't equal to 6443
+                    - message: .spec.httpsPort can't be 6443, it reserved for KubeApiServer
                       rule: 'self.httpsPort != 6443'
                   properties:
                     httpPort:

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -222,6 +222,9 @@ spec:
 
                         This parameter is mandatory if `httpPort` is not set.
                       x-doc-examples: ['443']
+                      x-kubernetes-validations:
+                        - message: .spec.httpsPort shouldn't equal to 6443 for .spec.annotationValidationEnabled to make effect
+                          rule: 'self.annotationValidationEnabled == true ? self.httpsPort != 6443: true'
                     behindL7Proxy:
                       type: boolean
                       description: |

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -204,7 +204,7 @@ spec:
                   - {required: ["httpPort"]}
                   - {required: ["httpsPort"]}
                   x-kubernetes-validations:
-                    - message: .spec.httpsPort can't be 6443, it reserved for KubeApiServer
+                    - message: .spec.httpsPort can't be 6443, it's reserved for kube-apiserver
                       rule: 'self.httpsPort != 6443'
                   properties:
                     httpPort:


### PR DESCRIPTION
## Description
Add ingressnginxcontrollers crd validation for httpsPort field. Forbid to use 6443 port for inlet HostPort mode.

## Why do we need it, and what problem does it solve?
Fix issue #3961
inlet HostPort with 6443 port may break k8s controlplane if ingress controller scheduled to control-plane nodes. Validation rule prevents that issue.

## Why do we need it in the patch release (if we do)?

The issue can be reproduced in all previous releases, so it's better to check a port there too.

## What is the expected result?
<pre>
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# ingressnginxcontrollers.deckhouse.io "main" was not valid:
# * spec.hostPort: Invalid value: "object": .spec.httpsPort shouldn't equal to 6443
#
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"deckhouse.io/v1","kind":"IngressNginxController","metadata":{"annotations":{},"name":"main"},"spec":{"hostPort":{"httpPort":80,"httpsPort":443},"ingressClass":"nginx","inlet":"HostPort","nodeSelector":{"node-role.kubernetes.io/master":""},"tolerations":[{"effect":"NoSchedule","operator":"Exists"}]}}
  creationTimestamp: "2023-11-16T13:04:31Z"
  generation: 1
  name: main
  resourceVersion: "8646"
  uid: 2ccd2801-18ce-4599-8c44-aebd3e279bf7
spec:
  annotationValidationEnabled: false
  chaosMonkey: false
  disableHTTP2: false
  hostPort:
    httpPort: 80
    httpsPort: 6443
    realIPHeader: X-Forwarded-For
  hsts: false
  ingressClass: nginx
  inlet: HostPort
  maxReplicas: 1
  minReplicas: 1
  nodeSelector:
    node-role.kubernetes.io/master: ""
  tolerations:
  - effect: NoSchedule
    operator: Exists
  underscoresInHeaders: false
  validationEnabled: true
</pre>
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: ingressnginxcontrollers crd validation for httpsPort
impact: ingress controller pods will be restarted
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
