### PR TITLE
[linstor] improved error display on dashboard

### DIFF
--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -1,63 +1,12 @@
 {
-  "__inputs": [
-    {
-      "name": "ds_prometheus",
-      "label": "main",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.2.6"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph (old)",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -72,18 +21,20 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": null,
   "graphTooltip": 2,
-  "id": null,
-  "iteration": 1659360879340,
+  "id": 38,
+  "iteration": 1701959751046,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -96,7 +47,237 @@
       "type": "row"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\",node=~\"$node\"} == 2) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_storage_pool_capacity_total_bytes{driver!=\"DISKLESS\",node=~\"$node\"}) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Storage Pools",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(linstor_resource_definition_count{}) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Definitions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_resource_state) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Resources",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -122,9 +303,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 18,
-        "x": 0,
+        "h": 9,
+        "w": 6,
+        "x": 12,
         "y": 1
       },
       "id": 41,
@@ -141,7 +322,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -155,7 +336,9 @@
       "type": "gauge"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -176,7 +359,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 6,
         "x": 18,
         "y": 1
@@ -197,7 +380,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -211,7 +394,197 @@
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\", node=~\"$node\"} != 2) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Offline Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_storage_pool_error_count{driver!=\"DISKLESS\", node=~\"$node\"} != 0) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Storage Pools",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "exemplar": true,
+          "expr": "count((linstor_volume_state != 1) != 4) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Resources",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -233,10 +606,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 6,
         "x": 18,
-        "y": 5
+        "y": 4
       },
       "id": 44,
       "options": {
@@ -254,7 +627,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -268,7 +641,80 @@
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 6
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 52,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (module) (round(increase(linstor_error_reports_count{module!=\"\", node=~\"$node\"}[$__interval_sx4])))",
+          "instant": false,
+          "legendFormat": "{{ module }}",
+          "refId": "A"
+        }
+      ],
+      "title": "New Error Reports",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -289,10 +735,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 6,
         "x": 18,
-        "y": 9
+        "y": 7
       },
       "id": 42,
       "options": {
@@ -310,7 +756,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -324,20 +770,50 @@
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
-      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "5": {
+                  "index": 0,
+                  "text": "Inconsistent"
+                },
+                "6": {
+                  "index": 2,
+                  "text": "Failed"
+                },
+                "-1": {
+                  "index": 1,
+                  "text": "DUnknown"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
               }
             ]
           }
@@ -345,206 +821,68 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
-        "w": 3,
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 11
+        "y": 10
       },
-      "id": 36,
+      "id": 54,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "footer": {
           "fields": "",
-          "values": false
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "text": {},
-        "textMode": "auto"
+        "frameIndex": 0,
+        "showHeader": true
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\",node=~\"$node\"} == 2) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Nodes",
-      "type": "stat"
-    },
-    {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 11
-      },
-      "id": 38,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
-        {
           "exemplar": true,
-          "expr": "count(linstor_storage_pool_capacity_total_bytes{driver!=\"DISKLESS\",node=~\"$node\"}) OR on() vector(0)",
+          "expr": "max by (node, resource) ((linstor_volume_state != 1) != 4)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Storage Pools",
-      "type": "stat"
-    },
-    {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 11
-      },
-      "id": 35,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
+      "title": "Linstor Resources not happen",
+      "transformations": [
         {
-          "exemplar": true,
-          "expr": "sum(linstor_resource_definition_count{}) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Quorum?",
+              "instance": "Instance",
+              "name": "DRBD Resource",
+              "node": "Node"
+            }
+          }
         }
       ],
-      "title": "Resource Definitions",
-      "type": "stat"
+      "type": "table"
     },
     {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "${ds_prometheus}"
       },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 11
