### PR TITLE
[istio] Delete orphan istio resources after disable module

### DIFF
--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -32,6 +32,7 @@ import (
 const (
 	istioSystemNs                = "d8-istio"
 	istioComponentsLabelSelector = "install.operator.istio.io/owning-resource-namespace=d8-istio"
+	iopCrdName                   = "istiooperators.install.istio.io"
 )
 
 var (
@@ -43,7 +44,12 @@ var (
 	iopGVR = schema.GroupVersionResource{
 		Group:    "install.istio.io",
 		Version:  "v1alpha1",
-		Resource: "IstioOperator",
+		Resource: "istiooperators",
+	}
+	crdGVR = schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
 	}
 )
 
@@ -60,70 +66,90 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 	if err != nil {
 		return err
 	}
-	// remove finalizers and delete iop in ns d8-istio
-	iops, err := k8sClient.Dynamic().Resource(iopGVR).Namespace(istioSystemNs).List(context.TODO(), metav1.ListOptions{})
-	if err == nil {
+
+	ns, _ := k8sClient.CoreV1().Namespaces().Get(context.TODO(), istioSystemNs, metav1.GetOptions{})
+	if ns != nil {
+		// iopcrd, _ := k8sClient.Dynamic().Resource(crdGVR).Get(context.TODO(), iopCrdName, metav1.GetOptions{})
+		// if iopcrd != nil {
+		// remove finalizers and delete iop in ns d8-istio
+		iops, err := k8sClient.Dynamic().Resource(iopGVR).Namespace(istioSystemNs).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
 		for _, iop := range iops.Items {
 			_, err = k8sClient.Dynamic().Resource(iopGVR).Namespace(istioSystemNs).Patch(context.TODO(), iop.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Remove finalizers from IstioOperator/%s in namespace %s", iop.GetName(), istioSystemNs)
+			if err != nil {
+				return err
 			}
+			input.LogEntry.Infof("Remove finalizers from IstioOperator/%s in namespace %s", iop.GetName(), istioSystemNs)
 			err := k8sClient.Dynamic().Resource(iopGVR).Namespace(istioSystemNs).Delete(context.TODO(), iop.GetName(), metav1.DeleteOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Delete IstioOperator/%s in namespace %s", iop.GetName(), istioSystemNs)
+			if err != nil {
+				return err
 			}
+			input.LogEntry.Infof("Delete IstioOperator/%s in namespace %s", iop.GetName(), istioSystemNs)
 		}
-	}
-	// delete ClusterRole
-	icrs, err := k8sClient.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
-	if err == nil {
-		for _, icr := range icrs.Items {
-			err := k8sClient.RbacV1().ClusterRoles().Delete(context.TODO(), icr.GetName(), metav1.DeleteOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Delete ClusterRoles/%s", icr.GetName())
-			}
-		}
-	}
-	// delete ClusterRoleBinding
-	icrbs, err := k8sClient.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
-	if err == nil {
-		for _, icrb := range icrbs.Items {
-			err := k8sClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), icrb.GetName(), metav1.DeleteOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Delete ClusterRoleBindings/%s", icrb.GetName())
-			}
-		}
-	}
-	// delete MutatingWebhookConfiguration
-	imwcs, err := k8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
-	if err == nil {
-		for _, imwc := range imwcs.Items {
-			err := k8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), imwc.GetName(), metav1.DeleteOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Delete MutatingWebhookConfigurations/%s", imwc.GetName())
-			}
-		}
-	}
-	// delete ValidatingWebhookConfiguration
-	ivwcs, err := k8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
-	if err == nil {
-		for _, ivwc := range ivwcs.Items {
-			err := k8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), ivwc.GetName(), metav1.DeleteOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Delete MutatingWebhookConfigurations/%s", ivwc.GetName())
-			}
-		}
-	}
-	// delete NS
-	ns, err := k8sClient.CoreV1().Namespaces().Get(context.TODO(), istioSystemNs, metav1.GetOptions{})
-	if err == nil {
+		// }
+		// delete NS
 		_, nsDeletionTimestampExists := ns.GetAnnotations()["deletionTimestamp"]
 		if !nsDeletionTimestampExists {
 			err := k8sClient.CoreV1().Namespaces().Delete(context.TODO(), ns.GetName(), metav1.DeleteOptions{})
-			if err == nil {
-				input.LogEntry.Infof("Delete namespace %s", ns.GetName())
+			if err != nil {
+				return err
 			}
+			input.LogEntry.Infof("Delete namespace %s", ns.GetName())
 		}
+	}
+
+	// delete ClusterRole
+	icrs, err := k8sClient.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
+	if err != nil {
+		return err
+	}
+	for _, icr := range icrs.Items {
+		err := k8sClient.RbacV1().ClusterRoles().Delete(context.TODO(), icr.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		input.LogEntry.Infof("Delete ClusterRole/%s", icr.GetName())
+	}
+
+	// delete ClusterRoleBinding
+	icrbs, err := k8sClient.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
+	if err != nil {
+		return err
+	}
+	for _, icrb := range icrbs.Items {
+		err := k8sClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), icrb.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		input.LogEntry.Infof("Delete ClusterRoleBinding/%s", icrb.GetName())
+	}
+
+	// delete MutatingWebhookConfiguration
+	imwcs, err := k8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
+	if err != nil {
+		return err
+	}
+	for _, imwc := range imwcs.Items {
+		err := k8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), imwc.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		input.LogEntry.Infof("Delete MutatingWebhookConfiguration/%s", imwc.GetName())
+	}
+
+	// delete ValidatingWebhookConfiguration
+	ivwcs, err := k8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{LabelSelector: istioComponentsLabelSelector})
+	if err != nil {
+		return err
+	}
+	for _, ivwc := range ivwcs.Items {
+		err := k8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), ivwc.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		input.LogEntry.Infof("Delete ValidatingWebhookConfiguration/%s", ivwc.GetName())
 	}
 
 	return nil

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -32,7 +32,6 @@ import (
 const (
 	istioSystemNs                = "d8-istio"
 	istioComponentsLabelSelector = "install.operator.istio.io/owning-resource-namespace=d8-istio"
-	iopCrdName                   = "istiooperators.install.istio.io"
 )
 
 var (

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -74,17 +74,16 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 			if err != nil {
 				return err
 			}
-			input.LogEntry.Infof("Remove finalizers from IstioOperator/%s in namespace %s", iop.GetName(), istioSystemNs)
+			input.LogEntry.Infof("Finalizers from IstioOperator/%s in namespace %s removed", iop.GetName(), istioSystemNs)
 			_, iopDeletionTimestampExists := iop.GetAnnotations()["deletionTimestamp"]
 			if !iopDeletionTimestampExists {
 				err := k8sClient.Dynamic().Resource(iopGVR).Namespace(istioSystemNs).Delete(context.TODO(), iop.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					return err
 				}
-				input.LogEntry.Infof("Delete IstioOperator/%s in namespace %s", iop.GetName(), istioSystemNs)
+				input.LogEntry.Infof("IstioOperator/%s deleted from namespace %s", iop.GetName(), istioSystemNs)
 			}
 		}
-		// }
 		// delete NS
 		_, nsDeletionTimestampExists := ns.GetAnnotations()["deletionTimestamp"]
 		if !nsDeletionTimestampExists {
@@ -92,7 +91,7 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 			if err != nil {
 				return err
 			}
-			input.LogEntry.Infof("Delete namespace %s", ns.GetName())
+			input.LogEntry.Infof("Namespace %s deleted", ns.GetName())
 		}
 	}
 
