### PR TITLE
[linstor] Enabling the Linstor module is prohibited when the SDS-DRBD module is enabled

### DIFF
--- a/modules/041-linstor/enabled
+++ b/modules/041-linstor/enabled
@@ -17,11 +17,11 @@
 source /deckhouse/shell_lib.sh
 
 function __main__() {
-    if values::array_has global.enabledModules "sds-drbd" ; then
-      echo "false" > $MODULE_ENABLED_RESULT
-    else
-      echo "true" > $MODULE_ENABLED_RESULT
-    fi
+  if values::array_has global.enabledModules "sds-drbd" ; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+  else
+    echo "true" > "$MODULE_ENABLED_RESULT"
+  fi
 }
 
 enabled::run "$@"

--- a/modules/041-linstor/enabled
+++ b/modules/041-linstor/enabled
@@ -17,7 +17,11 @@
 source /deckhouse/shell_lib.sh
 
 function __main__() {
-  echo "true" > "$MODULE_ENABLED_RESULT"
+    if values::array_has global.enabledModules "sds-drbd" ; then
+      echo "false" > $MODULE_ENABLED_RESULT
+    else
+      echo "true" > $MODULE_ENABLED_RESULT
+    fi
 }
 
 enabled::run "$@"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Enabling the Linstor module is prohibited when the SDS-DRBD module is enabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Simultaneously enabling the Linstor and SDS-DRBD modules is not possible, as it can lead to data corruption.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Simultaneously enabling the Linstor and SDS-DRBD modules is prohibited.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: chore
summary: Simultaneously enabling the Linstor and SDS-DRBD modules is prohibited.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
