### PR TITLE
[docs][openstack] GS and docs updates regarding Selectel Openstack setups

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -23,12 +23,20 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.ru/deckhouse/ce
   registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -47,6 +55,10 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -63,6 +75,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -84,6 +100,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -100,9 +120,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -23,9 +23,9 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -37,6 +37,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа)
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -49,6 +53,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -65,6 +73,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -86,6 +98,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -102,9 +118,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -23,6 +23,10 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -41,13 +45,17 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -57,6 +65,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -78,6 +90,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -94,9 +110,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -23,9 +23,9 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -37,6 +37,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа)
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -49,13 +53,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -65,6 +73,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -86,6 +98,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -102,9 +118,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,12 +21,20 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: cluster.local
 ---
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.ru/deckhouse/ce
   registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +53,10 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +73,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +98,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: cluster.local
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -64,6 +72,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -85,9 +97,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,6 +21,10 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: cluster.local
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -39,13 +43,17 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -55,6 +63,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -76,9 +88,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: cluster.local
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,13 +49,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -64,6 +72,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -85,9 +97,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration

--- a/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -22,9 +22,9 @@ proxy:
   httpsProxy: <HTTPS_PROXY_ADDRESS>
   noProxy: <NO_PROXY_LIST>
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -42,6 +42,10 @@ deckhouse:
   # [<ru>] Корневой сертификат, которым можно проверить сертификат registry (если registry использует самоподписанные сертификаты).
   registryCA: <REGISTRY_CA>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -54,6 +58,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -80,6 +88,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -111,10 +123,10 @@ spec:
   settings:
     disableLetsencrypt: true
 ---
-# [<en>] Enable the cni-flannel module.
-# [<ru>] Включить модуль cni-flannel.
-# [<en>] You might consider changing this.
-# [<ru>] Возможно, захотите изменить.
+# [<en>] cni-flannel module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/035-cni-flannel/configuration.html
+# [<ru>] Настройки модуля cni-flannel.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/035-cni-flannel/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -122,18 +134,16 @@ metadata:
 spec:
   version: 1
   enabled: true
-  # [<en>] Cni-flannel module settings.
-  # [<ru>] Настройки модуля cni-flannel.
-  # [<en>] You might consider changing this.
-  # [<ru>] Возможно, захотите изменить.
   settings:
     # [<en>] Flannel backend, available values are VXLAN (if your servers have L3 connectivity) and HostGW (for L2 networks).
     # [<ru>] Режим работы flannel, допустимые значения VXLAN (если ваши сервера имеют связность L3) или HostGW (для L2-сетей).
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
     podNetworkMode: VXLAN
 ---
-# [<en>] Section with the parameters of the static cluster.
+# [<en>] Static cluster settings.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами статического кластера.
+# [<ru>] Параметры статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -22,9 +22,9 @@ proxy:
   httpsProxy: <HTTPS_PROXY_ADDRESS>
   noProxy: <NO_PROXY_LIST>
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -42,6 +42,10 @@ deckhouse:
   # [<ru>] Корневой сертификат, которым можно проверить сертификат registry (если registry использует самоподписанные сертификаты).
   registryCA: <REGISTRY_CA>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -54,13 +58,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -80,6 +88,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -111,10 +123,10 @@ spec:
   settings:
     disableLetsencrypt: true
 ---
-# [<en>] Enable the cni-flannel module.
-# [<ru>] Включить модуль cni-flannel.
-# [<en>] You might consider changing this.
-# [<ru>] Возможно, захотите изменить.
+# [<en>] cni-flannel module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/035-cni-flannel/configuration.html
+# [<ru>] Настройки модуля cni-flannel.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/035-cni-flannel/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -122,18 +134,16 @@ metadata:
 spec:
   version: 1
   enabled: true
-  # [<en>] Cni-flannel module settings.
-  # [<ru>] Настройки модуля cni-flannel.
-  # [<en>] You might consider changing this.
-  # [<ru>] Возможно, захотите изменить.
   settings:
     # [<en>] Flannel backend, available values are VXLAN (if your servers have L3 connectivity) and HostGW (for L2 networks).
     # [<ru>] Режим работы flannel, допустимые значения VXLAN (если ваши сервера имеют связность L3) или HostGW (для L2-сетей).
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
     podNetworkMode: VXLAN
 ---
-# [<en>] Section with the parameters of the static cluster.
+# [<en>] Static cluster settings.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами статического кластера.
+# [<ru>] Параметры статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -16,12 +16,20 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.ru/deckhouse/ce
   registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -40,6 +48,10 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -59,6 +71,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -80,6 +96,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -96,9 +116,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section with the parameters of the static cluster.
