### PR TITLE
[admission-policy-engine] add policy for replicas limits

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/replica-limits.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/replica-limits.yaml
@@ -60,3 +60,13 @@ spec:
             range.min_replicas <= value
             range.max_replicas >= value
         }
+
+        value_within_range(range, value) {
+            not range.min_replicas
+            range.max_replicas >= value
+        }
+
+        value_within_range(range, value) {
+            range.min_replicas <= value
+            not range.max_replicas
+        }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/replica-limits.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/replica-limits.yaml
@@ -1,0 +1,62 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: d8replicalimits
+  labels:
+    heritage: deckhouse
+    module: admission-policy-engine
+    security.deckhouse.io: operation-policy
+  annotations:
+    metadata.gatekeeper.sh/title: "Replica Limits"
+    metadata.gatekeeper.sh/version: 1.0.1
+    description: >-
+      Requires that objects with the field `spec.replicas` (Deployments,
+      ReplicaSets, etc.) specify a number of replicas within defined ranges.
+spec:
+  crd:
+    spec:
+      names:
+        kind: D8ReplicaLimits
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            ranges:
+              type: array
+              description: Allowed ranges for numbers of replicas.  Values are inclusive.
+              items:
+                type: object
+                description: A range of allowed replicas.  Values are inclusive.
+                properties:
+                  min_replicas:
+                    description: The minimum number of replicas allowed, inclusive.
+                    type: integer
+                  max_replicas:
+                    description: The maximum number of replicas allowed, inclusive.
+                    type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package d8.operation_policies
+
+        object_name = input.review.object.metadata.name
+        object_kind = input.review.kind.kind
+
+        violation[{"msg": msg}] {
+            spec := input.review.object.spec
+            not input_replica_limit(spec)
+            msg := sprintf("The provided number of replicas is not allowed for %v: %v. Allowed ranges: %v", [object_kind, object_name, input.parameters])
+        }
+
+        input_replica_limit(spec) {
+            provided := input.review.object.spec.replicas
+            count(input.parameters.ranges) > 0
+            range := input.parameters.ranges[_]
+            value_within_range(range, provided)
+        }
+
+        value_within_range(range, value) {
+            range.min_replicas <= value
+            range.max_replicas >= value
+        }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/replica-limits.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/replica-limits.yaml
@@ -29,10 +29,10 @@ spec:
                 type: object
                 description: A range of allowed replicas.  Values are inclusive.
                 properties:
-                  min_replicas:
+                  minReplicas:
                     description: The minimum number of replicas allowed, inclusive.
                     type: integer
-                  max_replicas:
+                  maxReplicas:
                     description: The maximum number of replicas allowed, inclusive.
                     type: integer
   targets:
@@ -57,16 +57,16 @@ spec:
         }
 
         value_within_range(range, value) {
-            range.min_replicas <= value
-            range.max_replicas >= value
+            range.minReplicas <= value
+            range.maxReplicas >= value
         }
 
         value_within_range(range, value) {
-            not range.min_replicas
-            range.max_replicas >= value
+            not range.minReplicas
+            range.maxReplicas >= value
         }
 
         value_within_range(range, value) {
-            range.min_replicas <= value
-            not range.max_replicas
+            range.minReplicas <= value
+            not range.maxReplicas
         }

--- a/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
@@ -75,6 +75,8 @@ spec:
                       description: "Проверка, что dnsPolicy `ClusterFirstWithHostNet` установлена для подов с `hostNetwork: true`."
                     checkContainerDuplicates:
                       description: "Проверка имен контейнеров и переменных env на наличие дубликатов."
+                    replicaLimits:
+                      description: "Проверка диапазона разрешенных реплик. Значения включаются в диапазон."
                 match:
                   properties:
                     namespaceSelector:

--- a/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
@@ -77,6 +77,11 @@ spec:
                       description: "Проверка имен контейнеров и переменных env на наличие дубликатов."
                     replicaLimits:
                       description: "Проверка диапазона разрешенных реплик. Значения включаются в диапазон."
+                      properties:
+                        minReplicas:
+                          description: "Минимально разрешенное количество реплик, включительно."
+                        maxReplicas:
+                          description: "Максимально разрешенное количество реплик, включительно."
                 match:
                   properties:
                     namespaceSelector:

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -172,7 +172,7 @@ spec:
                       type: boolean
                       description: "Check container names and env variables for duplicates."
                     replicaLimits:
-                      type: array
+                      type: object
                       description: "Allowed ranges for numbers of replicas.  Values are inclusive."
                       items:
                         type: object

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -178,9 +178,11 @@ spec:
                         minReplicas:
                           description: "The minimum number of replicas allowed, inclusive."
                           type: integer