-      },
-      "id": 37,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "count(linstor_resource_state) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Resources",
-      "type": "stat"
-    },
-    {
-      "datasource": "${ds_prometheus}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -593,10 +931,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 6,
+        "h": 8,
+        "w": 12,
         "x": 12,
-        "y": 11
+        "y": 10
       },
       "id": 40,
       "options": {
@@ -606,7 +944,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.2.6",
@@ -622,259 +961,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "dark-yellow",
-                "value": 6
-              },
-              {
-                "color": "orange",
-                "value": 10
-              },
-              {
-                "color": "red",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 13
-      },
-      "id": 52,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (module) (round(increase(linstor_error_reports_count{module!=\"\", node=~\"$node\"}[$__interval_sx4])))",
-          "instant": false,
-          "legendFormat": "{{ module }}",
-          "refId": "A"
-        }
-      ],
-      "title": "New Error Reports",
-      "transformations": [],
-      "type": "stat"
-    },
-    {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 14
-      },
-      "id": 51,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\", node=~\"$node\"} != 2) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Offline Nodes",
-      "type": "stat"
-    },
-    {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 14
-      },
-      "id": 50,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "count(linstor_storage_pool_error_count{driver!=\"DISKLESS\", node=~\"$node\"} != 0) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Failed Storage Pools",
-      "type": "stat"
-    },
-    {
-      "datasource": "${ds_prometheus}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 14
-      },
-      "id": 49,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.2.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "count((linstor_volume_state != 1) != 4) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Failed Resources",
-      "type": "stat"
-    },
-    {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 46,
       "panels": [],
@@ -886,7 +982,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "binBps"
@@ -899,7 +997,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 24,
@@ -919,7 +1017,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -937,9 +1035,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Write Rate (5 Most Active Volumes)",
       "tooltip": {
         "shared": true,
@@ -948,9 +1044,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -958,25 +1052,18 @@
         {
           "$$hashKey": "object:104",
           "format": "binBps",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:105",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -984,7 +1071,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "binBps"
@@ -997,7 +1086,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 25,
@@ -1017,7 +1106,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1035,9 +1124,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Read Rate (5 Most Active Volumes)",
       "tooltip": {
         "shared": true,
@@ -1046,9 +1133,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1056,35 +1141,30 @@
         {
           "$$hashKey": "object:254",
           "format": "binBps",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:255",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 27
       },
       "id": 8,
       "panels": [],
@@ -1092,8 +1172,9 @@
       "type": "row"
     },
     {
-      "cacheTimeout": null,
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1116,7 +1197,7 @@
         "h": 11,
         "w": 16,
         "x": 0,
-        "y": 35
+        "y": 28
       },
       "id": 6,
       "links": [],
@@ -1134,7 +1215,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "$$hashKey": "object:470",
@@ -1159,7 +1240,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "s"
@@ -1172,7 +1255,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 28
       },
       "hiddenSeries": false,
       "id": 27,
@@ -1192,7 +1275,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1209,9 +1292,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Scrape Duration",
       "tooltip": {
         "shared": true,
@@ -1220,9 +1301,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1230,29 +1309,24 @@
         {
           "$$hashKey": "object:158",
           "format": "s",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:159",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "description": "DRBD data out of sync with a peer",
       "fieldConfig": {
         "defaults": {
@@ -1281,7 +1355,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 43
+        "y": 36
       },
       "id": 12,
       "options": {
@@ -1299,7 +1373,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1308,13 +1382,13 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "out-of-sync data",
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1341,7 +1415,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 46
+        "y": 39
       },
       "id": 14,
       "options": {
@@ -1359,7 +1433,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": false,
@@ -1368,13 +1442,13 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "disconnected",
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1412,7 +1486,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 46
+        "y": 39
       },
       "id": 20,
       "options": {
@@ -1430,7 +1504,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1449,13 +1523,13 @@
           "refId": "B"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "without quorum",
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1483,7 +1557,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 46
+        "y": 39
       },
       "id": 4,
       "options": {
@@ -1501,7 +1575,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1510,13 +1584,13 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "storage failure",
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "description": "DRBD data out of sync with a peer",
       "fieldConfig": {
         "defaults": {
@@ -1545,7 +1619,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 46
+        "y": 39
       },
       "id": 29,
       "options": {
@@ -1563,7 +1637,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1572,22 +1646,23 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "out-of-sync",
       "type": "stat"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
+            "align": "auto",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [
             {
@@ -1619,11 +1694,17 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 42
       },
       "id": 22,
-      "maxDataPoints": null,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "frameIndex": 0,
         "showHeader": true,
         "sortBy": [
@@ -1633,7 +1714,7 @@
           }
         ]
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1645,8 +1726,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Disconnected DRBD Resources",
       "transformations": [
         {
@@ -1695,16 +1774,19 @@
       "type": "table"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
+            "align": "auto",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -1761,15 +1843,22 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 42
       },
       "id": 16,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "frameIndex": 0,
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": false,
@@ -1820,16 +1909,19 @@
       "type": "table"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
+            "align": "auto",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [
             {
@@ -1861,15 +1953,21 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 50
       },
       "id": 31,
-      "maxDataPoints": null,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "frameIndex": 0,
         "showHeader": true
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1881,8 +1979,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "DRBD Resources Without Quorum",
       "transformations": [
         {
@@ -1909,16 +2005,19 @@
       "type": "table"
     },
     {
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
+            "align": "auto",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [
             {
@@ -1950,15 +2049,21 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 50
       },
       "id": 30,
-      "maxDataPoints": null,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "frameIndex": 0,
         "showHeader": true
       },
-      "pluginVersion": "8.2.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "exemplar": true,
@@ -1970,8 +2075,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "DRBD Resources with Storage Failure",
       "transformations": [
         {
@@ -2007,7 +2110,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 32,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2018,8 +2121,6 @@
           "text": "default",
           "value": "default"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus",
@@ -2034,15 +2135,22 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "${ds_prometheus}",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds_prometheus}"
+        },
         "definition": "label_values(linstor_node_state{nodetype=\"SATELLITE\"}, node)",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
-        "label": null,
         "multi": true,
         "name": "node",
         "options": [],
@@ -2067,7 +2175,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "LINSTOR / DRBD",
-  "uid": "f_tZtVlMz",
-  "version": 19
+  "title": "LINSTOR / DRBD -test",
+  "uid": "f_tZtVlMzczc",
+  "version": 3,
+  "weekStart": ""
 }

--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "id": 38,
-  "iteration": 1701959751046,
+  "id": 35,
+  "iteration": 1702296316755,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -845,12 +845,14 @@
             "type": "prometheus",
             "uid": "P0D6E4079E36703EB"
           },
-          "exemplar": true,
+          "editorMode": "code",
+          "exemplar": false,
           "expr": "max by (node, resource) ((linstor_volume_state != 1) != 4)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -865,10 +867,11 @@
           "options": {
             "excludeByName": {
               "Time": true,
-              "Value": true
+              "Value": false
             },
             "indexByName": {},
             "renameByName": {
+              "Value": "Status",
               "Value #A": "Quorum?",
               "instance": "Instance",
               "name": "DRBD Resource",
@@ -2175,8 +2178,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "LINSTOR / DRBD -test",
-  "uid": "f_tZtVlMzczc",
-  "version": 3,
+  "title": "LINSTOR / DRBD",
+  "uid": "f_tZtVlMz",
+  "version": 20,
   "weekStart": ""
 }

--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -869,16 +869,48 @@
           "mappings": [
             {
               "options": {
+                "1": {
+                  "index": 1,
+                  "text": "UpToDate"
+                },
+                "2": {
+                  "index": 2,
+                  "text": "Created"
+                },
+                "3": {
+                  "index": 3,
+                  "text": "Attached"
+                },
+                "4": {
+                  "index": 4,
+                  "text": "Diskless"
+                },
                 "5": {
-                  "index": 0,
+                  "index": 5,
                   "text": "Inconsistent"
                 },
                 "6": {
-                  "index": 2,
+                  "index": 6,
                   "text": "Failed"
                 },
+                "7": {
+                  "index": 7,
+                  "text": "To: Creating"
+                },
+                "8": {
+                  "index": 8,
+                  "text": "To: Attachable"
+                },
+                "9": {
+                  "index": 9,
+                  "text": "To: Attaching"
+                },
+                "90": {
+                  "index": 10,
+                  "text": "Diskless(Detached)"
+                },
                 "-1": {
-                  "index": 1,
+                  "index": 0,
                   "text": "DUnknown"
                 }
               },
@@ -907,8 +939,7 @@
             },
             "properties": [
               {
-                "id": "custom.width",
-                "value": 230
+                "id": "custom.width"
               }
             ]
           },
@@ -919,7 +950,8 @@
             },
             "properties": [
               {
-                "id": "custom.width"
+                "id": "custom.width",
+                "value": 330
               }
             ]
           },
@@ -930,8 +962,11 @@
             },
             "properties": [
               {
-                "id": "custom.width",
-                "value": 128
+                "id": "custom.width"
+              },
+              {
+                "id": "custom.minWidth",
+                "value": 98
               }
             ]
           }

--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
   "id": 36,

--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "id": 35,
-  "iteration": 1702296316755,
+  "id": 48,
+  "iteration": 1702300458163,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -771,119 +771,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "${ds_prometheus}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "filterable": false,
-            "inspect": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "5": {
-                  "index": 0,
-                  "text": "Inconsistent"
-                },
-                "6": {
-                  "index": 2,
-                  "text": "Failed"
-                },
-                "-1": {
-                  "index": 1,
-                  "text": "DUnknown"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 10
-      },
-      "id": 54,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "frameIndex": 0,
-        "showHeader": true
-      },
-      "pluginVersion": "8.5.13",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max by (node, resource) ((linstor_volume_state != 1) != 4)",
-          "format": "table",
-          "instant": true,
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Linstor Resources not happen",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": false
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Status",
-              "Value #A": "Quorum?",
-              "instance": "Instance",
-              "name": "DRBD Resource",
-              "node": "Node"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
         "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
@@ -935,8 +822,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 24,
+        "x": 0,
         "y": 10
       },
       "id": 40,
@@ -964,6 +851,306 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "5": {
+                  "index": 0,
+                  "text": "Inconsistent"
+                },
+                "6": {
+                  "index": 2,
+                  "text": "Failed"
+                },
+                "-1": {
+                  "index": 1,
+                  "text": "DUnknown"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Node"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 230
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "resource"
+            },
+            "properties": [
+              {
+                "id": "custom.width"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 128
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 54,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (node, resource) ((linstor_volume_state != 1) != 4)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Linstor Volumes not happen",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Status",
+              "Value #A": "Quorum?",
+              "instance": "Instance",
+              "name": "DRBD Resource",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "5": {
+                  "index": 0,
+                  "text": "Inconsistent"
+                },
+                "6": {
+                  "index": 2,
+                  "text": "Failed"
+                },
+                "-1": {
+                  "index": 1,
+                  "text": "DUnknown"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Node"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 230
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "resource"
+            },
+            "properties": [
+              {
+                "id": "custom.width"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 128
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 55,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (node, resource) (linstor_resource_state == -1)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Linstor Resources not happen",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Status",
+              "Value #A": "Quorum?",
+              "instance": "Instance",
+              "name": "DRBD Resource",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -973,7 +1160,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 26
       },
       "id": 46,
       "panels": [],
@@ -1000,7 +1187,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 24,
@@ -1089,7 +1276,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 25,
@@ -1167,7 +1354,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 8,
       "panels": [],
@@ -1175,75 +1362,12 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "uid": "${ds_prometheus}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 16,
-        "x": 0,
-        "y": 28
-      },
-      "id": 6,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "text": {}
-      },
-      "pluginVersion": "8.5.13",
-      "targets": [
-        {
-          "$$hashKey": "object:470",
-          "aggregation": "Last",
-          "decimals": 2,
-          "displayAliasType": "Warning / Critical",
-          "displayType": "Regular",
-          "displayValueWithAlias": "Never",
-          "exemplar": true,
-          "expr": "drbd_resource_resources",
-          "legendFormat": "{{instance}}",
-          "refId": "A",
-          "units": "none",
-          "valueHandler": "Number Threshold"
-        }
-      ],
-      "title": "Number of DRBD Resources",
-      "type": "gauge"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
@@ -1256,9 +1380,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 28
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 27,
@@ -1288,9 +1412,15 @@
       "steppedLine": true,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "avg_over_time(scrape_duration_seconds{job=\"linstor-node\"}[$__interval_sx3])",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{node}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -1328,9 +1458,9 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "DRBD data out of sync with a peer",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1343,28 +1473,22 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
               }
             ]
-          },
-          "unit": "bytes"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 36
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 44
       },
-      "id": 12,
+      "id": 6,
+      "links": [],
+      "maxDataPoints": 100,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -1373,20 +1497,35 @@
           "fields": "",
           "values": false
         },
-        "text": {},
-        "textMode": "auto"
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
       },
       "pluginVersion": "8.5.13",
       "targets": [
         {
+          "$$hashKey": "object:470",
+          "aggregation": "Last",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "decimals": 2,
+          "displayAliasType": "Warning / Critical",
+          "displayType": "Regular",
+          "displayValueWithAlias": "Never",
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(max by(name, volume) (drbd_peerdevice_outofsync_bytes > 0)) OR on() vector(0)",
-          "legendFormat": "",
-          "refId": "A"
+          "expr": "drbd_resource_resources",
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A",
+          "units": "none",
+          "valueHandler": "Number Threshold"
         }
       ],
