### PR TITLE
[cloud-provider-yandex] Add support for ru-central1-d zone in Yandex Cloud

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -89,6 +89,7 @@ apiVersions:
               - ru-central1-a
               - ru-central1-b
               - ru-central1-c
+              - ru-central1-d
             uniqueItems: true
           instanceClass:
             type: object
@@ -202,6 +203,7 @@ apiVersions:
                 - ru-central1-a
                 - ru-central1-b
                 - ru-central1-c
+                - ru-central1-d
               uniqueItems: true
             nodeTemplate:
               description: |
@@ -300,6 +302,7 @@ apiVersions:
           - ru-central1-a: e2lu8r1tbbtryhdpa9ro
             ru-central1-b: e2lu8r1tbbtryhdpa9ro
             ru-central1-c: e2lu8r1tbbtryhdpa9ro
+            ru-central1-d: e2lu8r1tbbtryhdpa9ro
         additionalProperties:
           type: string
         pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
@@ -417,6 +420,7 @@ apiVersions:
             - ru-central1-a
             - ru-central1-b
             - ru-central1-c
+            - ru-central1-d
         uniqueItems: true
     oneOf:
     - required: [layout]

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -19,6 +19,7 @@ locals {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
     "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
     "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
+    "ru-central1-d" = length(data.yandex_vpc_subnet.kube_d) > 0 ? data.yandex_vpc_subnet.kube_d[0] : object({})
   } : data.yandex_vpc_subnet.existing
 
   actual_zones    = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(keys(local.zone_to_subnet), var.providerClusterConfiguration.zones)) : keys(local.zone_to_subnet)
@@ -52,6 +53,11 @@ data "yandex_vpc_subnet" "kube_b" {
 data "yandex_vpc_subnet" "kube_c" {
   count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-c"
+}
+
+data "yandex_vpc_subnet" "kube_d" {
+  count = length(local.mapping) == 0 ? 1 : 0
+  name = "${local.prefix}-d"
 }
 
 resource "yandex_vpc_address" "addr" {

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -19,6 +19,7 @@ locals {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
     "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
     "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
+    "ru-central1-d" = length(data.yandex_vpc_subnet.kube_d) > 0 ? data.yandex_vpc_subnet.kube_d[0] : object({})
   } : data.yandex_vpc_subnet.existing
 
   actual_zones    = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(keys(local.zone_to_subnet), var.providerClusterConfiguration.zones)) : keys(local.zone_to_subnet)
@@ -51,6 +52,11 @@ data "yandex_vpc_subnet" "kube_b" {
 data "yandex_vpc_subnet" "kube_c" {
   count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-c"
+}
+
+data "yandex_vpc_subnet" "kube_d" {
+  count = length(local.mapping) == 0 ? 1 : 0
+  name = "${local.prefix}-d"
 }
 
 resource "yandex_vpc_address" "addr" {

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -18,10 +18,12 @@ locals {
   kube_a_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 0) : null
   kube_b_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 1) : null
   kube_c_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 2) : null
+  kube_d_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 3) : null
 
   not_have_existing_subnet_a = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null)
   not_have_existing_subnet_b = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null)
   not_have_existing_subnet_c = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null)
+  not_have_existing_subnet_d = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-d", null) == null)
 
   is_with_nat_instance = var.layout == "WithNATInstance"
   is_standard          = var.layout == "Standard"
