### PR TITLE
[cni-cilium] Bump cilium to 1.14.5

### DIFF
--- a/modules/021-cni-cilium/images/builder/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/builder/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $ciliumVersion := "1.14.4" }}
+{{- $ciliumVersion := "1.14.5" }}
 # https://github.com/cilium/cilium/blob/83f313918cd97dc48c63fda7a0e15b8821a6f0d2/images/runtime/Dockerfile#L8-L10
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-llvm-artifact
@@ -10,7 +10,7 @@ from: quay.io/cilium/cilium-bpftool:d3093f6aeefef8270306011109be623a7e80ad1b@sha
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-iptables-artifact
 from: quay.io/cilium/iptables:67f517af50e18f64cd12625021f1c39246bb4f92@sha256:d075f03e89aacf51908346ec8ed5d251b8d3ad528ce30a710fcd074cdf91f11d
 ---
-# https://github.com/cilium/cilium/blob/v1.14.4/images/cilium/Dockerfile#L9
+# https://github.com/cilium/cilium/blob/v1.14.5/images/cilium/Dockerfile#L9
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-envoy-artifact
 from: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d@sha256:52541e1726041b050c5d475b3c527ca4b8da487a0bbb0309f72247e8127af0ec
 ---

--- a/modules/021-cni-cilium/images/cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/cilium/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $ciliumVersion := "1.14.4" }}
+{{- $ciliumVersion := "1.14.5" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-builder-artifact
 git:

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $ciliumVersion := "1.14.4" }}
+{{- $ciliumVersion := "1.14.5" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: quay.io/cilium/operator:v{{- $ciliumVersion }}@sha256:56cc1822109c4b34d192784a3106150cfb645252ce0b34aab67e9c820ac41bab


### PR DESCRIPTION
## Description
Bump cni-cilium to 1.14.5.

## Why do we need it, and what problem does it solve?
There is [regression](https://github.com/cilium/cilium/issues/29175) in 1.14 which causes high cpu usage.

## Why do we need it in the patch release (if we do)?

There is a customer who faced the high cpu usage by agents.

## What is the expected result?
CPU usage is moderate.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Cilium version bumped to 1.14.5
impact: Cilium agents will restart, during restart some policies won't work.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
