### PR TITLE
[candi][bb] Handle registry packages fetch errors

### DIFF
--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -20,7 +20,7 @@ bb-var BB_RP_FETCHED_PACKAGES_STORE "${TMPDIR}/registrypackages"
 # Use d8-curl if installed, fallback to system package if not
 bb-rp-curl() {
   if command -v d8-curl > /dev/null ; then
-    d8-curl --parallel "$@"
+    d8-curl --remove-on-error --parallel "$@"
   else
     curl "$@"
   fi

--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -202,6 +202,12 @@ bb-rp-install() {
     local TMP_DIR=""
     TMP_DIR="$(mktemp -d)"
     tar -xf "${BB_RP_FETCHED_PACKAGES_STORE}/${PACKAGE}/${DIGEST}.tar.gz" -C "${TMP_DIR}"
+    if bb-error?
+    then
+        rm -rf "${TMP_DIR}" "${BB_RP_FETCHED_PACKAGES_STORE:?}/${PACKAGE}"
+        bb-log-error "Failed to unpack package '${PACKAGE}', it may be corrupted. The package will be refetched on the next attempt"
+        return $BB_ERROR
+    fi
 
     bb-log-info "Installing package '${PACKAGE}'"
     # shellcheck disable=SC2164


### PR DESCRIPTION
## Description
Handle registry packages fetch errors.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`curl` writes file as it is loading. If the download fails, we will get corrupted file. Since we don't currently have the ability to validate packages checksum (and we don't do it), we will get an error at the unpacking stage:
```
bashible.sh[1088426]: bb-rp [INFO] Unpacking package 'kubectl'
bashible.sh[1088426]: gzip: stdin: unexpected end of file
bashible.sh[1088426]: tar: Unexpected EOF in archive
bashible.sh[1088426]: tar: Unexpected EOF in archive
bashible.sh[1088426]: tar: Error is not recoverable: exiting now
bashible.sh[1086700]: Failed to execute step ...
```

Since we don't handle this error, it will start to fill up disk space 'cause the original corrupted blob will not be refetched (there is no such logic) and the temp directory is not deleted (they do fill up disk space). 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
It affects customers.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Handle registry packages fetch errors.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
