### PR TITLE
[getting-started][docs] Changing configs after the deprecation of configOverrides

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -13,42 +13,80 @@ cloud:
   # [<ru>] Возможно, захотите изменить.
   prefix: cloud-demo
 # [<en>] Address space of the cluster's Pods.
-# [<ru>] Адресное пространство Pod’ов кластера.
+# [<ru>] Адресное пространство подов кластера.
 podSubnetCIDR: 10.111.0.0/16
 # [<en>] Address space of the cluster's services.
-# [<ru>] Адресное пространство для service’ов кластера.
+# [<ru>] Адресное пространство сети сервисов кластера.
 serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
+# [<en>] Cluster domain (used for local routing).
+# [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
-          
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-cilium
+spec:
+  version: 1
+  # [<en>] Enable cni-cilium module
+  # [<ru>] Включить модуль cni-cilium
+  enabled: true
+  settings:
+    # [<en>] cni-cilium module settings
+    # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+    # [<ru>] Настройки модуля cni-cilium
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
+    tunnelMode: VXLAN
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -13,12 +13,14 @@ cloud:
   # [<ru>] Возможно, захотите изменить.
   prefix: cloud-demo
 # [<en>] Address space of the cluster's Pods.
-# [<ru>] Адресное пространство Pod’ов кластера.
+# [<ru>] Адресное пространство подов кластера.
 podSubnetCIDR: 10.111.0.0/16
 # [<en>] Address space of the cluster's services.
-# [<ru>] Адресное пространство для service’ов кластера.
+# [<ru>] Адресное пространство сети сервисов кластера.
 serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
+# [<en>] Cluster domain (used for local routing).
+# [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
 # [<en>] Section for bootstrapping the Deckhouse cluster.
@@ -28,31 +30,77 @@ clusterDomain: "cluster.local"
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
+  # [<en>] Address of the Docker registry where the Deckhouse images are located
+  # [<ru>] Адрес Docker registry с образами Deckhouse
   imagesRepo: registry.deckhouse.io/deckhouse/ee
-  # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
-  # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
+  # [<en>] A special string with your token to access Docker registry (generated automatically for your license token)
+  # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа)
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
-          
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-cilium
+spec:
+  version: 1
+  # [<en>] Enable cni-cilium module
+  # [<ru>] Включить модуль cni-cilium
+  enabled: true
+  settings:
+    # [<en>] cni-cilium module settings
+    # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+    # [<ru>] Настройки модуля cni-cilium
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
+    tunnelMode: VXLAN
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
@@ -21,33 +21,54 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: cluster.local
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ee.inc
@@ -32,26 +32,58 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
+    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
+    storageClass: localpath-deckhouse-system
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -6,12 +6,14 @@ apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 clusterType: Static
 # [<en>] Address space of the cluster's Pods.
-# [<ru>] Адресное пространство Pod’ов кластера.
+# [<ru>] Адресное пространство подов кластера.
 podSubnetCIDR: 10.111.0.0/16
 # [<en>] Address space of the cluster's services.
-# [<ru>] Адресное пространство для service’ов кластера.
+# [<ru>] Адресное пространство сети сервисов кластера.
 serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
+# [<en>] Cluster domain (used for local routing).
+# [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 # [<en>] Proxy server settings.
 # [<ru>] Настройки proxy-сервера.
@@ -27,43 +29,6 @@ proxy:
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template to use for system app domains within the cluster.
-        # [<en>] For example, in the case of %s.example.com, Grafana will be mapped to grafana.example.com.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
-        publicDomainTemplate: "%s.example.com"
-        # [<en>] The HTTPS implementation used by the Deckhouse modules.
-        # [<ru>] Способ реализации протокола HTTPS, используемый модулями Deckhouse.
-        https:
-          certManager:
-            # [<en>] Use self-signed certificates for Deckhouse modules.
-            # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
-            clusterIssuerName: selfsigned
-      # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-      # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-      storageClass: localpath-deckhouse-system
-    certManager:
-      disableLetsencrypt: true
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: FromIngressSecret
-    # [<en>] Enable the cni-flannel module.
-    # [<ru>] Включить модуль cni-flannel.
-    # [<en>] You might consider changing this.
-    # [<ru>] Возможно, захотите изменить.
-    cniFlannelEnabled: true
-    # [<en>] Cni-flannel module settings.
-    # [<ru>] Настройки модуля cni-flannel.
-    # [<en>] You might consider changing this.
-    # [<ru>] Возможно, захотите изменить.
-    cniFlannel:
-      # [<en>] Flannel backend, available values are VXLAN (if your servers have L3 connectivity) and HostGW (for L2 networks).
-      # [<ru>] Режим работы flannel, допустимые значения VXLAN (если ваши сервера имеют связность L3) или HostGW (для L2-сетей).
-      podNetworkMode: VXLAN
   # [<en>] Address of the Docker registry where the Deckhouse images are located.
   # [<ru>] Адрес Docker registry с образами Deckhouse.
   imagesRepo: <IMAGES_REPO_URI>
