### PR TITLE
[modules-docs] Add page metadata to the layout of module documentation.

### DIFF
--- a/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
+++ b/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
@@ -72,13 +72,17 @@ languages:
     disabled: false
     languageDirection: ""
     languageName: ""
-    title: Modules
+    title: Deckhouse modules
     weight: 0
     baseURL: https://deckhouse.io/
+    params:
+      description: "Kubernetes is flexibly and rapidly expanded by Deckhouse modules."
   ru:
     disabled: false
     languageDirection: ""
     languageName: ""
     weight: 1
-    title: Модули
+    title: Модули Deckhouse
     baseURL: https://deckhouse.ru/
+    params:
+      description: "Kubernetes гибко и быстро расширяется модулями Deckhouse."

--- a/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
+++ b/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
@@ -74,7 +74,7 @@ languages:
     languageName: ""
     title: Deckhouse modules
     weight: 0
-    baseURL: https://deckhouse.io/
+    baseURL: https://deckhouse.io
     params:
       description: "Kubernetes is flexibly and rapidly expanded by Deckhouse modules."
   ru:
@@ -83,6 +83,6 @@ languages:
     languageName: ""
     weight: 1
     title: Модули Deckhouse
-    baseURL: https://deckhouse.ru/
+    baseURL: https://deckhouse.ru
     params:
       description: "Kubernetes гибко и быстро расширяется модулями Deckhouse."

--- a/docs/site/backends/docs-builder-template/layouts/_default/baseof.html
+++ b/docs/site/backends/docs-builder-template/layouts/_default/baseof.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  {{ partial "head" . }}
   {{ "<!--#include virtual=\"/includes/head-site.html\" -->"  | safeHTML }}
   </head>
   <body>

--- a/docs/site/backends/docs-builder-template/layouts/partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/head.html
@@ -1,0 +1,20 @@
+{{ $description := "" }}
+{{ if .Description }}{{ $description = .Description }}{{ else }}{{ $description = .Summary }}{{ end }}
+{{ if lt ( $description | len ) 20 }}{{ $description = .Site.Params.description }}{{ end }}
+<title>{{ .Title }} | {{ .Site.Title }}</title>
+<meta name="description" content="{{  $description }}">
+<meta name="title" content="{{ .Title }} | {{ .Site.Title }}">
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ strings.TrimRight "readme.html" .Permalink  }}">
+<meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}">
+<meta property="og:description" content="{{ $description }}">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:url" content="{{ strings.TrimRight "readme.html" .Permalink }}">
+<meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}">
+<meta name="twitter:description" content="{{ $description }}">
+<meta name="twitter:image" content="{{ site.BaseURL }}/favicon-32x32.png" />
+<meta name="twitter:image:alt" content="{{ site.Title }}">

--- a/docs/site/backends/docs-builder-template/layouts/partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/head.html
@@ -6,7 +6,7 @@
 {{ $canonicalURL = replaceRE "^(/modules/[a-zA-Z0-9-]+)/[a-zA-Z0-9-]+/(.*)$" "$1/stable/$2" $canonicalURL 1 }}
 
 <title>{{ .Title }} | {{ .Site.Title }}</title>
-<link rel="canonical" href="{{ site.BaseURL }}{{ strings.TrimLeft "/" $canonicalURL }}" />
+<link rel="canonical" href="{{ site.BaseURL }}{{ $canonicalURL }}" />
 <meta name="description" content="{{  $description }}">
 <meta name="title" content="{{ .Title }} | {{ .Site.Title }}">
 
@@ -15,12 +15,12 @@
 <meta property="og:url" content="{{ strings.TrimRight "readme.html" .Permalink  }}">
 <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}">
 <meta property="og:description" content="{{ $description }}">
-<meta property="og:image" content="{{ site.BaseURL }}favicon-32x32.png" />
+<meta property="og:image" content="{{ site.BaseURL }}/favicon-32x32.png" />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary">
 <meta name="twitter:url" content="{{ strings.TrimRight "readme.html" .Permalink }}">
 <meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}">
 <meta name="twitter:description" content="{{ $description }}">
-<meta name="twitter:image" content="{{ site.BaseURL }}favicon-32x32.png" />
+<meta name="twitter:image" content="{{ site.BaseURL }}/favicon-32x32.png" />
 <meta name="twitter:image:alt" content="{{ site.Title }}">

--- a/docs/site/backends/docs-builder-template/layouts/partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/head.html
@@ -1,7 +1,12 @@
 {{ $description := "" }}
 {{ if .Description }}{{ $description = .Description }}{{ else }}{{ $description = .Summary }}{{ end }}
 {{ if lt ( $description | len ) 20 }}{{ $description = .Site.Params.description }}{{ end }}
+
+{{ $canonicalURL := strings.TrimRight "readme.html" .RelPermalink }}
+{{ $canonicalURL = replaceRE "^(/modules/[a-zA-Z0-9-]+)/[a-zA-Z0-9-]+/(.*)$" "$1/stable/$2" $canonicalURL 1 }}
+
 <title>{{ .Title }} | {{ .Site.Title }}</title>
+<link rel="canonical" href="{{ site.BaseURL }}{{ strings.TrimLeft "/" $canonicalURL }}" />
 <meta name="description" content="{{  $description }}">
 <meta name="title" content="{{ .Title }} | {{ .Site.Title }}">
 
@@ -10,11 +15,12 @@
 <meta property="og:url" content="{{ strings.TrimRight "readme.html" .Permalink  }}">
 <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}">
 <meta property="og:description" content="{{ $description }}">
+<meta property="og:image" content="{{ site.BaseURL }}favicon-32x32.png" />
 
 <!-- Twitter -->
-<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:card" content="summary">
 <meta name="twitter:url" content="{{ strings.TrimRight "readme.html" .Permalink }}">
 <meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}">
 <meta name="twitter:description" content="{{ $description }}">
-<meta name="twitter:image" content="{{ site.BaseURL }}/favicon-32x32.png" />
+<meta name="twitter:image" content="{{ site.BaseURL }}favicon-32x32.png" />
 <meta name="twitter:image:alt" content="{{ site.Title }}">


### PR DESCRIPTION
## Description
Add page metadata to the layout of module documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add page metadata to the layout of module documentation.
impact_level: low
```
