### PR TITLE
[global] Add default timeout to registry client

### DIFF
--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cr
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -37,6 +38,10 @@ import (
 
 //go:generate minimock -i Client -o cr_mock.go
 
+const (
+	defaultTimeout = 30 * time.Second
+)
+
 type Client interface {
 	Image(tag string) (v1.Image, error)
 	Digest(tag string) (string, error)
@@ -52,7 +57,9 @@ type client struct {
 // NewClient creates container registry client using `repo` as prefix for tags passed to methods. If insecure flag is set to true, then no cert validation is performed.
 // Repo example: "cr.example.com/ns/app"
 func NewClient(repo string, options ...Option) (Client, error) {
-	opts := &registryOptions{}
+	opts := &registryOptions{
+		timeout: defaultTimeout,
+	}
 
 	for _, opt := range options {
 		opt(opts)
@@ -96,6 +103,14 @@ func (r *client) Image(tag string) (v1.Image, error) {
 		imageOptions = append(imageOptions, remote.WithTransport(GetHTTPTransport(r.options.ca)))
 	}
 
+	if r.options.timeout > 0 {
+		// add default timeout to prevent endless request on a huge image
+		ctx, cancel := context.WithTimeout(context.Background(), r.options.timeout)
+		defer cancel()
+
+		imageOptions = append(imageOptions, remote.WithContext(ctx))
+	}
+
 	return remote.Image(
 		ref,
 		imageOptions...,
@@ -119,6 +134,14 @@ func (r *client) ListTags() ([]string, error) {
 	repo, err := name.NewRepository(r.registryURL, nameOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing repo %q: %w", r.registryURL, err)
+	}
+
+	if r.options.timeout > 0 {
+		// add default timeout to prevent endless request on a huge amount of tags
+		ctx, cancel := context.WithTimeout(context.Background(), r.options.timeout)
+		defer cancel()
+
+		imageOptions = append(imageOptions, remote.WithContext(ctx))
 	}
 
 	return remote.List(repo, imageOptions...)
@@ -184,8 +207,8 @@ func GetHTTPTransport(ca string) (transport http.RoundTripper) {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout:   defaultTimeout,
+			KeepAlive: defaultTimeout,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
@@ -202,6 +225,8 @@ type registryOptions struct {
 	withoutAuth bool
 	dockerCfg   string
 	userAgent   string
+
+	timeout time.Duration
 }
 
 type Option func(options *registryOptions)
@@ -238,6 +263,14 @@ func WithAuth(dockerCfg string) Option {
 func WithUserAgent(ua string) Option {
 	return func(options *registryOptions) {
 		options.userAgent = ua
+	}
+}
+
+// WithTimeout limit and request to a registry with a timeout
+// default timeout is 30 seconds
+func WithTimeout(timeout time.Duration) Option {
+	return func(options *registryOptions) {
+		options.timeout = timeout
 	}
 }
 


### PR DESCRIPTION
## Description
Add default 30 seconds timeout to registry client operations

With `REGISTRY_TIMEOUT` env variable we can hack this timeout in a cluster (just for emergency situation resolve)
example:
```
REGISTRY_TIMEOUT=5m
```

## Why do we need it, and what problem does it solve?
Registry call could be endless on a huge amount of tags or huge image. We have to limit this kind of operation

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: fix 
summary: Limit registry client operations with 30 seconds timeout.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