@@ -106,7 +105,7 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 		if err != nil {
 			return err
 		}
-		input.LogEntry.Infof("Delete ClusterRole/%s", icr.GetName())
+		input.LogEntry.Infof("ClusterRole/%s deleted", icr.GetName())
 	}
 
 	// delete ClusterRoleBinding
@@ -119,7 +118,7 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 		if err != nil {
 			return err
 		}
-		input.LogEntry.Infof("Delete ClusterRoleBinding/%s", icrb.GetName())
+		input.LogEntry.Infof("ClusterRoleBinding/%s deleted", icrb.GetName())
 	}
 
 	// delete MutatingWebhookConfiguration
@@ -132,7 +131,7 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 		if err != nil {
 			return err
 		}
-		input.LogEntry.Infof("Delete MutatingWebhookConfiguration/%s", imwc.GetName())
+		input.LogEntry.Infof("MutatingWebhookConfiguration/%s deleted", imwc.GetName())
 	}
 
 	// delete ValidatingWebhookConfiguration
@@ -145,7 +144,7 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 		if err != nil {
 			return err
 		}
-		input.LogEntry.Infof("Delete ValidatingWebhookConfiguration/%s", ivwc.GetName())
+		input.LogEntry.Infof("ValidatingWebhookConfiguration/%s deleted", ivwc.GetName())
 	}
 
 	return nil

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -316,14 +316,17 @@ func purgeOrphanResources(input *go_hook.HookInput) error {
 	for _, objRaw := range objects {
 		obj := objRaw.(removeObject)
 		if obj.FinalizersExists {
+			input.LogEntry.Infof("Remove finalizers from %s/%s in namespace %s", obj.Kind, obj.Name, obj.Namespace)
 			input.PatchCollector.MergePatch(deleteFinalizersPatch, obj.APIVersion, obj.Kind, obj.Namespace, obj.Name)
 		}
+		input.LogEntry.Infof("Delete %s/%s in namespace %s", obj.Kind, obj.Name, obj.Namespace)
 		input.PatchCollector.Delete(obj.APIVersion, obj.Kind, obj.Namespace, obj.Name, object_patch.InForeground())
 	}
 
 	if len(input.Snapshots["clwNamespace"]) > 0 {
 		ns := input.Snapshots["clwNamespace"][0].(removeObject)
 		if !ns.DeletionTimestampExists {
+			input.LogEntry.Infof("Delete namespace %s", ns.Name)
 			input.PatchCollector.Delete(ns.APIVersion, ns.Kind, "", ns.Name, object_patch.InForeground())
 		}
 	}

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	istioSystemNs = "d8-istio"
+)
+
+type removeObject struct {
+	APIVersion              string
+	Kind                    string
+	Namespace               string
+	Name                    string
+	DeletionTimestampExists bool
+	FinalizersExists        bool
+}
+
+var (
+	deleteFinalizersPatch = map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers": nil,
+		},
+	}
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterDeleteHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "clwNamespace",
+			ApiVersion:                   "v1",
+			Kind:                         "Namespace",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveNsFilter,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{istioSystemNs},
+			},
+		},
+		{
+			Name:                         "clwClusterRole",
+			ApiVersion:                   "rbac.authorization.k8s.io/v1",
+			Kind:                         "ClusterRole",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"install.operator.istio.io/owning-resource-namespace": "d8-istio",
+				},
+			},
+		},
+		{
+			Name:                         "clwClusterRoleBinding",
+			ApiVersion:                   "rbac.authorization.k8s.io/v1",
+			Kind:                         "ClusterRoleBinding",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"install.operator.istio.io/owning-resource-namespace": "d8-istio",
+				},
+			},
+		},
+		{
+			Name:                         "clwMutatingWebhookConfiguration",
+			ApiVersion:                   "admissionregistration.k8s.io/v1",
+			Kind:                         "MutatingWebhookConfiguration",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"install.operator.istio.io/owning-resource-namespace": "d8-istio",
+				},
+			},
+		},
+		{
+			Name:                         "clwValidatingWebhookConfiguration",
+			ApiVersion:                   "admissionregistration.k8s.io/v1",
+			Kind:                         "ValidatingWebhookConfiguration",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"install.operator.istio.io/owning-resource-namespace": "d8-istio",
+				},
+			},
+		},
+		{
+			Name:                         "nsdServiceAccount",
+			ApiVersion:                   "v1",
+			Kind:                         "ServiceAccount",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdRole",
+			ApiVersion:                   "rbac.authorization.k8s.io/v1",
+			Kind:                         "Role",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdRoleBinding",
+			ApiVersion:                   "rbac.authorization.k8s.io/v1",
+			Kind:                         "RoleBinding",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdIstioOperator",
+			ApiVersion:                   "install.istio.io/v1alpha1",
+			Kind:                         "IstioOperator",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdEnvoyFilter",
+			ApiVersion:                   "networking.istio.io/v1alpha3",
+			Kind:                         "EnvoyFilter",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdDeployment",
+			ApiVersion:                   "apps/v1",
+			Kind:                         "Deployment",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdReplicaSet",
+			ApiVersion:                   "apps/v1",
+			Kind:                         "ReplicaSet",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdPod",
+			ApiVersion:                   "v1",
+			Kind:                         "Pod",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdConfigMap",
+			ApiVersion:                   "v1",
+			Kind:                         "ConfigMap",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdPodDisruptionBudget",
+			ApiVersion:                   "policy/v1",
+			Kind:                         "PodDisruptionBudget",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+		{
+			Name:                         "nsdService",
+			ApiVersion:                   "v1",
+			Kind:                         "Service",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   applyRemoveObjectFilter,
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{istioSystemNs},
+				},
+			},
+		},
+	},
+}, purgeOrphanResources)
+
+func applyRemoveNsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	_, deletionTimestampExists := obj.GetAnnotations()["deletionTimestamp"]
+
+	var RemoveNsInfo = removeObject{
+		APIVersion:              obj.GetAPIVersion(),
+		Kind:                    obj.GetKind(),
+		Name:                    obj.GetName(),
+		DeletionTimestampExists: deletionTimestampExists,
+	}
+
+	return RemoveNsInfo, nil
+}
+
+func applyRemoveObjectFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	_, deletionTimestampExists := obj.GetAnnotations()["deletionTimestamp"]
+	// _, finalizersExists := obj.GetFinalizers()
+	var finalizersExists bool
+	if len(obj.GetFinalizers()) == 0 {
+		finalizersExists = false
+	} else {
+		finalizersExists = true
+	}
+
+	var RemoveObjectInfo = removeObject{
+		APIVersion:              obj.GetAPIVersion(),
+		Kind:                    obj.GetKind(),
+		Namespace:               obj.GetNamespace(),
+		Name:                    obj.GetName(),
+		FinalizersExists:        finalizersExists,
+		DeletionTimestampExists: deletionTimestampExists,
+	}
+
+	return RemoveObjectInfo, nil
+}
+
+func purgeOrphanResources(input *go_hook.HookInput) error {
+	objects := make([]go_hook.FilterResult, 0)
+	objects = append(objects, input.Snapshots["clwClusterRole"]...)
+	objects = append(objects, input.Snapshots["clwClusterRoleBinding"]...)
+	objects = append(objects, input.Snapshots["clwMutatingWebhookConfiguration"]...)
+	objects = append(objects, input.Snapshots["clwValidatingWebhookConfiguration"]...)
+	objects = append(objects, input.Snapshots["nsdServiceAccount"]...)
+	objects = append(objects, input.Snapshots["nsdRole"]...)
+	objects = append(objects, input.Snapshots["nsdRoleBinding"]...)
+	objects = append(objects, input.Snapshots["nsdIstioOperator"]...)
+	objects = append(objects, input.Snapshots["nsdEnvoyFilter"]...)
+	objects = append(objects, input.Snapshots["nsdDeployment"]...)
+	// objects = append(objects, input.Snapshots["nsdReplicaSet"]...)
+	// objects = append(objects, input.Snapshots["nsdPod"]...)
+	objects = append(objects, input.Snapshots["nsdConfigMap"]...)
+	objects = append(objects, input.Snapshots["nsdPodDisruptionBudget"]...)
+	objects = append(objects, input.Snapshots["nsdService"]...)
+	objects = append(objects, input.Snapshots["nsdConfigMap"]...)
+
+	for _, objRaw := range objects {
+		obj := objRaw.(removeObject)
+		if obj.FinalizersExists {
+			input.PatchCollector.MergePatch(deleteFinalizersPatch, obj.APIVersion, obj.Kind, obj.Namespace, obj.Name)
+		}
+		input.PatchCollector.Delete(obj.APIVersion, obj.Kind, obj.Namespace, obj.Name, object_patch.InForeground())
+	}
+
+	if len(input.Snapshots["namespace"]) > 0 {
+		ns := input.Snapshots["namespace"][0].(removeObject)
+		if !ns.DeletionTimestampExists {
+			input.PatchCollector.Delete(ns.APIVersion, ns.Kind, "", ns.Name, object_patch.InForeground())
+		}
+	}
+
+	return nil
+}

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -321,8 +321,8 @@ func purgeOrphanResources(input *go_hook.HookInput) error {
 		input.PatchCollector.Delete(obj.APIVersion, obj.Kind, obj.Namespace, obj.Name, object_patch.InForeground())
 	}
 