+                          default: 1
                         maxReplicas:
                           description: "The maximum number of replicas allowed, inclusive."
                           type: integer
+                          default: 30
                 match:
                   type: object
                   required: ["namespaceSelector"]

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -178,11 +178,9 @@ spec:
                         minReplicas:
                           description: "The minimum number of replicas allowed, inclusive."
                           type: integer
-                          default: 1
                         maxReplicas:
                           description: "The maximum number of replicas allowed, inclusive."
                           type: integer
-                          default: 30
                 match:
                   type: object
                   required: ["namespaceSelector"]

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -173,17 +173,14 @@ spec:
                       description: "Check container names and env variables for duplicates."
                     replicaLimits:
                       type: object
-                      description: "Allowed ranges for numbers of replicas.  Values are inclusive."
-                      items:
-                        type: object
-                        description: "A range of allowed replicas.  Values are inclusive."
-                        properties:
-                          min_replicas:
-                            description: "The minimum number of replicas allowed, inclusive."
-                            type: integer
-                          max_replicas:
-                            description: "The maximum number of replicas allowed, inclusive."
-                            type: integer
+                      description: "A range of allowed replicas.  Values are inclusive."
+                      properties:
+                        min_replicas:
+                          description: "The minimum number of replicas allowed, inclusive."
+                          type: integer
+                        max_replicas:
+                          description: "The maximum number of replicas allowed, inclusive."
+                          type: integer
                 match:
                   type: object
                   required: ["namespaceSelector"]

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -173,16 +173,16 @@ spec:
                       description: "Check container names and env variables for duplicates."
                     replicaLimits:
                       type: array
-                      description: Allowed ranges for numbers of replicas.  Values are inclusive.
+                      description: "Allowed ranges for numbers of replicas.  Values are inclusive."
                       items:
                         type: object
-                        description: A range of allowed replicas.  Values are inclusive.
+                        description: "A range of allowed replicas.  Values are inclusive."
                         properties:
                           min_replicas:
-                            description: The minimum number of replicas allowed, inclusive.
+                            description: "The minimum number of replicas allowed, inclusive."
                             type: integer
                           max_replicas:
-                            description: The maximum number of replicas allowed, inclusive.
+                            description: "The maximum number of replicas allowed, inclusive."
                             type: integer
                 match:
                   type: object

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -175,10 +175,10 @@ spec:
                       type: object
                       description: "A range of allowed replicas.  Values are inclusive."
                       properties:
-                        min_replicas:
+                        minReplicas:
                           description: "The minimum number of replicas allowed, inclusive."
                           type: integer
-                        max_replicas:
+                        maxReplicas:
                           description: "The maximum number of replicas allowed, inclusive."
                           type: integer
                 match:

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -171,6 +171,19 @@ spec:
                     checkContainerDuplicates:
                       type: boolean
                       description: "Check container names and env variables for duplicates."
+                    replicaLimits:
+                      type: array
+                      description: Allowed ranges for numbers of replicas.  Values are inclusive.
+                      items:
+                        type: object
+                        description: A range of allowed replicas.  Values are inclusive.
+                        properties:
+                          min_replicas:
+                            description: The minimum number of replicas allowed, inclusive.
+                            type: integer
+                          max_replicas:
+                            description: The maximum number of replicas allowed, inclusive.
+                            type: integer
                 match:
                   type: object
                   required: ["namespaceSelector"]

--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
@@ -83,9 +83,9 @@ spec:
       - bar
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true
-	replicaLimits:
-	  minReplicas: 1
-	  maxReplicas: 3
+    replicaLimits:
+      minReplicas: 1
+      maxReplicas: 3
   match:
     namespaceSelector:
       matchNames:

--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
@@ -83,6 +83,9 @@ spec:
       - bar
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true
+	replicaLimits:
+		minReplicas: 1
+		maxReplicas: 3
   match:
     namespaceSelector:
       matchNames:

--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
@@ -84,8 +84,8 @@ spec:
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true
 	replicaLimits:
