### PR TITLE
[loki] add kube-rbac-proxy

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
@@ -101,6 +101,7 @@ var auditPolicyBasicServiceAccounts = []string{
 	"system:serviceaccount:d8-monitoring:grafana",
 	"system:serviceaccount:d8-monitoring:image-availability-exporter",
 	"system:serviceaccount:d8-monitoring:kube-state-metrics",
+	"system:serviceaccount:d8-monitoring:loki",
 	"system:serviceaccount:d8-monitoring:monitoring-ping",
 	"system:serviceaccount:d8-monitoring:node-exporter",
 	"system:serviceaccount:d8-monitoring:prometheus",

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -176,6 +176,13 @@ spec:
                           type: boolean
                           default: true
                           description: Verifies that the name of the remote host matches the name specified in the remote host's TLS certificate.
+                        verifyCertificate:
+                          type: boolean
+                          default: true
+                          description: |
+                            Validate the TLS certificate of the remote host.
+
+                            If set to `false`, the certificate is not checked in the Certificate Revocation Lists.
                 elasticsearch:
                   type: object
                   required:

--- a/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
@@ -56,6 +56,11 @@ spec:
                               description: Закодированный в Base64 пароль для ключа.
                         verifyHostname:
                           description: Проверка соответствия имени удаленного хоста и имени, указанного в TLS-сертификате удаленного хоста.
+                        verifyCertificate:
+                          description: |
+                            Проверка TLS-сертификата удаленного хоста.
+
+                            Если параметр установлен в `false`, сертификат не проверяется на наличие в списке отозванных сертификатов (Certificate Revocation Lists).
                 elasticsearch:
                   properties:
                     auth:

--- a/modules/460-log-shipper/docs/FAQ.md
+++ b/modules/460-log-shipper/docs/FAQ.md
@@ -1,0 +1,44 @@
+---
+title: "The log-shipper module: FAQ"
+---
+
+## How to add authorization params to the ClusterLogDestination resource which is used to send logs to the d8-loki?
+
+You need to change the `ClusterLogDestination` endpoint scheme to `https` and add the `auth` section with the `strategy` field set to `Bearer` and the `token` field set to the `log-shipper-token` token from the `d8-log-shipper` namespace.
+
+For example:
+
+ClusterLogDestination resource without authorization:
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: loki
+spec:
+  type: Loki
+  loki:
+    endpoint: "http://loki.d8-monitoring:3100"
+```
+
+Get the `log-shipper-token` token from the `d8-log-shipper` namespace:
+```bash
+kubectl -n d8-log-shipper get secret log-shipper-token -o jsonpath='{.data.token}' | base64 -d
+```
+
+ClusterLogDestination resource with authorization:
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: loki
+spec:
+  type: Loki
+  loki:
+    endpoint: "https://loki.d8-monitoring:3100"
+    auth:
+      strategy: "Bearer"
+      token: <log-shipper-token>
+    tls:
+      verifyHostname: false
+      verifyCertificate: false
+```

--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -17,12 +17,17 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,6 +77,49 @@ func filterNamespaceName(obj *unstructured.Unstructured) (go_hook.FilterResult, 
 	return namespace.GetName(), nil
 }
 
+func filterLogShipperTokenSecret(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := new(corev1.Secret)
+
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return string(secret.Data["token"]), nil
+}
+
+func filterLokiEndpoints(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	endpoints := new(corev1.Endpoints)
+
+	err := sdk.FromUnstructured(obj, endpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	var lokiEndpoint endpoint
+
+	for _, subset := range endpoints.Subsets {
+		for _, p := range subset.Ports {
+			if p.Name == "loki" {
+				lokiEndpoint.port = strconv.FormatInt(int64(p.Port), 10)
+
+				break
+			}
+		}
+
+		for _, address := range subset.Addresses {
+			lokiEndpoint.addresses = append(lokiEndpoint.addresses, address.IP)
+		}
+	}
+
+	return lokiEndpoint, nil
+}
+
+type endpoint struct {
+	addresses []string
+	port      string
+}
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/log-shipper/generate_config",
 	Kubernetes: []go_hook.KubernetesConfig{
@@ -102,6 +150,34 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			FilterFunc: filterNamespaceName,
 		},
+		{
+			Name:       "token",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{
+					"d8-log-shipper",
+				}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"log-shipper-token",
+			}},
+			FilterFunc: filterLogShipperTokenSecret,
+		},
+		{
+			Name:       "loki_endpoint",
+			ApiVersion: "v1",
+			Kind:       "Endpoints",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{
+					"d8-monitoring",
+				}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"loki",
+			}},
+			FilterFunc: filterLokiEndpoints,
+		},
 	},
 }, generateConfig)
 