-	if len(input.Snapshots["namespace"]) > 0 {
-		ns := input.Snapshots["namespace"][0].(removeObject)
+	if len(input.Snapshots["clwNamespace"]) > 0 {
+		ns := input.Snapshots["clwNamespace"][0].(removeObject)
 		if !ns.DeletionTimestampExists {
 			input.PatchCollector.Delete(ns.APIVersion, ns.Kind, "", ns.Name, object_patch.InForeground())
 		}

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -35,7 +35,6 @@ var _ = Describe("Istio hooks :: purge_orphan_resources ::", func() {
 
 	const (
 		istioSystemNs = "d8-istio"
-		// istioComponentsLabelSelector = "install.operator.istio.io/owning-resource-namespace=d8-istio"
 		nsYAML = `
 ---
 apiVersion: v1
@@ -173,8 +172,8 @@ metadata:
 			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete namespace d8-istio"))
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Remove finalizers from IstioOperator/v1x16 in namespace d8-istio"))
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete IstioOperator/v1x16 in namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Finalizers from IstioOperator/v1x16 in namespace d8-istio removed"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("IstioOperator/v1x16 deleted from namespace d8-istio"))
 		})
 	})
 
@@ -199,24 +198,24 @@ metadata:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(string(f.LogrusOutput.Contents())).ToNot(HaveLen(0))
 			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Namespace d8-istio deleted"))
 
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Remove finalizers from IstioOperator/v1x16 in namespace d8-istio"))
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete IstioOperator/v1x16 in namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Finalizers removed from IstioOperator/v1x16 in namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("IstioOperator/v1x16 deleted from namespace d8-istio"))
 
 			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRole/istio-reader-d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ClusterRole/istio-reader-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRole/istio-reader-clusterrole-v1x16-d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ClusterRole/istio-reader-clusterrole-v1x16-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRoleBinding/istio-reader-d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ClusterRoleBinding/istio-reader-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRoleBinding/istio-reader-clusterrole-v1x16-d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ClusterRoleBinding/istio-reader-clusterrole-v1x16-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("MutatingWebhookConfiguration", "istio-sidecar-injector-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete MutatingWebhookConfiguration/istio-sidecar-injector-v1x16-d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("MutatingWebhookConfiguration/istio-sidecar-injector-v1x16-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("ValidatingWebhookConfiguration", "istio-validator-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ValidatingWebhookConfiguration/istio-validator-v1x16-d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ValidatingWebhookConfiguration/istio-validator-v1x16-d8-istio deleted"))
 		})
 	})
 

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Istio hooks :: purge_orphan_resources ::", func() {
 
 	const (
 		istioSystemNs = "d8-istio"
-		nsYAML = `
+		nsYAML        = `
 ---
 apiVersion: v1
 kind: Namespace
@@ -170,7 +170,7 @@ metadata:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(string(f.LogrusOutput.Contents())).ToNot(HaveLen(0))
 			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Namespace d8-istio deleted"))
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Finalizers from IstioOperator/v1x16 in namespace d8-istio removed"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("IstioOperator/v1x16 deleted from namespace d8-istio"))
@@ -201,7 +201,7 @@ metadata:
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Namespace d8-istio deleted"))
 
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Finalizers removed from IstioOperator/v1x16 in namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Finalizers from IstioOperator/v1x16 in namespace d8-istio removed"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("IstioOperator/v1x16 deleted from namespace d8-istio"))
 
 			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-d8-istio").Exists()).To(BeFalse())

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -100,66 +100,66 @@ kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.13-v1x16
   namespace: d8-istio
-  ---
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
-  ---
-  apiVersion: v1
-  kind: Service
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
-  ---
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
-  ---
-  apiVersion: policy/v1
-  kind: PodDisruptionBudget
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
-  ---
-  apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-	name: istiod-service-account
-	namespace: d8-istio
-  ---
-  apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-	name: istiod-d8-istio
-	namespace: d8-istio
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-	name: istiod-d8-istio
-	namespace: d8-istio
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-	name: istiod-v1x16
-	namespace: d8-istio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istiod-service-account
+  namespace: d8-istio
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istiod-d8-istio
+  namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istiod-d8-istio
+  namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istiod-v1x16
+  namespace: d8-istio
 `
 	)
 
@@ -169,6 +169,7 @@ metadata:
 
 	Context("Empty cluster and minimal settings", func() {
 		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()
 		})
 
@@ -181,6 +182,7 @@ metadata:
 	Context("Cluster with minimal settings and orphan iop", func() {
 		BeforeEach(func() {
 			f.KubeStateSet(iop)
+			f.BindingContexts.Set(f.GenerateAfterDeleteHelmContext())
 			f.RunHook()
 		})
 
@@ -194,6 +196,7 @@ metadata:
 	Context("Cluster with minimal settings and orphan istio resources", func() {
 		BeforeEach(func() {
 			f.KubeStateSet(ns + iop + clwRes + nsdRes)
+			f.BindingContexts.Set(f.GenerateAfterDeleteHelmContext())
 			f.RunHook()
 		})
 

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -81,7 +81,7 @@ metadata:
     install.operator.istio.io/owning-resource-namespace: d8-istio
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-validator-v1x16-d8-istio
   labels:
@@ -188,7 +188,9 @@ metadata:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+			Expect(string(f.LogrusOutput.Contents())).ToNot(HaveLen(0))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Remove finalizers from IstioOperator/v1x16 in namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete IstioOperator/v1x16 in namespace d8-istio"))
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
 		})
 	})
@@ -202,32 +204,52 @@ metadata:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+			Expect(string(f.LogrusOutput.Contents())).ToNot(HaveLen(0))
 			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
 
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Remove finalizers from IstioOperator/v1x16 in namespace d8-istio"))
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete IstioOperator/v1x16 in namespace d8-istio"))
 
 			Expect(f.KubernetesResource("EnvoyFilter", "d8-istio", "stats-filter-1.13-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete EnvoyFilter/stats-filter-1.13-v1x16 in namespace d8-istio"))
 			Expect(f.KubernetesResource("EnvoyFilter", "d8-istio", "tcp-stats-filter-1.13-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete EnvoyFilter/tcp-stats-filter-1.13-v1x16 in namespace d8-istio"))
 
 			Expect(f.KubernetesResource("Deployment", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete Deployment/istiod-v1x16 in namespace d8-istio"))
 			Expect(f.KubernetesResource("Service", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete Service/istiod-v1x16 in namespace d8-istio"))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ConfigMap/istiod-v1x16 in namespace d8-istio"))
 			Expect(f.KubernetesResource("PodDisruptionBudget", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete PodDisruptionBudget/istiod-v1x16 in namespace d8-istio"))
 
 			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "istiod-service-account").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ServiceAccount/istiod-service-account in namespace d8-istio"))
 			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ServiceAccount/istiod-v1x16 in namespace d8-istio"))
 			Expect(f.KubernetesResource("Role", "d8-istio", "istiod-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete Role/istiod-d8-istio in namespace d8-istio"))
 			Expect(f.KubernetesResource("Role", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete Role/istiod-v1x16 in namespace d8-istio"))
 			Expect(f.KubernetesResource("RoleBinding", "d8-istio", "istiod-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete RoleBinding/istiod-d8-istio in namespace d8-istio"))
 			Expect(f.KubernetesResource("RoleBinding", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete RoleBinding/istiod-v1x16 in namespace d8-istio"))
 
 			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRole/istio-reader-d8-istio in namespace "))
 			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRole/istio-reader-clusterrole-v1x16-d8-istio in namespace "))
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRoleBinding/istio-reader-d8-istio in namespace "))
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ClusterRoleBinding/istio-reader-clusterrole-v1x16-d8-istio in namespace "))
 			Expect(f.KubernetesGlobalResource("MutatingWebhookConfiguration", "istio-sidecar-injector-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete MutatingWebhookConfiguration/istio-sidecar-injector-v1x16-d8-istio in namespace "))
 			Expect(f.KubernetesGlobalResource("ValidatingWebhookConfiguration", "istio-validator-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("Delete ValidatingWebhookConfiguration/istio-validator-v1x16-d8-istio in namespace "))
 		})
 	})
 

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Istio hooks :: purge_orphan_resources ::", func() {
+
+	const (
+		ns = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-istio
+`
+		iop = `
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  finalizers:
+  - istio-finalizer.install.istio.io
+  name: v1x16
+  namespace: d8-istio
+`
+		clwRes = `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-reader-d8-istio
+  labels:
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-reader-clusterrole-v1x16-d8-istio
+  labels:
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-reader-d8-istio
+  labels:
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-reader-clusterrole-v1x16-d8-istio
+  labels:
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector-v1x16-d8-istio
+  labels:
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-validator-v1x16-d8-istio
+  labels:
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+`
+		nsdRes = `
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stats-filter-1.13-v1x16
+  namespace: d8-istio
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: tcp-stats-filter-1.13-v1x16
+  namespace: d8-istio
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+  ---
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+  ---
+  apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+	name: istiod-service-account
+	namespace: d8-istio
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+	name: istiod-d8-istio
+	namespace: d8-istio
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+	name: istiod-d8-istio
+	namespace: d8-istio
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+	name: istiod-v1x16
+	namespace: d8-istio
+`
+	)
+
+	f := HookExecutionConfigInit(`{}`, `{}`)
+	f.RegisterCRD("install.istio.io", "v1alpha1", "IstioOperator", true)
+	f.RegisterCRD("networking.istio.io", "v1alpha3", "EnvoyFilter", true)
+
+	Context("Empty cluster and minimal settings", func() {
+		BeforeEach(func() {
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+		})
+	})
+
+	Context("Cluster with minimal settings and orphan iop", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(iop)
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster with minimal settings and orphan istio resources", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(ns + iop + clwRes + nsdRes)
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesResource("EnvoyFilter", "d8-istio", "stats-filter-1.13-v1x16").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("EnvoyFilter", "d8-istio", "tcp-stats-filter-1.13-v1x16").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Service", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-v1x16").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("PodDisruptionBudget", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "istiod-service-account").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Role", "d8-istio", "istiod-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Role", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("RoleBinding", "d8-istio", "istiod-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("RoleBinding", "d8-istio", "istiod-v1x16").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("MutatingWebhookConfiguration", "istio-sidecar-injector-v1x16-d8-istio").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ValidatingWebhookConfiguration", "istio-validator-v1x16-d8-istio").Exists()).To(BeFalse())
+		})
+	})
+
+})


### PR DESCRIPTION
## Description

Add a hook to check for orphaned resources and remove them when the module is shut down

## Why do we need it, and what problem does it solve?

If an operator's pod fails to start or was deleted before its resources, they remain in the cluster as orphaned and cannot be deleted because of `finalizers`.
To avoid this, we add a check for orphaned resources and delete them when the module is disabled.

Fixes https://github.com/deckhouse/deckhouse/issues/5285.

## What is the expected result?

After disabling the module, there are no remaining Istio system-components in the cluster.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: After disabling the module, clean up any orphaned Istio components.
impact_level: default
```
