### PR TITLE
Fix the wrong field name in the NodeGroup schema

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -238,7 +238,7 @@ spec:
                         List of availability zones to create instances in.
 
                         The default value depends on the cloud provider selected and usually corresponds to all zones of the region being used.
-                      x-doc-x-doc-examples: [[Helsinki, Espoo, Tampere]]
+                      x-doc-examples: [[Helsinki, Espoo, Tampere]]
                       type: array
                       items:
                         type: string


### PR DESCRIPTION
## Description
Fix the wrong field name in the NodeGroup schema.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: doc
type: fix
summary: Fix the wrong field name in the NodeGroup schema.
impact_level: low
```
