### PR TITLE
[docs][cloud-provider-yandex] Fix example of the additionalSubnets field

### DIFF
--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -105,7 +105,7 @@ spec:
                   description: |
                     Subnet IDs that VirtualMachines' secondary NICs will connect to. Each subnet listed here translates into one additional network interface.
                   x-doc-examples:
-                    - b0csh41c1or82vuch89v
+                  - - b0csh41c1or82vuch89v
                     - e2lgddi5svochh5fbq96
                   type: array
                   items:


### PR DESCRIPTION
## Description
Fix the example of the `additionalSubnets` field of the YandexInstanceClass.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix the example of the `additionalSubnets` field of the YandexInstanceClass.
impact_level: low
```