@@ -112,7 +188,45 @@ func generateConfig(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	configContent, err := composer.FromInput(input).Do()
+	destSnap := input.Snapshots["cluster_log_destination"]
+	tokenSnap := input.Snapshots["token"]
+
+	var token string
+
+	if len(tokenSnap) > 0 {
+		token = tokenSnap[0].(string)
+	}
+
+	lokiEndpointSnap := input.Snapshots["loki_endpoint"]
+
+	var lokiEndpoint endpoint
+
+	if len(lokiEndpointSnap) > 0 {
+		lokiEndpoint = lokiEndpointSnap[0].(endpoint)
+	}
+
+	clusterDomain := input.Values.Get("global.discovery.clusterDomain").String()
+
+	var destinations []v1alpha1.ClusterLogDestination
+
+	for _, destination := range destSnap {
+		dest := destination.(v1alpha1.ClusterLogDestination)
+
+		if dest.Spec.Type != "Loki" || token == "" {
+			destinations = append(destinations, dest)
+
+			continue
+		}
+
+		d, err := migrateClusterLogDestinationLoki(dest, clusterDomain, lokiEndpoint, token)
+		if err != nil {
+			return errors.Wrap(err, "failed to migrate cluster log destination loki")
+		}
+
+		destinations = append(destinations, *d)
+	}
+
+	configContent, err := composer.FromInput(input, destinations).Do()
 	if err != nil {
 		return err
 	}
@@ -171,4 +285,50 @@ func generateConfig(input *go_hook.HookInput) error {
 	input.PatchCollector.Create(event)
 
 	return nil
+}
+
+// migrateClusterLogDestinationLoki migrates ClusterLogDestination pointing to d8-loki.
+// There may be ClusterLogDestination resources in the cluster pointing to d8-loki besides the one we create in the Deckhouse loki module.
+// We also have handleClusterLogDestinationD8Loki function which is notifying users that they should migrate ClusterLogDestination resources manually.
+func migrateClusterLogDestinationLoki(destination v1alpha1.ClusterLogDestination, clusterDomain string, endpoint endpoint, token string) (*v1alpha1.ClusterLogDestination, error) {
+	endpointURL, err := url.Parse(destination.Spec.Loki.Endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse loki endpoint '%s'", destination.Spec.Loki.Endpoint)
+	}
+
+	if !matchLokiEndpoint(endpointURL.Host, clusterDomain, endpoint) {
+		return &destination, nil
+	}
+
+	endpointURL.Scheme = "https"
+
+	destination.Spec.Loki.Endpoint = endpointURL.String()
+
+	destination.Spec.Loki.Auth.Strategy = "Bearer"
+	destination.Spec.Loki.Auth.Token = token
+
+	verifyHostname := false
+	verifyCertificate := false
+
+	destination.Spec.Loki.TLS.VerifyHostname = &verifyHostname
+	destination.Spec.Loki.TLS.VerifyCertificate = &verifyCertificate
+
+	return &destination, nil
+}
+
+func matchLokiEndpoint(hostPort string, clusterDomain string, endpoint endpoint) bool {
+	if hostPort == net.JoinHostPort("loki.d8-monitoring", endpoint.port) ||
+		hostPort == net.JoinHostPort("loki.d8-monitoring.", endpoint.port) ||
+		hostPort == net.JoinHostPort(fmt.Sprintf("loki.d8-monitoring.svc.%s", clusterDomain), endpoint.port) ||
+		hostPort == net.JoinHostPort(fmt.Sprintf("loki.d8-monitoring.svc.%s.", clusterDomain), endpoint.port) {
+		return true
+	}
+
+	for _, address := range endpoint.addresses {
+		if net.JoinHostPort(address, endpoint.port) == hostPort {
+			return true
+		}
+	}
+
+	return false
 }

--- a/modules/460-log-shipper/hooks/handle_cluster_log_destination_d8_loki.go
+++ b/modules/460-log-shipper/hooks/handle_cluster_log_destination_d8_loki.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"net/url"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"github.com/pkg/errors"
+
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
+)
+
+const (
+	lokiAuthorizationRequiredGroup      = "loki_authorization_required"
+	lokiAuthorizationRequiredMetricName = "d8_log_shipper_cluster_log_destination_d8_loki_authorization_required"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/log-shipper/cluster_log_destination_d8_loki",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "cluster_log_destination",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ClusterLogDestination",
+			FilterFunc: filterClusterLogDestination,
+		},
+		{
+			Name:       "loki_endpoint",
+			ApiVersion: "v1",
+			Kind:       "Endpoints",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{
+					"d8-monitoring",
+				}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"loki",
+			}},
+			FilterFunc: filterLokiEndpoints,
+		},
+	},
+}, handleClusterLogDestinationD8Loki)
+
+func handleClusterLogDestinationD8Loki(input *go_hook.HookInput) error {
+	destinationSnapshots := input.Snapshots["cluster_log_destination"]
+	lokiEndpointSnap := input.Snapshots["loki_endpoint"]
+
+	var lokiEndpoint endpoint
+
+	if len(lokiEndpointSnap) > 0 {
+		lokiEndpoint = lokiEndpointSnap[0].(endpoint)
+	}
+
+	clusterDomain := input.Values.Get("global.discovery.clusterDomain").String()
+
+	input.MetricsCollector.Expire(lokiAuthorizationRequiredGroup)
+
+	for _, destinationSnapshot := range destinationSnapshots {
+		destination := destinationSnapshot.(v1alpha1.ClusterLogDestination)
+
+		if destination.Name == "d8-loki" {
+			continue
+		}
+
+		if destination.Spec.Type != v1alpha1.DestLoki {
+			continue
+		}
+
+		endpointURL, err := url.Parse(destination.Spec.Loki.Endpoint)
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse loki endpoint '%s'", destination.Spec.Loki.Endpoint)
+		}
+
+		if !matchLokiEndpoint(endpointURL.Host, clusterDomain, lokiEndpoint) {
+			continue
+		}
+
+		if endpointURL.Scheme == "https" &&
+			destination.Spec.Loki.Auth.Strategy == "Bearer" &&
+			destination.Spec.Loki.Auth.Token != "" {
+			continue
+		}
+
+		input.MetricsCollector.Set(lokiAuthorizationRequiredMetricName, 1, map[string]string{"resource_name": destination.Name}, metrics.WithGroup(lokiAuthorizationRequiredGroup))
+	}
+
+	return nil
+}