-		minReplicas: 1
-		maxReplicas: 3
+	  minReplicas: 1
+	  maxReplicas: 3
   match:
     namespaceSelector:
       matchNames:

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -134,6 +134,10 @@ type OperationPolicySpec struct {
 		PriorityClassNames        []string `json:"priorityClassNames,omitempty"`
 		CheckHostNetworkDNSPolicy bool     `json:"checkHostNetworkDNSPolicy,omitempty"`
 		CheckContainerDuplicates  bool     `json:"checkContainerDuplicates,omitempty"`
+		ReplicaLimits             struct {
+			MinReplicas string `json:"minReplicas,omitempty"`
+			MaxReplicas string `json:"maxReplicas,omitempty"`
+		} `json:"replicaLimits,omitempty"`
 	} `json:"policies"`
 	Match struct {
 		NamespaceSelector NamespaceSelector    `json:"namespaceSelector,omitempty"`

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -135,8 +135,8 @@ type OperationPolicySpec struct {
 		CheckHostNetworkDNSPolicy bool     `json:"checkHostNetworkDNSPolicy,omitempty"`
 		CheckContainerDuplicates  bool     `json:"checkContainerDuplicates,omitempty"`
 		ReplicaLimits             struct {
-			MinReplicas string `json:"minReplicas,omitempty"`
-			MaxReplicas string `json:"maxReplicas,omitempty"`
+			MinReplicas int `json:"minReplicas,omitempty"`
+			MaxReplicas int `json:"maxReplicas,omitempty"`
 		} `json:"replicaLimits,omitempty"`
 	} `json:"policies"`
 	Match struct {

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"imagePullPolicy":"Always",
 			"priorityClassNames":["foo","bar"],
 			"checkHostNetworkDNSPolicy":true,
-			"checkContainerDuplicates":true
+			"checkContainerDuplicates":true,
 			"replicaLimits":{"min_replicas": 1, "max_replicas": 10}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"priorityClassNames":["foo","bar"],
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
-			"replicaLimits":{"replicas": 2}
+			"replicaLimits":{"min_replicas":1,"max_replicas":10}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],
 		"trackedConstraintResources": [{"apiGroups":[""],"resources":["pods"]},{"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -57,11 +57,10 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
 			"replicaLimits":{
-				"ranges":
-					{
-						"min_replicas":1,
-						"max_replicas":10
-					}
+				{
+					"min_replicas":1,
+					"max_replicas":10
+				}
 			}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -56,7 +56,14 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"priorityClassNames":["foo","bar"],
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
-			"replicaLimits":{"min_replicas":1,"max_replicas":10}
+			"replicaLimits":{
+				"ranges": [
+					{
+						"min_replicas":1,
+						"max_replicas":10
+					}
+				]
+			}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],
 		"trackedConstraintResources": [{"apiGroups":[""],"resources":["pods"]},{"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"priorityClassNames":["foo","bar"],
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
-			"replicaLimits":{"min_replicas": 1, "max_replicas": 10}
+			"replicaLimits":{"replicas": 2}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],
 		"trackedConstraintResources": [{"apiGroups":[""],"resources":["pods"]},{"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -57,8 +57,8 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
 			"replicaLimits":{
-					"min_replicas":1,
-					"max_replicas":10
+					"minReplicas":1,
+					"maxReplicas":10
 			}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"priorityClassNames":["foo","bar"],
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true
+			"replicaLimits":{"min_replicas": 1, "max_replicas": 10}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],
 		"trackedConstraintResources": [{"apiGroups":[""],"resources":["pods"]},{"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}],
@@ -83,6 +84,8 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			Expect(f.KubernetesGlobalResource("D8RequiredLabels", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8RequiredAnnotations", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8ContainerDuplicates", testPolicyName).Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("D8ReplicaLimits", testPolicyName).Exists()).To(BeTrue())
+
 		})
 	})
 })

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -57,10 +57,8 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
 			"replicaLimits":{
-				{
 					"min_replicas":1,
 					"max_replicas":10
-				}
 			}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -57,12 +57,11 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
 			"replicaLimits":{
-				"ranges": [
+				"ranges":
 					{
 						"min_replicas":1,
 						"max_replicas":10
 					}
-				]
 			}
 		},
 		"match":{"namespaceSelector":{"matchNames":["default"]}}}}],

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -303,7 +303,6 @@ spec:
     {{- include "constraint_selector" (list $cr) }}
   {{- end }}
   parameters:
-    replicas:
-      ranges:
-        - min_replicas: 1
-          max_replicas: 10
+    ranges:
+      - min_replicas: 1
+        max_replicas: 10

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -293,7 +293,7 @@ spec:
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: D8ReplicaLimits
 metadata:
