### PR TITLE
[linstor-test]release 1.53 + linstor 1.25.1

### DIFF
--- a/modules/041-linstor/images/linstor-server/Dockerfile
+++ b/modules/041-linstor/images/linstor-server/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_GOLANG_19_BULLSEYE
 FROM $BASE_UBUNTU as linstor-builder
 
 ARG LINSTOR_GITREPO=https://github.com/LINBIT/linstor-server
-ARG LINSTOR_VERSION=1.24.2
+ARG LINSTOR_VERSION=1.25.1
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
@@ -43,9 +43,9 @@ RUN dpkg-buildpackage -us -uc
 FROM $BASE_UBUNTU as client-builder
 
 ARG API_GITREPO=https://github.com/LINBIT/linstor-api-py
-ARG API_VERSION=1.19.0
+ARG API_VERSION=1.20.1
 ARG CLIENT_GITREPO=https://github.com/LINBIT/linstor-client
-ARG CLIENT_VERSION=1.19.0
+ARG CLIENT_VERSION=1.20.1
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
@@ -134,7 +134,7 @@ RUN dpkg-buildpackage -us -uc
 
 FROM $BASE_UBUNTU
 ARG PIRAEUS_GITREPO=https://github.com/piraeusdatastore/piraeus
-ARG PIRAEUS_COMMIT_REF=20e96f83f52631dc06d011b7f96293d4026236a1
+ARG PIRAEUS_COMMIT_REF=b438aed8dc05f4afcbfe764e8c7d015b5d2890f1
 
 COPY --from=linstor-builder /linstor-common_*.deb /linstor-controller_*.deb /linstor-satellite_*.deb /packages/
 COPY --from=client-builder /python-linstor_*.deb /linstor-client_*.deb /packages/

--- a/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
+++ b/modules/041-linstor/images/linstor-server/patches/fix-symlinks.patch
@@ -1,4 +1,4 @@
-From c72f5942bd665c245fcd51113764335a49046306 Mon Sep 17 00:00:00 2001
+From 4b43e38076ab073198d06f81a26ebed18834b2d4 Mon Sep 17 00:00:00 2001
 From: Andrei Kvapil <kvapss@gmail.com>
 Date: Tue, 3 Oct 2023 13:32:21 +0200
 Subject: [PATCH] Automatically fix symlinks for devices
@@ -12,13 +12,13 @@ fixes: https://github.com/LINBIT/linstor-server/issues/326
 
 Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
 ---
- .../linstor/layer/dmsetup/DmSetupUtils.java   | 79 ++++++++++++++++++-
- .../linbit/linstor/layer/drbd/DrbdLayer.java  | 13 +++
+ .../linstor/layer/dmsetup/DmSetupUtils.java   | 77 +++++++++++++++++++
+ .../linbit/linstor/layer/drbd/DrbdLayer.java  | 13 ++++
  .../linstor/layer/storage/utils/Commands.java | 14 ++++
- 3 files changed, 105 insertions(+), 1 deletion(-)
+ 3 files changed, 104 insertions(+)
 
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
-index ba753577d..cc90ad898 100644
+index b4867c463..cc90ad898 100644
 --- a/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
 +++ b/satellite/src/main/java/com/linbit/linstor/layer/dmsetup/DmSetupUtils.java
 @@ -18,6 +18,8 @@ import com.linbit.utils.StringUtils;
@@ -30,15 +30,6 @@ index ba753577d..cc90ad898 100644
  import java.util.HashSet;
  import java.util.Set;
  import java.util.regex.Matcher;
-@@ -29,7 +31,7 @@ public class DmSetupUtils
-     private static final String DM_SETUP_MESSAGE_FLUSH_ON_SUSPEND = "flush_on_suspend";
- 
-     private static final Pattern DM_SETUP_LS_PATTERN = Pattern.compile(
--        "^([^\\s]+)\\s+\\(([0-9]+)(?::\\s|,\\s)([0-9]+)\\)$",
-+        "^([^\\s]+)\\s+\\(([0-9]+)[:,]\\s*([0-9]+)\\)$",
-         Pattern.MULTILINE
-     );
- 
 @@ -187,6 +189,81 @@ public class DmSetupUtils
          return ret;
      }
@@ -122,7 +113,7 @@ index ba753577d..cc90ad898 100644
      {
          Commands.genericExecutor(
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
-index 16034c550..d44d2bc57 100644
+index 7a537a30b..2d4cf272c 100644
 --- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
 +++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
 @@ -37,6 +37,7 @@ import com.linbit.linstor.core.objects.Volume;
@@ -130,9 +121,9 @@ index 16034c550..d44d2bc57 100644
  import com.linbit.linstor.dbdrivers.DatabaseException;
  import com.linbit.linstor.layer.DeviceLayer;
 +import com.linbit.linstor.layer.dmsetup.DmSetupUtils;
+ import com.linbit.linstor.layer.drbd.drbdstate.DiskState;
  import com.linbit.linstor.layer.drbd.drbdstate.DrbdConnection;
  import com.linbit.linstor.layer.drbd.drbdstate.DrbdEventPublisher;
- import com.linbit.linstor.layer.drbd.drbdstate.DrbdResource;
 @@ -1143,6 +1144,18 @@ public class DrbdLayer implements DeviceLayer
              metaDiskPath = drbdVlmData.getDataDevice();
          }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
