### PR TITLE
[modules-docs] Rewrite to stable channel

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -21,6 +21,7 @@ metadata:
       ssi on;
       ssi_silent_errors on;
       rewrite ^/source/modules/(.*)$ /modules/$1 permanent;
+      rewrite ^/modules/([^/]+)/$ /modules/$1/stable/ permanent;
       rewrite ^(/en|/ru)?/documentation/v1\.3[0-7](\.[0-9]+)?(/.*)$ /documentation/v1.38$3 permanent;
       rewrite ^(/en|/ru)?(/documentation/v1\.[0-9]+)\.[0-9]+(/.*)$ $2$3 permanent;
       rewrite ^/ru/(.*) https://{{ $hostRu }}/$1 permanent;


### PR DESCRIPTION
## Description
Add redirect to the stable channel for modules documentation by default.

## Changelog entries
```changes
section: docs
type: chore
summary: Add redirect to the stable channel for modules documentation by default.
impact_level: low
```
