### PR TITLE
[dhctl] mirror: Allow missing module release channels

### DIFF
--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -271,6 +271,10 @@ func fetchVersionsFromModuleReleaseChannels(
 }
 
 func isImageNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	errMsg := err.Error()
 	return strings.Contains(errMsg, "MANIFEST_UNKNOWN") || strings.Contains(errMsg, "404 Not Found")
 }

--- a/dhctl/pkg/operations/mirror_module.go
+++ b/dhctl/pkg/operations/mirror_module.go
@@ -71,14 +71,14 @@ func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string) err
 		}
 
 		log.InfoLn("Beginning to pull module contents")
-		err = mirror.PullImageSet(authProvider, moduleLayout, moduleImageSet, insecure)
+		err = mirror.PullImageSet(authProvider, moduleLayout, moduleImageSet, insecure, false)
 		if err != nil {
 			return fmt.Errorf("Pull images: %w", err)
 		}
 		log.InfoLn("✅ Module contents pulled successfully")
 
 		log.InfoLn("Beginning to pull module releases")
-		err = mirror.PullImageSet(authProvider, moduleReleasesLayout, releasesImageSet, insecure)
+		err = mirror.PullImageSet(authProvider, moduleReleasesLayout, releasesImageSet, insecure, false)
 		if err != nil {
 			return fmt.Errorf("Pull images: %w", err)
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

When `dhctl mirror` pulls module release channel images, it will no longer report missing images as a critical error and abort pulling. Instead it will log this as a warning and continue.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes https://github.com/deckhouse/deckhouse/issues/6809

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This is a fix for a top priority bug.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Allow missing module release channels.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
