### PR TITLE
[dhctl] Clarify tar bundle flag usage and validate it more strictly

### DIFF
--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -100,7 +100,7 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("skip-gost-digest", "Do not calculate GOST R 34.11-2012 STREEBOG digest for downloaded bundle").
 		Envar(configEnvName("MIRROR_SKIP_GOST_DIGESTS")).
 		BoolVar(&MirrorSkipGOSTHashing)
-	cmd.Flag("images-bundle-path", "Path of tar bundle with pulled images").
+	cmd.Flag("images-bundle-path", "Path of tar bundle with pulled images. Should be a path to tar archive (.tar)").
 		Short('i').
 		PlaceHolder("PATH").
 		Required().
@@ -137,6 +137,10 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 
 func validateImagesBundlePathFlag() error {
 	MirrorTarBundle = filepath.Clean(MirrorTarBundle)
+	if filepath.Ext(MirrorTarBundle) != ".tar" {
+		return errors.New("--images-bundle-path should be a path to tar archive (.tar)")
+	}
+
 	stats, err := os.Stat(MirrorTarBundle)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Clarified the help text of `--images-bundle-path` flag, saying that it should point to a .tar file. Added validation of that.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There were some complaints about the subject beign unclear to users.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Clarify tar bundle flag usage and validate it more strictly.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