@@ -77,18 +42,107 @@ deckhouse:
   # [<ru>] Корневой сертификат, которым можно проверить сертификат registry (если registry использует самоподписанные сертификаты).
   registryCA: <REGISTRY_CA>
 ---
-# [<en>] Section with the parameters of the bare metal cluster (StaticClusterConfiguration).
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+      # [<en>] The HTTPS implementation used by the Deckhouse modules.
+      # [<ru>] Способ реализации протокола HTTPS, используемый модулями Deckhouse.
+      https:
+        certManager:
+          # [<en>] Use self-signed certificates for Deckhouse modules.
+          # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
+          clusterIssuerName: selfsigned
+    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
+    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
+    storageClass: localpath-deckhouse-system
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: FromIngressSecret
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cert-manager
+spec:
+  version: 1
+  enabled: true
+  settings:
+    disableLetsencrypt: true
+---
+# [<en>] Enable the cni-flannel module.
+# [<ru>] Включить модуль cni-flannel.
+# [<en>] You might consider changing this.
+# [<ru>] Возможно, захотите изменить.
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-flannel
+spec:
+  version: 1
+  enabled: true
+  # [<en>] Cni-flannel module settings.
+  # [<ru>] Настройки модуля cni-flannel.
+  # [<en>] You might consider changing this.
+  # [<ru>] Возможно, захотите изменить.
+  settings:
+    # [<en>] Flannel backend, available values are VXLAN (if your servers have L3 connectivity) and HostGW (for L2 networks).
+    # [<ru>] Режим работы flannel, допустимые значения VXLAN (если ваши сервера имеют связность L3) или HostGW (для L2-сетей).
+    podNetworkMode: VXLAN
+---
+# [<en>] Section with the parameters of the static cluster.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами bare metal кластера (StaticClusterConfiguration).
+# [<ru>] Секция с параметрами статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration
-# [<en>] list of internal cluster networks (e.g., '10.0.4.0/24'), which is
-# [<en>] used for linking Kubernetes components (kube-apiserver, kubelet etc.)
-# [<en>] if every node in cluster has only one network interface
+# [<en>] List of internal cluster networks (e.g., '10.0.4.0/24'), which is
+# [<en>] used for linking Kubernetes components (kube-apiserver, kubelet etc.).
+# [<en>] If every node in cluster has only one network interface
 # [<en>] StaticClusterConfiguration resource can be skipped.
-# [<ru>] список внутренних сетей узлов кластера (например, '10.0.4.0/24'), который
-# [<ru>] используется для связи компонентов Kubernetes (kube-apiserver, kubelet...) между собой
+# [<ru>] Список внутренних сетей узлов кластера (например, '10.0.4.0/24'), который
+# [<ru>] используется для связи компонентов Kubernetes (kube-apiserver, kubelet...) между собой.
 # [<ru>] Если каждый узел в кластере имеет только один сетевой интерфейс,
 # [<ru>] ресурс StaticClusterConfiguration можно не создавать.
 internalNetworkCIDRs:

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
@@ -16,49 +16,73 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-      # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-      # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-      storageClass: localpath-deckhouse-system
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
-      # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
-      # [<en>] Enabling access to the API server through Ingress.
-      # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
-    # [<en>] Enable cni-cilium module
-    # [<ru>] Включить модуль cni-cilium
-    cniCiliumEnabled: true
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
+    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
+    storageClass: localpath-deckhouse-system
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-cilium
+spec:
+  version: 1
+  # [<en>] Enable cni-cilium module
+  # [<ru>] Включить модуль cni-cilium
+  enabled: true
+  settings:
     # [<en>] cni-cilium module settings
     # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
     # [<ru>] Настройки модуля cni-cilium
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-    cniCilium:
-      tunnelMode: VXLAN
+    tunnelMode: VXLAN
 ---
 # [<en>] Section with the parameters of the static cluster.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
