### PR TITLE
[deckhouse-controller] fix module cleanup on startup

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -758,7 +758,6 @@ func (c *Controller) deleteModulesWithAbsentRelease() error {
 			c.logger.Warnf("Module %q has neither ModuleRelease nor ModuleOverride. Purging from FS", module)
 			_ = os.RemoveAll(moduleLinkPath)
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Don't delete modules from fs, which have ModulePullOverride

## Why do we need it, and what problem does it solve?
On Deckhouse startup we check ModuleReleases and delete directories for absent.
We also have. to check ModulePullOverride, otherwise module will be purged from fs

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Before:
```json
{"component":"ModulePullOverrideController","level":"info","msg":"Restarting Deckhouse because \"sds-node-configurator\" ModulePullOverride image was updated","time":"2023-12-07T11:34:40Z"}
{"component":"ModuleReleaseController","level":"warning","msg":"Module \"sds-node-configurator\" has no releases. Purging from FS","time":"2023-12-07T11:34:41Z"}
```

After:
```json
{"component":"ModulePullOverrideController","level":"info","msg":"Restarting Deckhouse because \"sds-node-configurator\" ModulePullOverride image was updated","time":"2023-12-07T12:21:09Z"}
...
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Don' purge module on startup if ModulePullOverride exists.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
