### PR TITLE
[monitoring-kubernetes] Add alert when LoadBalancer have not been created

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -18,4 +18,4 @@
 
           Check the cloud-controller-manager logs in the 'd8-cloud-provider-*' namespace
           If you are using a bare-metal cluster with the metallb module enabled, check that the address space of the pool has not been exhausted.
-        summary: A load balancer does not start.
+        summary: A load balancer has not been created.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -18,4 +18,4 @@
 
           Check the cloud-controller-manager logs in the 'd8-cloud-provider-*' namespace
           If you are using a bare-metal cluster with the metallb module enabled, check that the address space of the pool has not been exhausted.
-        summary: Load balancer does not starts
+        summary: A load balancer does not start.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -11,9 +11,11 @@
         plk_create_group_if_not_exists__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         description: |-
-          Check does service LoadBalancer were started.
+          Checks whether the Load Balancer service has been started.
 
-          On some providers system sometimes cant create node for LoadBalancer service.
+          On some cloud providers sometimes can't create node for LoadBalancer service.
 
-          You can check unloaded resource with command kubectl get svc -A
+          You can check services LoadBalancer status with command:
+          kubectl get svc -A -o json | jq -r '.items[] | select(.spec.allocateLoadBalancerNodePorts == true) | "name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
+          For more information about not started LoadBalancer you can watch logs of cloud-controller-manager
         summary: Load balancer does not starts

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -1,0 +1,19 @@
+- name: kubernetes.node
+  rules:
+    - alert: LoadBalancerServiceWithoutExternalIP
+      expr: sum(kube_service_status_load_balancer_ingress or vector(0)) < sum(kube_service_spec_type{type="LoadBalancer"})
+      for: 30m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        description: |-
+          Check does service LoadBalancer were started.
+
+          On some providers system sometimes cant create node for LoadBalancer service.
+
+          You can check unloaded resource with command kubectl get svc -A
+        summary: Load balancer does not starts

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -2,7 +2,7 @@
   rules:
     - alert: LoadBalancerServiceWithoutExternalIP
       expr: sum(kube_service_status_load_balancer_ingress or vector(0)) < sum(kube_service_spec_type{type="LoadBalancer"})
-      for: 30m
+      for: 5m
       labels:
         severity_level: "4"
         tier: cluster
@@ -11,11 +11,11 @@
         plk_create_group_if_not_exists__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         plk_grouped_by__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         description: |-
-          Checks whether the Load Balancer service has been started.
+          One or more services with the LoadBalancer type cannot get an external address.
 
-          On some cloud providers sometimes can't create node for LoadBalancer service.
+          The list of services can be obtained with the following command:
+          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.allocateLoadBalancerNodePorts == true) | "name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
 
-          You can check services LoadBalancer status with command:
-          kubectl get svc -A -o json | jq -r '.items[] | select(.spec.allocateLoadBalancerNodePorts == true) | "name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
-          For more information about not started LoadBalancer you can watch logs of cloud-controller-manager
+          Check the cloud-controller-manager logs in the 'd8-cloud-provider-*' namespace
+          If you are using a bare-metal cluster with the metallb module enabled, check that the address space of the pool has not been exhausted.
         summary: Load balancer does not starts


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
On some cloud providers deckhouse can't order vm for LoadBalancer. So we need to know when it is happened. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Need to know when LoadBalancer not started

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
When LoadBalancer was created with Kubernetes by not starts al alert _LoadBalancerServiceWithoutExternalIP_ should appear 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: feature
summary: Add alert when LoadBalancer has not been created.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
