### PR TITLE
[testing] Fixes

### DIFF
--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script_eks.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script_eks.sh
@@ -43,7 +43,7 @@ for i in $(seq $attempts); do
   sleep 30
 
   if upmeter_addr=$(kubectl -n d8-upmeter get ep upmeter -o json | jq -re '.subsets[].addresses[0] | .ip') 2>/dev/null; then
-    if upmeter_auth_token="$(kubectl -n d8-upmeter exec ds/upmeter-agent -c agent -- cat /run/secrets/kubernetes.io/serviceaccount/token)" 2>/dev/null; then
+    if upmeter_auth_token="$(kubectl -n d8-upmeter create token upmeter-agent)" 2>/dev/null; then
 
       # Getting availability data based on last 30 seconds of probe stats, note 'peek=1' query
       # param.


### PR DESCRIPTION
## Description
Fix e2e tests to test release updates.

## Why do we need it, and what problem does it solve?
E2e test for testing release updates doesn't work.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: chore
summary: Fix e2e tests to test release updates.
impact_level: low
```
