### PR TITLE
[cni-cilium] add RBAC for ciliumnetworkpolicies

### DIFF
--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -11,29 +11,11 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumclusterwidenetworkpolicies
   verbs:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: Editor
-  name: d8:user-authz:cni-cilium:editor
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - cilium.io
-  resources:
-  - ciliumnetworkpolicies
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -47,10 +29,8 @@ rules:
   - cilium.io
   resources:
   - ciliumclusterwidenetworkpolicies
+  - ciliumnetworkpolicies
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
   - deletecollection

--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   annotations:
     user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cni-cilium:privileged-user
+  name: d8:user-authz:cni-cilium:user
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
@@ -40,7 +40,7 @@ kind: ClusterRole
 metadata:
   annotations:
     user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cni-cilium:cluster-editor
+  name: d8:user-authz:cni-cilium:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:

--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: PrivilegedUser
+    user-authz.deckhouse.io/access-level: User
   name: d8:user-authz:cni-cilium:privileged-user
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
@@ -39,7 +39,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: ClusterEditor
+    user-authz.deckhouse.io/access-level: ClusterAdmin
   name: d8:user-authz:cni-cilium:cluster-editor
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:

--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   annotations:
     user-authz.deckhouse.io/access-level: PrivilegedUser
-  name: d8:user-authz:cni-cilium:privilegeduser
+  name: d8:user-authz:cni-cilium:privileged-user
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
@@ -40,7 +40,7 @@ kind: ClusterRole
 metadata:
   annotations:
     user-authz.deckhouse.io/access-level: ClusterEditor
-  name: d8:user-authz:cni-cilium:clustereditor
+  name: d8:user-authz:cni-cilium:cluster-editor
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:

--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: PrivilegedUser
+  name: d8:user-authz:cni-cilium:privilegeduser
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Editor
+  name: d8:user-authz:cni-cilium:editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterEditor
+  name: d8:user-authz:cni-cilium:clustereditor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumclusterwidenetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -28,8 +28,8 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
-  - ciliumclusterwidenetworkpolicies
   - ciliumnetworkpolicies
+  - ciliumclusterwidenetworkpolicies
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Description

Grant users access to view and edit `ciliumnetworkpolicies` based on `user-authz` roles

## Why do we need it, and what problem does it solve?

Currently, users created and configured with `user-authz` and `user-authn` do not have access to view and edit `ciliumnetworkpolicies`.

## What is the expected result?

Users created and configured with `user-authz` and `user-authn` will have access to view and edit `ciliumnetworkpolicies`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: Add user-authz RBACs for `ciliumnetworkpolicies`.
```