@@ -29,39 +29,74 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token)
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа)
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
-      # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
-      # [<en>] Enabling access to the API server through Ingress.
-      # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
-    # [<en>] Enable cni-cilium module
-    # [<ru>] Включить модуль cni-cilium
-    cniCiliumEnabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
+    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
+    storageClass: localpath-deckhouse-system
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-cilium
+spec:
+  version: 1
+  # [<en>] Enable cni-cilium module
+  # [<ru>] Включить модуль cni-cilium
+  enabled: true
+  settings:
     # [<en>] cni-cilium module settings
     # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
     # [<ru>] Настройки модуля cni-cilium
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-    cniCilium:
-      tunnelMode: VXLAN
+    tunnelMode: VXLAN
 ---
 # [<en>] Section with the parameters of the static cluster.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration

--- a/docs/site/_includes/getting_started/existing/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.yml.ce.inc
@@ -1,41 +1,56 @@
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  # [<en>] The Minimal bundle is used when installing Deckhouse in an existing cluster.
-  # [<ru>] При установке Deckhouse в существующий кластер используется вариант поставки — Minimal.
-  bundle: Minimal
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-        # [<ru>] If necessary, specify in the customTolerationKeys array
-        # [<ru>] all the tains to which Deckhouse should have toleration.
-        # [<ru>] The following is an example for the case if you need Deckhouse and its components to be able
-        # [<ru>] to run on nodes that have taint SystemLoad.
-        # [<ru>] При необходимости, укажите в массиве customTolerationKeys все taint'ы
-        # [<ru>] к которым Deckhouse должен иметь toleration.
-        # [<ru>] Далее приведен пример для случая, если нужно чтобы Deckhouse и его компоненты смогли запускаться
-        # [<ru>] на узлах, имеющих taint SystemLoad
-        # [<en>] You might consider changing this.
-        # [<ru>] Возможно, захотите изменить.
-        placement:
-          customTolerationKeys:
-          - SystemLoad
-    certManagerEnabled: true
-    # [<en>] Use for Deckhouse 1.46 or newer.
-    # [<ru>] для Deckhouse 1.46 и новее.
-    # documentationEnabled: true
-    # [<en>] Use for Deckhouse 1.45 or older.
-    # [<ru>] Для Deckhouse 1.45 и старее.
-    deckhouseWebEnabled: true
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Minimal
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+      # [<ru>] If necessary, specify in the customTolerationKeys array
+      # [<ru>] all the tains to which Deckhouse should have toleration.
+      # [<ru>] The following is an example for the case if you need Deckhouse and its components to be able
+      # [<ru>] to run on nodes that have taint SystemLoad.
+      # [<ru>] При необходимости, укажите в массиве customTolerationKeys все taint'ы
+      # [<ru>] к которым Deckhouse должен иметь toleration.
+      # [<ru>] Далее приведен пример для случая, если нужно чтобы Deckhouse и его компоненты смогли запускаться
+      # [<ru>] на узлах, имеющих taint SystemLoad
+      # [<en>] You might consider changing this.
+      # [<ru>] Возможно, захотите изменить.
+      placement:
+        customTolerationKeys:
+        - SystemLoad
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cert-manager
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: documentation
+spec:
+  version: 1
+  enabled: true

