### PR TITLE
[virtualization] add remove module script

### DIFF
--- a/modules/490-virtualization/docs/FAQ.md
+++ b/modules/490-virtualization/docs/FAQ.md
@@ -24,3 +24,9 @@ Example of a `Dockerfile`:
 FROM scratch
 ADD https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img /disk/jammy-server-cloudimg-amd64.img
 ```
+
+## How do I disable the virtualization module?
+
+Before you can disable the virtualization module, all virtual machines and disks must first be uninstalled.
+
+To disable the module, use the following [script](https://github.com/deckhouse/deckhouse/blob/main/modules/490-virtualization/hack/remove-module.sh).

--- a/modules/490-virtualization/docs/FAQ.md
+++ b/modules/490-virtualization/docs/FAQ.md
@@ -27,6 +27,6 @@ ADD https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.im
 
 ## How do I disable the virtualization module?
 
-Before you can disable the virtualization module, all virtual machines and disks must first be uninstalled.
+Before the virtualization module can be disabled, you must uninstall all virtual machines and disks.
 
-To disable the module, use the following [script](https://github.com/deckhouse/deckhouse/blob/main/modules/490-virtualization/hack/remove-module.sh).
+Use the [script](https://github.com/deckhouse/deckhouse/blob/main/modules/490-virtualization/hack/remove-module.sh) to disable the module.

--- a/modules/490-virtualization/docs/FAQ_RU.md
+++ b/modules/490-virtualization/docs/FAQ_RU.md
@@ -24,3 +24,9 @@ kubectl delete virtualmachineinstance <vmName>
 FROM scratch
 ADD https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img /disk/jammy-server-cloudimg-amd64.img
 ```
+
+## Как выключить модуль виртуализации?
+
+Прежде чем выключить модуль виртуализации, все виртуальные машины и диски должны быть предварительно удалены.
+
+Для удаления модуля, воспользуйтесь следующим [скриптом](https://github.com/deckhouse/deckhouse/blob/main/modules/490-virtualization/hack/remove-module.sh).

--- a/modules/490-virtualization/docs/FAQ_RU.md
+++ b/modules/490-virtualization/docs/FAQ_RU.md
@@ -27,6 +27,6 @@ ADD https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.im
 
 ## Как выключить модуль виртуализации?
 
-Прежде чем выключить модуль виртуализации, все виртуальные машины и диски должны быть предварительно удалены.
+Прежде чем выключить модуль виртуализации, необходимо предварительно удалить все виртуальные машины и диски.
 
-Для удаления модуля, воспользуйтесь следующим [скриптом](https://github.com/deckhouse/deckhouse/blob/main/modules/490-virtualization/hack/remove-module.sh).
+Для удаления модуля воспользуйтесь следующим [скриптом](https://github.com/deckhouse/deckhouse/blob/main/modules/490-virtualization/hack/remove-module.sh).

--- a/modules/490-virtualization/hack/remove-module.sh
+++ b/modules/490-virtualization/hack/remove-module.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+red=$(tput setaf 1)
+bold=$(tput bold)
+sgr0=$(tput sgr0)
+
+color_echo(){
+  echo "$red$bold$@ $sgr0"
+}
+
+remove_webhooks() {
+  color_echo "Remove kubevirt webhooks"
+  kubectl delete validatingwebhookconfigurations -l app.kubernetes.io/component=kubevirt
+  kubectl delete validatingwebhookconfigurations -l cdi.kubevirt.io=cdi-api
+
+  kubectl delete mutatingwebhookconfigurations -l app.kubernetes.io/component=kubevirt
+  kubectl delete mutatingwebhookconfigurations -l cdi.kubevirt.io=cdi-api
+}
+
+remove_cdi() {
+  color_echo "Remove CDI resource"
+  # delete CDI and wait for it to be deleted
+  kubectl patch cdi cdi --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]' 2>/dev/null
+  kubectl delete cdi cdi --force --grace-period 0 2>/dev/null
+  kubectl wait --for=delete -n cdi cdi --timeout=300s
+}
+
+remove_kubevirt() {
+  color_echo "Remove kubevirt resource"
+  # delete kubevirt and wait for it to be deleted
+  kubectl -n d8-virtualization patch kubevirt kubevirt --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]' 2>/dev/null
+  kubectl -n d8-virtualization delete kubevirt kubevirt --force --grace-period=0 2>/dev/null
+  kubectl wait --for=delete -n d8-virtualization kubevirt kubevirt --timeout=300s
+}
+
+disable_virtualization_module() {
+  color_echo "Disable virtualization module"
+  # disable virtualization module
+  kubectl patch mc virtualization --type='merge' --patch '{"spec":{"enabled":false}}'
+  kubectl wait mc virtualization --for="jsonpath={.status.state}=Disabled" --timeout=320s
+}
+
+remove_crds() {
+  color_echo "Remove kubvirt and deckhouse virtualizatiun CRDs"
+  # remove deckhouse virtualization CRDs
+  kubectl get crd -o name | grep -E 'virtualmachine.+deckhouse.io' | xargs kubectl delete --force --grace-period=0 2>/dev/null
+  # remove kubevirt CRDs
+  kubectl get crd -o name | grep kubevirt | xargs kubectl delete --force --grace-period=0 2>/dev/null
+}
+
+remove_apiservices() {
+  color_echo "Remove kubevirt apiservice"
+  kubectl get apiservices -o name | grep -E "(kubevirt|cdi)" | xargs kubectl delete --force --grace-period=0 2>/dev/null
+}
+
+remove_rbac() {
+  color_echo "Remove virtualization module rbac"
+  kubectl get clusterrole -o name | grep -E "(kubevirt|cdi)" | xargs kubectl delete --force --grace-period=0 2>/dev/null
+  kubectl get clusterrolebindings -o name | grep -E "(kubevirt|cdi)" | xargs kubectl delete --force --grace-period=0 2>/dev/null
+}
+
+main(){
+  remove_webhooks
+  remove_cdi
+  remove_kubevirt
+
+  disable_virtualization_module
+
+  remove_apiservices
+  remove_rbac
+  remove_crds
+
+  # Let's delete webhooks again just in case, because the controller might have time to put them back in place.
+  remove_webhooks
+}
+
+main


### PR DESCRIPTION
## Description
Add information on how to disable the module correctly.

## Why do we need it, and what problem does it solve?
Before enabling the new virtualization module, you must correctly clean up all old configurations of the embedded module.

## Why do we need it in the patch release (if we do)?
We need to inform users on how to correctly disable an embedded module before the module is removed.

## What is the expected result?

Nothing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: virtualization
type: chore
summary: Add a module removal script.
impact_level: low
```

