### PR TITLE
Preventing the creation of a new "helm" release when no changes are made

### DIFF
--- a/ee/modules/160-multitenancy-manager/templates/user-resources/user-resources-templates.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/user-resources-templates.yaml
@@ -71,7 +71,7 @@ metadata:
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
-  name: {{ list $kebabCaseAuthName $rootContext | include "slugify" | replace "--" "-" }}
+  name: {{ list $kebabCaseAuthName $rootContext | replace "--" "-" }}
   namespace: {{ $projectName }}
 spec:
   accessLevel: {{ $values.role }}

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/user-resources-templates.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/user-resources-templates.yaml
@@ -11,6 +11,32 @@ metadata:
   {{- end }}
 {{- end }}
 
+{{- define "slugify" }}
+  {{- /* https://gitlab.com/gitlab-org/gitlab/-/blob/6db59634ecbb1581bbb16b627b9631ca96ce2e8d/lib/gitlab/utils.rb#L100 */}}
+  {{- $oldName := index . 0 }}
+  {{- $rootContext := index . 1 }}
+
+  {{- $newName := lower $oldName }}
+  {{- $newName = regexReplaceAllLiteral "[^a-z0-9]" $newName "-" }}
+
+  {{- if gt (len $newName) 63 }}
+    {{- if not ( index $rootContext.Release "bigNamePostfixes" ) }}
+      {{- $_ := set $rootContext.Release "bigNamePostfixes" dict }}
+    {{- end }}
+
+    {{- /* This will allow us to reuse random string after helm release upgrade */}}
+    {{- if not ( index $rootContext.Release.bigNamePostfixes $newName ) }}
+      {{- $_ := set $rootContext.Release.bigNamePostfixes $newName ( randAlphaNum 10 | lower ) }}
+    {{- end }}
+
+    {{- $newNameShortened := substr 0 52 $newName }}
+    {{- $newName = printf "%s-%s" $newNameShortened ( index $rootContext.Release.bigNamePostfixes $newName ) }}
+  {{- end }}
+
+  {{- $newName = regexReplaceAllLiteral "(^-+|-+$)" $newName "" }}
+  {{- print $newName }}
+{{- end }}
+
 {{- define "prepare.template" }}
   {{- $template := index . 0 }}
   {{- $projectName := index . 1 }}
@@ -48,7 +74,6 @@ metadata:
   {{- end }}
 {{- end }}
 
-
 {{- define "prepare.templates" }}
   {{- $templates := splitList "---" ( index . 0) }}
   {{- $projectName := index . 1 }}
@@ -71,7 +96,7 @@ metadata:
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
-  name: {{ list $kebabCaseAuthName $rootContext | replace "--" "-" }}
+  name: {{ list $kebabCaseAuthName $rootContext | include "slugify" | replace "--" "-" }}
   namespace: {{ $projectName }}
 spec:
   accessLevel: {{ $values.role }}

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/user-resources-templates.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/user-resources-templates.yaml
@@ -91,7 +91,7 @@ metadata:
   {{- $projectName := index . 0 }}
   {{- $values := index . 1 }}
   {{- $rootContext := index . 2 }}
-  {{- $kebabCaseAuthName := printf "%s-%s-%s-%s" $projectName $values.role $values.kind $values.name | kebabcase }}
+  {{- $kebabCaseAuthName := printf "%s-%s-%s" $values.role $values.kind $values.name | kebabcase }}
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule

--- a/go_lib/dependency/helm/hash.go
+++ b/go_lib/dependency/helm/hash.go
@@ -23,12 +23,9 @@ import (
 )
 
 func hashObject(sum map[string]interface{}, hash *hash.Hash) {
-
-	barrier(hash)
 	var keys = sortedKeys(sum)
 	for _, key := range keys {
 		v := sum[key]
-
 		escapeKey(key, hash)
 		switch o := v.(type) {
 		case map[string]interface{}:
@@ -39,14 +36,10 @@ func hashObject(sum map[string]interface{}, hash *hash.Hash) {
 			escapeValue(o, hash)
 		}
 	}
-	barrier(hash)
 }
 
 func hashArray(array []interface{}, hash *hash.Hash) {
-
-	barrier(hash)
 	for _, v := range array {
-
 		switch o := v.(type) {
 		case map[string]interface{}:
 			hashObject(o, hash)
@@ -56,26 +49,15 @@ func hashArray(array []interface{}, hash *hash.Hash) {
 			escapeValue(o, hash)
 		}
 	}
-	barrier(hash)
 }
 
 func escapeKey(key string, writer *hash.Hash) {
 	(*writer).Write([]byte(key))
-	barrier(writer)
 }
 
 func escapeValue(value interface{}, writer *hash.Hash) {
 	(*writer).Write([]byte(fmt.Sprintf(`%T`, value)))
-	barrier(writer)
 	(*writer).Write([]byte(fmt.Sprintf("%v", value)))
-	barrier(writer)
-}
-
-// an invalide utf8 byte is used as a barrier
-var barrierValue = []byte{byte('\255')}
-
-func barrier(writer *hash.Hash) {
-	(*writer).Write(barrierValue)
 }
 
 func sortedKeys(sum map[string]interface{}) []string {

--- a/go_lib/dependency/helm/hash.go
+++ b/go_lib/dependency/helm/hash.go
@@ -78,9 +78,9 @@ func barrier(writer *hash.Hash) {
 	(*writer).Write(barrierValue)
 }
 
-func sortedKeys(json map[string]interface{}) []string {
+func sortedKeys(sum map[string]interface{}) []string {
 	var keys []string
-	for k := range json {
+	for k := range sum {
 		keys = append(keys, k)
 	}
 

--- a/go_lib/dependency/helm/hash.go
+++ b/go_lib/dependency/helm/hash.go
@@ -1,0 +1,73 @@
+package helm
+
+import (
+	"fmt"
+	"hash"
+	"sort"
+)
+
+func hashObject(sum map[string]interface{}, hash *hash.Hash) {
+
+	barrier(hash)
+	var keys = sortedKeys(sum)
+	for _, key := range keys {
+		v := sum[key]
+
+		escapeKey(key, hash)
+		switch o := v.(type) {
+		case map[string]interface{}:
+			hashObject(o, hash)
+		case []interface{}:
+			hashArray(o, hash)
+		default:
+			escapeValue(o, hash)
+		}
+	}
+	barrier(hash)
+}
+
+func hashArray(array []interface{}, hash *hash.Hash) {
+
+	barrier(hash)
+	for _, v := range array {
+
+		switch o := v.(type) {
+		case map[string]interface{}:
+			hashObject(o, hash)
+		case []interface{}:
+			hashArray(o, hash)
+		default:
+			escapeValue(o, hash)
+		}
+	}
+	barrier(hash)
+}
+
+func escapeKey(key string, writer *hash.Hash) {
+	(*writer).Write([]byte(key))
+	barrier(writer)
+}
+
+func escapeValue(value interface{}, writer *hash.Hash) {
+	(*writer).Write([]byte(fmt.Sprintf(`%T`, value)))
+	barrier(writer)
+	(*writer).Write([]byte(fmt.Sprintf("%v", value)))
+	barrier(writer)
+}
+
+// an invalide utf8 byte is used as a barrier
+var barrierValue = []byte{byte('\255')}
+
+func barrier(writer *hash.Hash) {
+	(*writer).Write(barrierValue)
+}
+
+func sortedKeys(json map[string]interface{}) []string {
+	var keys []string
+	for k := range json {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	return keys
+}

--- a/go_lib/dependency/helm/hash.go
+++ b/go_lib/dependency/helm/hash.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package helm
 
 import (

--- a/go_lib/dependency/helm/helm.go
+++ b/go_lib/dependency/helm/helm.go
@@ -149,7 +149,7 @@ func (client *helmClient) Upgrade(releaseName string, templates, values map[stri
 		val, ok := latestRelease.Labels["hashsum"]
 		if ok {
 			if val == hashsum {
-				klog.Warningf("the hashes matched")
+				klog.Info("the hashes matched")
 				return nil
 			}
 		}
@@ -180,14 +180,11 @@ func (client *helmClient) Delete(releaseName string) error {
 func (client *helmClient) rollbackLatestRelease(releases []*release.Release) {
 	latestRelease := releases[0]
 
-	// TODO fix logger client.LogEntry.Infof("Trying to rollback '%s'", nsReleaseName)
-
 	if latestRelease.Version == 1 || client.options.HistoryMax == 1 || len(releases) == 1 {
 		uninstallObject := action.NewUninstall(client.actionConfig)
 		uninstallObject.KeepHistory = false
 		_, err := uninstallObject.Run(latestRelease.Name)
 		if err != nil {
-			// TODO fix logger client.LogEntry.Warnf("Failed to uninstall pending release %s: %s", nsReleaseName, err)
 			return
 		}
 	} else {
@@ -203,12 +200,9 @@ func (client *helmClient) rollbackLatestRelease(releases []*release.Release) {
 		rollbackObject.CleanupOnFail = true
 		err := rollbackObject.Run(latestRelease.Name)
 		if err != nil {
-			// TODO fix logger client.LogEntry.Warnf("Failed to rollback pending release %s: %s", nsReleaseName, err)
 			return
 		}
 	}
-
-	// TODO fix logger client.LogEntry.Infof("Rollback '%s' successful", nsReleaseName)
 }
 
 func getActionConfig(namespace string) (*action.Configuration, error) {

--- a/go_lib/dependency/helm/helm.go
+++ b/go_lib/dependency/helm/helm.go
@@ -239,7 +239,7 @@ func getMD5Hash(templates, values map[string]interface{}) string {
 
 	hash := md5.New()
 	hashObject(sum, &hash)
-	res := md5.Sum(nil)
+	res := hash.Sum(nil)
 
 	return hex.EncodeToString(res[:])
 

--- a/go_lib/dependency/helm/helm.go
+++ b/go_lib/dependency/helm/helm.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"maps"
 	"time"
 
@@ -222,7 +221,7 @@ func getActionConfig(namespace string) (*action.Configuration, error) {
 	kubeConfig.BearerToken = &config.BearerToken
 	kubeConfig.CAFile = &config.CAFile
 	kubeConfig.Namespace = &namespace
-	if err := actionConfig.Init(kubeConfig, namespace, helmDriver, log.Printf); err != nil { // TODO <-- logger replace
+	if err := actionConfig.Init(kubeConfig, namespace, helmDriver, klog.Infof); err != nil {
 		return nil, err
 	}
 	return actionConfig, nil
@@ -237,10 +236,7 @@ func getMD5Hash(templates, values map[string]interface{}) string {
 
 	// TODO is not an ideal algorithm, since the order of elements in map is not
 	// guaranteed and may lead to a different hash result.
-	byteResult, err := json.Marshal(sum)
-	if err != nil {
-		klog.Errorf("sum template and values marshal error: %v", err)
-	}
+	byteResult, _ := json.Marshal(sum)
 
 	hash := md5.Sum(byteResult)
 	return hex.EncodeToString(hash[:])

--- a/go_lib/dependency/helm/helm.go
+++ b/go_lib/dependency/helm/helm.go
@@ -19,7 +19,6 @@ package helm
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"time"
@@ -236,8 +235,14 @@ func getMD5Hash(templates, values map[string]interface{}) string {
 
 	// TODO is not an ideal algorithm, since the order of elements in map is not
 	// guaranteed and may lead to a different hash result.
-	byteResult, _ := json.Marshal(sum)
+	// byteResult, _ := json.Marshal(sum)
 
-	hash := md5.Sum(byteResult)
-	return hex.EncodeToString(hash[:])
+	hash := md5.New()
+	hashObject(sum, &hash)
+	res := md5.Sum(nil)
+
+	return hex.EncodeToString(res[:])
+
+	// hash := md5.Sum(byteResult)
+	// return hex.EncodeToString(hash[:])
 }

--- a/go_lib/dependency/helm/helm.go
+++ b/go_lib/dependency/helm/helm.go
@@ -233,16 +233,9 @@ func getMD5Hash(templates, values map[string]interface{}) string {
 		sum[k] = v
 	}
 
-	// TODO is not an ideal algorithm, since the order of elements in map is not
-	// guaranteed and may lead to a different hash result.
-	// byteResult, _ := json.Marshal(sum)
-
 	hash := md5.New()
 	hashObject(sum, &hash)
 	res := hash.Sum(nil)
 
 	return hex.EncodeToString(res[:])
-
-	// hash := md5.Sum(byteResult)
-	// return hex.EncodeToString(hash[:])
 }

--- a/go_lib/dependency/helm/helm.go
+++ b/go_lib/dependency/helm/helm.go
@@ -237,5 +237,5 @@ func getMD5Hash(templates, values map[string]interface{}) string {
 	hashObject(sum, &hash)
 	res := hash.Sum(nil)
 
-	return hex.EncodeToString(res[:])
+	return hex.EncodeToString(res)
 }


### PR DESCRIPTION
## Description

What we've got:
When we make changes to any project or projectTemplate, we make a call to Helm.Update for all projects. This leads to unnecessary increase of Helm release version.

What we're getting at:
We compute an md5 hash based on templates and template values and store this hash in the release custom label.   When changes are made, we compare the hash and prevent helm.Update from being called.

## Why do we need it, and what problem does it solve?

It prevents the creation of a new "helm" release when no changes are made to it.

## What is the expected result?

When changes are made to a project or project template helm.update will only be called for projects that have changes or for new projects.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: fix
summary: Prevents the creation of a new "helm" release when no changes are made to it
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
