### PR TITLE
[node-manager] Use dependency-free cross-version python script for second phase bootstrap loading

### DIFF
--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -24,56 +24,35 @@ function detect_bundle() {
 }
 
 function check_python() {
-  if command -v python3 >/dev/null 2>&1; then
-    python_binary="python3"
-    script="$(p3_script)"
-    return 0
-  fi
-  if command -v python2 >/dev/null 2>&1; then
-    python_binary="python2"
-    script="$(p2_script)"
-    return 0
-  fi
-  if command -v python >/dev/null 2>&1; then
-    python_binary="python"
-    if python --version | grep -q "Python 3"; then
-      script="$(p3_script)"
+  for pybin in python3 python2 python; do
+    if command -v "$pybin" >/dev/null 2>&1; then
+      python_binary="$pybin"
       return 0
     fi
-    if python --version | grep -q "Python 2"; then
-      script="$(p2_script)"
-      return 0
-    fi
-  fi
+  done
   echo "Python not found, exiting..."
   return 1
 }
 
-function p2_script() {
+function load_phase2_script() {
   cat - <<EOF
-import os
 import sys
 import json
-import urllib2
 import ssl
+
+try:
+    from urllib.request import urlopen, Request
+except ImportError as e:
+    from urllib2 import urlopen, Request
+
 ssl.match_hostname = lambda cert, hostname: True
-request = urllib2.Request(sys.argv[1], headers={'Authorization': 'Bearer ' + sys.argv[2]})
-response = urllib2.urlopen(request, cafile='/var/lib/bashible/ca.crt')
+request = Request(sys.argv[1], headers={'Authorization': 'Bearer ' + sys.argv[2]})
+response = urlopen(request, cafile='/var/lib/bashible/ca.crt')
 data = json.loads(response.read())
 sys.stdout.write(data["bootstrap"])
 EOF
 }
 
-function p3_script() {
-  cat - <<EOF
-import sys
-import requests
-import json
-response = requests.get(sys.argv[1], headers={'Authorization': 'Bearer ' + sys.argv[2]}, verify='/var/lib/bashible/ca.crt')
-data = json.loads(response.content)
-sys.stdout.write(data["bootstrap"])
-EOF
-}
 
 function get_phase2() {
   check_python
@@ -82,7 +61,7 @@ function get_phase2() {
   while true; do
     for server in {{ $context.Values.nodeManager.internal.clusterMasterAddresses | join " " }}; do
       url="https://${server}/apis/bashible.deckhouse.io/v1alpha1/bootstrap/${bootstrap_bundle_name}"
-      if eval "${python_binary}" - "${url}" "${token}" <<< "${script}"; then
+      if eval "${python_binary}" - "${url}" "${token}" <<< "$(load_phase2_script)"; then
         return 0
       fi
       >&2 echo "failed to get bootstrap ${bootstrap_bundle_name} from $url"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Use dependency-free cross-version python script for second phase bootstrap loading.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
- No longer need to support multiple versions of python
- No third-party packages (`requests`) are used that are not included in python by default

## Why do we need it in the patch release (if we do)?
We don't

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
We can bootstrap node without cloud-init package (which brings `requests` python package).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Use dependency-free cross-version python script for second phase bootstrap loading.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