--- a/modules/460-log-shipper/hooks/internal/composer/composer.go
+++ b/modules/460-log-shipper/hooks/internal/composer/composer.go
@@ -32,18 +32,16 @@ type Composer struct {
 	Dest   []v1alpha1.ClusterLogDestination
 }
 
-func FromInput(input *go_hook.HookInput) *Composer {
+func FromInput(input *go_hook.HookInput, destinations []v1alpha1.ClusterLogDestination) *Composer {
 	sourceSnap := input.Snapshots["cluster_log_source"]
 	namespacedSourceSnap := input.Snapshots["namespaced_log_source"]
-	destSnap := input.Snapshots["cluster_log_destination"]
 
 	res := &Composer{
 		Source: make([]v1alpha1.ClusterLoggingConfig, 0, len(sourceSnap)+len(namespacedSourceSnap)),
-		Dest:   make([]v1alpha1.ClusterLogDestination, 0, len(destSnap)),
+		Dest:   make([]v1alpha1.ClusterLogDestination, 0, len(destinations)),
 	}
 
-	for _, d := range destSnap {
-		dest := d.(v1alpha1.ClusterLogDestination)
+	for _, dest := range destinations {
 		res.Dest = append(res.Dest, dest)
 		customResourceMetric(input, "ClusterLogDestination", dest.Name, dest.Namespace, dest.Spec.Type)
 	}

--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -34,7 +34,7 @@ type Kafka struct {
 
 	Compression string `json:"compression,omitempty"`
 
-	TLS CommonTLS `json:"tls,omitempty"`
+	TLS CommonTLS `json:"tls"`
 
 	SASL KafkaSASL `json:"sasl,omitempty"`
 }

--- a/modules/460-log-shipper/hooks/internal/vector/destination/logstash.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/logstash.go
@@ -30,7 +30,7 @@ type Logstash struct {
 
 	Mode string `json:"mode"`
 
-	TLS CommonTLS `json:"tls,omitempty"`
+	TLS CommonTLS `json:"tls"`
 
 	Keepalive LogstashKeepalive `json:"keepalive,omitempty"`
 }

--- a/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
@@ -39,7 +39,7 @@ type Loki struct {
 
 	Auth LokiAuth `json:"auth,omitempty"`
 
-	TLS CommonTLS `json:"tls,omitempty"`
+	TLS CommonTLS `json:"tls"`
 
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/modules/460-log-shipper/hooks/internal/vector/destination/vector.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/vector.go
@@ -28,7 +28,7 @@ type Vector struct {
 
 	Address string `json:"address"`
 
-	TLS CommonTLS `json:"tls,omitempty"`
+	TLS CommonTLS `json:"tls"`
 
 	Keepalive VectorKeepalive `json:"keepalive,omitempty"`
 }

--- a/modules/460-log-shipper/hooks/testdata/file-to-vector/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-vector/result.json
@@ -43,7 +43,11 @@
         "enabled": false
       },
       "version": "2",
-      "address": "192.168.1.1:9200"
+      "address": "192.168.1.1:9200",
+      "tls": {
+        "verify_certificate": false,
+        "verify_hostname": false
+      }
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/many-to-one/result.json
+++ b/modules/460-log-shipper/hooks/testdata/many-to-one/result.json
@@ -89,7 +89,11 @@
         "enabled": false
       },
       "version": "2",
-      "address": "192.168.1.1:9200"
+      "address": "192.168.1.1:9200",
+      "tls": {
+        "verify_certificate": false,
+        "verify_hostname": false
+      }
     }
   }
 }

