### PR TITLE
[prometheus-operator] fix update alertmanagers hook for customalertmanagers via labeled services

### DIFF
--- a/modules/300-prometheus/hooks/update_alertmanager_status.go
+++ b/modules/300-prometheus/hooks/update_alertmanager_status.go
@@ -59,6 +59,10 @@ func updateAmStatus(input *go_hook.HookInput) error {
 	}
 
 	for _, am := range serviceDeclaredAlertmanagers {
+		// customalertmanagers via labeled services (https://github.com/deckhouse/deckhouse/blob/30c51d36178942825ab26e895cc0a01dbdfb1a73/modules/300-prometheus/hooks/alertmanager_crd_discovery.go#L45)  have empty ResoruceNames and are deprecated
+		if len(am.ResourceName) == 0 {
+			continue
+		}
 		input.PatchCollector.Filter(set_cr_statuses.SetProcessedStatus(applyAlertmanagerCRDFilter), "deckhouse.io/v1alpha1", "customalertmanager", "", am.ResourceName, object_patch.WithSubresource("/status"), object_patch.IgnoreHookError())
 	}
 

--- a/modules/300-prometheus/hooks/update_alertmanager_status_test.go
+++ b/modules/300-prometheus/hooks/update_alertmanager_status_test.go
@@ -35,13 +35,22 @@ const (
 			"target": "alertmanager.mycompany.com",
 			"tlsConfig": {}
 		}],
-		"byService": [{
+		"byService": [
+			{
 			"name": "alerts-receiver",
 			"namespace": "d8-monitoring",
 			"pathPrefix": "/",
 			"port": "http",
 			"resourceName": "alerts-receiver"
-		}],
+			},
+			{
+			"name": "another-alert-receiver",
+			"namespace": "d8-monitoring",
+			"pathPrefix": "/",
+			"port": "http",
+			"resourceName": ""
+			},
+		],
 		"internal": [{
 			"name": "webhook",
 			"receivers": [{
@@ -89,7 +98,7 @@ var _ = Describe("Modules :: prometheus :: hooks :: update alertmanagers' status
 		It("should have generated resources with 'synced' false", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("prometheus.internal.alertmanagers.byAddress").Array()).To(HaveLen(1))
-			Expect(f.ValuesGet("prometheus.internal.alertmanagers.byService").Array()).To(HaveLen(1))
+			Expect(f.ValuesGet("prometheus.internal.alertmanagers.byService").Array()).To(HaveLen(2))
 			Expect(f.ValuesGet("prometheus.internal.alertmanagers.internal").Array()).To(HaveLen(1))
 			const expectedStatus = `{
 				"deckhouse": {
@@ -120,7 +129,7 @@ var _ = Describe("Modules :: prometheus :: hooks :: update alertmanagers' status
 		It("should have generated resources with 'synced' true", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("prometheus.internal.alertmanagers.byAddress").Array()).To(HaveLen(1))
-			Expect(f.ValuesGet("prometheus.internal.alertmanagers.byService").Array()).To(HaveLen(1))
+			Expect(f.ValuesGet("prometheus.internal.alertmanagers.byService").Array()).To(HaveLen(2))
 			Expect(f.ValuesGet("prometheus.internal.alertmanagers.internal").Array()).To(HaveLen(1))
 			const expectedStatus = `{
 				"deckhouse": {


### PR DESCRIPTION
## Description
PR updates `update_alertmanager_status.go` hook to skip `customalertmanagers` created via labeled services (deprecated functionality).
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We need it because otherwise `update_alertmanager_status.go` hook fails to converge due to missing CRs for `CustomAlertManagers` created via `labeled services` (by design). Such customalertmanagers have `ResourceName` field set to empty string in internal values.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It fixes deckhouse converge issue when there is a customalertmanager-labeled service in a cluster.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
`update_alertmanager_status.go` hook successfully executes even if there is a customalertmanager-labeled service in the cluster.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fixes update_alertmanager_status hook when there is an alertmanager via a labeled service in the cluster.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
