### PR TITLE
[candi] Set badge for ClusterConfiguration proxy parameters

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -124,6 +124,7 @@ apiVersions:
         - "1.28"
         - "Automatic"
       proxy:
+        x-doc-d8Revision: ee
         type: object
         description: |
           Global proxy setup (especially for working in air-gapped environments).
@@ -133,6 +134,7 @@ apiVersions:
         properties:
           httpProxy:
             type: string
+            x-doc-d8Revision: ee
             pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
             description: |
               Proxy URL for HTTP requests.
@@ -143,6 +145,7 @@ apiVersions:
             - 'https://user:password@proxy.company.my:8443'
           httpsProxy:
             type: string
+            x-doc-d8Revision: ee
             pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
             description: |
               Proxy URL for HTTPS requests.
@@ -152,6 +155,7 @@ apiVersions:
             - 'http://proxy.company.my'
             - 'https://user:password@proxy.company.my:8443'
           noProxy:
+            x-doc-d8Revision: ee
             description: |
               List of no proxy IP and domain entries.
 

--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -20,11 +20,6 @@ module Jekyll
         item['linkAnchor'] = linkAnchor
         item['resourceType'] = resourceType
         item['title'] = %Q(#{if resourceType == 'crd' and  resourceName then resourceName + ":&nbsp;" end}#{parameterName})
-        if resourceType == 'moduleConfig' then
-          puts %Q(moduleName - #{moduleName},
-          resourceName - #{resourceName},
-          parameterName - #{parameterName})
-        end
         if get_hash_value(@context.registers[:site].data['modules'], 'modules', moduleName, %Q(parameters-#{revision})) == nil then
           @context.registers[:site].data['modules']['modules'][moduleName][%Q(parameters-#{revision})] = Hash.new
         end
@@ -479,7 +474,7 @@ module Jekyll
 
         result.push(format_attribute(name, attributes, parent, primaryLanguage, fallbackLanguage)) if attributes.is_a?(Hash)
 
-        if attributes.has_key?('x-doc-d8Revision')
+        if (@moduleName != '') and attributes.has_key?('x-doc-d8Revision')
           case attributes['x-doc-d8Revision']
           when "ee"
             addRevisionParameter(@moduleName, 'ee', @resourceType, resourceName, name, linkAnchor)


### PR DESCRIPTION
## Description
Set a badge for the proxy parameters of the ClusterConfiguration resource that the parameters are for Deckhouse EE only.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Set a badge for the proxy parameters of the _ClusterConfiguration_ resource.
impact_level: low
```