@@ -43,6 +45,11 @@ data "yandex_vpc_subnet" "kube_b" {
 data "yandex_vpc_subnet" "kube_c" {
   count     = local.not_have_existing_subnet_c ? 0 : 1
   subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-c
+}
+
+data "yandex_vpc_subnet" "kube_d" {
+  count     = local.not_have_existing_subnet_d ? 0 : 1
+  subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-d
 }
 
 resource "yandex_vpc_gateway" "kube" {
@@ -131,6 +138,31 @@ resource "yandex_vpc_subnet" "kube_c" {
   v4_cidr_blocks = [local.kube_c_v4_cidr_block]
   route_table_id = yandex_vpc_route_table.kube.id
   zone           = "ru-central1-c"
+
+  dynamic "dhcp_options" {
+    for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []
+    content {
+      domain_name         = var.dhcp_domain_name
+      domain_name_servers = var.dhcp_domain_name_servers
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      v4_cidr_blocks,
+    ]
+  }
+
+  labels = var.labels
+}
+
+resource "yandex_vpc_subnet" "kube_d" {
+  count          = local.should_create_subnets ? 1 : 0
+  name           = "${var.prefix}-d"
+  network_id     = var.network_id
+  v4_cidr_blocks = [local.kube_d_v4_cidr_block]
+  route_table_id = yandex_vpc_route_table.kube.id
+  zone           = "ru-central1-d"
 
   dynamic "dhcp_options" {
     for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -36,6 +36,7 @@ locals {
       "ru-central1-a" = local.should_create_subnets ? yandex_vpc_subnet.kube_a[0].id : (local.not_have_existing_subnet_a ? null : data.yandex_vpc_subnet.kube_a[0].id)
       "ru-central1-b" = local.should_create_subnets ? yandex_vpc_subnet.kube_b[0].id : (local.not_have_existing_subnet_b ? null : data.yandex_vpc_subnet.kube_b[0].id)
       "ru-central1-c" = local.should_create_subnets ? yandex_vpc_subnet.kube_c[0].id : (local.not_have_existing_subnet_c ? null : data.yandex_vpc_subnet.kube_c[0].id)
+      "ru-central1-d" = local.should_create_subnets ? yandex_vpc_subnet.kube_d[0].id : (local.not_have_existing_subnet_d ? null : data.yandex_vpc_subnet.kube_d[0].id)
     })
 
   # we can not use one map because we will get cycle
@@ -44,6 +45,7 @@ locals {
     "ru-central1-a" = local.should_create_subnets ? local.kube_a_v4_cidr_block : (local.not_have_existing_subnet_a ? null : data.yandex_vpc_subnet.kube_a[0].v4_cidr_blocks[0])
     "ru-central1-b" = local.should_create_subnets ? local.kube_b_v4_cidr_block : (local.not_have_existing_subnet_b ? null : data.yandex_vpc_subnet.kube_b[0].v4_cidr_blocks[0])
     "ru-central1-c" = local.should_create_subnets ? local.kube_c_v4_cidr_block : (local.not_have_existing_subnet_c ? null : data.yandex_vpc_subnet.kube_c[0].v4_cidr_blocks[0])
+    "ru-central1-d" = local.should_create_subnets ? local.kube_d_v4_cidr_block : (local.not_have_existing_subnet_d ? null : data.yandex_vpc_subnet.kube_d[0].v4_cidr_blocks[0])
   })
 
   # if user set internal subnet id for nat instance get cidr from its subnet

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
@@ -16,6 +16,7 @@ locals {
   zone_to_subnet_id_map_a = merge({}, (length(data.yandex_vpc_subnet.kube_a) > 0 ? {(data.yandex_vpc_subnet.kube_a[0].zone): data.yandex_vpc_subnet.kube_a[0].id } : {} ))
   zone_to_subnet_id_map_b = merge(local.zone_to_subnet_id_map_a, (length(data.yandex_vpc_subnet.kube_b) > 0 ?{(data.yandex_vpc_subnet.kube_b[0].zone): data.yandex_vpc_subnet.kube_b[0].id } : {} ))
   zone_to_subnet_id_map_c_final = merge(local.zone_to_subnet_id_map_b, (length(data.yandex_vpc_subnet.kube_c) > 0 ? {(data.yandex_vpc_subnet.kube_c[0].zone): data.yandex_vpc_subnet.kube_c[0].id } : {} ))
+  zone_to_subnet_id_map_d = merge(local.zone_to_subnet_id_map_c_final, (length(data.yandex_vpc_subnet.kube_d) > 0 ? {(data.yandex_vpc_subnet.kube_d[0].zone): data.yandex_vpc_subnet.kube_d[0].id } : {} ))
 }
 
 output "route_table_id" {
@@ -27,6 +28,7 @@ output "zone_to_subnet_id_map" {
       (yandex_vpc_subnet.kube_a[0].zone): yandex_vpc_subnet.kube_a[0].id
       (yandex_vpc_subnet.kube_b[0].zone): yandex_vpc_subnet.kube_b[0].id
       (yandex_vpc_subnet.kube_c[0].zone): yandex_vpc_subnet.kube_c[0].id
+      (yandex_vpc_subnet.kube_d[0].zone): yandex_vpc_subnet.kube_d[0].id
     } : local.zone_to_subnet_id_map_c_final
 }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
@@ -15,8 +15,8 @@
 locals {
   zone_to_subnet_id_map_a = merge({}, (length(data.yandex_vpc_subnet.kube_a) > 0 ? {(data.yandex_vpc_subnet.kube_a[0].zone): data.yandex_vpc_subnet.kube_a[0].id } : {} ))
   zone_to_subnet_id_map_b = merge(local.zone_to_subnet_id_map_a, (length(data.yandex_vpc_subnet.kube_b) > 0 ?{(data.yandex_vpc_subnet.kube_b[0].zone): data.yandex_vpc_subnet.kube_b[0].id } : {} ))
-  zone_to_subnet_id_map_c_final = merge(local.zone_to_subnet_id_map_b, (length(data.yandex_vpc_subnet.kube_c) > 0 ? {(data.yandex_vpc_subnet.kube_c[0].zone): data.yandex_vpc_subnet.kube_c[0].id } : {} ))
-  zone_to_subnet_id_map_d = merge(local.zone_to_subnet_id_map_c_final, (length(data.yandex_vpc_subnet.kube_d) > 0 ? {(data.yandex_vpc_subnet.kube_d[0].zone): data.yandex_vpc_subnet.kube_d[0].id } : {} ))
+  zone_to_subnet_id_map_c = merge(local.zone_to_subnet_id_map_b, (length(data.yandex_vpc_subnet.kube_c) > 0 ? {(data.yandex_vpc_subnet.kube_c[0].zone): data.yandex_vpc_subnet.kube_c[0].id } : {} ))
+  zone_to_subnet_id_map_d_final = merge(local.zone_to_subnet_id_map_c, (length(data.yandex_vpc_subnet.kube_d) > 0 ? {(data.yandex_vpc_subnet.kube_d[0].zone): data.yandex_vpc_subnet.kube_d[0].id } : {} ))
 }
 
 output "route_table_id" {
@@ -29,7 +29,7 @@ output "zone_to_subnet_id_map" {
       (yandex_vpc_subnet.kube_b[0].zone): yandex_vpc_subnet.kube_b[0].id
       (yandex_vpc_subnet.kube_c[0].zone): yandex_vpc_subnet.kube_c[0].id
       (yandex_vpc_subnet.kube_d[0].zone): yandex_vpc_subnet.kube_d[0].id
-    } : local.zone_to_subnet_id_map_c_final
+    } : local.zone_to_subnet_id_map_d_final
 }
 
 output "nat_instance_name" {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add support for ru-central1-d availability zone in Yandex Cloud

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Closes #6513
Closes #6546

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We don't

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
- New clusters successfully bootstrapped in new zone
- Existing clusters does not broken after converge
- It is possible to successfully change a zone of nodes in an existing `NodeGroup`

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Add support for the `ru-central1-d` zone in Yandex Cloud.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
