### PR TITLE
[cni-cilium][fix] restoring removed api versions in CRDs

### DIFF
--- a/modules/021-cni-cilium/crds/ciliumclusterwideenvoyconfigs.yaml
+++ b/modules/021-cni-cilium/crds/ciliumclusterwideenvoyconfigs.yaml
@@ -28,6 +28,95 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              backendServices:
+                description: BackendServices specifies Kubernetes services whose backends
+                  are automatically synced to Envoy using EDS.  Traffic for these
+                  services is not forwarded to an Envoy listener. This allows an Envoy
+                  listener load balance traffic to these backends while normal Cilium
+                  service load balancing takes care of balancing traffic for these
+                  services at the same time.
+                items:
+                  properties:
+                    name:
+                      description: Name is the name of a destination Kubernetes service
+                        that identifies traffic to be redirected.
+                      type: string
+                    namespace:
+                      description: Namespace is the Kubernetes service namespace.
+                        In CiliumEnvoyConfig namespace defaults to the namespace of
+                        the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
+                        to "default".
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              resources:
+                description: 'Envoy xDS resources, a list of the following Envoy resource
+                  types: type.googleapis.com/envoy.config.listener.v3.Listener, type.googleapis.com/envoy.config.route.v3.RouteConfiguration,
+                  type.googleapis.com/envoy.config.cluster.v3.Cluster, type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment,
+                  and type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret.'
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              services:
+                description: Services specifies Kubernetes services for which traffic
+                  is forwarded to an Envoy listener for L7 load balancing. Backends
+                  of these services are automatically synced to Envoy usign EDS.
+                items:
+                  properties:
+                    listener:
+                      description: "Listener specifies the name of the Envoy listener
+                        the service traffic is redirected to. The listener must be
+                        specified in the Envoy 'resources' of the same CiliumEnvoyConfig.
+                        \n If omitted, the first listener specified in 'resources'
+                        is used."
+                      type: string
+                    name:
+                      description: Name is the name of a destination Kubernetes service
+                        that identifies traffic to be redirected.
+                      type: string
+                    namespace:
+                      description: Namespace is the Kubernetes service namespace.
+                        In CiliumEnvoyConfig namespace this is overridden to the namespace
+                        of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
+                        to "default".
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: The age of the identity
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v2
     schema:
       openAPIV3Schema:

--- a/modules/021-cni-cilium/crds/ciliumenvoyconfigs.yaml
+++ b/modules/021-cni-cilium/crds/ciliumenvoyconfigs.yaml
@@ -23,95 +23,95 @@ spec:
     singular: ciliumenvoyconfig
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: The age of the identity
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v2alpha1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                backendServices:
-                  description: BackendServices specifies Kubernetes services whose backends
-                    are automatically synced to Envoy using EDS.  Traffic for these
-                    services is not forwarded to an Envoy listener. This allows an Envoy
-                    listener load balance traffic to these backends while normal Cilium
-                    service load balancing takes care of balancing traffic for these
-                    services at the same time.
-                  items:
-                    properties:
-                      name:
-                        description: Name is the name of a destination Kubernetes service
-                          that identifies traffic to be redirected.
-                        type: string
-                      namespace:
-                        description: Namespace is the Kubernetes service namespace.
-                          In CiliumEnvoyConfig namespace defaults to the namespace of
-                          the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
-                          to "default".
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                resources:
-                  description: 'Envoy xDS resources, a list of the following Envoy resource
-                  types: type.googleapis.com/envoy.config.listener.v3.Listener, type.googleapis.com/envoy.config.route.v3.RouteConfiguration,
-                  type.googleapis.com/envoy.config.cluster.v3.Cluster, type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment,
-                  and type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret.'
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                services:
-                  description: Services specifies Kubernetes services for which traffic
-                    is forwarded to an Envoy listener for L7 load balancing. Backends
-                    of these services are automatically synced to Envoy usign EDS.
-                  items:
-                    properties:
-                      listener:
-                        description: "Listener specifies the name of the Envoy listener
-                        the service traffic is redirected to. The listener must be
-                        specified in the Envoy 'resources' of the same CiliumEnvoyConfig.
-                        \n If omitted, the first listener specified in 'resources'
-                        is used."
-                        type: string
-                      name:
-                        description: Name is the name of a destination Kubernetes service
-                          that identifies traffic to be redirected.
-                        type: string
-                      namespace:
-                        description: Namespace is the Kubernetes service namespace.
-                          In CiliumEnvoyConfig namespace this is overridden to the namespace
-                          of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
-                          to "default".
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-              type: object
-          required:
-            - metadata
-          type: object
-      served: false
-      storage: false
-      subresources: {}
+  - additionalPrinterColumns:
+      - description: The age of the identity
+        jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+    name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              backendServices:
+                description: BackendServices specifies Kubernetes services whose backends
+                  are automatically synced to Envoy using EDS.  Traffic for these
+                  services is not forwarded to an Envoy listener. This allows an Envoy
+                  listener load balance traffic to these backends while normal Cilium
+                  service load balancing takes care of balancing traffic for these
+                  services at the same time.
+                items:
+                  properties:
+                    name:
+                      description: Name is the name of a destination Kubernetes service
+                        that identifies traffic to be redirected.
+                      type: string
+                    namespace:
+                      description: Namespace is the Kubernetes service namespace.
+                        In CiliumEnvoyConfig namespace defaults to the namespace of
+                        the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
+                        to "default".
+                      type: string
+                  required:
+                    - name
+                  type: object
+                type: array
+              resources:
+                description: 'Envoy xDS resources, a list of the following Envoy resource
+                types: type.googleapis.com/envoy.config.listener.v3.Listener, type.googleapis.com/envoy.config.route.v3.RouteConfiguration,
+                type.googleapis.com/envoy.config.cluster.v3.Cluster, type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment,
+                and type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret.'
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              services:
+                description: Services specifies Kubernetes services for which traffic
+                  is forwarded to an Envoy listener for L7 load balancing. Backends
+                  of these services are automatically synced to Envoy usign EDS.
+                items:
+                  properties:
+                    listener:
+                      description: "Listener specifies the name of the Envoy listener
+                      the service traffic is redirected to. The listener must be
+                      specified in the Envoy 'resources' of the same CiliumEnvoyConfig.
+                      \n If omitted, the first listener specified in 'resources'
+                      is used."
+                      type: string
+                    name:
+                      description: Name is the name of a destination Kubernetes service
+                        that identifies traffic to be redirected.
+                      type: string
+                    namespace:
+                      description: Namespace is the Kubernetes service namespace.
+                        In CiliumEnvoyConfig namespace this is overridden to the namespace
+                        of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
+                        to "default".
+                      type: string
+                  required:
+                    - name
+                  type: object
+                type: array
+            type: object
+        required:
+          - metadata
+        type: object
+    served: false
+    storage: false
+    subresources: {}
   - additionalPrinterColumns:
     - description: The age of the identity
       jsonPath: .metadata.creationTimestamp

