### PR TITLE
[log-shipper] Fix empty field trailing dot in filters

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/transform/filter.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/filter.go
@@ -45,7 +45,11 @@ func CreateLogFilterTransforms(filters []v1alpha1.Filter) ([]apis.LogTransform, 
 	transforms, err := createFilterTransform("log_filter", filters, func(filter *v1alpha1.Filter, rule *vrl.Rule) {
 		// parsed_data is a key for parsed json data from a message, we use it to quickly filter inputs
 		// "filter_field" -> "parsed_data.filter_field", "" -> "parsed_data"
-		filter.Field = strings.Join([]string{"parsed_data", filter.Field}, ".")
+		if filter.Field == "" {
+			filter.Field = "parsed_data"
+		} else {
+			filter.Field = strings.Join([]string{"parsed_data", filter.Field}, ".")
+		}
 	})
 	if err != nil {
 		return nil, err

--- a/modules/460-log-shipper/hooks/internal/vector/transform/testdata/filters.json
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/testdata/filters.json
@@ -13,23 +13,30 @@
 		"type": "filter"
 	},
 	{
-		"condition": "if is_boolean(.parsed_data.severity) || is_float(.parsed_data.severity) {\n    data, err = to_string(.parsed_data.severity);\n    if err != null {\n        false;\n    } else {\n        includes([\"aaa\",42], data);\n    };\n} else if .parsed_data.severity == null {\n    \"null\";\n} else {\n    includes([\"aaa\",42], .parsed_data.severity);\n}",
+		"condition": "if is_boolean(.parsed_data) || is_float(.parsed_data) {\n    data, err = to_string(.parsed_data);\n    if err != null {\n        false;\n    } else {\n        includes([\".*\"], data);\n    };\n} else if .parsed_data == null {\n    \"null\";\n} else {\n    includes([\".*\"], .parsed_data);\n}",
 		"inputs": [
 			"transform/prefix/testit/01_log_filter"
 		],
 		"type": "filter"
 	},
 	{
-		"condition": "match!(.parsed_data.namespace, r'^d8-.*$') || match!(.parsed_data.namespace, r'^kube-.*$')",
+		"condition": "if is_boolean(.parsed_data.severity) || is_float(.parsed_data.severity) {\n    data, err = to_string(.parsed_data.severity);\n    if err != null {\n        false;\n    } else {\n        includes([\"aaa\",42], data);\n    };\n} else if .parsed_data.severity == null {\n    \"null\";\n} else {\n    includes([\"aaa\",42], .parsed_data.severity);\n}",
 		"inputs": [
 			"transform/prefix/testit/02_log_filter"
 		],
 		"type": "filter"
 	},
 	{
-		"condition": "if exists(.parsed_data.namespace) \u0026\u0026 is_string(.parsed_data.namespace) {\n    matched = false\n    matched0, err = match(.parsed_data.namespace, r'^dev-.*$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    matched1, err = match(.parsed_data.namespace, r'^prod-.*$')\n    if err != null {\n        true\n    }\n    matched = matched || matched1\n    !matched\n} else {\n    true\n}",
+		"condition": "match!(.parsed_data.namespace, r'^d8-.*$') || match!(.parsed_data.namespace, r'^kube-.*$')",
 		"inputs": [
 			"transform/prefix/testit/03_log_filter"
+		],
+		"type": "filter"
+	},
+	{
+		"condition": "if exists(.parsed_data.namespace) \u0026\u0026 is_string(.parsed_data.namespace) {\n    matched = false\n    matched0, err = match(.parsed_data.namespace, r'^dev-.*$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    matched1, err = match(.parsed_data.namespace, r'^prod-.*$')\n    if err != null {\n        true\n    }\n    matched = matched || matched1\n    !matched\n} else {\n    true\n}",
+		"inputs": [
+			"transform/prefix/testit/04_log_filter"
 		],
 		"type": "filter"
 	}

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms_test.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms_test.go
@@ -54,6 +54,14 @@ func TestTransformSnippet(t *testing.T) {
 		})
 
 		filters = append(filters, v1alpha1.Filter{
+			Field:    "",
+			Operator: v1alpha1.FilterOpIn,
+			Values: []interface{}{
+				".*",
+			},
+		})
+
+		filters = append(filters, v1alpha1.Filter{
 			Field:    "severity",
 			Operator: v1alpha1.FilterOpIn,
 			Values: []interface{}{
@@ -88,7 +96,7 @@ func TestTransformSnippet(t *testing.T) {
 		tr, err := BuildFromMapSlice("prefix", "testit", transforms)
 		require.NoError(t, err)
 
-		assert.Len(t, tr, 5)
+		assert.Len(t, tr, 6)
 		assert.Len(t, tr[0].GetInputs(), 0)
 
 		data, err := json.MarshalIndent(tr, "", "\t")


### PR DESCRIPTION
## Description
If in the `logFilter` the empty field is specified, vector was throwing an error because of the `.parsed_data.` selector with the trailing dot symbol. This PR fixes the error by making the deckhouse rendering only the `.parsed_data` key without the trailing dot.

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/6611

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Fix empty field trailing dots in filters
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
