### PR TITLE
Update

### DIFF
--- a/deckhouse-controller/pkg/controller/models/definition.go
+++ b/deckhouse-controller/pkg/controller/models/definition.go
@@ -22,7 +22,7 @@ const (
 
 type DeckhouseModuleDefinition struct {
 	Name        string   `yaml:"name"`
-	Weight      uint32   `yaml:"weight"`
+	Weight      uint32   `yaml:"weight,omitempty"`
 	Tags        []string `yaml:"tags"`
 	Description string   `yaml:"description"`
 

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
@@ -318,8 +318,6 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, im
 		return def, err
 	}
 
-	fmt.Println("MMM DEF BUF", buf.String())
-
 	if buf.Len() == 0 {
 		return def, nil
 	}
@@ -328,8 +326,6 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, im
 	if err != nil {
 		return def, err
 	}
-
-	fmt.Println("MMM DEF ", def)
 
 	return def, nil
 }
@@ -347,11 +343,7 @@ func (md *ModuleDownloader) fetchModuleReleaseMetadata(img v1.Image) (moduleRele
 		return meta, err
 	}
 
-	fmt.Println("MMM UNTAR META", buf.String())
-
 	err = json.Unmarshal(buf.Bytes(), &meta)
-
-	fmt.Println("MMM AFTER JSON", meta)
 
 	return meta, err
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
@@ -318,14 +318,18 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, im
 		return def, err
 	}
 
+	fmt.Println("MMM DEF BUF", buf.String())
+
 	if buf.Len() == 0 {
 		return def, nil
 	}
 
-	err = json.Unmarshal(buf.Bytes(), &def)
+	err = yaml.NewDecoder(buf).Decode(&def)
 	if err != nil {
 		return def, err
 	}
+
+	fmt.Println("MMM DEF ", def)
 
 	return def, nil
 }
@@ -343,7 +347,11 @@ func (md *ModuleDownloader) fetchModuleReleaseMetadata(img v1.Image) (moduleRele
 		return meta, err
 	}
 
+	fmt.Println("MMM UNTAR META", buf.String())
+
 	err = json.Unmarshal(buf.Bytes(), &meta)
+
+	fmt.Println("MMM AFTER JSON", meta)
 
 	return meta, err
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -499,7 +499,7 @@ func (c *Controller) reconcilePendingRelease(ctx context.Context, mr *v1alpha1.M
 			}
 
 			md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
-			err = md.DownloadByModuleVersion(release.Spec.ModuleName, "v"+release.Spec.Version.String())
+			err = md.DownloadByModuleVersion(release.Spec.ModuleName, release.Spec.Version.String())
 			if err != nil {
 				return ctrl.Result{RequeueAfter: defaultCheckInterval}, err
 			}

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -492,6 +492,18 @@ func (c *Controller) reconcilePendingRelease(ctx context.Context, mr *v1alpha1.M
 				return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 			}
 
+			// download desired module version
+			ms, err := c.moduleSourcesLister.Get(mr.GetModuleSource())
+			if err != nil {
+				return ctrl.Result{Requeue: true}, err
+			}
+
+			md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
+			err = md.DownloadByModuleVersion(release.Spec.ModuleName, "v"+release.Spec.Version.String())
+			if err != nil {
+				return ctrl.Result{RequeueAfter: defaultCheckInterval}, err
+			}
+
 			modulePath := generateModulePath(moduleName, release.Spec.Version.String())
 			newModuleSymlink := path.Join(c.symlinksDir, fmt.Sprintf("%d-%s", release.Spec.Weight, moduleName))
 


### PR DESCRIPTION
## Description
Create module on a file system only when release is deployed

## Why do we need it, and what problem does it solve?
We have update mode and update windows. If we create directory on module release pull, then release could be deployed on the other master (in multi-master configuration).
We have to avoid this, deploying module jointly with ModuleRelease

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Release is pending:
```sh
echo-v0.3.19                        Pending      losev-test-alpha   2m44s            Waiting for manual approval
```

Directory does not exist:
```sh
# ls -l /var/lib/deckhouse/external-modules/echo/
drwx------ 8 64535 64535 4096 Dec  6 09:18 v0.3.15
drwx------ 8 64535 64535 4096 Dec  6 10:27 v0.3.16
drwx------ 8 64535 64535 4096 Dec  6 16:03 v0.3.17
drwx------ 8 64535 64535 4096 Dec  7 08:33 v0.3.18
```

Release deployed:
```
echo-v0.3.19                        Deployed     losev-test-alpha   1s
```

directory with version created:
```
# ls -l /var/lib/deckhouse/external-modules/echo/
drwx------ 8 64535 64535 4096 Dec  6 09:18 v0.3.15
drwx------ 8 64535 64535 4096 Dec  6 10:27 v0.3.16
drwx------ 8 64535 64535 4096 Dec  6 16:03 v0.3.17
drwx------ 8 64535 64535 4096 Dec  7 08:33 v0.3.18
drwx------ 8 64535 64535 4096 Dec  7 13:30 v0.3.19
```
symlink created:
```
lrwxrwxrwx 1 64535 64535 15 Dec  7 13:30 935-echo -> ../echo/v0.3.19
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Create module directory with desired version only when ModuleRelease is deployed.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