--- a/docs/site/_includes/getting_started/existing/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.yml.ee.inc
@@ -11,37 +11,60 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  # [<en>] the Minimal bundle is used when installing Deckhouse in an existing cluster.
-  # [<ru>] при установке Deckhouse в существующий кластер используется вариант поставки — Minimal.
-  bundle: Minimal
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-        # [<ru>] If necessary, specify in the customTolerationKeys array
-        # [<ru>] all the tains to which Deckhouse should have toleration.
-        # [<ru>] The following is an example for the case if you need Deckhouse and its components to be able
-        # [<ru>] to run on nodes that have taint SystemLoad.
-        # [<ru>] При необходимости, укажите в массиве customTolerationKeys все taint'ы
-        # [<ru>] к которым Deckhouse должен иметь toleration.
-        # [<ru>] Далее приведен пример для случая, если нужно чтобы Deckhouse и его компоненты смогли запускаться
-        # [<ru>] на узлах, имеющих taint SystemLoad
-        # [<en>] You might consider changing this.
-        # [<ru>] Возможно, захотите изменить.
-        placement:
-          customTolerationKeys:
-          - SystemLoad
-    certManagerEnabled: true
-    # [<en>] Use for Deckhouse 1.46 or newer.
-    # [<ru>] для Deckhouse 1.46 и новее.
-    # documentationEnabled: true
-    # [<en>] Use for Deckhouse 1.45 or older.
-    # [<ru>] Для Deckhouse 1.45 и старее.
-    deckhouseWebEnabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Minimal
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+      # [<ru>] If necessary, specify in the customTolerationKeys array
+      # [<ru>] all the tains to which Deckhouse should have toleration.
+      # [<ru>] The following is an example for the case if you need Deckhouse and its components to be able
+      # [<ru>] to run on nodes that have taint SystemLoad.
+      # [<ru>] При необходимости, укажите в массиве customTolerationKeys все taint'ы
+      # [<ru>] к которым Deckhouse должен иметь toleration.
+      # [<ru>] Далее приведен пример для случая, если нужно чтобы Deckhouse и его компоненты смогли запускаться
+      # [<ru>] на узлах, имеющих taint SystemLoad
+      # [<en>] You might consider changing this.
+      # [<ru>] Возможно, захотите изменить.
+      placement:
+        customTolerationKeys:
+        - SystemLoad
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cert-manager
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: documentation
+spec:
+  version: 1
+  enabled: true

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
@@ -21,33 +21,54 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/kind/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/kind/partials/config.yml.ce.inc
@@ -4,30 +4,73 @@
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  # [<en>] The Minimal bundle is used when installing Deckhouse in an existing cluster.
-  # [<ru>] При установке Deckhouse в существующий кластер используется вариант поставки — Minimal.
-  bundle: Minimal
   configOverrides:
-    global:
-      modules:
-        # [<en>] Template for Ingress resources of Deckhouse modules.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] The sslip.io service is used as as a working example.
-        # [<ru>] Шаблон для создания Ingress-ресурсов модулей Deckhouse.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
-        # [<ru>] В качестве рабочего примера используется сервис sslip.io.
-        publicDomainTemplate: "%s.127.0.0.1.sslip.io"
-        https:
-          mode: Disabled
     operatorPrometheusCrdEnabled: true
     operatorPrometheusEnabled: true
     prometheusCrdEnabled: true
-    prometheusEnabled: true
-    monitoringKubernetesEnabled: true
     monitoringDeckhouseEnabled: true
-    monitoringKubernetesControlPlaneEnabled: true
-    ingressNginxEnabled: true
-    prometheus:
-      longtermRetentionDays: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    # [<en>] The Minimal bundle is used when installing Deckhouse in an existing cluster.
+    # [<ru>] При установке Deckhouse в существующий кластер используется вариант поставки — Minimal.
+    bundle: Minimal
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template for Ingress resources of Deckhouse modules.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] The sslip.io service is used as as a working example.
+      # [<ru>] Шаблон для создания Ingress-ресурсов модулей Deckhouse.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
+      # [<ru>] В качестве рабочего примера используется сервис sslip.io.
+      publicDomainTemplate: "%s.127.0.0.1.sslip.io"
+      https:
+          mode: Disabled
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus
+spec:
+  version: 2
+  enabled: true
+  settings:
+    longtermRetentionDays: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingress-nginx
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes-control-plane
+spec:
+  enabled: true

--- a/docs/site/_includes/getting_started/kind/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/kind/partials/config.yml.ce.inc
@@ -1,15 +1,3 @@
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-  configOverrides:
-    operatorPrometheusCrdEnabled: true
-    operatorPrometheusEnabled: true
-    prometheusCrdEnabled: true
-    monitoringDeckhouseEnabled: true
----
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -72,5 +60,19 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: monitoring-kubernetes-control-plane
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-prometheus-crd
 spec:
   enabled: true