+# [<en>] Static cluster settings.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами статического кластера.
+# [<ru>] Параметры статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -16,9 +16,9 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -30,6 +30,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа)
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -42,6 +46,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,6 +94,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -98,9 +114,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section with the parameters of the static cluster.
+# [<en>] Static cluster settings.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами статического кластера.
+# [<ru>] Параметры статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -16,6 +16,10 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -34,13 +38,17 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -53,6 +61,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -74,6 +86,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -90,9 +106,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section with the parameters of the static cluster.
+# [<en>] Static cluster settings.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами статического кластера.
+# [<ru>] Параметры статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -16,9 +16,9 @@ kubernetesVersion: "Automatic"
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -30,6 +30,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа)
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -42,13 +46,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -61,6 +69,10 @@ spec:
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
     storageClass: localpath-deckhouse-system
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,6 +94,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cni-cilium module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
+# [<ru>] Настройки модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -98,9 +114,9 @@ spec:
     # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
     tunnelMode: VXLAN
 ---
-# [<en>] Section with the parameters of the static cluster.
+# [<en>] Static cluster settings.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
-# [<ru>] Секция с параметрами статического кластера.
+# [<ru>] Параметры статического кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration

--- a/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ce.inc
@@ -1,3 +1,7 @@
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -16,12 +20,20 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.ru/deckhouse/ce
   registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -51,6 +63,10 @@ spec:
         customTolerationKeys:
         - SystemLoad
 ---
+# [<en>] cert-manager module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/101-cert-manager/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/101-cert-manager/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -59,6 +75,10 @@ spec:
   version: 1
   enabled: true
 ---
+# [<en>] documentation module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/810-documentation/configuration.html
+# [<ru>] Настройки модуля documentation.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/810-documentation/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:

--- a/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ee.inc
@@ -1,6 +1,6 @@
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -12,6 +12,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -24,6 +28,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -53,6 +61,10 @@ spec:
         customTolerationKeys:
         - SystemLoad
 ---
+# [<en>] cert-manager module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/101-cert-manager/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/101-cert-manager/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +73,10 @@ spec:
   version: 1
   enabled: true
 ---
+# [<en>] documentation module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/810-documentation/configuration.html
+# [<ru>] Настройки модуля documentation.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/810-documentation/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:

--- a/docs/site/_includes/getting_started/existing/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.yml.ce.inc
@@ -1,3 +1,7 @@
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -16,13 +20,17 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -45,6 +53,10 @@ spec:
         customTolerationKeys:
         - SystemLoad
 ---
+# [<en>] cert-manager module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/101-cert-manager/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/101-cert-manager/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -53,6 +65,10 @@ spec:
   version: 1
   enabled: true
 ---
+# [<en>] documentation module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/810-documentation/configuration.html
+# [<ru>] Настройки модуля documentation.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/810-documentation/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:

--- a/docs/site/_includes/getting_started/existing/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.yml.ee.inc
@@ -1,6 +1,6 @@
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -12,6 +12,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -24,13 +28,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -53,6 +61,10 @@ spec:
         customTolerationKeys:
         - SystemLoad
 ---
+# [<en>] cert-manager module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/101-cert-manager/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/101-cert-manager/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +73,10 @@ spec:
   version: 1
   enabled: true
 ---
+# [<en>] documentation module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/810-documentation/configuration.html
+# [<ru>] Настройки модуля documentation.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/810-documentation/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,12 +21,20 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.ru/deckhouse/ce
   registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +53,10 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +73,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +98,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: GCPClusterConfiguration

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: GCPClusterConfiguration

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,6 +21,10 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -39,13 +43,17 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -55,6 +63,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -76,9 +88,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-gcp/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-gcp/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: GCPClusterConfiguration

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,13 +49,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-gcp/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-gcp/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: GCPClusterConfiguration

--- a/docs/site/_includes/getting_started/kind/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/kind/partials/config.yml.ce.inc
@@ -30,7 +30,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template for Ingress resources of Deckhouse modules.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/kind/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/kind/partials/config.yml.ee.inc
@@ -18,7 +18,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template for Ingress resources of Deckhouse modules.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
@@ -51,7 +51,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -82,9 +82,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера..
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,13 +49,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,26 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Module settings for working with OpenStack.
+# [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+# [<ru>] Настройки модуля для работы с OpenStack.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-openstack
+spec:
+  version: 1
+  enabled: true
+  settings:
+    # [<en>] Default Storage Class.
+    # [<ru>] Storage Class по-умолчанию.
+    storageClass:
+      default: fast.ru-3a
+---
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -60,9 +68,11 @@ spec:
       # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
