### PR TITLE
[dhctl] Fix Deckhouse CE registry setting do not set if InitConfiguration was skipped

### DIFF
--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -174,6 +174,60 @@ func parseConfigFromCluster(kubeCl *client.KubernetesClient) (*MetaConfig, error
 	return metaConfig.Prepare()
 }
 
+func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore) error {
+	doc = strings.TrimSpace(doc)
+	if doc == "" {
+		return nil
+	}
+
+	docData := []byte(doc)
+
+	var index SchemaIndex
+	err := yaml.Unmarshal(docData, &index)
+	if err != nil {
+		return err
+	}
+
+	if index.Kind == ModuleConfigKind {
+		moduleConfig := ModuleConfig{}
+		err = yaml.Unmarshal(docData, &moduleConfig)
+		if err != nil {
+			return err
+		}
+
+		_, err = schemaStore.Validate(&docData)
+		if err != nil {
+			return fmt.Errorf("module config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
+		}
+
+		metaConfig.ModuleConfigs = append(metaConfig.ModuleConfigs, &moduleConfig)
+		return nil
+	}
+
+	_, err = schemaStore.Validate(&docData)
+	if err != nil {
+		return fmt.Errorf("config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
+	}
+
+	var data map[string]json.RawMessage
+	if err = yaml.Unmarshal(docData, &data); err != nil {
+		return fmt.Errorf("config unmarshal: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
+	}
+
+	switch {
+	case index.Kind == "InitConfiguration":
+		metaConfig.InitClusterConfig = data
+	case index.Kind == "ClusterConfiguration":
+		metaConfig.ClusterConfig = data
+	case index.Kind == "StaticClusterConfiguration":
+		metaConfig.StaticClusterConfig = data
+	case strings.HasSuffix(index.Kind, "ClusterConfiguration"):
+		metaConfig.ProviderClusterConfig = data
+	}
+
+	return nil
+}
+
 func ParseConfigFromData(configData string) (*MetaConfig, error) {
 	schemaStore := NewSchemaStore()
 
@@ -182,54 +236,20 @@ func ParseConfigFromData(configData string) (*MetaConfig, error) {
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {
-		doc = strings.TrimSpace(doc)
-		if doc == "" {
-			continue
-		}
-
-		docData := []byte(doc)
-
-		var index SchemaIndex
-		err := yaml.Unmarshal(docData, &index)
-		if err != nil {
+		if err := parseDocument(doc, &metaConfig, schemaStore); err != nil {
 			return nil, err
 		}
+	}
 
-		if index.Kind == ModuleConfigKind {
-			moduleConfig := ModuleConfig{}
-			err = yaml.Unmarshal(docData, &moduleConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			_, err = schemaStore.Validate(&docData)
-			if err != nil {
-				return nil, fmt.Errorf("module config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
-			}
-
-			metaConfig.ModuleConfigs = append(metaConfig.ModuleConfigs, &moduleConfig)
-			continue
-		}
-
-		_, err = schemaStore.Validate(&docData)
-		if err != nil {
-			return nil, fmt.Errorf("config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
-		}
-
-		var data map[string]json.RawMessage
-		if err = yaml.Unmarshal(docData, &data); err != nil {
-			return nil, fmt.Errorf("config unmarshal: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
-		}
-
-		switch {
-		case index.Kind == "InitConfiguration":
-			metaConfig.InitClusterConfig = data
-		case index.Kind == "ClusterConfiguration":
-			metaConfig.ClusterConfig = data
-		case index.Kind == "StaticClusterConfiguration":
-			metaConfig.StaticClusterConfig = data
-		case strings.HasSuffix(index.Kind, "ClusterConfiguration"):
-			metaConfig.ProviderClusterConfig = data
+	// init configuration can be empty, but we need default from openapi spec
+	if len(metaConfig.InitClusterConfig) == 0 {
+		doc := `
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse: {}
+`
+		if err := parseDocument(doc, &metaConfig, schemaStore); err != nil {
+			return nil, err
 		}
 	}
 

--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -142,6 +142,28 @@ spec:
 		require.Equal(t, "Static", metaConfig.ClusterType)
 	})
 
+	t.Run("Without init configuration", func(t *testing.T) {
+		metaConfig, err := ParseConfigFromData(clusterConfig)
+		require.NoError(t, err)
+
+		parsedStaticConfig, err := metaConfig.StaticClusterConfigYAML()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(parsedStaticConfig))
+
+		parsedProviderConfig, err := metaConfig.ProviderClusterConfigYAML()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(parsedProviderConfig))
+
+		require.Equal(t, "10.111.0.10", metaConfig.ClusterDNSAddress)
+		require.Equal(t, "Static", metaConfig.ClusterType)
+
+		require.Equal(t, metaConfig.Registry.Address, "registry.deckhouse.io")
+		require.Equal(t, metaConfig.Registry.Address, "registry.deckhouse.io")
+		require.Equal(t, metaConfig.Registry.Path, "/deckhouse/ce")
+		require.Equal(t, metaConfig.Registry.DockerCfg, "eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5pbyI6IHt9fX0=")
+		require.Equal(t, metaConfig.Registry.Scheme, "https")
+	})
+
 	t.Run("Static with StaticClusterConfig", func(t *testing.T) {
 		metaConfig, err := ParseConfigFromData(clusterConfig + initConfig + staticConfig)
 		require.NoError(t, err)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add fake InitConfiguretion for getting default from openapi spec if InitConfiguration was skipped

## Why do we need it, and what problem does it solve?
Init configuration is unnecessary and can be skipped. But without InitConfiguration cluster does not bootstrap.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
New getting started does not work.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix Deckhouse CE registry setting do not set if InitConfiguration was skipped.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
