### PR TITLE
[candi][bashible] Fix cleanup script

### DIFF
--- a/candi/bashible/common-steps/node-group/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_create_static_node_cleanup_script.sh.tpl
@@ -24,14 +24,25 @@ systemctl stop bashible.service bashible.timer
 for pid in $(ps ax | grep "bash /var/lib/bashible/bashible" | grep -v grep | awk '{print $1}'); do
   kill $pid
 done
+
+systemctl disable sysctl-tuner.service sysctl-tuner.timer
+systemctl disable old-csi-mount-cleaner.service old-csi-mount-cleaner.timer
+systemctl disable d8-containerd-cgroup-migration.service
+systemctl disable containerd-deckhouse.service
+systemctl disable kubelet.service
+
 systemctl stop sysctl-tuner.service sysctl-tuner.timer
 systemctl stop old-csi-mount-cleaner.service old-csi-mount-cleaner.timer
 systemctl stop d8-containerd-cgroup-migration.service
 systemctl stop containerd-deckhouse.service
 systemctl stop kubelet.service
-systemctl daemon-reload
 
-killall /opt/deckhouse/bin/containerd-shim-runc-v2
+# `killall` needs `psmisc` package
+# `pkill` needs `procps` on debian-like systems and `procps-ng` on centos-like
+# looks like procps(-ng) already installed by default in systems
+# killall /opt/deckhouse/bin/containerd-shim-runc-v2
+pkill containerd-shim
+
 for i in $(mount -t tmpfs | grep /var/lib/kubelet | cut -d " " -f3); do umount $i ; done
 
 rm -rf /etc/systemd/system/bashible.*
@@ -40,6 +51,8 @@ rm -rf /etc/systemd/system/old-csi-mount-cleaner.*
 rm -rf /etc/systemd/system/d8-containerd-cgroup-migration.*
 rm -rf /etc/systemd/system/containerd-deckhouse.service /etc/systemd/system/containerd-deckhouse.service.d
 rm -rf /etc/systemd/system/kubelet.service /etc/systemd/system/kubelet.service.d
+
+systemctl daemon-reload
 
 rm -rf /var/cache/registrypackages
 rm -rf /etc/kubernetes

--- a/candi/bashible/common-steps/node-group/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_create_static_node_cleanup_script.sh.tpl
@@ -20,6 +20,7 @@ if [ -z $1 ] || [ "$1" != "--yes-i-am-sane-and-i-understand-what-i-am-doing" ]; 
   exit 1
 fi
 
+systemctl disable bashible.service bashible.timer
 systemctl stop bashible.service bashible.timer
 for pid in $(ps ax | grep "bash /var/lib/bashible/bashible" | grep -v grep | awk '{print $1}'); do
   kill $pid


### PR DESCRIPTION
## Description
Fixes in cleanup script
1. Migrate from `killall` to `pkill`. With `killall` we have error `bash: killall: command not found`, because package `psmisc` not installed by default. `pkill` exists in package `procps` on debian-like systems and in package `procps-ng` on centos-like systems and looks like this packages installed by default
2. Disable our services and timers lets systemd remove symlinks
3. `systemctl daemon-reload` must be executed after remove services and timers

## Why do we need it, and what problem does it solve?
After cleanup node with command `bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing` and bootstrap again we have strange problems like
```
=== Step: /var/lib/bashible/bundle_steps/032_configure_and_start_containerd.sh
===
bash [WARNING] 'containerd-need-restart' flag was set. Containerd should be restarted!
===
=== Step: /var/lib/bashible/bundle_steps/041_configure_sysctl_tuner.sh
===
Failed to stop sysctl-tuner.timer: Unit sysctl-tuner.timer not loaded.
Failed to execute step /var/lib/bashible/bundle_steps/041_configure_sysctl_tuner.sh ... retry in 10 seconds.
===
=== Step: /var/lib/bashible/bundle_steps/041_configure_sysctl_tuner.sh
===
/var/lib/bashible/bashible-new.sh: line 20: kubectl: command not found
===
=== Step: /var/lib/bashible/bundle_steps/043_configure_kubectl_passwordless_sudo_for_flant.sh
===
===
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Bootstrap process run without errors about `sysctl-tuner.timer` and `/var/lib/bashible/bashible-new.sh: line 20: kubectl: command not found`
```
===
=== Step: /var/lib/bashible/bundle_steps/032_configure_and_start_containerd.sh
===
bash [WARNING] 'containerd-need-restart' flag was set. Containerd should be restarted!
===
=== Step: /var/lib/bashible/bundle_steps/041_configure_sysctl_tuner.sh
===
Created symlink /etc/systemd/system/multi-user.target.wants/sysctl-tuner.timer → /etc/systemd/system/sysctl-tuner.timer.
===
=== Step: /var/lib/bashible/bundle_steps/043_configure_kubectl_passwordless_sudo_for_flant.sh
===
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixes for cleanup script 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