-# [<en>] Section containing ModuleConfigs resources.
-# [<ru>] Секция, описывающая параметры ресурсы модулей ModuleConfigs.
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -84,6 +94,10 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] Module settings for working with OpenStack.
+# [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+# [<ru>] Настройки модуля для работы с OpenStack.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -97,9 +111,9 @@ spec:
     storageClass:
       default: fast.ru-3a
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration
@@ -108,7 +122,7 @@ standard:
   # [<en>] Clusters in Selectel VPC should be installed with a bastion host because Security Groups are not supported.
   # [<en>] Otherwise ports on master nodes will be exposed to WAN.
   # [<ru>] Кластера в Selectel VPC должны устанавливаться с bastion-хостом в целях безопасности, из-за отсутствия поддержки Security Groups.
-  # [<ru>] В противном случае в WAN будут открыты порты на master-нодах.
+  # [<ru>] В противном случае в WAN будут открыты порты на master-узлах.
   bastion:
     zone: ru-3a
     volumeType: fast.ru-3a
@@ -172,8 +186,8 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    # [<en>] Don't use images provided by Selectel VPC. Upload and use cloud images, provided by distribution maintainer.
-    # [<ru>] Не используйте образа, предоставленные Selectel VPC. Загружайте и используйте cloudimg, предоставленные разработчиком дистрибутива.
+    # [<en>] Don't use images provided by Selectel. Upload and use cloud images, provided by distribution maintainers.
+    # [<ru>] Не используйте образы, предоставленные Selectel. Загружайте и используйте образы для облачных сред, предоставленные разработчиками дистрибутива.
     imageName: ubuntu-22.04
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
@@ -95,7 +95,7 @@ spec:
     # [<en>] Default Storage Class.
     # [<ru>] Storage Class по-умолчанию.
     storageClass:
-      default: fast.ru-7a
+      default: fast.ru-3a
 ---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
@@ -51,7 +51,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -60,6 +60,8 @@ spec:
       # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
+# [<en>] Section containing ModuleConfigs resources.
+# [<ru>] Секция, описывающая параметры ресурсы модулей ModuleConfigs.
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -82,6 +84,19 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-openstack
+spec:
+  version: 1
+  enabled: true
+  settings:
+    # [<en>] Default Storage Class.
+    # [<ru>] Storage Class по-умолчанию.
+    storageClass:
+      default: fast.ru-7a
+---
 # [<en>] Section containing the parameters of the cloud provider.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 # [<ru>] Секция, описывающая параметры облачного провайдера.
@@ -90,9 +105,20 @@ apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration
 layout: Standard
 standard:
-  # [<en>] Network name for external communication.
-  # [<ru>] Имя сети для внешнего взаимодействия.
-  externalNetworkName: *!CHANGE_EXT_NET*
+  # [<en>] Clusters in Selectel VPC should be installed with a bastion host because Security Groups are not supported.
+  # [<en>] Otherwise ports on master nodes will be exposed to WAN.
+  # [<ru>] Кластера в Selectel VPC должны устанавливаться с bastion-хостом в целях безопасности, из-за отсутствия поддержки Security Groups.
+  # [<ru>] В противном случае в WAN будут открыты порты на master-нодах.
+  bastion:
+    zone: ru-3a
+    volumeType: fast.ru-3a
+    instanceClass:
+      flavorName: c2m2-d0
+      imageName: ubuntu-22-04
+      rootDiskSize: 20
+  # [<en>] Network name for external communication. Default is external-network
+  # [<ru>] Имя сети для внешнего взаимодействия. Значение по-умолчанию: external-network
+  externalNetworkName: external-network
   # [<en>] Addressing for the internal network of the cluster nodes.
   # [<ru>] Адресация для внутренней сети узлов кластера.
   internalNetworkCIDR: 192.168.198.0/24
@@ -103,9 +129,9 @@ standard:
   internalNetworkDNSServers:
     - 8.8.8.8
     - 8.8.4.4
-  # [<en>] A flag that determines whether SecurityGroups and AllowedAddressPairs should be configured on internal network ports.
-  # [<ru>] Флаг, который определяет необходимо ли настраивать SecurityGroups и AllowedAddressPairs на портах внутренней сети.
-  internalNetworkSecurity: true
+  # [<en>] SecurityGroups are not supported by Selectel VPC.
+  # [<ru>] SecurityGroups не поддерживаются в Selectel VPC.
+  internalNetworkSecurity: false
 # [<en>] OpenStack API access parameters
 # [<ru>] параметры доступа к OpenStack API
 provider:
@@ -146,6 +172,8 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
+    # [<en>] Don't use images provided by Selectel VPC. Upload and use cloud images, provided by distribution maintainer.
+    # [<ru>] Не используйте образа, предоставленные Selectel VPC. Загружайте и используйте cloudimg, предоставленные разработчиком дистрибутива.
     imageName: ubuntu-22.04
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,13 +49,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: OpenStackClusterConfiguration

--- a/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-vsphere/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-vsphere/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: VsphereClusterConfiguration

