### PR TITLE
[documentation] add docs-builder build error handling

### DIFF
--- a/docs/site/backends/docs-builder/build.go
+++ b/docs/site/backends/docs-builder/build.go
@@ -91,9 +91,11 @@ func (b *buildHandler) buildHugo() error {
 			return nil
 		}
 
-		if !b.removeBrokenFile(err) {
-			return err
+		if b.removeBrokenFile(err) {
+			continue
 		}
+
+		return err
 	}
 }
 

--- a/docs/site/backends/docs-builder/build_test.go
+++ b/docs/site/backends/docs-builder/build_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "testing"

--- a/docs/site/backends/docs-builder/build_test.go
+++ b/docs/site/backends/docs-builder/build_test.go
@@ -33,3 +33,28 @@ func TestAssembleErrorWithColorRegexp(t *testing.T) {
 		t.Fatalf("unedxpcted path %q", path)
 	}
 }
+
+func TestGetModulePath(t *testing.T) {
+	var tests = []struct {
+		filePath string
+		expected string
+	}{
+		{
+			filePath: "/app/hugo/content/modules/moduleName/BROKEN.md",
+			expected: "/app/hugo/content/modules/moduleName",
+		},
+		{
+			filePath: "/app/hugo/content/modules/moduleName/alpha/BROKEN.md",
+			expected: "/app/hugo/content/modules/moduleName/alpha",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filePath, func(t *testing.T) {
+			got := getModulePath(test.filePath)
+			if got != test.expected {
+				t.Error("unexpected result", got)
+			}
+		})
+	}
+}

--- a/docs/site/backends/docs-builder/build_test.go
+++ b/docs/site/backends/docs-builder/build_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestAssembleErrorRegexp(t *testing.T) {
+	input := "error building site: assemble: \x1b[1;36m\"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\"\x1b[0m: EOF looking for end YAML front matter delimiter"
+	match := assembleErrorRegexp.FindStringSubmatch(input)
+	if match == nil || len(match) != 4 {
+		t.Fatalf("unexpected match %#v", match)
+	}
+
+	path := match[1]
+	if path != "/app/hugo/content/modules/moduleName/BROKEN.md" {
+		t.Fatalf("unedxpcted path %q", path)
+	}
+}

