### PR TITLE
[monitoring-kubernetes] Add alert NodeFilesystemIsRO

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-ro-fs.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-ro-fs.yaml
@@ -11,8 +11,8 @@
       tier: cluster
     annotations:
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__node_filesustem_is_r_o: "NodeFilesystemIsRO,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__node_filesustem_is_r_o: "NodeFilesystemIsRO,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__node_filesustem_is_r_o_cluster: "NodeFilesystemIsROCluster,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__node_filesustem_is_r_o_cluster: "NodeFilesystemIsROCluster,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       description: |-
         The file system has entered read-only mode.
 

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-ro-fs.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-ro-fs.yaml
@@ -1,0 +1,20 @@
+- name: kubernetes.node.rofs
+  rules:
+  - alert: NodeFilesystemIsRO
+    expr: |-
+      max by (node, mountpoint, device, fstype) (
+        node_filesystem_readonly{mountpoint=~"(/|/mnt/kubernetes-data|/var/lib/containerd/)"}
+      ) != 0
+    for: 5m
+    labels:
+      severity_level: "4"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__node_filesustem_is_r_o: "NodeFilesystemIsRO,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__node_filesustem_is_r_o: "NodeFilesystemIsRO,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      description: |-
+        The file system has entered read-only mode.
+
+        You need to find out the cause and fix it.
+      summary: The file system has entered read-only mode.


### PR DESCRIPTION
## Description

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/3893 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: feature
summary: Add alert NodeFilesystemIsRO
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
