### PR TITLE
[external-module-controller] restart single module with PullOverride on update

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -177,15 +177,15 @@ func run(ctx context.Context, operator *addon_operator.AddonOperator) error {
 
 	operator.ModuleManager.SetModuleLoader(dController)
 
+	// Init deckhouse-config service with ModuleManager instance.
+	d8config.InitService(operator.ModuleManager)
+
 	err = operator.Start()
 	if err != nil {
 		return err
 	}
 
 	dController.RunControllers()
-
-	// Init deckhouse-config service with ModuleManager instance.
-	d8config.InitService(operator.ModuleManager)
 
 	// Block main thread by waiting signals from OS.
 	utils_signal.WaitForProcessInterruption(func() {

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -40,6 +40,8 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/models"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/release"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/source"
+	sm "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/source_modules"
+	deckhouseconfig "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
 	d8http "github.com/deckhouse/deckhouse/go_lib/dependency/http"
 )
 
@@ -60,7 +62,7 @@ type DeckhouseController struct {
 
 	deckhouseModules map[string]*models.DeckhouseModule
 	// <module-name>: <module-source>
-	sourceModules           map[string]string
+	sourceModules           *sm.SourceModules
 	embeddedDeckhousePolicy *v1alpha1.ModuleUpdatePolicySpec
 
 	// separate controllers
@@ -88,6 +90,7 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	modulePullOverrideInformer := informerFactory.Deckhouse().V1alpha1().ModulePullOverrides()
 
 	httpClient := d8http.NewClient()
+	sourceModules := sm.InitSourceModules()
 	embeddedDeckhousePolicy := &v1alpha1.ModuleUpdatePolicySpec{
 		Update: v1alpha1.ModuleUpdatePolicySpecUpdate{
 			Mode: "Auto",
@@ -102,13 +105,13 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 		mm:         mm,
 
 		deckhouseModules:        make(map[string]*models.DeckhouseModule),
-		sourceModules:           make(map[string]string),
+		sourceModules:           sourceModules,
 		embeddedDeckhousePolicy: embeddedDeckhousePolicy,
 
 		informerFactory:              informerFactory,
 		moduleSourceController:       source.NewController(mcClient, moduleSourceInformer, moduleReleaseInformer, moduleUpdatePolicyInformer, modulePullOverrideInformer, embeddedDeckhousePolicy),
-		moduleReleaseController:      release.NewController(cs, mcClient, moduleReleaseInformer, moduleSourceInformer, moduleUpdatePolicyInformer, modulePullOverrideInformer, mm, httpClient, metricStorage, embeddedDeckhousePolicy),
-		modulePullOverrideController: release.NewModulePullOverrideController(cs, mcClient, moduleSourceInformer, modulePullOverrideInformer, mm),
+		moduleReleaseController:      release.NewController(cs, mcClient, moduleReleaseInformer, moduleSourceInformer, moduleUpdatePolicyInformer, modulePullOverrideInformer, mm, httpClient, metricStorage, embeddedDeckhousePolicy, sourceModules),
+		modulePullOverrideController: release.NewModulePullOverrideController(cs, mcClient, moduleSourceInformer, modulePullOverrideInformer, mm, sourceModules),
 	}, nil
 }
 
@@ -121,8 +124,6 @@ func (dml *DeckhouseController) Start(ec chan events.ModuleEvent, deckhouseConfi
 	if err != nil {
 		return err
 	}
-
-	dml.sourceModules = dml.moduleReleaseController.GetModuleSources()
 
 	err = dml.searchAndLoadDeckhouseModules()
 	if err != nil {
@@ -221,15 +222,22 @@ func (dml *DeckhouseController) handleModulePurge(m *models.DeckhouseModule) err
 
 func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModule) error {
 	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
-		src := dml.sourceModules[m.GetBasicModule().GetName()]
+		src := dml.sourceModules.GetSource(m.GetBasicModule().GetName())
 		newModule := m.AsKubeObject(src)
+		moduleName := newModule.GetName()
 		newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
 
-		existModule, err := dml.kubeClient.DeckhouseV1alpha1().Modules().Get(dml.ctx, newModule.GetName(), v1.GetOptions{})
+		existModule, err := dml.kubeClient.DeckhouseV1alpha1().Modules().Get(dml.ctx, moduleName, v1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				_, err = dml.kubeClient.DeckhouseV1alpha1().Modules().Create(dml.ctx, newModule, v1.CreateOptions{})
-				return err
+				if err != nil {
+					return err
+				}
+				// update d8service state
+				deckhouseconfig.Service().AddModuleNameToSource(moduleName, src)
+				deckhouseconfig.Service().AddPossibleName(moduleName)
+				return nil
 			}
 
 			return err
@@ -255,6 +263,8 @@ func (dml *DeckhouseController) handleEnabledModule(m *models.DeckhouseModule, e
 			return err
 		}
 
+		// update module's properties
+		obj.Properties.Weight = m.GetBasicModule().GetOrder()
 		obj.Properties.State = "Disabled"
 		obj.Status.Status = "Disabled"
 		if enable {

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -227,17 +227,15 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 		moduleName := newModule.GetName()
 		newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
 
+		// update d8service state
+		deckhouseconfig.Service().AddModuleNameToSource(moduleName, src)
+		deckhouseconfig.Service().AddPossibleName(moduleName)
+
 		existModule, err := dml.kubeClient.DeckhouseV1alpha1().Modules().Get(dml.ctx, moduleName, v1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				_, err = dml.kubeClient.DeckhouseV1alpha1().Modules().Create(dml.ctx, newModule, v1.CreateOptions{})
-				if err != nil {
-					return err
-				}
-				// update d8service state
-				deckhouseconfig.Service().AddModuleNameToSource(moduleName, src)
-				deckhouseconfig.Service().AddPossibleName(moduleName)
-				return nil
+				return err
 			}
 
 			return err

--- a/deckhouse-controller/pkg/controller/loader.go
+++ b/deckhouse-controller/pkg/controller/loader.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -33,6 +34,7 @@ import (
 )
 
 var (
+	ErrModuleAlreadyExists = errors.New("module already exists")
 	// some ephemeral modules, which we even don't want to load
 	excludeModules = map[string]struct{}{
 		"000-common":           {},
@@ -40,8 +42,26 @@ var (
 	}
 )
 
-func (dml *DeckhouseController) LoadModule(_, _ string) (*modules.BasicModule, error) {
-	return nil, fmt.Errorf("not implemented yet")
+// reads single directory and returns BasicModule
+func (dml *DeckhouseController) LoadModule(moduleSource, modulePath string) (*modules.BasicModule, error) {
+	_, err := readDir(modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	def, err := dml.parseModuleDir(filepath.Base(modulePath), modulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	dm, err := dml.processModuleDefinition(*def)
+	if err != nil && !errors.Is(err, ErrModuleAlreadyExists) {
+		return nil, err
+	}
+
+	dml.deckhouseModules[def.Name] = dm
+	dml.sourceModules.SetSource(def.Name, moduleSource)
+	return dm.GetBasicModule(), nil
 }
 
 func (dml *DeckhouseController) LoadModules() ([]*modules.BasicModule, error) {
@@ -54,6 +74,47 @@ func (dml *DeckhouseController) LoadModules() ([]*modules.BasicModule, error) {
 	return result, nil
 }
 
+func (dml *DeckhouseController) processModuleDefinition(def models.DeckhouseModuleDefinition) (*models.DeckhouseModule, error) {
+	err := validateModuleName(def.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// load values for module
+	valuesModuleName := utils.ModuleNameToValuesKey(def.Name)
+	// 1. from static values.yaml inside the module
+	moduleStaticValues, err := utils.LoadValuesFileFromDir(def.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	if moduleStaticValues.HasKey(valuesModuleName) {
+		moduleStaticValues = moduleStaticValues.GetKeySection(valuesModuleName)
+	}
+
+	// 2. from openapi defaults
+	cb, vb, err := utils.ReadOpenAPIFiles(filepath.Join(def.Path, "openapi"))
+	if err != nil {
+		return nil, err
+	}
+
+	if cb != nil && vb != nil {
+		log.Debugf("Add openapi schema for %q module", valuesModuleName)
+		err = dml.mm.GetValuesValidator().SchemaStorage.AddModuleValuesSchemas(valuesModuleName, cb, vb)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	dm := models.NewDeckhouseModule(def, moduleStaticValues, dml.mm.GetValuesValidator())
+
+	if _, ok := dml.deckhouseModules[def.Name]; ok {
+		return dm, ErrModuleAlreadyExists
+	}
+
+	return dm, nil
+}
+
 func (dml *DeckhouseController) searchAndLoadDeckhouseModules() error {
 	for _, dir := range dml.dirs {
 		definitions, err := dml.findModulesInDir(dir)
@@ -62,43 +123,15 @@ func (dml *DeckhouseController) searchAndLoadDeckhouseModules() error {
 		}
 
 		for _, def := range definitions {
-			err = validateModuleName(def.Name)
+			dm, err := dml.processModuleDefinition(def)
 			if err != nil {
-				return err
-			}
-
-			// load values for module
-			valuesModuleName := utils.ModuleNameToValuesKey(def.Name)
-			// 1. from static values.yaml inside the module
-			moduleStaticValues, err := utils.LoadValuesFileFromDir(def.Path)
-			if err != nil {
-				return err
-			}
-
-			if moduleStaticValues.HasKey(valuesModuleName) {
-				moduleStaticValues = moduleStaticValues.GetKeySection(valuesModuleName)
-			}
-
-			// 2. from openapi defaults
-			cb, vb, err := utils.ReadOpenAPIFiles(filepath.Join(def.Path, "openapi"))
-			if err != nil {
-				return err
-			}
-
-			if cb != nil && vb != nil {
-				log.Debugf("Add openapi schema for %q module", valuesModuleName)
-				err = dml.mm.GetValuesValidator().SchemaStorage.AddModuleValuesSchemas(valuesModuleName, cb, vb)
-				if err != nil {
-					return err
+				if errors.Is(err, ErrModuleAlreadyExists) {
+					log.Warnf("Module %q is already exists. Skipping module from %q", def.Name, def.Path)
+					continue
 				}
+				return err
 			}
 
-			if _, ok := dml.deckhouseModules[def.Name]; ok {
-				log.Warnf("Module %q is already exists. Skipping module from %q", def.Name, def.Path)
-				continue
-			}
-
-			dm := models.NewDeckhouseModule(def, moduleStaticValues, dml.mm.GetValuesValidator())
 			dml.deckhouseModules[def.Name] = dm
 		}
 	}
@@ -106,13 +139,40 @@ func (dml *DeckhouseController) searchAndLoadDeckhouseModules() error {
 	return nil
 }
 
-func (dml *DeckhouseController) findModulesInDir(modulesDir string) ([]models.DeckhouseModuleDefinition, error) {
-	dirEntries, err := os.ReadDir(modulesDir)
-	if err != nil && os.IsNotExist(err) {
-		return nil, fmt.Errorf("path '%s' does not exist", modulesDir)
-	}
+// checks if dir exists and returns entries
+func readDir(dir string) ([]os.DirEntry, error) {
+	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("listing modules directory '%s': %s", modulesDir, err)
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("path '%s' does not exist", dir)
+		}
+		return nil, fmt.Errorf("listing modules directory '%s': %s", dir, err)
+	}
+	return dirEntries, nil
+}
+
+// get module's definition out of a target dir
+func (dml *DeckhouseController) parseModuleDir(moduleName, moduleDir string) (*models.DeckhouseModuleDefinition, error) {
+	definition, err := dml.moduleFromFile(moduleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if definition == nil {
+		log.Debugf("module.yaml for module %q does not exist", moduleName)
+		definition, err = dml.moduleFromDirName(moduleName, moduleDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return definition, nil
+}
+
+func (dml *DeckhouseController) findModulesInDir(modulesDir string) ([]models.DeckhouseModuleDefinition, error) {
+	dirEntries, err := readDir(modulesDir)
+	if err != nil {
+		return nil, err
 	}
 
 	definitions := make([]models.DeckhouseModuleDefinition, 0)
@@ -130,12 +190,7 @@ func (dml *DeckhouseController) findModulesInDir(modulesDir string) ([]models.De
 			continue
 		}
 
-		definition, err := dml.moduleFromDirName(name, absPath)
-		if err != nil {
-			return nil, err
-		}
-
-		definition, err = dml.overwriteModuleFromModuleYamlFile(absPath, definition)
+		definition, err := dml.parseModuleDir(name, absPath)
 		if err != nil {
 			return nil, err
 		}
@@ -154,38 +209,28 @@ const (
 	ModuleNameIdx  = 3
 )
 
-func (dml *DeckhouseController) overwriteModuleFromModuleYamlFile(absPath string, definition *models.DeckhouseModuleDefinition) (*models.DeckhouseModuleDefinition, error) {
+func (dml *DeckhouseController) moduleFromFile(absPath string) (*models.DeckhouseModuleDefinition, error) {
 	mFilePath := filepath.Join(absPath, models.ModuleDefinitionFile)
 	if _, err := os.Stat(mFilePath); err != nil {
 		if os.IsNotExist(err) {
-			return definition, nil
+			return nil, nil
 		}
-
 		return nil, err
 	}
-
 	f, err := os.Open(mFilePath)
 	if err != nil {
 		return nil, err
 	}
-
 	var def models.DeckhouseModuleDefinition
-
 	err = yaml.NewDecoder(f).Decode(&def)
 	if err != nil {
 		return nil, err
 	}
-
-	if def.Name != "" {
-		definition.Name = def.Name
+	if def.Name == "" || def.Weight == 0 {
+		return nil, nil
 	}
-	if def.Weight != 0 {
-		definition.Weight = def.Weight
-	}
-	definition.Description = def.Description
-	definition.Stage = def.Stage
-
-	return definition, nil
+	def.Path = absPath
+	return &def, nil
 }
 
 // moduleFromDirName returns Module instance filled with name, order and its absolute path.

--- a/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/flant/addon-operator/pkg/utils/logger"
@@ -41,6 +40,7 @@ import (
 	d8listers "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/client/listers/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	sm "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/source_modules"
 	deckhouseconfig "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
 )
 
@@ -65,6 +65,7 @@ type ModulePullOverrideController struct {
 	modulesValidator   moduleValidator
 	externalModulesDir string
 	symlinksDir        string
+	sourceModules      *sm.SourceModules
 }
 
 // NewModulePullOverrideController returns a new sample controller
@@ -73,6 +74,7 @@ func NewModulePullOverrideController(ks kubernetes.Interface,
 	moduleSourceInformer d8informers.ModuleSourceInformer,
 	modulePullOverridesInformer d8informers.ModulePullOverrideInformer,
 	modulesValidator moduleValidator,
+	sourceModules *sm.SourceModules,
 ) *ModulePullOverrideController {
 	ratelimiter := workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 1000*time.Second),
@@ -92,6 +94,8 @@ func NewModulePullOverrideController(ks kubernetes.Interface,
 		workqueue: workqueue.NewRateLimitingQueue(ratelimiter),
 
 		logger: lg,
+
+		sourceModules: sourceModules,
 
 		modulesValidator:   modulesValidator,
 		externalModulesDir: os.Getenv("EXTERNAL_MODULES_DIR"),
@@ -133,8 +137,7 @@ func (c *ModulePullOverrideController) Run(ctx context.Context, workers int) {
 	// Check if controller's dependencies have been initialized
 	_ = wait.PollUntilContextCancel(ctx, utils.SyncedPollPeriod, false,
 		func(context.Context) (bool, error) {
-			// TODO: add modulemanager initialization check c.modulesValidator.AreModulesInited() (required for reloading modules without restarting deckhouse)
-			return deckhouseconfig.IsServiceInited(), nil
+			return deckhouseconfig.IsServiceInited() && c.modulesValidator.AreModulesInited(), nil
 		})
 
 	// Start the informer factories to begin populating the informer caches
@@ -260,6 +263,8 @@ func (c *ModulePullOverrideController) moduleOverrideReconcile(ctx context.Conte
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	c.sourceModules.SetSource(mo.Name, mo.Spec.Source)
+
 	md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
 	newChecksum, moduleDef, err := md.DownloadDevImageTag(mo.Name, mo.Spec.ImageTag, mo.Status.ImageDigest)
 	if err != nil {
@@ -305,29 +310,26 @@ func (c *ModulePullOverrideController) moduleOverrideReconcile(ctx context.Conte
 
 		return ctrl.Result{Requeue: true}, err
 	}
-	// disable target module hooks so as not to invoke them before restart
-	if c.modulesValidator.GetModule(mo.Name) != nil {
-		c.modulesValidator.DisableModuleHooks(mo.Name)
-	}
-	defer func() {
-		c.logger.Infof("Restarting Deckhouse because %q ModulePullOverride image was updated", mo.Name)
-		err := syscall.Kill(1, syscall.SIGUSR2)
-		if err != nil {
-			c.logger.Fatalf("Send SIGUSR2 signal failed: %s", err)
-		}
-	}()
 
 	mo.Status.Message = ""
 	mo.Status.ImageDigest = newChecksum
 
-	if e := c.updateModulePullOverrideStatus(ctx, mo); e != nil {
-		return ctrl.Result{Requeue: true}, e
+	if err := c.updateModulePullOverrideStatus(ctx, mo); err != nil {
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	if _, ok := mo.Labels["renew"]; ok {
 		delete(mo.Labels, "renew")
 		_, _ = c.d8ClientSet.DeckhouseV1alpha1().ModulePullOverrides().Update(ctx, mo, metav1.UpdateOptions{})
 	}
+
+	// register/reload module
+	err = c.modulesValidator.RegisterModule(mo.Spec.Source, symlinkPath)
+	if err != nil {
+		c.logger.Errorf("Module %q registration/reload failed: %v", mo.Name, err)
+		return ctrl.Result{Requeue: true}, err
+	}
+	c.logger.Infof("Module %s was reloaded because its ModulePullOverride image was updated", mo.Name)
 
 	return ctrl.Result{RequeueAfter: mo.Spec.ScanInterval.Duration}, nil
 }

--- a/deckhouse-controller/pkg/controller/source_modules/source_modules.go
+++ b/deckhouse-controller/pkg/controller/source_modules/source_modules.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source_modules
+
+import (
+	"sync"
+)
+
+type SourceModules struct {
+	lck  sync.RWMutex
+	dict map[string]string
+}
+
+func InitSourceModules() *SourceModules {
+	return &SourceModules{dict: make(map[string]string)}
+}
+
+func (sm *SourceModules) GetSource(module string) string {
+	sm.lck.RLock()
+	defer sm.lck.RUnlock()
+	return sm.dict[module]
+}
+
+func (sm *SourceModules) SetSource(moduleName, moduleSource string) {
+	sm.lck.Lock()
+	sm.dict[moduleName] = moduleSource
+	sm.lck.Unlock()
+}

--- a/go_lib/deckhouse-config/service.go
+++ b/go_lib/deckhouse-config/service.go
@@ -113,3 +113,9 @@ func (srv *ConfigService) GetValuesValidator() *validation.ValuesValidator {
 func (srv *ConfigService) ValidateModule(module *modules.BasicModule) error {
 	return srv.moduleManager.ValidateModule(module)
 }
+
+func (srv *ConfigService) AddPossibleName(name string) {
+	serviceInstanceLock.Lock()
+	srv.possibleNames.Add(name)
+	serviceInstanceLock.Unlock()
+}

--- a/go_lib/deckhouse-config/service.go
+++ b/go_lib/deckhouse-config/service.go
@@ -37,7 +37,7 @@ func InitService(mm ModuleManager) {
 	serviceInstanceLock.Lock()
 	defer serviceInstanceLock.Unlock()
 
-	possibleNames := set.New(mm.GetModuleNames()...)
+	possibleNames := set.New()
 	possibleNames.Add("global")
 
 	serviceInstance = &ConfigService{

--- a/modules/002-deckhouse/hooks/dconfig_update_status_test.go
+++ b/modules/002-deckhouse/hooks/dconfig_update_status_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
-		        d8config.Service().AddPossibleName("module-one")
+			d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
@@ -136,7 +136,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
-		        d8config.Service().AddPossibleName("module-one")
+			d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
@@ -182,7 +182,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
-		        d8config.Service().AddPossibleName("module-one")
+			d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
@@ -207,7 +207,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
-		        d8config.Service().AddPossibleName("module-one")
+			d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()

--- a/modules/002-deckhouse/hooks/dconfig_update_status_test.go
+++ b/modules/002-deckhouse/hooks/dconfig_update_status_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
+		        d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
@@ -135,6 +136,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
+		        d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
@@ -180,6 +182,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
+		        d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
@@ -204,6 +207,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
+		        d8config.Service().AddPossibleName("module-one")
 
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()


### PR DESCRIPTION
## Description
Changes:
* shows correct module sources for modules deployed by `MPO`;
* new subsctructure `sourceModules` (a map with a lock) that is shared among `deckhouse`, `release` and `override` controllers;
* override controller handles `MPO` updates by means of `RegisterModule` method of the module manager to Register a new `MPO`-deployed module, or, if the module already exists, to Reload its configuration and apply changes;

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
This pr enables us to not reload `deckhouse` controller each time a `MPO`-deployed module is updated, but rather reapply new configuration to all enabled modules (`ConvergeModules`), maintaining modules' values in a coherent state.
Closes #6697 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
External modules with PullOverrides can be updated without reloading deckhouse.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: feature
summary: Provides a way of registering a MPO module without reloading deckhouse controller.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
