### PR TITLE
[cni-cilium] Enabling pprof interface for agents

### DIFF
--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   cluster-name: default # make sense only for cluster mesh
 
   debug: {{ .Values.cniCilium.debugLogging | quote }}
+  pprof: "true"
 
   metrics: "+cilium_bpf_map_pressure"
 


### PR DESCRIPTION
## Description
Enabling pprof interface for agents.

## Why do we need it, and what problem does it solve?
In case of cpu leaks it is convenient to profile the agent code with pprof.

## What is the expected result?
The pprof gathering works inside cilium-agent pod:
```
cilium-bugtool --get-pprof --pprof-trace-seconds 30
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: Enabled pprof interface in cilium-agent.
impact: cillium-agent pods will restart.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
