### PR TITLE
[candi] CSI old mount cleaner improvements

### DIFF
--- a/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -83,6 +83,9 @@ mapfile -t mounted_elsewhere_pvcs < <(journalctl --since "$log_period_minutes mi
 
 for pvc in "${mounted_elsewhere_pvcs[@]}"; do
     mount="$(mount | grep -oE "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/$pvc/globalmount")"
+    if [ "$mount" == "" ]; then
+      continue
+    fi
     if out=$(umount "$mount" 2>&1); then
         echo_err "Mountpoint $mount successfully unmounted"
     else


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Cleanup of old CSI mounts that follow pre Kubernetes 1.24 naming convention.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It enabled successful Pod volume unmounts when upgrading Kubernetes on the go (without draining a Node).



## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
When a kubelet reports that it cannot delete a Pod because there is a mount (with path adhering to an old format), parse a log statement an umount manually.

## Tests

These changes were manually tested using the following data to simulate the problem.

kubelet log
```shell
Dec 06 07:19:16 kube-node d8-kubelet-forker[964237]: E1206 07:19:16.009285  964237 nestedpendingoperations.go:348] Operation for "{volumeName:kubernetes.io/csi/vsphere.csi.vmware.com^3e2ebbae-9d94-4e91-80d7-8b9ffd6199e2 podName: nodeName:}" failed. No retries permitted until 2023-12-06 07:21:18.009263458 +0000 UTC m=+22601.717363160 (durationBeforeRetry 2m2s). Error: MountVolume.MountDevice failed for volume "pvc-b12ef30a-89da-40a6-9ae9-9e08198a702e" (UniqueName: "kubernetes.io/csi/vsphere.csi.vmware.com^3e2ebbae-9d94-4e91-80d7-8b9ffd6199e2") pod "loki-0" (UID: "a52b1419-ed9a-4437-86e6-dd2cf1d544d0") : rpc error: code = Internal desc = device already in use and mounted elsewhere
```

mount
```shell
root@kube-node:~# mount | grep pvc-b12ef30a-89da-40a6-9ae9-9e08198a702e
/dev/sdb on /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-b12ef30a-89da-40a6-9ae9-9e08198a702e/globalmount type ext4 (rw,relatime)
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Parsing kubelet logs for the message "device already in use and mounted elsewhere" and umount if the mount point exists.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
