### PR TITLE
[candi] Minor docs fix

### DIFF
--- a/candi/cloud-providers/aws/docs/LAYOUTS.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS.md
@@ -3,7 +3,7 @@ title: "Cloud provider — AWS: Layouts"
 description: "Schemes of placement and interaction of resources in AWS when working with the Deckhouse cloud provider."
 ---
 
-Three layouts are supported. Below is more information about each of them.
+Two layouts are supported. Below is more information about each of them.
 
 ## WithoutNAT
 
@@ -72,8 +72,8 @@ apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration
 layout: WithNAT
 provider:
-  providerAccessKeyId: MYACCESSKEY
-  providerSecretAccessKey: mYsEcReTkEy
+  providerAccessKeyId: '<AWS_ACCESS_KEY>'
+  providerSecretAccessKey: '<AWS_SECRET_ACCESS_KEY>'
   region: eu-central-1
 withNAT:
   bastionInstance:

--- a/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
@@ -3,7 +3,7 @@ title: "Cloud provider — AWS: схемы размещения"
 description: "Описание схем размещения и взаимодействия ресурсов в AWS при работе облачного провайдера Deckhouse."
 ---
 
-Поддерживаются три схемы размещения. Ниже подробнее о каждой их них.
+Поддерживаются две схемы размещения. Ниже подробнее о каждой их них.
 
 ## WithoutNAT
 
@@ -74,8 +74,8 @@ apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration
 layout: WithNAT
 provider:
-  providerAccessKeyId: MYACCESSKEY
-  providerSecretAccessKey: mYsEcReTkEy
+  providerAccessKeyId: '<AWS_ACCESS_KEY>'
+  providerSecretAccessKey: '<AWS_SECRET_ACCESS_KEY>'
   region: eu-central-1
 withNAT:
   bastionInstance:


### PR DESCRIPTION
## Description
Minor docs fix

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: candi
type: chore
summary: Minor docs fix.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
