### PR TITLE
[virtualization] add remove module script

### DIFF
--- a/tools/virtualization/remove-module.sh
+++ b/tools/virtualization/remove-module.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+red=$(tput setaf 1)
+bold=$(tput bold)
+sgr0=$(tput sgr0)
+
+color_echo(){
+  echo "$red$bold$@ $sgr0"
+}
+
+remove_webhooks() {
+  color_echo "Remove kubevirt webhooks"
+  kubectl delete validatingwebhookconfigurations -l app.kubernetes.io/component=kubevirt
+  kubectl delete validatingwebhookconfigurations -l cdi.kubevirt.io=cdi-api
+
+  kubectl delete mutatingwebhookconfigurations -l app.kubernetes.io/component=kubevirt
+  kubectl delete mutatingwebhookconfigurations -l cdi.kubevirt.io=cdi-api
+}
+
+remove_cdi() {
+  color_echo "Remove CDI resource"
+  # delete CDI and wait for it to be deleted
+  kubectl patch cdi cdi --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]' 2>/dev/null
+  kubectl delete cdi cdi --force --grace-period 0 2>/dev/null
+  kubectl wait --for=delete -n cdi cdi --timeout=300s
+}
+
+remove_kubevirt() {
+  color_echo "Remove kubevirt resource"
+  # delete kubevirt and wait for it to be deleted
+  kubectl -n d8-virtualization patch kubevirt kubevirt --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]' 2>/dev/null
+  kubectl -n d8-virtualization delete kubevirt kubevirt --force --grace-period=0 2>/dev/null
+  kubectl wait --for=delete -n d8-virtualization kubevirt kubevirt --timeout=300s
+}
+
+disable_virtualization_module() {
+  color_echo "Disable virtualization module"
+  # disable virtualization module
+  kubectl patch mc virtualization --type='merge' --patch '{"spec":{"enabled":false}}'
+  kubectl wait mc virtualization --for="jsonpath={.status.state}=Disabled" --timeout=320s
+}
+
+remove_crds() {
+  color_echo "Remove kubvirt and deckhouse virtualizatiun CRDs"
+  # remove deckhouse virtualization CRDs
+  kubectl get crd -o name | grep -E 'virtualmachine.+deckhouse.io' | xargs kubectl delete --force --grace-period=0 2>/dev/null
+  # remove kubevirt CRDs
+  kubectl get crd -o name | grep kubevirt | xargs kubectl delete --force --grace-period=0 2>/dev/null
+}
+
+remove_apiservices() {
+  color_echo "Remove kubevirt apiservice"
+  kubectl get apiservices -o name | grep -E "(kubevirt|cdi)" | xargs kubectl delete --force --grace-period=0 2>/dev/null
+}
+
+remove_rbac() {
+  color_echo "Remove virtualization module rbac"
+  kubectl get clusterrole -o name | grep -E "(kubevirt|cdi)" | xargs kubectl delete --force --grace-period=0 2>/dev/null
+  kubectl get clusterrolebindings -o name | grep -E "(kubevirt|cdi)" | xargs kubectl delete --force --grace-period=0 2>/dev/null
+}
+
+main(){
+  remove_webhooks
+  remove_cdi
+  remove_kubevirt
+
+  disable_virtualization_module
+
+  remove_apiservices
+  remove_rbac
+  remove_crds
+
+  # Let's delete webhooks again just in case, because the controller might have time to put them back in place.
+  remove_webhooks
+}
+
+main


### PR DESCRIPTION
## Description
Fix remove module script location

## Why do we need it, and what problem does it solve?
No module, so no link to script in docs

## Why do we need it in the patch release (if we do)?
Stupid fail

## What is the expected result?
Script will be located in persistent place

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: virtualization
type: fix 
summary: Fix remove module script location
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