-      "title": "out-of-sync data",
-      "type": "stat"
+      "title": "Number of DRBD Resources",
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -1418,7 +1557,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 39
+        "y": 57
       },
       "id": 14,
       "options": {
@@ -1489,7 +1628,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 39
+        "y": 57
       },
       "id": 20,
       "options": {
@@ -1560,7 +1699,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 39
+        "y": 57
       },
       "id": 4,
       "options": {
@@ -1622,7 +1761,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 39
+        "y": 57
       },
       "id": 29,
       "options": {
@@ -1650,6 +1789,68 @@
         }
       ],
       "title": "out-of-sync",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${ds_prometheus}"
+      },
+      "description": "DRBD data out of sync with a peer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 57
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(max by(name, volume) (drbd_peerdevice_outofsync_bytes > 0)) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "out-of-sync data",
       "type": "stat"
     },
     {
@@ -1697,7 +1898,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 60
       },
       "id": 22,
       "options": {
@@ -1778,6 +1979,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
@@ -1811,8 +2013,7 @@
             },
             "properties": [
               {
-                "id": "custom.width",
-                "value": 279
+                "id": "custom.width"
               }
             ]
           },
@@ -1823,8 +2024,7 @@
             },
             "properties": [
               {
-                "id": "custom.width",
-                "value": 238
+                "id": "custom.width"
               }
             ]
           },
