### PR TITLE
[monitoring-kubernetes]  merged kube_persistentvolume_is_local into one query 

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kube-state-metrics.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kube-state-metrics.yaml
@@ -31,14 +31,10 @@
   # kube_persistentvolume_is_local migration.
   # The patch was not generic enough, but it is used in many alerts/panels.
   # This recording rule is aimed to avoid rewriting them.
-  #
-  # kube_persistentvolume_is_local {instance="", job="", persistentvolume="", scrape_endpoint="", storageclass=""} 0
-  - expr: max by (instance, job, persistentvolume, scrape_endpoint, storageclass) (kube_persistentvolume_info{local_path!~".+"} - 1)
-    record: kube_persistentvolume_is_local
-  - expr: max by (instance, job, persistentvolume, scrape_endpoint, storageclass) (kube_persistentvolume_info{host_path!~".+"} - 1)
-    record: kube_persistentvolume_is_local
-  # kube_persistentvolume_is_local {instance="", job="", persistentvolume="", scrape_endpoint="", storageclass=""} 1
-  - expr: max by (instance, job, persistentvolume, scrape_endpoint, storageclass) (kube_persistentvolume_info{local_path=~".+"})
-    record: kube_persistentvolume_is_local
-  - expr: max by (instance, job, persistentvolume, scrape_endpoint, storageclass) (kube_persistentvolume_info{host_path=~".+"})
+  - expr: |
+      max by (instance, job, persistentvolume, scrape_endpoint, storageclass) (
+          kube_persistentvolume_info{local_path=~".+"} or kube_persistentvolume_info{host_path=~".+"}
+        or
+          (kube_persistentvolume_info - 1)
+      )
     record: kube_persistentvolume_is_local


### PR DESCRIPTION
## Description
In the new version of Prometheus only the values of the first query were given. the other queries did not overwrite the metrics values, which broke the logic. 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/6238
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: fixed generation of metrics kube_persistentvolume_is_local
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
