### PR TITLE
[admission-policy-engine][docs] Fix table with CE and EE comparison and make some text typos

### DIFF
--- a/modules/015-admission-policy-engine/openapi/config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/config-values.yaml
@@ -56,13 +56,13 @@ properties:
   denyVulnerableImages:
     type: object
     default: {}
+    x-doc-d8Revision: ee
     description: |
       Trivy provider will deny creation of the `Pod`/`Deployment`/`StatefulSet`/`DaemonSet` with vulnerable images in namespaces with `security.deckhouse.io/trivy-provider: ""` label.
     properties:
       enabled:
         type: boolean
         default: false
-        x-doc-d8Revision: ee
         description: "Enable trivy provider."
       registrySecrets:
         type: array

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -763,11 +763,11 @@ Test PASSED
 Done
 ```
 
-## How to deploy custom containerd configuration ?
+## How to deploy custom containerd configuration?
 
 Bashible on nodes merges main deckhouse containerd config with configs from `/etc/containerd/conf.d/*.toml`.
 
-### How to add additional registry auth ?
+### How to add additional registry auth?
 
 Deploy `NodeGroupConfiguration` script:
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -770,11 +770,11 @@ Test PASSED
 Done
 ```
 
-## Как развернуть кастомный конфиг containerd ?
+## Как развернуть кастомный конфиг containerd?
 
 Bashible на узлах мержит основной конфиг containerd для Deckhouse с  конфигами из `/etc/containerd/conf.d/*.toml`.
 
-### Как добавить авторизацию в дополнительный registry ?
+### Как добавить авторизацию в дополнительный registry?
 
 Разверните скрипт `NodeGroupConfiguration`:
 


### PR DESCRIPTION
## Description

* Inaccuracies in the comparison table of CE and EE versions have been eliminated.
* Several typos have been eliminated.

## Why do we need it, and what problem does it solve?

This will make the documentation more accurate and relevant.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Make the documentation more consistent.
impact_level: low
```
