### PR TITLE
[external-module-controller] add module update policy migration hook

### DIFF
--- a/modules/005-external-module-manager/hooks/migration_create_update_policies.go
+++ b/modules/005-external-module-manager/hooks/migration_create_update_policies.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This migration hook creates module update policies for all but deckhouse module sources on first run.
+// After creation, d8-system namespace gets annotated and migration doesn't fire up anymore.
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+const (
+	defaultUpdateMode   = "Auto"
+	migrationAnnotation = "modules.deckhouse.io/ensured-update-policies"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// ensure crds hook has order 5, for creating a module source we should use greater number
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 6},
+}, dependency.WithExternalDependencies(createModuleUpdatePolicies))
+
+var msResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "modulesources"}
+
+func createModuleUpdatePolicies(input *go_hook.HookInput, dc dependency.Container) error {
+	k8sCli, err := dc.GetK8sClient()
+	if err != nil {
+		return err
+	}
+
+	d8System, err := k8sCli.CoreV1().Namespaces().Get(context.TODO(), "d8-system", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// have already run the migration
+	if _, migrated := d8System.ObjectMeta.Annotations[migrationAnnotation]; migrated {
+		return nil
+	}
+
+	// get all modulesources
+	moduleSources, err := k8sCli.Dynamic().Resource(msResource).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, source := range moduleSources.Items {
+		// skip deckhouse source as its update policy is ensured by another hook
+		if source.GetName() == "deckhouse" {
+			continue
+		}
+		moduleSource := &v1alpha1.ModuleSource{}
+		err := sdk.FromUnstructured(&source, moduleSource)
+		if err != nil {
+			return err
+		}
+
+		// if not exists, ensure ModuleUpdatePolicy
+		deckhouseMup := &v1alpha1.ModuleUpdatePolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ModuleUpdatePolicy",
+				APIVersion: "deckhouse.io/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: moduleSource.ObjectMeta.Name,
+			},
+			Spec: v1alpha1.ModuleUpdatePolicySpec{
+				ModuleReleaseSelector: v1alpha1.ModuleUpdatePolicySpecReleaseSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"source": moduleSource.ObjectMeta.Name,
+						},
+					},
+				},
+				ReleaseChannel: moduleSource.Spec.ReleaseChannel,
+				Update: v1alpha1.ModuleUpdatePolicySpecUpdate{
+					Mode: "Auto",
+				},
+			},
+		}
+		input.PatchCollector.Create(deckhouseMup, object_patch.IgnoreIfExists())
+	}
+
+	// annotate d8-system as migrated
+	d8SystemPatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				migrationAnnotation: "",
+			},
+		},
+	}
+	input.PatchCollector.MergePatch(d8SystemPatch, "v1", "Namespace", "", "d8-system")
+
+	return nil
+}

--- a/modules/005-external-module-manager/hooks/migration_create_update_policies_test.go
+++ b/modules/005-external-module-manager/hooks/migration_create_update_policies_test.go
@@ -1,0 +1,219 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+func createNs(namespace string) error {
+	var ns *v1.Namespace
+
+	err := yaml.Unmarshal([]byte(namespace), &ns)
+	if err != nil {
+		return err
+	}
+
+	_, err = dependency.TestDC.K8sClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ = Describe("Modules :: external module manager :: hooks :: migration create module update policies ::", func() {
+
+	const (
+		d8SystemWithoutAnnotation = `
+---
+apiVersion: v1
+data:
+kind: Namespace
+metadata:
+  name: d8-system
+`
+		d8SystemWithAnnotation = `
+---
+apiVersion: v1
+data:
+kind: Namespace
+metadata:
+  annotations:
+    modules.deckhouse.io/ensured-update-policies: ""
+  name: d8-system
+`
+		deckhouseMs = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  labels:
+    heritage: deckhouse
+  name: deckhouse
+spec:
+  registry:
+    ca: ""
+    dockerCfg: cfg
+    repo: dev-registry.deckhouse.io/sys/deckhouse-oss/modules
+    scheme: HTTPS
+`
+		customMss = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  labels:
+  name: tetris
+spec:
+  registry:
+    ca: ""
+    dockerCfg: cfg
+    repo: dev-registry.deckhouse.io/sys/deckhouse-oss/modules
+    scheme: HTTPS
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: pingpong
+spec:
+  registry:
+    ca: ""
+    dockerCfg: cfg
+    repo: dev-registry.deckhouse.io/sys/deckhouse-oss/modules
+    scheme: HTTPS
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: tictactoe
+spec:
+  registry:
+    ca: ""
+    dockerCfg: cfg
+    repo: dev-registry.deckhouse.io/sys/deckhouse-oss/modules
+    scheme: HTTPS
+`
+	)
+
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleSource", false)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleUpdatePolicy", false)
+
+	Context("An empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(d8SystemWithoutAnnotation))
+
+			err := createNs(d8SystemWithoutAnnotation)
+			if err != nil {
+				Fail(err.Error())
+			}
+
+			f.RunHook()
+		})
+
+		It("Should execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("A cluster with deckhouse ModuleSource", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(d8SystemWithoutAnnotation + deckhouseMs))
+
+			err := createNs(d8SystemWithoutAnnotation)
+			if err != nil {
+				Fail(err.Error())
+			}
+
+			f.RunHook()
+		})
+
+		It("Should ignore deckhouse ModuleSource", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			mupDeckhouse := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
+			Expect(mupDeckhouse.Exists()).To(BeFalse())
+			msDeckhouse := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(msDeckhouse.Exists()).To(BeTrue())
+		})
+	})
+
+	Context("A cluster with client's ModuleSources without annotation", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(d8SystemWithoutAnnotation + deckhouseMs + customMss))
+
+			err := createNs(d8SystemWithoutAnnotation)
+			if err != nil {
+				Fail(err.Error())
+			}
+
+			f.RunHook()
+		})
+
+		It("Should create ModuleUpdatePolicies and annotate d8-system", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			mupDeckhouse := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
+			Expect(mupDeckhouse.Exists()).To(BeFalse())
+			msDeckhouse := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(msDeckhouse.Exists()).To(BeTrue())
+			for _, ms := range []string{"tetris", "pingpong", "tictactoe"} {
+				mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", ms)
+				Expect(mup.Exists()).To(BeTrue())
+			}
+			ns := f.KubernetesGlobalResource("Namespace", "d8-system")
+			Expect(ns.Field(`metadata.annotations.modules\.deckhouse\.io/ensured-update-policies`).Exists()).To(BeTrue())
+		})
+	})
+
+	Context("A cluster with client's ModuleSources with annotation", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(d8SystemWithAnnotation + deckhouseMs + customMss))
+
+			err := createNs(d8SystemWithAnnotation)
+			if err != nil {
+				Fail(err.Error())
+			}
+
+			f.RunHook()
+		})
+
+		It("Shouldn't create/update ModuleUpdatePolicies", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			mupDeckhouse := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
+			Expect(mupDeckhouse.Exists()).To(BeFalse())
+			msDeckhouse := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
+			Expect(msDeckhouse.Exists()).To(BeTrue())
+			ns := f.KubernetesGlobalResource("Namespace", "d8-system")
+			Expect(ns.Field(`metadata.annotations.modules\.deckhouse\.io/ensured-update-policies`).Exists()).To(BeTrue())
+			for _, ms := range []string{"tetris", "pingpong", "tictactoe"} {
+				mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", ms)
+				Expect(mup.Exists()).To(BeFalse())
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
