### PR TITLE
[dhctl] Fix release channel does not get from InitConfiguration

### DIFF
--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -164,10 +164,13 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	bundle := DefaultBundle
 	logLevel := DefaultLogLevel
 
+	releaseChannel := ""
+
 	// todo after release 1.55 remove it and from openapi schema
 	deprecatedFields := make([]string, 0, 3)
 	deprecatedFieldsExamples := make([]string, 0, 3)
 	if metaConfig.DeckhouseConfig.ReleaseChannel != "" {
+		releaseChannel = metaConfig.DeckhouseConfig.ReleaseChannel
 		deprecatedFields = append(deprecatedFields, "releaseChannel")
 		deprecatedFieldsExamples = append(deprecatedFieldsExamples, "releaseChannel: Stable")
 	}
@@ -222,8 +225,6 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 			bundle = bundleRaw.(string)
 		}
 	}
-
-	releaseChannel := ""
 
 	if deckhouseCm == nil {
 		deckhouseCm, err = buildModuleConfigWithOverrides(schemasStore, "deckhouse", true, map[string]any{

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -30,6 +30,35 @@ func generateMetaConfigForDeckhouseConfigTestWithErr(t *testing.T, data map[stri
 	return generateMetaConfig(t, configOverridesTemplate, data, true)
 }
 
+func TestDeckhouseReleaseChannelDeprecated(t *testing.T) {
+	metaConfig := generateMetaConfig(t, `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: "1.28"
+clusterDomain: "cluster.local"
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  devBranch: aaaa
+  releaseChannel: Beta
+---
+apiVersion: deckhouse.io/v1alpha1
+# type of the configuration section
+kind: StaticClusterConfiguration
+# address space for the cluster's internal network
+internalNetworkCIDRs:
+- 192.168.199.0/24
+
+`, map[string]interface{}{}, false)
+	iCfg, err := PrepareDeckhouseInstallConfig(metaConfig)
+	require.NoError(t, err)
+	require.Equal(t, iCfg.ReleaseChannel, "Beta")
+}
+
 func TestModuleDeckhouseConfigOverridesAndMc(t *testing.T) {
 	t.Run("Fail whe module config and config overrides", func(t *testing.T) {
 		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -400,11 +400,15 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 					if createMsg != "" {
 						log.InfoLn(createMsg)
 					}
+					// need for invalidate cache
+					_, _ = kubeCl.APIResourceList(config.ModuleConfigGroup + "/" + config.ModuleConfigVersion)
 					_, err := kubeCl.Dynamic().Resource(config.ModuleConfigGVR).
 						Create(context.TODO(), manifest.(*unstructured.Unstructured), metav1.CreateOptions{})
 					return err
 				},
 				UpdateFunc: func(manifest interface{}) error {
+					// need for invalidate cache
+					_, _ = kubeCl.APIResourceList(config.ModuleConfigGroup + "/" + config.ModuleConfigVersion)
 					_, err := kubeCl.Dynamic().Resource(config.ModuleConfigGVR).
 						Update(context.TODO(), manifest.(*unstructured.Unstructured), metav1.UpdateOptions{})
 					return err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -400,10 +401,13 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 					if createMsg != "" {
 						log.InfoLn(createMsg)
 					}
-					// need for invalidate cache
-					_, err := kubeCl.APIResource(config.ModuleConfigGroup+"/"+config.ModuleConfigVersion, config.ModuleConfigKind)
-					if err != nil {
-						log.DebugF("Error getting mc api resource: %v\n", err)
+					// fake client does not support cache
+					if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
+						// need for invalidate cache
+						_, err := kubeCl.APIResource(config.ModuleConfigGroup+"/"+config.ModuleConfigVersion, config.ModuleConfigKind)
+						if err != nil {
+							log.DebugF("Error getting mc api resource: %v\n", err)
+						}
 					}
 
 					_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).
@@ -415,10 +419,13 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 					return err
 				},
 				UpdateFunc: func(manifest interface{}) error {
-					// need for invalidate cache
-					_, err := kubeCl.APIResource(config.ModuleConfigGroup+"/"+config.ModuleConfigVersion, config.ModuleConfigKind)
-					if err != nil {
-						log.DebugF("Error getting mc api resource: %v\n", err)
+					// fake client does not support cache
+					if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
+						// need for invalidate cache
+						_, err := kubeCl.APIResource(config.ModuleConfigGroup+"/"+config.ModuleConfigVersion, config.ModuleConfigKind)
+						if err != nil {
+							log.DebugF("Error getting mc api resource: %v\n", err)
+						}
 					}
 
 					_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -421,7 +421,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 
 	err := log.Process("default", "Create Manifests", func() error {
 		for _, task := range tasks {
-			err := retry.NewSilentLoop(task.Name, 15, 5*time.Second).Run(task.CreateOrUpdate)
+			err := retry.NewSilentLoop(task.Name, 45, 10*time.Second).Run(task.CreateOrUpdate)
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -32,10 +32,16 @@ import (
 )
 
 func TestDeckhouseInstall(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
 	log.InitLogger("simple")
 	fakeClient := client.NewFakeKubernetesClient()
 
-	err := os.WriteFile("/deckhouse/version", []byte("1.54.1"), 0o666)
+	err = os.WriteFile("/deckhouse/version", []byte("1.54.1"), 0o666)
 	if err != nil {
 		panic(err)
 	}
@@ -121,9 +127,15 @@ func TestDeckhouseInstall(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithDevBranch(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
 	fakeClient := client.NewFakeKubernetesClient()
 
-	err := os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
 	if err != nil {
 		panic(err)
 	}
@@ -140,7 +152,13 @@ func TestDeckhouseInstallWithDevBranch(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
-	err := os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
 	if err != nil {
 		panic(err)
 	}
@@ -184,7 +202,13 @@ func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
-	err := os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
 	if err != nil {
 		panic(err)
 	}

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -39,6 +39,7 @@ type KubeClient interface {
 	kubernetes.Interface
 	Dynamic() dynamic.Interface
 	APIResourceList(apiVersion string) ([]*metav1.APIResourceList, error)
+	APIResource(apiVersion, kind string) (*metav1.APIResource, error)
 	GroupVersionResource(apiVersion, kind string) (schema.GroupVersionResource, error)
 }
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -57,7 +57,7 @@ func getSSHClient() (*ssh.Client, error) {
 	}
 
 	if bastionHost != "" {
-		setBastionHostFromCloudProvider(bastionHost, nil)
+		setBastionHost(bastionHost, nil)
 	}
 
 	return ssh.NewClientFromFlags().Start()

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -334,6 +334,14 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		}
 		_ = json.Unmarshal(metaConfig.ClusterConfig["static"], &static)
 		nodeIP = static.NodeIP
+
+		if sshClient.Settings.BastionHost != "" {
+			SaveBastionHostToCache(sshClient.Settings.BastionHost)
+		}
+
+		SaveMasterHostsToCache(map[string]string{
+			"first-master": sshClient.Settings.Host(),
+		})
 	}
 
 	// next parse and check resources

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -304,7 +304,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			deckhouseInstallConfig.TerraformState = baseOutputs.TerraformState
 
 			if baseOutputs.BastionHost != "" {
-				setBastionHostFromCloudProvider(baseOutputs.BastionHost, sshClient)
+				setBastionHost(baseOutputs.BastionHost, sshClient)
 				SaveBastionHostToCache(baseOutputs.BastionHost)
 			}
 
@@ -525,7 +525,7 @@ func bootstrapAdditionalNodesForCloudCluster(kubeCl *client.KubernetesClient, me
 	})
 }
 
-func setBastionHostFromCloudProvider(host string, sshClient *ssh.Client) {
+func setBastionHost(host string, sshClient *ssh.Client) {
 	app.SSHBastionHost = host
 
 	if app.SSHBastionUser == "" {

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -54,7 +54,7 @@ type ClusterDestroyer struct {
 
 	skipResources bool
 
-	staticDestroyer *staticMastersDestroyer
+	staticDestroyer *StaticMastersDestroyer
 
 	*phases.PhasedExecutionContext
 }
@@ -66,7 +66,7 @@ func NewClusterDestroyer(params *Params) *ClusterDestroyer {
 	terraStateLoader := terraform.NewLazyTerraStateLoader(terraform.NewCachedTerraStateLoader(d8Destroyer, state.cache))
 	clusterInfra := infra.NewClusterInfraWithOptions(terraStateLoader, state.cache, infra.ClusterInfraOptions{PhasedExecutionContext: pec})
 
-	staticDestroyer := newStaticMastersDestroyer(params.SSHClient)
+	staticDestroyer := NewStaticMastersDestroyer(params.SSHClient)
 
 	return &ClusterDestroyer{
 		state:           state,
@@ -152,17 +152,17 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 	return d.PhasedExecutionContext.Complete()
 }
 
-type staticMastersDestroyer struct {
+type StaticMastersDestroyer struct {
 	SSHClient *ssh.Client
 }
 
-func newStaticMastersDestroyer(c *ssh.Client) *staticMastersDestroyer {
-	return &staticMastersDestroyer{
+func NewStaticMastersDestroyer(c *ssh.Client) *StaticMastersDestroyer {
+	return &StaticMastersDestroyer{
 		SSHClient: c,
 	}
 }
 
-func (d *staticMastersDestroyer) DestroyCluster(autoApprove bool) error {
+func (d *StaticMastersDestroyer) DestroyCluster(autoApprove bool) error {
 	if !autoApprove {
 		if !input.NewConfirmation().WithMessage("Do you really want to cleanup control-plane nodes?").Ask() {
 			return fmt.Errorf("Cleanup master nodes disallow")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix release channel does not get from InitConfiguration.
Dhctl cannot create module config resources during bootstrap fixed. We now invalidate kube-client cache.
Abort did not work with static clusters fixed

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Old set release channel mechanism not work.

## Why do we need it in the patch release (if we do)?

Instructions from getting started don't work

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix release channel does not get from InitConfiguration
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
