### PR TITLE
[dhctl] Fix mirror not adding module-named tags at modules repo root

### DIFF
--- a/dhctl/pkg/operations/mirror_module.go
+++ b/dhctl/pkg/operations/mirror_module.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"sigs.k8s.io/yaml"
 
@@ -162,6 +163,8 @@ func PushModulesToRegistry(
 		return fmt.Errorf("Read modules directory: %w", err)
 	}
 
+	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure)
+
 	for i, entry := range dirEntries {
 		if !entry.IsDir() {
 			continue
@@ -191,6 +194,22 @@ func PushModulesToRegistry(
 			return fmt.Errorf("Push module to registry: %w", err)
 		}
 
+		log.InfoF("Pushing index tag for module %s...\n", moduleName)
+
+		imageRef, err := name.ParseReference(registryPath+":"+moduleName, refOpts...)
+		if err != nil {
+			return fmt.Errorf("Parse image reference: %w", err)
+		}
+
+		img, err := random.Image(16, 1)
+		if err != nil {
+			return fmt.Errorf("random.Image: %w", err)
+		}
+
+		if err = remote.Write(imageRef, img, remoteOpts...); err != nil {
+			return fmt.Errorf("Write module index tag: %w", err)
+		}
+
 		log.InfoF("✅Module %s pushed successfully\n", moduleName)
 	}
 
@@ -203,13 +222,7 @@ func pushLayoutToRepo(
 	authProvider authn.Authenticator,
 	insecure bool,
 ) error {
-	refOpts, remoteOpts := []name.Option{}, []remote.Option{}
-	if insecure {
-		refOpts = append(refOpts, name.Insecure)
-	}
-	if authProvider != nil {
-		remoteOpts = append(remoteOpts, remote.WithAuth(authProvider))
-	}
+	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure)
 
 	index, err := imagesLayout.ImageIndex()
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added module-named tags at modules repo root after all of module images were pushed

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes module discovery in Deckhouse, which is listing module subrepo tags to find modules instead of looking in the repo catalog

## Why do we need it in the patch release (if we do)?

This fixes a bug in modules mirroring, which was reported by a user

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix mirror not adding module-named tags at modules repo root.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