--- a/modules/460-log-shipper/monitoring/prometheus-rules/warnings.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/warnings.yaml
@@ -1,0 +1,16 @@
+- name: d8.log-shipper.warnings
+  rules:
+    - alert: D8LogShipperClusterLogDestinationD8LokiAuthorizationRequired
+      expr: |
+        max by (resource_name) (d8_log_shipper_cluster_log_destination_d8_loki_authorization_required) == 1
+      for: 5m
+      labels:
+        severity_level: "9"
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: markdown
+        description: |-
+          Found ClusterLogDestination resource {{$labels.resource_name}} without authorization params.
+          You should [add](https://deckhouse.io/documentation/v1/modules/460-log-shipper/faq.html#how-to-add-authorization-params-to-the-cluster-log-destination-resource-which-is-used-to-send-logs-to-the-d8-loki) authorization params to the ClusterLogDestination resource.
+        summary: >
+          Required authorization params for ClusterLogDestination.

--- a/modules/460-log-shipper/templates/log-shipper-token.yaml
+++ b/modules/460-log-shipper/templates/log-shipper-token.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: log-shipper-token
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "log-shipper")) | nindent 2 }}
+  annotations:
+    kubernetes.io/service-account.name: log-shipper
+type: kubernetes.io/service-account-token

--- a/modules/462-loki/hooks/tokens.go
+++ b/modules/462-loki/hooks/tokens.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/loki/tokens",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "grafana_token",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{
+					"d8-monitoring",
+				}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"prometheus-token",
+			}},
+			FilterFunc: filterTokenSecret,
+		},
+		{
+			Name:       "log_shipper_token",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{
+					"d8-log-shipper",
+				}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"log-shipper-token",
+			}},
+			FilterFunc: filterTokenSecret,
+		},
+	},
+}, handleTokens)
+
+func filterTokenSecret(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := new(corev1.Secret)
+
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return string(secret.Data["token"]), nil
+}
+
+func handleTokens(input *go_hook.HookInput) error {
+	grafanaTokenSnapshots := input.Snapshots["grafana_token"]
+
+	if len(grafanaTokenSnapshots) > 0 {
+		input.Values.Set("loki.internal.grafanaToken", grafanaTokenSnapshots[0].(string))
+	}
+
+	logShipperTokenSnapshots := input.Snapshots["log_shipper_token"]
+
+	if len(logShipperTokenSnapshots) > 0 {
+		input.Values.Set("loki.internal.logShipperToken", logShipperTokenSnapshots[0].(string))
+	}
+
+	return nil
+}

