### PR TITLE
[node-manager] Fix node-manager does not remove node.deckhouse.io/unitialized taint when use one taint with different effects

### DIFF
--- a/go_lib/taints/slice.go
+++ b/go_lib/taints/slice.go
@@ -48,13 +48,17 @@ func (s Slice) WithoutKey(key string) Slice {
 
 // Merge returns new merged slice.
 func (s Slice) Merge(in []v1.Taint) Slice {
+	taintKey := func(t v1.Taint) string {
+		return t.Key + string(t.Effect) + t.Value
+	}
+
 	resMap := make(Map)
 	for _, t := range s {
-		resMap[t.Key] = t
+		resMap[taintKey(t)] = t
 	}
 
 	for _, t := range in {
-		resMap[t.Key] = t
+		resMap[taintKey(t)] = t
 	}
 
 	// Sort keys and return taints as an array.

--- a/modules/040-node-manager/hooks/handle_node_templates_test.go
+++ b/modules/040-node-manager/hooks/handle_node_templates_test.go
@@ -900,6 +900,83 @@ spec:
 			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_taint_missing", pointer.Float64(1))).To(BeTrue())
 		})
 	})
+
+	Context("NG Cloud Node with different taint effects", func() {
+		BeforeEach(func() {
+			state := `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: wor-ker
+spec:
+  nodeType: CloudEphemeral
+  nodeTemplate:
+    taints:
+    - effect: NoExecute
+      key: node-role
+      value: monitoring
+    - effect: NoSchedule
+      key: node-role
+      value: monitoring
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: wor-ker
+  labels:
+    node.deckhouse.io/group: wor-ker
+    node-role.kubernetes.io/wor-ker: ""
+spec:
+  taints:
+  - effect: NoExecute
+    key: node-role
+    value: monitoring
+  - effect: NoSchedule
+    key: node-role
+    value: monitoring
+  - effect: NoSchedule
+    key: node.deckhouse.io/uninitialized
+`
+			f.BindingContexts.Set(f.KubeStateSet(state))
+			f.RunHook()
+		})
+
+		It("Deletes taint node.deckhouse.io/uninitialized when ng and node have one taint with different effects", func() {
+			expectedJSON := `
+            {
+              "apiVersion": "v1",
+              "kind": "Node",
+              "metadata": {
+                "labels": {
+                  "node.deckhouse.io/group": "wor-ker",
+                  "node-role.kubernetes.io/wor-ker": ""
+                },
+                "name": "wor-ker"
+              },
+                "spec": {
+                  "taints": [
+                    {
+                      "effect": "NoExecute",
+                      "key": "node-role",
+                      "value": "monitoring"
+                    },
+                    {
+                      "effect": "NoSchedule",
+                      "key": "node-role",
+                      "value": "monitoring"
+                    }
+                  ]
+                }
+              }
+          `
+			Expect(f).To(ExecuteSuccessfully())
+			n := f.KubernetesGlobalResource("Node", "wor-ker")
+			Expect(n.Parse().DropFields("status", "metadata.creationTimestamp")).
+				To(MatchJSON(expectedJSON))
+			Expect(f.MetricsCollector.CollectedMetrics()).Should(HaveLen(1), "should have only expire metric for managed node")
+		})
+	})
 })
 
 func metricEqual(metrics []operation.MetricOperation, name string, value *float64) bool {


### PR DESCRIPTION

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
