### PR TITLE
[getting-started][docs] Updating the config in the kind installation script

### DIFF
--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -379,27 +379,76 @@ EOF
 
   echo "Creating Deckhouse installation config file (${CONFIG_DIR}/config.yml)..."
   cat <<EOF >${CONFIG_DIR}/config.yml
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: $D8_RELEASE_CHANNEL_NAME
-  bundle: Minimal
-  configOverrides:
-    global:
-      modules:
-        publicDomainTemplate: "%s.127.0.0.1.sslip.io"
-        https:
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Minimal
+    releaseChannel: Stable
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 1
+  settings:
+    modules:
+      publicDomainTemplate: "%s.127.0.0.1.sslip.io"
+      https:
           mode: Disabled
-    operatorPrometheusCrdEnabled: true
-    operatorPrometheusEnabled: true
-    prometheusCrdEnabled: true
-    prometheusEnabled: true
-    monitoringKubernetesEnabled: true
-    monitoringDeckhouseEnabled: true
-    monitoringKubernetesControlPlaneEnabled: true
-    ingressNginxEnabled: true
-    prometheus:
-      longtermRetentionDays: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus
+spec:
+  version: 2
+  enabled: true
+  settings:
+    longtermRetentionDays: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingress-nginx
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes
+spec:
+  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes-control-plane
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-prometheus-crd
+spec:
+  enabled: true
 EOF
 
   if [[ -n "$D8_LICENSE_KEY" ]]; then

--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -418,21 +418,33 @@ kind: ModuleConfig
 metadata:
   name: ingress-nginx
 spec:
-  version: 1
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-prometheus-crd
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-prometheus
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus-crd
+spec:
   enabled: true
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: monitoring-kubernetes
-spec:
-  version: 1
-  enabled: true
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: monitoring-kubernetes-control-plane
 spec:
   enabled: true
 ---
@@ -446,7 +458,7 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
-  name: operator-prometheus-crd
+  name: monitoring-kubernetes-control-plane
 spec:
   enabled: true
 EOF


### PR DESCRIPTION
## Description

A new configuration file has been added to the kind installation script, which takes into account the deprecation of configOverrides.

## Why do we need it, and what problem does it solve?

Solves the problems of installing new clusters according to the manual from GS.

## Why do we need it in the patch release (if we do)?

GS will become relevant.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Make the Getting Started more consistent.
impact_level: low
```