### PR TITLE
[docs] Rename the item for the admission-policy-engine module in the sidebar

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -949,7 +949,7 @@ entries:
                   url: /modules/160-multitenancy-manager/cr.html
         - title:
             en: Admission Policy
-            ru: Политики контроля допуска
+            ru: Политики безопасности
           folders:
             - title:
                 en: Description

--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -949,7 +949,7 @@ entries:
                   url: /modules/160-multitenancy-manager/cr.html
         - title:
             en: Admission Policy
-            ru: Политики контроля доступа
+            ru: Политики контроля допуска
           folders:
             - title:
                 en: Description


### PR DESCRIPTION
## Description
Rename the item for the admission-policy-engine module in the sidebar.

```changes
section: docs
type: chore
summary: Rename the item for the admission-policy-engine module in the sidebar.
impact_level: low
```