--- a/modules/462-loki/openapi/values.yaml
+++ b/modules/462-loki/openapi/values.yaml
@@ -16,3 +16,9 @@ properties:
           - type: string
           - type: boolean
             enum: [false]
+      grafanaToken:
+        type: string
+        default: ""
+      logShipperToken:
+        type: string
+        default: ""

--- a/modules/462-loki/templates/configmap.yaml
+++ b/modules/462-loki/templates/configmap.yaml
@@ -10,7 +10,8 @@ data:
     auth_enabled: false
 
     server:
-      http_listen_port: 3100
+      http_listen_address: 127.0.0.1
+      http_listen_port: 3101
 
     limits_config:
       retention_period: {{ .Values.loki.retentionPeriodHours | default 168 }}h

--- a/modules/462-loki/templates/grafana-datasource.yaml
+++ b/modules/462-loki/templates/grafana-datasource.yaml
@@ -8,9 +8,13 @@ metadata:
 spec:
   type: loki
   access: proxy
-  url: "http://loki.d8-monitoring:3100"
+  url: "https://loki.d8-monitoring:3100"
   basicAuth: false
   jsonData:
     timeInterval: 30s
     maxLines: 5000
+    tlsSkipVerify: true
+    httpHeaderName1: 'Authorization'
+  secureJsonData:
+    httpHeaderValue1: 'Bearer {{ .Values.loki.internal.grafanaToken }}'
 {{- end }}

--- a/modules/462-loki/templates/logshipper-log-destination.yaml
+++ b/modules/462-loki/templates/logshipper-log-destination.yaml
@@ -7,7 +7,13 @@ metadata:
 spec:
   type: Loki
   loki:
-    endpoint: "http://loki.d8-monitoring:3100"
+    endpoint: "https://loki.d8-monitoring:3100"
+    auth:
+      strategy: "Bearer"
+      token: {{ .Values.loki.internal.logShipperToken | quote }}
+    tls:
+      verifyHostname: false
+      verifyCertificate: false
 {{- if .Values.loki.storeSystemLogs }}
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/modules/462-loki/templates/rbac-for-us.yaml
+++ b/modules/462-loki/templates/rbac-for-us.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:{{ .Chart.Name }}:rbac-proxy
+  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}
+    namespace: d8-monitoring

