### PR TITLE
[deckhouse] Add annotation to apply DeckhouseRelease immediately

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/release.go
+++ b/modules/002-deckhouse/hooks/internal/updater/release.go
@@ -44,6 +44,7 @@ type DeckhouseRelease struct {
 type DeckhouseReleaseAnnotationsFlags struct {
 	Suspend            bool
 	Force              bool
+	ApplyNow           bool
 	DisruptionApproved bool
 	NotificationShift  bool // time shift by the notification process
 }

--- a/modules/002-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image.go
@@ -202,6 +202,11 @@ func updateDeckhouse(input *go_hook.HookInput, dc dependency.Container) error {
 		return nil
 	}
 
+	if deckhouseUpdater.HasAppliedNowRelease() {
+		deckhouseUpdater.ApplyAppliedNowRelease()
+		return nil
+	}
+
 	if deckhouseUpdater.PredictedReleaseIsPatch() {
 		// patch release does not respect update windows or ManualMode
 		deckhouseUpdater.ApplyPredictedRelease(nil)
@@ -251,6 +256,12 @@ func filterDeckhouseRelease(unstructured *unstructured.Unstructured) (go_hook.Fi
 	if v, ok := release.Annotations["release.deckhouse.io/force"]; ok {
 		if v == "true" {
 			annotationFlags.Force = true
+		}
+	}
+
+	if v, ok := release.Annotations["release.deckhouse.io/apply-now"]; ok {
+		if v == "true" {
+			annotationFlags.ApplyNow = true
 		}
 	}
 

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -819,6 +819,97 @@ metadata:
 			Expect(r126.Field("metadata.annotations.release\\.deckhouse\\.io/notification-time-shift").Exists()).To(BeTrue())
 		})
 	})
+
+	Context("release with apply-now annotation out of window", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("deckhouse.update.windows", []byte(`[{"from": "8:00", "to": "10:00"}]`))
+
+			f.KubeStateSet(deckhousePodYaml + appliedNowReleases)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+		It("Should upgrade deckhouse deployment", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
+			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.26.0"))
+
+			release := f.KubernetesGlobalResource("DeckhouseRelease", "v1.26.0")
+			Expect(release.Field(`metadata.annotations.release\.deckhouse\.io/apply-now`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Deckhouse previous release is not ready", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("deckhouse.update.windows", []byte(`[{"from": "00:00", "to": "23:59"}]`))
+
+			f.KubeStateSet(deckhouseDeployment + deckhouseNotReadyPod + appliedNowReleases)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+		It("Should not upgrade deckhouse version", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
+			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.0"))
+		})
+	})
+
+	Context("Manual approval mode is set", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("deckhouse.update.mode", []byte(`"Manual"`))
+			f.ValuesDelete("deckhouse.update.windows")
+
+			f.KubeStateSet(deckhouseDeployment + deckhouseReadyPod + appliedNowReleases)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+		It("Should upgrade deckhouse deployment", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
+			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.26.0"))
+
+			release := f.KubernetesGlobalResource("DeckhouseRelease", "v1.26.0")
+			Expect(release.Field(`metadata.annotations.release\.deckhouse\.io/apply-now`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("applied now postponed release", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(deckhousePodYaml + `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.25.0
+spec:
+  version: "v1.25.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.25.1
+  annotations:
+    release.deckhouse.io/apply-now: "true"
+spec:
+  version: "v1.25.1"
+  applyAfter: "2222-11-11T23:23:23Z"
+status:
+  phase: Pending
+`)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+
+		It("Should upgrade deckhouse deployment", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
+			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.1"))
+
+			release := f.KubernetesGlobalResource("DeckhouseRelease", "v1.25.1")
+			Expect(release.Field(`metadata.annotations.release\.deckhouse\.io/apply-now`).Exists()).To(BeFalse())
+		})
+	})
 })
 
 const (
@@ -934,6 +1025,27 @@ metadata:
 spec:
   version: "v1.26.0"
 approved: true
+`
+
+	appliedNowReleases = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.25.0
+spec:
+  version: "v1.25.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.26.0
+  annotations:
+    release.deckhouse.io/apply-now: "true"
+spec:
+  version: "v1.26.0"
 `
 
 	deckhousePatchRelease = `


### PR DESCRIPTION
## Description
Add the release.deckhouse.io/apply-now: true annotation
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/5772
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---
## Why do we need it in the patch release (if we do)?

Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->


<!---
## What is the expected result?

  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Added annotation `release.deckhouse.io/apply-now` which allows to apply the update without waiting for time restrictions.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
