### PR TITLE
[Addon-operator ] Add debug routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.3-0.20231110093142-7fff3e06f194
+	github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df
 	github.com/flant/kube-client v1.0.3
 	github.com/flant/shell-operator v1.4.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1
+	github.com/flant/addon-operator v1.3.3-0.20231130131638-fbcea0916209
 	github.com/flant/kube-client v1.0.3
 	github.com/flant/shell-operator v1.4.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6
+	github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1
 	github.com/flant/kube-client v1.0.3
 	github.com/flant/shell-operator v1.4.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df
+	github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6
 	github.com/flant/kube-client v1.0.3
 	github.com/flant/shell-operator v1.4.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df h1:/2mHG1lwOCk5MO1zMHVyCGtyaHl84oB5xHYjRbhfcvY=
-github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
+github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6 h1:R/wLZrxEuFNkarC/SsO8IxZTN0mJfIJus3jeiALaJbM=
+github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/gogost/v5 v5.13.0 h1:xU60PYSePgtvS7Z1zP9jeT/7e0KsLlFZ/VAn6m+kAJc=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6 h1:R/wLZrxEuFNkarC/SsO8IxZTN0mJfIJus3jeiALaJbM=
-github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
+github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1 h1:EGTKjo3j39IsIML4lpfnipmL6U0+s8F9gwDJp54Grsg=
+github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/gogost/v5 v5.13.0 h1:xU60PYSePgtvS7Z1zP9jeT/7e0KsLlFZ/VAn6m+kAJc=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.3-0.20231110093142-7fff3e06f194 h1:Q0YaX2dgrmwRCHO9SzFPgAqkq9JhmRH8zLTqrtUpEwE=
-github.com/flant/addon-operator v1.3.3-0.20231110093142-7fff3e06f194/go.mod h1:LPzafCdjfWfDkHUsLwuw5Y7dIuJ/H0VgM42d83wu1Ps=
+github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df h1:/2mHG1lwOCk5MO1zMHVyCGtyaHl84oB5xHYjRbhfcvY=
+github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/gogost/v5 v5.13.0 h1:xU60PYSePgtvS7Z1zP9jeT/7e0KsLlFZ/VAn6m+kAJc=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1 h1:EGTKjo3j39IsIML4lpfnipmL6U0+s8F9gwDJp54Grsg=
-github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
+github.com/flant/addon-operator v1.3.3-0.20231130131638-fbcea0916209 h1:ZgFwtfrecLiS7UhqGFKJbIvb6sYk9/DaqZj7ypWAsGA=
+github.com/flant/addon-operator v1.3.3-0.20231130131638-fbcea0916209/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/gogost/v5 v5.13.0 h1:xU60PYSePgtvS7Z1zP9jeT/7e0KsLlFZ/VAn6m+kAJc=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1065,7 +1065,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.3-0.20231110093142-7fff3e06f194/go.mod h1:LPzafCdjfWfDkHUsLwuw5Y7dIuJ/H0VgM42d83wu1Ps=
+github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/gogost/v5 v5.13.0/go.mod h1:Uc2FKYMOm/1NZAze/LOufgP57tNZxijLEFB5+At7GWw=
 github.com/flant/kube-client v1.0.3/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1065,7 +1065,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.3-0.20231130065704-b6c78d5d05df/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
+github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/gogost/v5 v5.13.0/go.mod h1:Uc2FKYMOm/1NZAze/LOufgP57tNZxijLEFB5+At7GWw=
 github.com/flant/kube-client v1.0.3/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1065,7 +1065,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.3-0.20231130110640-a9668a3e93e6/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
+github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/gogost/v5 v5.13.0/go.mod h1:Uc2FKYMOm/1NZAze/LOufgP57tNZxijLEFB5+At7GWw=
 github.com/flant/kube-client v1.0.3/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1065,7 +1065,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flant/addon-operator v1.3.3-0.20231130124155-ee23247181f1/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
+github.com/flant/addon-operator v1.3.3-0.20231130131638-fbcea0916209/go.mod h1:XaJoBq4nhmaXl8hMn6xW7KkQxAEwXn4JaXSvBaNjaF8=
 github.com/flant/gogost/v5 v5.13.0/go.mod h1:Uc2FKYMOm/1NZAze/LOufgP57tNZxijLEFB5+At7GWw=
 github.com/flant/kube-client v1.0.3/go.mod h1:YVcJ8PxomM0iYsK7nj2I3lmog2D0j/GloJfLYnhjlls=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=


### PR DESCRIPTION
## Description

Added an endpoint  "/discovery" for the "/global/*" and "/module/*" routes. 
```
$curl http://localhost:9652/discovery

GET /global/config.{format:(json|yaml)}
GET /global/list.{format:(json|yaml)}
GET /global/patches.{format:(json|yaml)}
GET /global/snapshots.{format:(json|yaml)}
GET /global/values.{format:(json|yaml)}
GET /module/list.{format:(json|yaml|text)}
GET /module/resource-monitor.{format:(json|yaml)}
GET /module/{name}/patches.json
GET /module/{name}/render
GET /module/{name}/snapshots.{format:(json|yaml)}
GET /module/{name}/{type:(config|values)}.{format:(json|yaml)}
```

## Why do we need it, and what problem does it solve?

Fix https://github.com/deckhouse/deckhouse/issues/5827

## What is the expected result?

A new endpoint is available. Calling the endpoint returns a list of available routes "/global/*" and "/module/*".

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