--- a/modules/462-loki/templates/rbac-to-us.yaml
+++ b/modules/462-loki/templates/rbac-to-us.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-loki-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+  - apiGroups: ["apps"]
+    resources:
+      - "statefulsets/prometheus-metrics"
+    resourceNames: ["loki"]
+    verbs: ["get"]
+{{- if (.Values.global.enabledModules | has "prometheus") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-loki-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-loki-metrics
+subjects:
+  - kind: User
+    name: d8-monitoring:scraper
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: d8-monitoring
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-loki-from-http
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+  - apiGroups: ["apps"]
+    resources:
+      - "statefulsets/http"
+    resourceNames: ["loki"]
+    verbs: ["get"]
+{{- if (.Values.global.enabledModules | has "prometheus") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-loki-from-http
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-loki-from-http
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: d8-monitoring
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-loki-from-http-create
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+  - apiGroups: ["apps"]
+    resources:
+      - "statefulsets/http-create"
+    resourceNames: ["loki"]
+    verbs: ["create"]
+{{- if (.Values.global.enabledModules | has "log-shipper") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-loki-from-http-create
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-loki-from-http-create
+subjects:
+  - kind: ServiceAccount
+    name: log-shipper
+    namespace: d8-log-shipper
+{{- end }}

--- a/modules/462-loki/templates/servicemonitor.yaml
+++ b/modules/462-loki/templates/servicemonitor.yaml
@@ -10,8 +10,13 @@ spec:
   sampleLimit: 10000
   endpoints:
   - port: loki
-    scheme: http
+    scheme: https
     path: /metrics
+    tlsConfig:
+      insecureSkipVerify: true
+    bearerTokenSecret:
+      name: "prometheus-token"
+      key: "token"
   selector:
     matchLabels:
       app: loki

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -7,7 +7,10 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
 spec:
-  {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "StatefulSet" .Chart.Name "loki" .Values.loki.resourcesManagement ) | nindent 2}}
+  {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "StatefulSet" .Chart.Name "loki" .Values.loki.resourcesManagement ) | nindent 2 }}
+  {{- if eq (.Values.loki.resourcesManagement.mode) "VPA" }}
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+  {{- end }}
 {{- end }}
 ---
 apiVersion: apps/v1
@@ -31,6 +34,7 @@ spec:
     spec:
       imagePullSecrets:
       - name: deckhouse-registry
+      serviceAccountName: {{ .Chart.Name }}
       terminationGracePeriodSeconds: 4800
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
@@ -66,22 +70,96 @@ spec:
             mountPath: /loki
           - name: tmp
             mountPath: /tmp
-        ports:
-          - name: http-metrics
-            containerPort: 3100
-            protocol: TCP
         livenessProbe:
           httpGet:
             path: /ready
-            port: http-metrics
+            port: 3100
+            scheme: HTTPS
           initialDelaySeconds: 45
         readinessProbe:
           httpGet:
             path: /ready
-            port: http-metrics
+            port: 3100
+            scheme: HTTPS
           initialDelaySeconds: 45
         resources:
           {{ include "helm_lib_resources_management_pod_resources" (list $.Values.loki.resourcesManagement) | nindent 10 }}
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+        args:
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):3100"
+          - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+          - "--v=2"
+          - "--logtostderr=true"
+          - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
+        env:
+          - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: KUBE_RBAC_PROXY_CONFIG
+            value: |
+              excludePaths:
+              - /ready
+              upstreams:
+              - upstream: http://127.0.0.1:3101/metrics
+                path: /metrics
+                authorization:
+                  resourceAttributes:
+                    namespace: d8-monitoring
+                    apiGroup: apps
+                    apiVersion: v1
+                    resource: statefulsets
+                    subresource: prometheus-metrics
+                    name: loki
+              - upstream: http://127.0.0.1:3101/
+                path: /
+                authorization:
+                  resourceAttributes:
+                    namespace: d8-monitoring
+                    apiGroup: apps
+                    apiVersion: v1
+                    resource: statefulsets
+                    subresource: http
+                    name: loki
+              - upstream: http://127.0.0.1:3101/loki/api/v1/push
+                path: /loki/api/v1/push
+                authorization:
+                  resourceAttributes:
+                    namespace: d8-monitoring
+                    apiGroup: apps
+                    apiVersion: v1
+                    resource: statefulsets
+                    subresource: http-create
+                    name: loki
+              - upstream: http://127.0.0.1:3101/loki/api/v1/delete
+                path: /-/protected-endpoint-404
+        ports:
+          - containerPort: 3100
+            name: https-metrics
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3100
+            scheme: HTTPS
+          initialDelaySeconds: 45
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 3100
+            scheme: HTTPS
+          initialDelaySeconds: 45
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+  {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+  {{- end }}
+        volumeMounts:
+          - name: kube-rbac-proxy-ca
+            mountPath: /etc/kube-rbac-proxy
       volumes:
       - name: config
         configMap:
@@ -89,6 +167,10 @@ spec:
           defaultMode: 0644
       - name: tmp
         emptyDir: {}
+      - name: kube-rbac-proxy-ca
+        configMap:
+          defaultMode: 420
+          name: kube-rbac-proxy-ca.crt
 {{- $storageClass := .Values.loki.internal.effectiveStorageClass }}
 {{- if $storageClass }}
   volumeClaimTemplates:

--- a/testing/matrix/linter/rules/roles/binding-subject.go
+++ b/testing/matrix/linter/rules/roles/binding-subject.go
@@ -65,6 +65,16 @@ func ObjectBindingSubjectServiceAccountCheck(m utils.Module, object storage.Stor
 			continue
 		}
 
+		// Grafana service account has binding in loki module.
+		if m.Name == "loki" && subject.Name == "grafana" && subject.Namespace == "d8-monitoring" {
+			continue
+		}
+
+		// Log-shipper service account has binding in loki module.
+		if m.Name == "loki" && subject.Name == "log-shipper" && subject.Namespace == "d8-log-shipper" {
+			continue
+		}
+
 		if subject.Namespace == m.Namespace && !objectStore.Exists(storage.ResourceIndex{
 			Name: subject.Name, Kind: subject.Kind, Namespace: subject.Namespace,
 		}) {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add `kube-rbac-proxy` to prevent access to `Loki` from unauthorized clients.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to limit access to `Loki`.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: feature
summary: Add kube-rbac-proxy to prevent access to Loki from unauthorized clients.
impact: Loki and Grafana will restart.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