--- a/docs/site/_includes/getting_started/kind/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/kind/partials/config.yml.ee.inc
@@ -1,20 +1,3 @@
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  imagesRepo: registry.deckhouse.io/deckhouse/ee
-  # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
-  # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
-  registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  configOverrides:
-    operatorPrometheusCrdEnabled: true
-    operatorPrometheusEnabled: true
-    prometheusCrdEnabled: true
-    monitoringDeckhouseEnabled: true
----
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -77,5 +60,19 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: monitoring-kubernetes-control-plane
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-prometheus-crd
 spec:
   enabled: true

--- a/docs/site/_includes/getting_started/kind/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/kind/partials/config.yml.ee.inc
@@ -9,29 +9,73 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  # [<en>] The Minimal bundle is used when installing Deckhouse in an existing cluster.
-  # [<ru>] При установке Deckhouse в существующий кластер используется вариант поставки — Minimal.
-  bundle: Minimal
   configOverrides:
-    global:
-      modules:
-        # [<en>] Template for Ingress resources of Deckhouse modules.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] The sslip.io service is used as as a working example.
-        # [<ru>] Шаблон для создания Ingress-ресурсов модулей Deckhouse.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
-        # [<ru>] В качестве рабочего примера используется сервис sslip.io.
-        publicDomainTemplate: "%s.127.0.0.1.sslip.io"
-        https:
-          mode: Disabled
     operatorPrometheusCrdEnabled: true
     operatorPrometheusEnabled: true
     prometheusCrdEnabled: true
-    prometheusEnabled: true
-    monitoringKubernetesEnabled: true
     monitoringDeckhouseEnabled: true
-    monitoringKubernetesControlPlaneEnabled: true
-    ingressNginxEnabled: true
-    prometheus:
-      longtermRetentionDays: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    # [<en>] The Minimal bundle is used when installing Deckhouse in an existing cluster.
+    # [<ru>] При установке Deckhouse в существующий кластер используется вариант поставки — Minimal.
+    bundle: Minimal
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template for Ingress resources of Deckhouse modules.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] The sslip.io service is used as as a working example.
+      # [<ru>] Шаблон для создания Ingress-ресурсов модулей Deckhouse.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
+      # [<ru>] В качестве рабочего примера используется сервис sslip.io.
+      publicDomainTemplate: "%s.127.0.0.1.sslip.io"
+      https:
+          mode: Disabled
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus
+spec:
+  version: 2
+  enabled: true
+  settings:
+    longtermRetentionDays: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingress-nginx
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes-control-plane
+spec:
+  enabled: true

--- a/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html

--- a/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-vsphere/cluster_configuration.html

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
@@ -21,33 +21,54 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
-# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
-# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
@@ -32,26 +32,55 @@ deckhouse:
   # [<en>] A special string with your token to access Docker registry (generated automatically for your license token).
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
-  releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        # [<en>] Template that will be used for system apps domains within the cluster.
-        # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
-        # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
-        # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
-        # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
-        # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
-        publicDomainTemplate: "%s.example.com"
-    userAuthn:
-      controlPlaneConfigurator:
-        dexCAMode: DoNotNeed
-      publishAPI:
-        enable: true
-        https:
-          mode: Global
-          global:
-            kubeconfigGeneratorMasterCA: ""
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+    modules:
+      # [<en>] Template that will be used for system apps domains within the cluster.
+      # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
+      # [<en>] You can change it to your own or follow the steps in the guide and change it after installation.
+      # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
+      # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
+      # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
+      publicDomainTemplate: "%s.example.com"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
+    controlPlaneConfigurator:
+      dexCAMode: DoNotNeed
+    # [<ru>] Включение доступа к API-серверу Kubernetes через Ingress.
+    # [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    # [<en>] Enabling access to the API server through Ingress.
+    # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
+    publishAPI:
+      enable: true
+      https:
+        mode: Global
+        global:
+          kubeconfigGeneratorMasterCA: ""
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html


### PR DESCRIPTION
## Description

The configuration files for installing Deckhouse have been changed in accordance with the deprecation of the configOverrides section.

## Why do we need it, and what problem does it solve?

Solves the problems of installing new clusters according to the manual from GS.

## What is the expected result?

GS will become relevant.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Make the Getting Started more consistent.
impact_level: low
```