-  name: replica-limits
+  name: {{$cr.metadata.name}}
   {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
 spec:
   match:

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -286,17 +286,21 @@ spec:
     {{- include "constraint_selector" (list $cr) }}
 {{- end }}
 
+{{- define "replica_limits_policy" }}
+  {{- $context := index . 0 }}
+  {{- $cr := index . 1 }}
 ---
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: D8ReplicaLimits
 metadata:
   name: replica-limits
+  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
 spec:
   match:
     kinds:
       - apiGroups: ["apps"]
         kinds: ["Deployment"]
+    {{- include "constraint_selector" (list $cr) }}
   parameters:
-    ranges:
-    - min_replicas: 1
-      max_replicas: 10
+    {{- $cr.spec.policies.replicaLimits | toYaml | nindent 6 }}
+{{- end }}

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -302,5 +302,6 @@ spec:
         kinds: ["Deployment"]
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    {{- $cr.spec.policies.replicaLimits | toYaml | nindent 6 }}
+    ranges:
+      - {{- $cr.spec.policies.replicaLimits | toYaml | nindent 8 }}
 {{- end }}

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -293,7 +293,7 @@ spec:
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: D8ReplicaLimits
 metadata:
-  name: {{$cr.metadata.name}}
+  name: replica-limits
   {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
 spec:
   match:
@@ -304,5 +304,5 @@ spec:
   {{- end }}
   parameters:
     ranges:
-      - min_replicas: 1
-        max_replicas: 10
+    - min_replicas: 1
+      max_replicas: 10

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -303,7 +303,7 @@ spec:
     {{- include "constraint_selector" (list $cr) }}
   {{- end }}
   parameters:
-    replicaLimits:
+    replicas:
       ranges:
         - min_replicas: 1
           max_replicas: 10

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -286,22 +286,16 @@ spec:
     {{- include "constraint_selector" (list $cr) }}
 {{- end }}
 
-{{- define "replica_limits_policy" }}
-  {{- $context := index . 0 }}
-  {{- $cr := index . 1 }}
 ---
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: D8ReplicaLimits
 metadata:
   name: replica-limits
-  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
 spec:
   match:
     kinds:
       - apiGroups: ["apps"]
         kinds: ["Deployment"]
-    {{- include "constraint_selector" (list $cr) }}
-{{- end }}
   parameters:
     ranges:
     - min_replicas: 1

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -37,7 +37,7 @@
     {{- include "container_duplicates_policy" (list $context $cr) }}
   {{- end }}
   {{- if hasKey $cr.spec.policies "replicaLimits" }}
-    {{ - include "replica_limits_policy" (list $context $cr) }}
+    {{- include "replica_limits_policy" (list $context $cr) }}
   {{- end }}
 {{- end }}
 

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -304,5 +304,5 @@ spec:
   {{- end }}
   parameters:
     ranges:
-      - min_replicas: {{- $cr.spec.policies.replicaLimits.min_replicas | default 1 }}
-        max_replicas: {{- $cr.spec.policies.replicaLimits.max_replicas | default 10 }}
+      - min_replicas: 1
+        max_replicas: 10

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -292,7 +292,7 @@ spec:
   match:
     kinds:
       - apiGroups: [ "apps" ]
-        kinds: [ "Deployment" ]
+        kinds: [ "Deployment", "ReplicaSet", "StatefulSet" ]
     { { - include "constraint_selector" (list $cr) } }
   { { - end } }
   parameters:

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -36,9 +36,9 @@
   {{- if hasKey $cr.spec.policies "checkContainerDuplicates" }}
     {{- include "container_duplicates_policy" (list $context $cr) }}
   {{- end }}
-  { { - if hasKey $cr.spec.policies "replicaLimits" } }
-  { { - include "replica_limits_policy" (list $context $cr) } }
-  { { - end } }
+  {{- if hasKey $cr.spec.policies "replicaLimits" }}
+    {{ - include "replica_limits_policy" (list $context $cr) }}
+  {{- end }}
 {{- end }}
 
 {{- end }} # end if bootstrapped
@@ -286,23 +286,23 @@ spec:
     {{- include "constraint_selector" (list $cr) }}
 {{- end }}
 
-  { { - define "replica_limits_policy" } }
-  { { - $context := index . 0 } }
-  { { - $cr := index . 1 } }
+{{- define "replica_limits_policy" }}
+  {{- $context := index . 0 }}
+  {{- $cr := index . 1 }}
 ---
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: D8ReplicaLimits
 metadata:
   name: {{$cr.metadata.name}}
-  { { - include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 } }
+  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
 spec:
   match:
     kinds:
       - apiGroups: [ "apps" ]
         kinds: [ "Deployment", "ReplicaSet", "StatefulSet" ]
-    { { - include "constraint_selector" (list $cr) } }
-  { { - end } }
+    {{- include "constraint_selector" (list $cr) }}
+  {{- end }}
   parameters:
     ranges:
-      - min_replicas: { { - $cr.spec.policies.replicaLimits.min_replicas | default 1 } }
-        max_replicas: { { - $cr.spec.policies.replicaLimits.max_replicas | default 10 } }
+      - min_replicas: {{- $cr.spec.policies.replicaLimits.min_replicas | default 1 }}
+        max_replicas: {{- $cr.spec.policies.replicaLimits.max_replicas | default 10 }}

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -303,6 +303,7 @@ spec:
     {{- include "constraint_selector" (list $cr) }}
   {{- end }}
   parameters:
-    ranges:
-      - min_replicas: 1
-        max_replicas: 10
+    replicaLimits:
+      ranges:
+        - min_replicas: 1
+          max_replicas: 10

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -282,3 +282,20 @@ spec:
         kinds: ["Pod"]
     {{- include "constraint_selector" (list $cr) }}
 {{- end }}
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8ReplicaLimits
+metadata:
+  name: {{$cr.metadata.name}}
+  { { - include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 } }
+spec:
+  match:
+    kinds:
+      - apiGroups: [ "apps" ]
+        kinds: [ "Deployment" ]
+    { { - include "constraint_selector" (list $cr) } }
+  { { - end } }
+  parameters:
+    ranges:
+      - min_replicas: 1
+        max_replicas: 50

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -36,6 +36,9 @@
   {{- if hasKey $cr.spec.policies "checkContainerDuplicates" }}
     {{- include "container_duplicates_policy" (list $context $cr) }}
   {{- end }}
+  { { - if hasKey $cr.spec.policies "replicaLimits" } }
+  { { - include "replica_limits_policy" (list $context $cr) } }
+  { { - end } }
 {{- end }}
 
 {{- end }} # end if bootstrapped
@@ -282,6 +285,10 @@ spec:
         kinds: ["Pod"]
     {{- include "constraint_selector" (list $cr) }}
 {{- end }}
+
+  { { - define "replica_limits_policy" } }
+  { { - $context := index . 0 } }
+  { { - $cr := index . 1 } }
 ---
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: D8ReplicaLimits

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -298,10 +298,10 @@ metadata:
 spec:
   match:
     kinds:
-      - apiGroups: [ "apps" ]
-        kinds: [ "Deployment", "ReplicaSet", "StatefulSet" ]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment"]
     {{- include "constraint_selector" (list $cr) }}
-  {{- end }}
+{{- end }}
   parameters:
     ranges:
     - min_replicas: 1

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -297,5 +297,5 @@ spec:
   { { - end } }
   parameters:
     ranges:
-      - min_replicas: 1
-        max_replicas: 50
+      - min_replicas: { { - $cr.spec.policies.replicaLimits.min_replicas | default 1 } }
+        max_replicas: { { - $cr.spec.policies.replicaLimits.max_replicas | default 10 } }


### PR DESCRIPTION
## Description
New operation policy for checking replica values for Deployments, ReplicaSets and StatefulSets

## Why do we need it, and what problem does it solve?
We would need to control low and high ranges of replicas to prevent zero replicas or check too high values.

## What is the expected result?
If replica value is not in range we'll get an error

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
New operation policy for replica value checking
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: OperationPolicy
metadata:
  name: foo
spec:
  policies:
    replicaLimits:
      minReplicas: 1
      maxReplicas: 3
  match:
    namespaceSelector:
      matchNames: ["default"]
```

```sh
$ kubectl -n default patch deployment echo-server  --type='merge' -p '{"spec":{"replicas":5}}'
Error from server (Forbidden): admission webhook "admission-policy-engine.deckhouse.io" denied the request: [foo] The provided number of replicas is not allowed for Deployment: echo-server. Allowed ranges: {"ranges": [{"maxReplicas": 3, "minReplicas": 1}]}
```

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: OperationPolicy
metadata:
  name: foo
spec:
  policies:
    replicaLimits:
      minReplicas: 3
  match:
    namespaceSelector:
      matchNames: ["default"]
```

```sh
$ kubectl -n default patch deployment echo-server  --type='merge' -p '{"spec":{"replicas":5}}'
deployment.apps/echo-server patched

$ kubectl -n default patch deployment echo-server  --type='merge' -p '{"spec":{"replicas":1}}'
Error from server (Forbidden): admission webhook "admission-policy-engine.deckhouse.io" denied the request: [foo] The provided number of replicas is not allowed for Deployment: echo-server. Allowed ranges: {"ranges": [{"minReplicas": 3}]}
```

```changes
section:admission-policy-engine
type:  feature
summary: operation policy for replica value checking
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