--- a/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,13 +49,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-vsphere/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-vsphere/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: VsphereClusterConfiguration

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,12 +21,20 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.ru/deckhouse/ce
   registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +53,10 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +73,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +98,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,6 +49,10 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,6 +21,10 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -39,13 +43,17 @@ spec:
     releaseChannel: EarlyAccess
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -55,6 +63,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -76,9 +88,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
@@ -1,6 +1,6 @@
 # [<en>] General cluster parameters.
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
-# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] Общие параметры кластера.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
@@ -21,9 +21,9 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] Settings for the bootstrapping the Deckhouse cluster
 # [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
-# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] Настройки первичной инициализации кластера Deckhouse.
 # [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
@@ -33,6 +33,10 @@ deckhouse:
   # [<ru>] Строка с ключом для доступа к Docker registry (сгенерировано автоматически для вашего токена доступа).
   registryDockerCfg: <YOUR_ACCESS_STRING_IS_HERE>
 ---
+# [<en>] Deckhouse module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/002-deckhouse/configuration.html
+# [<ru>] Настройки модуля deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/002-deckhouse/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -45,13 +49,17 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Global Deckhouse settings.
+# [<en>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#parameters
+# [<ru>] Глобальные настройки Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/deckhouse-configure-global.html#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.
@@ -61,6 +69,10 @@ spec:
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
 ---
+# [<en>] user-authn module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html
+# [<ru>] Настройки модуля user-authn.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/configuration.html
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -82,9 +94,9 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] Section containing the parameters of the cloud provider.
+# [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
-# [<ru>] Секция, описывающая параметры облачного провайдера.
+# [<ru>] Настройки облачного провайдера.
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
@@ -10,7 +10,7 @@ Four layouts are supported. Below is more information about each of them.
 In this scheme, an internal cluster network is created with a gateway to the public network; the nodes do not have public IP addresses. Note that the floating IP is assigned to the master node.
 
 > **Caution!**
-> If the provider does not support SecurityGroups, all applications running on nodes with Floating IPs assigned will be available at a public IP. For example, `kube-apiserver` on master nodes will be available on port 6443. To avoid this, we recommend using the [SimpleWithInternalNetwork](#simplewithinternalnetwork) placement strategy.
+> If the provider does not support SecurityGroups, all applications running on nodes with Floating IPs assigned will be available at a public IP. For example, `kube-apiserver` on master nodes will be available on port 6443. To avoid this, we recommend using the [SimpleWithInternalNetwork](#simplewithinternalnetwork) placement strategy or [Standard](#standard) strategy with bastion host.
 
 ![resources](https://docs.google.com/drawings/d/e/2PACX-1vSTIcQnxcwHsgANqHE5Ry_ZcetYX2lTFdDjd3Kip5cteSbUxwRjR3NigwQzyTMDGX10_Avr_mizOB5o/pub?w=960&h=720)
 <!--- Source: https://docs.google.com/drawings/d/1hjmDn2aJj3ru3kBR6Jd6MAW3NWJZMNkend_K43cMN0w/edit --->

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
@@ -11,7 +11,7 @@ description: "Описание схем размещения и взаимоде
 
 > **Внимание!**
 > Если провайдер не поддерживает SecurityGroups, все приложения, запущенные на узлах с Floating IP, будут доступны по белому IP-адресу.
-> Например, `kube-apiserver` на master-узлах будет доступен на порту 6443. Чтобы избежать этого, рекомендуется использовать схему размещения [SimpleWithInternalNetwork](#simplewithinternalnetwork).
+> Например, `kube-apiserver` на master-узлах будет доступен на порту 6443. Чтобы избежать этого, рекомендуется использовать схему размещения [SimpleWithInternalNetwork](#simplewithinternalnetwork), либо [Standard](#standard) с bastion-узлом.
 
 ![resources](https://docs.google.com/drawings/d/e/2PACX-1vSTIcQnxcwHsgANqHE5Ry_ZcetYX2lTFdDjd3Kip5cteSbUxwRjR3NigwQzyTMDGX10_Avr_mizOB5o/pub?w=960&h=720)
 <!--- Исходник: https://docs.google.com/drawings/d/1hjmDn2aJj3ru3kBR6Jd6MAW3NWJZMNkend_K43cMN0w/edit --->


### PR DESCRIPTION
## Description
Docs and GS changes regarding cluster setups in Selectel Openstack:
- Upload vanilla cloud images instead of ones provided by Openstack
- Use Standard layout with bastion because of lack of Security Groups
- Set `internalNetworkSecurity: false`

## Why do we need it, and what problem does it solve?

Getting started for Selectel suggested unsetuppable configs. Choosing which layout to use was unclear.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: openstack
type: chore
summary: Documentation and Getting Started updates regarding Selectel Openstack setups.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
