### PR TITLE
[deckhouse] Add annotation to apply DeckhouseRelease immediately

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -105,17 +105,17 @@ In this case, Deckhouse does not check for updates and even doesn't apply patch 
 It is highly not recommended to disable automatic updates! It will block updates to patch releases that may contain critical vulnerabilities and bugs fixes.
 {% endalert %}
 
-### How to apply an update bypassing update windows?
+### How do I apply an update without having to wait for the update window?
 
-To apply an update immediately, regardless update windows, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) resource.
+To apply an update immediately without having to wait for the update window, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) resource.
 
-An example of the  command to set the annotation of skipping update windows for version `v1.56.2`:
+An example of a command to set the annotation to skip the update windows for version `v1.56.2`:
 
 ```shell
 kubectl annotate deckhousereleases v1.56.2 release.deckhouse.io/apply-now="true"
 ```
 
-An example of a resource with the annotation of skipping update windows:
+An example of a resource with the update window skipping annotation in place:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -76,19 +76,6 @@ There are three possible update modes:
 * **Automatic + update windows are set.** The cluster will be updated in the nearest available window after the new version appears on the release channel.
 * **Manual.** [Manual action](modules/002-deckhouse/usage.html#manual-update-confirmation) is required to apply the update.
 
-### How to apply an update bypassing windows?
-
-To apply the update at the current moment, regardless of time restrictions, you need to add a special annotation release.deckhouse.io/apply-now with the value true to the [Deckhouse Release](modules/002-deckhouse/cr.html#deckhouserelease) object
-
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: DeckhouseRelease
-metadata:
-  annotations:
-    release.deckhouse.io/apply-now: "true"
-...
-```
-
 ### How do I set the desired release channel?
 
 Change (set) the [releaseChannel](modules/002-deckhouse/configuration.html#parameters-releasechannel) parameter in the `deckhouse` module [configuration](modules/002-deckhouse/configuration.html) to automatically switch to another release channel.
@@ -117,6 +104,27 @@ In this case, Deckhouse does not check for updates and even doesn't apply patch 
 {% alert level="danger" %}
 It is highly not recommended to disable automatic updates! It will block updates to patch releases that may contain critical vulnerabilities and bugs fixes.
 {% endalert %}
+
+### How to apply an update bypassing update windows?
+
+To apply an update immediately, regardless update windows, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) resource.
+
+An example of the  command to set the annotation of skipping update windows for version `v1.56.2`:
+
+```shell
+kubectl annotate deckhousereleases v1.56.2 release.deckhouse.io/apply-now="true"
+```
+
+An example of a resource with the annotation of skipping update windows:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/apply-now: "true"
+...
+```
 
 ### How to understand what changes the update contains and how it will affect the cluster?
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -76,6 +76,19 @@ There are three possible update modes:
 * **Automatic + update windows are set.** The cluster will be updated in the nearest available window after the new version appears on the release channel.
 * **Manual.** [Manual action](modules/002-deckhouse/usage.html#manual-update-confirmation) is required to apply the update.
 
+### How to apply an update bypassing windows?
+
+To apply the update at the current moment, regardless of time restrictions, you need to add a special annotation release.deckhouse.io/apply-now with the value true to the [Deckhouse Release](modules/002-deckhouse/cr.html#deckhouserelease) object
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/apply-now: "true"
+...
+```
+
 ### How do I set the desired release channel?
 
 Change (set) the [releaseChannel](modules/002-deckhouse/configuration.html#parameters-releasechannel) parameter in the `deckhouse` module [configuration](modules/002-deckhouse/configuration.html) to automatically switch to another release channel.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -77,19 +77,6 @@ status:
 * **Автоматический + заданы окна обновлений.** Кластер обновится в ближайшее доступное окно после появления новой версии на канале обновлений.
 * **Ручной режим.** Для применения обновления требуются [ручные действия](modules/002-deckhouse/usage.html#ручное-подтверждение-обновлений).
 
-### Как применить обновление минуя окна?
-
-Чтобы применить обновление в текущий момент, не зависимо от временных ограничений, нужно добавить в объекте [Deckhouse Release](modules/002-deckhouse/cr.html#deckhouserelease) добавить специальную аннотацию release.deckhouse.io/apply-now со значением true
-
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: DeckhouseRelease
-metadata:
-  annotations:
-    release.deckhouse.io/apply-now: "true"
-...
-```
-
 ### Как установить желаемый канал обновлений?
 
 Чтобы перейти на другой канал обновлений автоматически, нужно в [конфигурации](modules/002-deckhouse/configuration.html) модуля `deckhouse` изменить (установить) параметр [releaseChannel](modules/002-deckhouse/configuration.html#parameters-releasechannel).
@@ -118,6 +105,27 @@ spec:
 {% alert level="danger" %}
 Крайне не рекомендуется отключать автоматическое обновление! Это заблокирует обновления на patch-релизы, которые могут содержать исправления критических уязвимостей и ошибок.
 {% endalert %}
+
+### Как применить обновление минуя окна обновлений?
+
+Чтобы применить обновление немедленно, не дожидаясь ближайшего окна обновлений, установите в соответствующем ресурсе [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) аннотацию `release.deckhouse.io/apply-now: "true"`.
+
+Пример команды установки аннотации пропуска окон обновлений для версии `v1.56.2`:
+
+```shell
+kubectl annotate deckhousereleases v1.56.2 release.deckhouse.io/apply-now="true"
+```
+
+Пример ресурса с установленной аннотацией пропуска окон обновлений:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/apply-now: "true"
+...
+```
 
 ### Как понять, какие изменения содержит обновление и как это повлияет на работу кластера?
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -77,6 +77,19 @@ status:
 * **Автоматический + заданы окна обновлений.** Кластер обновится в ближайшее доступное окно после появления новой версии на канале обновлений.
 * **Ручной режим.** Для применения обновления требуются [ручные действия](modules/002-deckhouse/usage.html#ручное-подтверждение-обновлений).
 
+### Как применить обновление минуя окна?
+
+Чтобы применить обновление в текущий момент, не зависимо от временных ограничений, нужно добавить в объекте [Deckhouse Release](modules/002-deckhouse/cr.html#deckhouserelease) добавить специальную аннотацию release.deckhouse.io/apply-now со значением true
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/apply-now: "true"
+...
+```
+
 ### Как установить желаемый канал обновлений?
 
 Чтобы перейти на другой канал обновлений автоматически, нужно в [конфигурации](modules/002-deckhouse/configuration.html) модуля `deckhouse` изменить (установить) параметр [releaseChannel](modules/002-deckhouse/configuration.html#parameters-releasechannel).


### PR DESCRIPTION
## Description
Added documentation for https://github.com/deckhouse/deckhouse/pull/6651
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/5772
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---
## Why do we need it in the patch release (if we do)?

Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->


<!---
## What is the expected result?

  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
impact: Update documentation about how to add an annotation to apply DeckhouseRelease immediately.
impact_level: low
```
