### PR TITLE
[testing] Correct mistake with alerts in e2e test

### DIFF
--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -51,3 +51,11 @@ spec:
     modules:
       publicDomainTemplate: "%s.k8s.smoke.flant.com"
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: node-manager
+spec:
+  earlyOomEnabled: false
+  version: 1

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -57,6 +57,7 @@ kind: ModuleConfig
 metadata:
   name: node-manager
 spec:
+  enabled: true
   settings:
     earlyOomEnabled: false
   version: 1

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -57,5 +57,6 @@ kind: ModuleConfig
 metadata:
   name: node-manager
 spec:
-  earlyOomEnabled: false
+  settings:
+    earlyOomEnabled: false
   version: 1

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -18,7 +18,13 @@ set -Eeuo pipefail
 availability=""
 attempts=50
 
-allow_alerts=("D8DeckhouseIsNotOnReleaseChannel" "DeadMansSwitch")
+allow_alerts=(
+"D8DeckhouseIsNotOnReleaseChannel" # Tests may be made on dev branch
+"DeadMansSwitch" # Always active in system. Tells that monitoring works.
+"CertmanagerCertificateExpired" # On some system do not have DNS
+"CertmanagerCertificateExpiredSoon" # Same as above
+"DeckhouseModuleUseEmptyDir" # TODO Need made split storage class
+)
 
 # With sleep timeout of 30s, we have 25 minutes period in total to catch the 100% availability from upmeter
 for i in $(seq $attempts); do

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -795,29 +795,27 @@ function wait_cluster_ready() {
     fi
   done
 
-  write_deckhouse_logs
-
   if [[ $test_failed == "true" ]] ; then
     return 1
   fi
 
-#  testAlerts=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh")
-#
-#  testRunAttempts=5
-#  for ((i=1; i<=$testRunAttempts; i++)); do
-#    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
-#      test_failed=""
-#      break
-#    else
-#      test_failed="true"
-#      >&2 echo "Run test script via SSH: attempt $i/$testRunAttempts failed. Sleeping 30 seconds..."
-#      sleep 30
-#    fi
-#  done
-#
-#  if [[ $test_failed == "true" ]] ; then
-#      return 1
-#  fi
+  testAlerts=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh")
+
+  testRunAttempts=5
+  for ((i=1; i<=$testRunAttempts; i++)); do
+    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
+      test_failed=""
+      break
+    else
+      test_failed="true"
+      >&2 echo "Run test script via SSH: attempt $i/$testRunAttempts failed. Sleeping 30 seconds..."
+      sleep 30
+    fi
+  done
+
+  if [[ $test_failed == "true" ]] ; then
+      return 1
+  fi
 
   write_deckhouse_logs
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Tests can failed on AWS and on static because of incorrect alert checking.
Should to ignore alerts CertmanagerCertificateExpired.*, Deckhouse ModuleEmpty.
Disable earlyOOM killer for AWS tests, cause AWS use Centos with kernel version below 4

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without fixes tests failed every time

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

All test pass (primary AWS and static). All alerts that need to be ignored are ignored.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Fix some errors on e2e tests in AWS and static
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
