### PR TITLE
[external-module-manager] remove default ModuleUpdatePolicy

### DIFF
--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source_test.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source_test.go
@@ -36,7 +36,6 @@ global:
 
 	var msResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "modulesources"}
 	f.RegisterCRD(msResource.Group, msResource.Version, "ModuleSource", false)
-	f.RegisterCRD(msResource.Group, msResource.Version, "ModuleUpdatePolicy", false)
 
 	const (
 		discoverySecret = `
@@ -61,18 +60,15 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should deploy the module source and update policy", func() {
+		It("Should deploy the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Exists()).To(BeTrue())
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.CA").String()).To(Equal(""))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
 			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Stable"))
 		})
 	})
 
@@ -82,18 +78,15 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should deploy the module source and update policy", func() {
+		It("Should deploy the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Exists()).To(BeTrue())
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.CA").String()).To(Equal(""))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
 			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Alpha"))
 		})
 	})
 
@@ -104,11 +97,9 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should deploy the module source and update policy", func() {
+		It("Should deploy the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Exists()).To(BeTrue())
 		})
@@ -121,11 +112,9 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should deploy the module source and update policy", func() {
+		It("Should deploy the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Exists()).To(BeTrue())
 		})
@@ -138,16 +127,13 @@ type: Opaque
 			f.RunHook()
 		})
 
-		It("Should deploy the module source with CA and update policy", func() {
+		It("Should deploy the module source with CA", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.ca").String()).To(Equal("--- BEGIN ..."))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Alpha"))
 		})
 	})
 
@@ -172,16 +158,13 @@ spec:
 			f.RunHook()
 		})
 
-		It("Should update the module source and update policy", func() {
+		It("Should update the module source ", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
-			Expect(ms.Field("spec.releaseChannel").String()).To(Equal("EarlyAccess"))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("EarlyAccess"))
+			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
 		})
 	})
 
@@ -205,20 +188,17 @@ spec:
 			f.RunHook()
 		})
 
-		It("Should update the module source and update policy", func() {
+		It("Should update the module source ", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
 			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Alpha"))
 		})
 	})
 
-	Context("With existing ModuleSource and ModuleUpdatePolicy", func() {
+	Context("With existing ModuleSource", func() {
 		existingResources := `
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -232,17 +212,6 @@ spec:
   registry:
     repo: xxx
     dockerCfg: yyy
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleUpdatePolicy
-metadata:
-  labels:
-    heritage: deckhouse
-  name: deckhouse
-spec:
-  releaseChannel: Stable
-  update:
-    mode: Auto
 `
 
 		BeforeEach(func() {
@@ -250,20 +219,17 @@ spec:
 			f.RunHook()
 		})
 
-		It("Should update the module source and update policy", func() {
+		It("Should update the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
-			Expect(ms.Field("spec.releaseChannel").String()).To(Equal("EarlyAccess"))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Stable"))
+			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
 		})
 	})
 
-	Context("With existing ModuleSource and ModuleUpdatePolicy, and releaseChannel not set", func() {
+	Context("With existing ModuleSource and releaseChannel not set", func() {
 		existingResources := `
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -276,17 +242,6 @@ spec:
   registry:
     repo: xxx
     dockerCfg: yyy
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleUpdatePolicy
-metadata:
-  labels:
-    heritage: deckhouse
-  name: deckhouse
-spec:
-  releaseChannel: Beta
-  update:
-    mode: Auto
 `
 
 		BeforeEach(func() {
@@ -294,50 +249,13 @@ spec:
 			f.RunHook()
 		})
 
-		It("Should update the module source and update policy", func() {
+		It("Should update the module source", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
 			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
 			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
 			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Beta"))
 		})
 	})
-
-	Context("With existing ModuleUpdatePolicy", func() {
-		existingResources := `
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleUpdatePolicy
-metadata:
-  labels:
-    heritage: deckhouse
-  name: deckhouse
-spec:
-  releaseChannel: Beta
-  update:
-    mode: Auto
-`
-
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(discoverySecret + existingResources))
-			f.RunHook()
-		})
-
-		It("Should update the module source and update policy", func() {
-			Expect(f).To(ExecuteSuccessfully())
-
-			mup := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mup.Exists()).To(BeTrue())
-			ms := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
-			Expect(ms.Field("spec.registry.repo").String()).To(Equal("registry.deckhouse.io/deckhouse/fe/modules"))
-			Expect(ms.Field("spec.registry.dockerCfg").String()).To(Equal("PGI2ND4K"))
-			Expect(ms.Field("spec.releaseChannel").String()).To(Equal(""))
-			Expect(mup.Field("spec.releaseChannel").String()).To(Equal("Beta"))
-		})
-	})
-
 })

--- a/modules/005-external-module-manager/hooks/migration_create_update_policies.go
+++ b/modules/005-external-module-manager/hooks/migration_create_update_policies.go
@@ -63,10 +63,6 @@ func createModuleUpdatePolicies(input *go_hook.HookInput, dc dependency.Containe
 	}
 
 	for _, source := range moduleSources.Items {
-		// skip deckhouse source as its update policy is ensured by another hook
-		if source.GetName() == "deckhouse" {
-			continue
-		}
 		moduleSource := &v1alpha1.ModuleSource{}
 		err := sdk.FromUnstructured(&source, moduleSource)
 		if err != nil {

--- a/modules/005-external-module-manager/hooks/migration_create_update_policies.go
+++ b/modules/005-external-module-manager/hooks/migration_create_update_policies.go
@@ -31,7 +31,6 @@ import (
 )
 
 const (
-	defaultUpdateMode   = "Auto"
 	migrationAnnotation = "modules.deckhouse.io/ensured-update-policies"
 )
 

--- a/modules/005-external-module-manager/hooks/migration_create_update_policies_test.go
+++ b/modules/005-external-module-manager/hooks/migration_create_update_policies_test.go
@@ -187,7 +187,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 
 			mupDeckhouse := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mupDeckhouse.Exists()).To(BeFalse())
+			Expect(mupDeckhouse.Exists()).To(BeTrue())
 			msDeckhouse := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(msDeckhouse.Exists()).To(BeTrue())
 		})
@@ -209,7 +209,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 
 			mupDeckhouse := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mupDeckhouse.Exists()).To(BeFalse())
+			Expect(mupDeckhouse.Exists()).To(BeTrue())
 			msDeckhouse := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(msDeckhouse.Exists()).To(BeTrue())
 			for _, ms := range []string{"tetris", "pingpong", "tictactoe"} {
@@ -237,7 +237,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 
 			mupDeckhouse := f.KubernetesGlobalResource("ModuleUpdatePolicy", "deckhouse")
-			Expect(mupDeckhouse.Exists()).To(BeFalse())
+			Expect(mupDeckhouse.Exists()).To(BeTrue())
 			msDeckhouse := f.KubernetesGlobalResource("ModuleSource", "deckhouse")
 			Expect(msDeckhouse.Exists()).To(BeTrue())
 			for _, ms := range []string{"tetris", "pingpong", "tictactoe", "gtaV"} {


### PR DESCRIPTION
## Description
We don't want to create default update policy, only to migrate the old one

## Why do we need it, and what problem does it solve?
A lot of modules will be pulled by default, we want just to observe them, not load

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Remove default ModuleUpdatePolicy for the `deckhouse` ModuleSource.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