--- a/modules/021-cni-cilium/crds/ciliumenvoyconfigs.yaml
+++ b/modules/021-cni-cilium/crds/ciliumenvoyconfigs.yaml
@@ -23,6 +23,95 @@ spec:
     singular: ciliumenvoyconfig
   scope: Namespaced
   versions:
+    - additionalPrinterColumns:
+        - description: The age of the identity
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                backendServices:
+                  description: BackendServices specifies Kubernetes services whose backends
+                    are automatically synced to Envoy using EDS.  Traffic for these
+                    services is not forwarded to an Envoy listener. This allows an Envoy
+                    listener load balance traffic to these backends while normal Cilium
+                    service load balancing takes care of balancing traffic for these
+                    services at the same time.
+                  items:
+                    properties:
+                      name:
+                        description: Name is the name of a destination Kubernetes service
+                          that identifies traffic to be redirected.
+                        type: string
+                      namespace:
+                        description: Namespace is the Kubernetes service namespace.
+                          In CiliumEnvoyConfig namespace defaults to the namespace of
+                          the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
+                          to "default".
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                resources:
+                  description: 'Envoy xDS resources, a list of the following Envoy resource
+                  types: type.googleapis.com/envoy.config.listener.v3.Listener, type.googleapis.com/envoy.config.route.v3.RouteConfiguration,
+                  type.googleapis.com/envoy.config.cluster.v3.Cluster, type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment,
+                  and type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret.'
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                services:
+                  description: Services specifies Kubernetes services for which traffic
+                    is forwarded to an Envoy listener for L7 load balancing. Backends
+                    of these services are automatically synced to Envoy usign EDS.
+                  items:
+                    properties:
+                      listener:
+                        description: "Listener specifies the name of the Envoy listener
+                        the service traffic is redirected to. The listener must be
+                        specified in the Envoy 'resources' of the same CiliumEnvoyConfig.
+                        \n If omitted, the first listener specified in 'resources'
+                        is used."
+                        type: string
+                      name:
+                        description: Name is the name of a destination Kubernetes service
+                          that identifies traffic to be redirected.
+                        type: string
+                      namespace:
+                        description: Namespace is the Kubernetes service namespace.
+                          In CiliumEnvoyConfig namespace this is overridden to the namespace
+                          of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults
+                          to "default".
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+          required:
+            - metadata
+          type: object
+      served: false
+      storage: false
+      subresources: {}
   - additionalPrinterColumns:
     - description: The age of the identity
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Description

Restoring removed api versions in cilium's CRDs.

## Why do we need it, and what problem does it solve?

In some clusters the CRDs have `status.storedVersions` with old version, but there aren't any resources. So, there is an error during deckhouse update:
```
Error: module hook '021-cni-cilium/hooks/ensure_crds.go' failed: 2 errors occurred:
	* CustomResourceDefinition.apiextensions.k8s.io "ciliumclusterwideenvoyconfigs.cilium.io" is invalid: status.storedVersions[0]: Invalid value: "v2alpha1": must appear in spec.versions
	* CustomResourceDefinition.apiextensions.k8s.io "ciliumenvoyconfigs.cilium.io" is invalid: status.storedVersions[0]: Invalid value: "v2alpha1": must appear in spec.versions
```

## Why do we need it in the patch release (if we do)?

Some clusters can't complete D8 update to version 1.55.

## What is the expected result?

D8 update to version 1.55 completed without errors.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Restore removed API versions in CRDs.
impact_level: default
```