--- a/docs/site/backends/docs-builder/build_test.go
+++ b/docs/site/backends/docs-builder/build_test.go
@@ -17,14 +17,19 @@ package main
 import "testing"
 
 func TestAssembleErrorRegexp(t *testing.T) {
-	input := "error building site: assemble: \x1b[1;36m\"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\"\x1b[0m: EOF looking for end YAML front matter delimiter"
-	match := assembleErrorRegexp.FindStringSubmatch(input)
-	if match == nil || len(match) != 4 {
-		t.Fatalf("unexpected match %#v", match)
-	}
+	input := "error building site: assemble: \"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\": EOF looking for end YAML front matter delimiter"
 
-	path := match[1]
-	if path != "/app/hugo/content/modules/moduleName/BROKEN.md" {
+	path, ok := getAssembleErrorPath(input)
+	if !ok || path != "/app/hugo/content/modules/moduleName/BROKEN.md" {
+		t.Fatalf("unedxpcted path %q", path)
+	}
+}
+
+func TestAssembleErrorWithColorRegexp(t *testing.T) {
+	input := "error building site: assemble: \x1b[1;36m\"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\"\x1b[0m: EOF looking for end YAML front matter delimiter"
+
+	path, ok := getAssembleErrorPath(input)
+	if !ok || path != "/app/hugo/content/modules/moduleName/BROKEN.md" {
 		t.Fatalf("unedxpcted path %q", path)
 	}
 }

--- a/docs/site/backends/docs-builder/build_test.go
+++ b/docs/site/backends/docs-builder/build_test.go
@@ -40,10 +40,6 @@ func TestGetModulePath(t *testing.T) {
 		expected string
 	}{
 		{
-			filePath: "/app/hugo/content/modules/moduleName/BROKEN.md",
-			expected: "/app/hugo/content/modules/moduleName",
-		},
-		{
 			filePath: "/app/hugo/content/modules/moduleName/alpha/BROKEN.md",
 			expected: "/app/hugo/content/modules/moduleName/alpha",
 		},
@@ -54,6 +50,33 @@ func TestGetModulePath(t *testing.T) {
 			got := getModulePath(test.filePath)
 			if got != test.expected {
 				t.Error("unexpected result", got)
+			}
+		})
+	}
+}
+
+func TestParseModulePath(t *testing.T) {
+	var tests = []struct {
+		modulePath string
+		moduleName string
+		channel    string
+	}{
+		{
+			modulePath: "/app/hugo/content/modules/moduleName/alpha",
+			moduleName: "moduleName",
+			channel:    "alpha",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.modulePath, func(t *testing.T) {
+			moduleName, channel := parseModulePath(test.modulePath)
+			if moduleName != test.moduleName {
+				t.Errorf("unexpected module name %q", moduleName)
+			}
+
+			if channel != test.channel {
+				t.Errorf("unexpected channel %q", channel)
 			}
 		})
 	}

--- a/docs/site/backends/docs-builder/channel_mapping.go
+++ b/docs/site/backends/docs-builder/channel_mapping.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+func newChannelMappingEditor(baseDir string) *channelMappingEditor {
+	return &channelMappingEditor{baseDir: baseDir}
+}
+
+type channelMappingEditor struct {
+	baseDir string
+	mu      sync.Mutex
+}
+
+type versionEntity struct {
+	Version string `json:"version" yaml:"version"`
+}
+
+// moduleName - "channels" - channelCode
+type channelMapping map[string]map[string]map[string]versionEntity
+
+func (m *channelMappingEditor) edit(fn func(channelMapping)) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	path := filepath.Join(m.baseDir, "data/modules/channels.yaml")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return fmt.Errorf("open %q: %w", path, err)
+	}
+
+	var cm = make(channelMapping)
+
+	err = yaml.NewDecoder(f).Decode(&cm)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("decode yaml: %w", err)
+	}
+
+	fn(cm)
+
+	err = f.Truncate(0)
+	if err != nil {
+		return fmt.Errorf("truncate %q: %w", path, err)
+	}
+
+	_, err = f.Seek(0, io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("seek %q: %w", path, err)
+	}
+
+	err = yaml.NewEncoder(f).Encode(cm)
+	if err != nil {
+		return fmt.Errorf("encode yaml: %w", err)
+	}
+
+	return nil
+}

--- a/docs/site/backends/docs-builder/handler.go
+++ b/docs/site/backends/docs-builder/handler.go
@@ -29,11 +29,13 @@ func newHandler(highAvailability bool) *mux.Router {
 		isReady.Store(true)
 	}
 
+	channelMappingEditor := newChannelMappingEditor(src)
+
 	r := mux.NewRouter()
 	r.Handle("/readyz", newReadinessHandler(&isReady))
 	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = io.WriteString(w, "OK") })
-	r.Handle("/loadDocArchive/{moduleName}/{version}", newLoadHandler(src)).Methods(http.MethodPost)
-	r.Handle("/build", newBuildHandler(src, dst, &isReady)).Methods(http.MethodPost)
+	r.Handle("/loadDocArchive/{moduleName}/{version}", newLoadHandler(src, channelMappingEditor)).Methods(http.MethodPost)
+	r.Handle("/build", newBuildHandler(src, dst, &isReady, channelMappingEditor)).Methods(http.MethodPost)
 
 	return r
 }

--- a/docs/site/backends/docs-builder/upload_test.go
+++ b/docs/site/backends/docs-builder/upload_test.go
@@ -80,7 +80,7 @@ func TestLoadHandlerGetLocalPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.fileName, func(t *testing.T) {
-			u := newLoadHandler("/app/hugo/")
+			u := newLoadHandler("/app/hugo/", nil)
 
 			got, ok := u.getLocalPath("moduleName", "stable", tt.fileName)
 			if got != tt.want || ok != tt.wantOK {


### PR DESCRIPTION
## Description
Added removal of invalid documentation during build
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

<!---
## Why do we need it, and what problem does it solve?

  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---
## Why do we need it in the patch release (if we do)?

Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: documentation
type: fix
summary: Improved stability of the documentation site
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