@@ -1846,7 +2046,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 60
       },
       "id": 16,
       "options": {
@@ -1864,6 +2064,10 @@
       "pluginVersion": "8.5.13",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
           "exemplar": false,
           "expr": "sum(drbd_peerdevice_outofsync_bytes) by(name, node) > 0",
           "format": "table",
@@ -1956,7 +2160,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 68
       },
       "id": 31,
       "options": {
@@ -2052,7 +2256,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 68
       },
       "id": 30,
       "options": {
@@ -2180,6 +2384,6 @@
   "timezone": "",
   "title": "LINSTOR / DRBD",
   "uid": "f_tZtVlMz",
-  "version": 20,
+  "version": 21,
   "weekStart": ""
 }

--- a/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/041-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "id": 48,
-  "iteration": 1702300458163,
+  "id": 36,
+  "iteration": 1702301893505,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1019,17 +1019,17 @@
           "mappings": [
             {
               "options": {
-                "5": {
-                  "index": 0,
-                  "text": "Inconsistent"
+                "0": {
+                  "index": 1,
+                  "text": "secondary"
                 },
-                "6": {
+                "1": {
                   "index": 2,
-                  "text": "Failed"
+                  "text": "primary"
                 },
                 "-1": {
-                  "index": 1,
-                  "text": "DUnknown"
+                  "index": 0,
+                  "text": "Unknown"
                 }
               },
               "type": "value"

--- a/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/041-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.drbd.device_state
   rules:
     - alert: D8LinstorVolumeIsNotHealthy
-      expr: max by (exported_node, resource) (linstor_volume_state != 1 and linstor_volume_state != 4)
+      expr: max by (node, resource) ((linstor_volume_state != 1) != 4)
       for: 5m
       labels:
         severity_level: "6"
@@ -13,7 +13,7 @@
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: LINSTOR volume is not healthy
         description: |
-          LINSTOR volume {{ $labels.resource }} on node {{ $labels.exported_node }} is not healthy
+          LINSTOR volume {{ $labels.resource }} on node {{ $labels.node }} is not healthy
 
           The recommended course of action:
           1. Login into node with the problem:
@@ -25,7 +25,7 @@
           2. Check the LINSTOR node state:
 
              ```
-             linstor node list -n {{ $labels.exported_node }}
+             linstor node list -n {{ $labels.node }}
              ```
 
           3. Check the LINSTOR resource states:


### PR DESCRIPTION
## Description
Added display of lists of problematic linstor_volume_state and linstor_resource_state lists
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
internal customer request to expand information on dashboards
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: chore
summary: Improved error display on dashboard.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
