### PR TITLE
[ingress-nginx] remove ingress-nginx version 1.1

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -59,7 +59,7 @@ spec:
                     One of the supported NGINX Ingress controller versions.
 
                     **By default**: the version in the [module settings](configuration.html#parameters-defaultcontrollerversion) is used.
-                  enum: ['1.1','1.6','1.9']
+                  enum: ['1.6','1.9']
                 enableIstioSidecar:
                   type: boolean
                   description: |

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -4,7 +4,7 @@ properties:
     default: "1.6"
     oneOf:
       - type: string
-        enum: ["1.1", "1.6", "1.9"]
+        enum: ["1.6", "1.9"]
     description: |
       The version of the ingress-nginx controller that is used for all controllers by default if the `controllerVersion` parameter is omitted in the IngressNginxController CR.
   highAvailability:

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
 		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler-crd"})
 		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
 
-		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.1")
+		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.6")
 
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.ca", "test")
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.cert", "test")
@@ -76,7 +76,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
     additionalLogFields:
       my-cookie: "$cookie_MY_COOKIE"
     validationEnabled: true
-    controllerVersion: "1.1"
+    controllerVersion: "1.6"
     inlet: LoadBalancer
     hsts: true
     hstsOptions:
@@ -100,7 +100,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
     config:
       load-balance: ewma
     ingressClass: nginx
-    controllerVersion: "1.1"
+    controllerVersion: "1.6"
     inlet: LoadBalancerWithProxyProtocol
     resourcesRequests:
       mode: Static
@@ -119,13 +119,13 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
   spec:
     inlet: LoadBalancer
     ingressClass: nginx
-    controllerVersion: "1.1"
+    controllerVersion: "1.6"
     maxReplicas: 3
     minReplicas: 3
 - name: test-next
   spec:
     ingressClass: test
-    controllerVersion: "1.1"
+    controllerVersion: "1.6"
     inlet: "HostPortWithProxyProtocol"
     geoIP2:
       maxmindLicenseKey: abc12345
@@ -138,7 +138,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
 - name: solid
   spec:
     ingressClass: solid
-    controllerVersion: "1.1"
+    controllerVersion: "1.6"
     inlet: "HostWithFailover"
     resourcesRequests:
       mode: VPA
@@ -234,7 +234,7 @@ memory: 200Mi`))
 			testNextDaemonSet := hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-test-next")
 			Expect(testNextDaemonSet.Exists()).To(BeTrue())
 
-			Expect(testNextDaemonSet.Field(`metadata.annotations.ingress-nginx-controller\.deckhouse\.io/controller-version`).String()).To(Equal(`1.1`))
+			Expect(testNextDaemonSet.Field(`metadata.annotations.ingress-nginx-controller\.deckhouse\.io/controller-version`).String()).To(Equal(`1.6`))
 			Expect(testNextDaemonSet.Field(`metadata.annotations.ingress-nginx-controller\.deckhouse\.io/inlet`).String()).To(Equal(`HostPortWithProxyProtocol`))
 			Expect(testNextDaemonSet.Field("spec.template.spec.containers.0.args").Array()).To(ContainElement(ContainSubstring(`--shutdown-grace-period=60`)))
 			// should not have --publish-service, inlet: HostPort

--- a/release.yaml
+++ b/release.yaml
@@ -24,7 +24,7 @@
 # release requirements, don't forget to register check function in a file requirements.go
 requirements:
   "k8s": "1.24.0" # modules/040-control-plane-manager/requirements/check.go
-  "ingressNginx": "1.1" # modules/402-ingress-nginx/requirements/check.go
+  "ingressNginx": "1.6" # modules/402-ingress-nginx/requirements/check.go
   "nodesMinimalOSVersionUbuntu": "18.04" # modules/040-node-manager/requirements/check.go
   "containerdOnAllNodes": "true" # modules/040-node-manager/requirements/check.go
 


### PR DESCRIPTION
## Description
Remove ingress-nginx controller version 1.1

## Why do we need it, and what problem does it solve?

Ingress controller 1.1 uses endpoints, and it causes https://github.com/deckhouse/deckhouse/issues/5435

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Remove  ingress-nginx controller ver 1.1 

```changes
section: ingress-nginx
type: chore
summary: Remove  ingress-nginx controller ver 1.1 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
