### PR TITLE
[ci] Change name of action 'e2e destroy faled'

### DIFF
--- a/.github/workflow_templates/e2e.abort.multi.yml
+++ b/.github/workflow_templates/e2e.abort.multi.yml
@@ -48,7 +48,7 @@ $CI_COMMIT_REF_SLUG is a tag of published deckhouse images. It has a form
 {!{/* Template with e2e jobs for one provider. */}!}
 {!{- define "e2e_clean_workflow_template" -}!}
 {!{- $ctx := . -}!}
-{!{- $workflowName := printf "remove failed e2e cluster: %s" $ctx.providerName -}!}
+{!{- $workflowName := printf "destroy cluster: %s" $ctx.providerName -}!}
 # <template: e2e_workflow_template>
 name: '{!{ $workflowName }!}'
 on:

--- a/.github/workflow_templates/e2e.abort.multi.yml
+++ b/.github/workflow_templates/e2e.abort.multi.yml
@@ -48,7 +48,7 @@ $CI_COMMIT_REF_SLUG is a tag of published deckhouse images. It has a form
 {!{/* Template with e2e jobs for one provider. */}!}
 {!{- define "e2e_clean_workflow_template" -}!}
 {!{- $ctx := . -}!}
-{!{- $workflowName := printf "e2e destroy failed: %s" $ctx.providerName -}!}
+{!{- $workflowName := printf "remove failed e2e cluster: %s" $ctx.providerName -}!}
 # <template: e2e_workflow_template>
 name: '{!{ $workflowName }!}'
 on:

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: AWS'
+name: 'destroy cluster: AWS'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: AWS, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: AWS, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -319,7 +319,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -340,7 +340,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: AWS, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: AWS, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
@@ -374,7 +374,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -585,7 +585,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -606,7 +606,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: AWS, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: AWS, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
@@ -640,7 +640,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -851,7 +851,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -872,7 +872,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: AWS, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: AWS, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
@@ -906,7 +906,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1117,7 +1117,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1138,7 +1138,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: AWS, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: AWS, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
@@ -1172,7 +1172,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1383,7 +1383,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: AWS, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: AWS, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1410,7 +1410,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: AWS, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: AWS, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: AWS, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: AWS, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: AWS, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: AWS, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: AWS, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: AWS, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: AWS, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: AWS, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1432,7 +1432,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: AWS';
+            const name = 'destroy cluster: AWS';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: Azure'
+name: 'destroy cluster: Azure'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: Azure, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: Azure, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -323,7 +323,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -344,7 +344,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: Azure, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: Azure, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
@@ -378,7 +378,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -593,7 +593,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -614,7 +614,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: Azure, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: Azure, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
@@ -648,7 +648,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -863,7 +863,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -884,7 +884,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: Azure, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: Azure, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
@@ -918,7 +918,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1133,7 +1133,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1154,7 +1154,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: Azure, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: Azure, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
@@ -1188,7 +1188,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1403,7 +1403,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Azure, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: Azure, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1430,7 +1430,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: Azure, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: Azure, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: Azure, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: Azure, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: Azure, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: Azure, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: Azure, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: Azure, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: Azure, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: Azure, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1452,7 +1452,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: Azure';
+            const name = 'destroy cluster: Azure';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: EKS'
+name: 'destroy cluster: EKS'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: EKS, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: EKS, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -319,7 +319,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -340,7 +340,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: EKS, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: EKS, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
@@ -374,7 +374,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -585,7 +585,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -606,7 +606,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: EKS, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: EKS, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
@@ -640,7 +640,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -851,7 +851,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -872,7 +872,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: EKS, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: EKS, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
@@ -906,7 +906,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1117,7 +1117,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1138,7 +1138,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: EKS, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: EKS, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
@@ -1172,7 +1172,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1383,7 +1383,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: EKS, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: EKS, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1410,7 +1410,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: EKS, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: EKS, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: EKS, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: EKS, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: EKS, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: EKS, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: EKS, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: EKS, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: EKS, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: EKS, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1432,7 +1432,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: EKS';
+            const name = 'destroy cluster: EKS';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: GCP'
+name: 'destroy cluster: GCP'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: GCP, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: GCP, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -317,7 +317,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -338,7 +338,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: GCP, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: GCP, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
@@ -372,7 +372,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -581,7 +581,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -602,7 +602,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: GCP, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: GCP, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
@@ -636,7 +636,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -845,7 +845,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -866,7 +866,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: GCP, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: GCP, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
@@ -900,7 +900,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1109,7 +1109,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1130,7 +1130,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: GCP, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: GCP, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
@@ -1164,7 +1164,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1373,7 +1373,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: GCP, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: GCP, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1400,7 +1400,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: GCP, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: GCP, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: GCP, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: GCP, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: GCP, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: GCP, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: GCP, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: GCP, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: GCP, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: GCP, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1422,7 +1422,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: GCP';
+            const name = 'destroy cluster: GCP';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: OpenStack'
+name: 'destroy cluster: OpenStack'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: OpenStack, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -317,7 +317,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -338,7 +338,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: OpenStack, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
@@ -372,7 +372,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -581,7 +581,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -602,7 +602,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: OpenStack, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
@@ -636,7 +636,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -845,7 +845,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -866,7 +866,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: OpenStack, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
@@ -900,7 +900,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1109,7 +1109,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1130,7 +1130,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: OpenStack, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
@@ -1164,7 +1164,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1373,7 +1373,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: OpenStack, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: OpenStack, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1400,7 +1400,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: OpenStack, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: OpenStack, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: OpenStack, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: OpenStack, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: OpenStack, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: OpenStack, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: OpenStack, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: OpenStack, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: OpenStack, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: OpenStack, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1422,7 +1422,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: OpenStack';
+            const name = 'destroy cluster: OpenStack';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: Static'
+name: 'destroy cluster: Static'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: Static, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: Static, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -317,7 +317,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -338,7 +338,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: Static, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: Static, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
@@ -372,7 +372,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -581,7 +581,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -602,7 +602,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: Static, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: Static, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
@@ -636,7 +636,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -845,7 +845,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -866,7 +866,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: Static, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: Static, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
@@ -900,7 +900,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1109,7 +1109,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1130,7 +1130,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: Static, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: Static, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
@@ -1164,7 +1164,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1373,7 +1373,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Static, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: Static, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1400,7 +1400,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: Static, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: Static, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: Static, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: Static, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: Static, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: Static, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: Static, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: Static, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: Static, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: Static, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1422,7 +1422,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: Static';
+            const name = 'destroy cluster: Static';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: vSphere'
+name: 'destroy cluster: vSphere'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: vSphere, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: vSphere, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -319,7 +319,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -340,7 +340,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: vSphere, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: vSphere, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
@@ -374,7 +374,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -585,7 +585,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -606,7 +606,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: vSphere, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: vSphere, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
@@ -640,7 +640,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -851,7 +851,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -872,7 +872,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: vSphere, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: vSphere, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
@@ -906,7 +906,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1117,7 +1117,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1138,7 +1138,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: vSphere, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: vSphere, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
@@ -1172,7 +1172,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1383,7 +1383,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: vSphere, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: vSphere, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1410,7 +1410,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: vSphere, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: vSphere, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: vSphere, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: vSphere, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: vSphere, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: vSphere, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: vSphere, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: vSphere, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: vSphere, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: vSphere, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1432,7 +1432,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: vSphere';
+            const name = 'destroy cluster: vSphere';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'e2e destroy failed: Yandex.Cloud'
+name: 'destroy cluster: Yandex.Cloud'
 on:
   workflow_dispatch:
     inputs:
@@ -74,7 +74,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_24:
-    name: "e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.24"
+    name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.24"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.24' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.24';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -321,7 +321,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.24';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.24';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -342,7 +342,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_25:
-    name: "e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.25"
+    name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.25"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.25' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
@@ -376,7 +376,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.25';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -589,7 +589,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.25';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.25';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -610,7 +610,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
@@ -644,7 +644,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -857,7 +857,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -878,7 +878,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
@@ -912,7 +912,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1125,7 +1125,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1146,7 +1146,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
@@ -1180,7 +1180,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1393,7 +1393,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1420,7 +1420,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_24":"e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.24","run_containerd_1_25":"e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.25","run_containerd_1_26":"e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e destroy failed: Yandex.Cloud, Containerd, Kubernetes 1.28"}
+        {"run_containerd_1_24":"destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.24","run_containerd_1_25":"destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.25","run_containerd_1_26":"destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28"}
     steps:
 
       # <template: checkout_step>
@@ -1442,7 +1442,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e destroy failed: Yandex.Cloud';
+            const name = 'destroy cluster: Yandex.Cloud';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Current name of action 'e2e destroy failed' is misleading

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It is necessary to change the name to a more correct one

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Name of action changed

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix | feature | chore
summary: Change name of action 'e2e destroy faled'.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
