### PR TITLE
[prometheus] add metrics and alert for deprecated scrape config method

### DIFF
--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true")) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -808,6 +808,8 @@ kind: ScrapeConfig
 metadata:
   name: example-scrape-config
   namespace: example-ns
+  labels:
+    additional-configs-for-prometheus: main
 spec:
   honorLabels: true
   staticConfigs:

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -800,7 +800,7 @@ status:
 
 Remember the special alert `DeadMansSwitch` — its presence in the cluster indicates that Prometheus is working.
 
-## How to add additional endpoints to scrape config. New way with CRD
+## How do I add additional endpoints to a scrape config?
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1alpha1

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -802,18 +802,34 @@ Remember the special alert `DeadMansSwitch` — its presence in the cluster indi
 
 ## How do I add additional endpoints to a scrape config?
 
+Add the label `prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"` to the namespace where the ScrapeConfig was created.
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"
+```
+
+Add the ScrapeConfig with the required label `prometheus: main`:
+
 ```yaml
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: example-scrape-config
-  namespace: d8-monitoring
+  namespace: frontend
   labels:
-    additional-configs-for-prometheus: main
+    prometheus: main
 spec:
   honorLabels: true
   staticConfigs:
-    - targets: ['example-app.example-ns.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
+    - targets: ['example-app.frontend.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
   relabelings:
     - regex: endpoint|namespace|pod|service
       action: labeldrop

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -807,7 +807,7 @@ apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: example-scrape-config
-  namespace: example-ns
+  namespace: d8-monitoring
   labels:
     additional-configs-for-prometheus: main
 spec:

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -799,3 +799,25 @@ status:
 ```
 
 Remember the special alert `DeadMansSwitch` — its presence in the cluster indicates that Prometheus is working.
+
+## How to add additional endpoints to scrape config. New way with CRD
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: example-scrape-config
+  namespace: example-ns
+spec:
+  honorLabels: true
+  staticConfigs:
+    - targets: ['example-app.example-ns.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
+  relabelings:
+    - regex: endpoint|namespace|pod|service
+      action: labeldrop
+    - targetLabel: scrape_endpoint
+      replacement: main
+    - targetLabel: job
+      replacement: kube-state-metrics
+  metricsPath: '/metrics'
+```

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -805,6 +805,8 @@ kind: ScrapeConfig
 metadata:
   name: example-scrape-config
   namespace: example-ns
+  labels:
+    additional-configs-for-prometheus: main
 spec:
   honorLabels: true
   staticConfigs:

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -797,7 +797,7 @@ status:
 
 Помните о специальном алерте `DeadMansSwitch` — его присутствие в кластере говорит о работоспособности Prometheus.
 
-## Как добавить дополнительные эндпойнты в scrape config
+## Как добавить дополнительные эндпойнты в scrape config?
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1alpha1

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -799,18 +799,34 @@ status:
 
 ## Как добавить дополнительные эндпоинты в scrape config?
 
+Добавьте в namespace, в котором находится ScrapeConfig, лейбл `prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"`.
+
+Пример:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"
+```
+
+Добавьте ScrapeConfig, который имеет обязательный лейбл `prometheus: main`:
+
 ```yaml
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: example-scrape-config
-  namespace: d8-monitoring
+  namespace: frontend
   labels:
-    additional-configs-for-prometheus: main
+    prometheus: main
 spec:
   honorLabels: true
   staticConfigs:
-    - targets: ['example-app.example-ns.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
+    - targets: ['example-app.frontend.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
   relabelings:
     - regex: endpoint|namespace|pod|service
       action: labeldrop

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -804,7 +804,7 @@ apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
   name: example-scrape-config
-  namespace: example-ns
+  namespace: d8-monitoring
   labels:
     additional-configs-for-prometheus: main
 spec:

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -796,3 +796,25 @@ status:
 ```
 
 Помните о специальном алерте `DeadMansSwitch` — его присутствие в кластере говорит о работоспособности Prometheus.
+
+## Как добавить дополнительные эндпойнты в scrape config
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: example-scrape-config
+  namespace: example-ns
+spec:
+  honorLabels: true
+  staticConfigs:
+    - targets: ['example-app.example-ns.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
+  relabelings:
+    - regex: endpoint|namespace|pod|service
+      action: labeldrop
+    - targetLabel: scrape_endpoint
+      replacement: main
+    - targetLabel: job
+      replacement: kube-state-metrics
+  metricsPath: '/metrics'
+```

--- a/modules/300-prometheus/hooks/additional_configs_render.go
+++ b/modules/300-prometheus/hooks/additional_configs_render.go
@@ -78,6 +78,9 @@ func handleConfigRender(input *go_hook.HookInput) error {
 		}
 
 		if v, ok := data["scrapes.yaml"]; ok {
+			if len(scrapes.Bytes()) > 0 {
+				input.MetricsCollector.Set("d8_deprecated_scrape_config", 1, nil)
+			}
 			scrapes.Write(v)
 			scrapes.WriteString("\n")
 		}

--- a/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
@@ -33,7 +33,7 @@
     - alert: PrometheusScapeConfigDeclarationDeprecated
       expr: count(d8_deprecated_scrape_config) > 0
       labels:
-        severity_level: "4"
+        severity_level: "8"
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"

--- a/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
@@ -41,5 +41,5 @@
         summary: |-
           AdditionalScrapeConfigs from secrets will be deprecated in soon
         description: |-
-          Old way for describing additional scrape config via secrets will be deprecated soon. Please use CRD instead.
+          Old way for describing additional scrape config via secrets will be deprecated in prometheus-operator > v0.65.1. Please use CRD instead.
           ```https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202212-scrape-config.md```

--- a/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
@@ -30,3 +30,16 @@
           __meta_kubernetes_endpoint_address_target_kind -> __meta_kubernetes_endpointslice_address_target_kind
           __meta_kubernetes_endpoint_address_target_name -> __meta_kubernetes_endpointslice_address_target_name
           ```
+    - alert: PrometheusScapeConfigDeclarationDeprecated
+      expr: count(d8_deprecated_scrape_config) > 0
+      labels:
+        severity_level: "4"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_ignore_labels: "name"
+        summary: |-
+          AdditionalScrapeConfigs from secrets will be deprecated in soon
+        description: |-
+          Old way for describing additional scrape config via secrets will be deprecated soon. Please use CRD instead.
+          ```https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202212-scrape-config.md```

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -65,8 +65,10 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  scrapeConfigNamespaceSelector: {}
-  scrapeConfigSelector: {}
+  scrapeConfigNamespaceSelector: null
+  scrapeConfigSelector:
+    matchLabels:
+      additional-configs-for-prometheus: main
   initContainers:
   - command:
     - sh

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -65,12 +65,6 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  scrapeConfigNamespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: d8-monitoring
-  scrapeConfigSelector:
-    matchLabels:
-      additional-configs-for-prometheus: main
   initContainers:
   - command:
     - sh
@@ -173,6 +167,9 @@ spec:
   ruleNamespaceSelector:
     matchLabels:
       prometheus.deckhouse.io/rules-watcher-enabled: "true"
+  scrapeConfigNamespaceSelector:
+    matchLabels:
+      prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"
   probeNamespaceSelector:
     matchLabels:
       heritage: deckhouse
@@ -189,6 +186,9 @@ spec:
     matchLabels:
       prometheus: main
   probeSelector:
+    matchLabels:
+      prometheus: main
+  scrapeConfigSelector:
     matchLabels:
       prometheus: main
   secrets:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -65,6 +65,8 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
+  scrapeConfigNamespaceSelector: {}
+  scrapeConfigSelector: {}
   initContainers:
   - command:
     - sh

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -65,7 +65,9 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  scrapeConfigNamespaceSelector: null
+  scrapeConfigNamespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: d8-monitoring
   scrapeConfigSelector:
     matchLabels:
       additional-configs-for-prometheus: main

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
@@ -4,7 +4,7 @@ kind: ScrapeConfig
 metadata:
   name: kube-state-metrics-main
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "prometheus" "main")) | nindent 2 }}
 spec:
   honorLabels: true
   authorization:
@@ -30,7 +30,7 @@ kind: ScrapeConfig
 metadata:
   name: kube-state-metrics-self
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "prometheus" "main")) | nindent 2 }}
 spec:
   honorLabels: true
   authorization:

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
@@ -7,6 +7,13 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
 spec:
   honorLabels: true
+  authorization:
+    credentials:
+      key: token
+      name: prometheus-token
+  scheme: HTTPS
+  tlsConfig:
+    insecureSkipVerify: true
   staticConfigs:
     - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
   relabelings:
@@ -26,6 +33,13 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
 spec:
   honorLabels: true
+  authorization:
+    credentials:
+      key: token
+      name: prometheus-token
+  scheme: HTTPS
+  tlsConfig:
+    insecureSkipVerify: true
   staticConfigs:
     - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
   relabelings:

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
@@ -1,49 +1,38 @@
-{{/* We have to define static targets for `kube-state-metrics` against of using ServiceMonitor. */}}
-{{/* Because it exports a lot of samples and we don't want to scrape all its Pods. */}}
-{{- define "additional-scrape-config" }}
-- job_name: kube-state-metrics/main
-  honor_labels: true
-  metrics_path: '/main/metrics'
-  scheme: https
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  scrape_timeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 20) }}
-  tls_config:
-    insecure_skip_verify: true
-  static_configs:
-  - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
-  relabel_configs:
-  - regex: endpoint|namespace|pod|service
-    action: labeldrop
-  - target_label: scrape_endpoint
-    replacement: main
-  - target_label: job
-    replacement: kube-state-metrics
-
-- job_name: kube-state-metrics/self
-  honor_labels: true
-  metrics_path: '/self/metrics'
-  scheme: https
-  tls_config:
-    insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  scrape_timeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 20) }}
-  static_configs:
-  - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
-  relabel_configs:
-  - regex: endpoint|namespace|pod|service
-    action: labeldrop
-  - target_label: scrape_endpoint
-    replacement: self
-  - target_label: job
-    replacement: kube-state-metrics
-{{- end }}
 ---
-apiVersion: v1
-kind: Secret
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
 metadata:
-  name: prometheus-main-additional-configs-kube-state-metrics
+  name: kube-state-metrics/main
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
-data:
-  scrapes.yaml: |
-    {{ include "additional-scrape-config" . | b64enc }}
+spec:
+  honorLabels: true
+  staticConfigs:
+    - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
+  relabelings:
+    - regex: endpoint|namespace|pod|service
+      action: labeldrop
+    - target_label: scrape_endpoint
+      replacement: main
+    - target_label: job
+      replacement: kube-state-metrics
+  metricsPath: '/main/metrics'
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kube-state-metrics/self
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
+spec:
+  honorLabels: true
+  staticConfigs:
+    - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
+  relabelings:
+    - regex: endpoint|namespace|pod|service
+      action: labeldrop
+    - target_label: scrape_endpoint
+      replacement: main
+    - target_label: job
+      replacement: kube-state-metrics
+  metricsPath: '/self/metrics'

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
@@ -12,9 +12,9 @@ spec:
   relabelings:
     - regex: endpoint|namespace|pod|service
       action: labeldrop
-    - target_label: scrape_endpoint
+    - targetLabel: scrape_endpoint
       replacement: main
-    - target_label: job
+    - targetLabel: job
       replacement: kube-state-metrics
   metricsPath: '/main/metrics'
 ---
@@ -31,8 +31,8 @@ spec:
   relabelings:
     - regex: endpoint|namespace|pod|service
       action: labeldrop
-    - target_label: scrape_endpoint
+    - targetLabel: scrape_endpoint
       replacement: main
-    - target_label: job
+    - targetLabel: job
       replacement: kube-state-metrics
   metricsPath: '/self/metrics'

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
-  name: kube-state-metrics/main
+  name: kube-state-metrics-main
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
 spec:
@@ -21,7 +21,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
-  name: kube-state-metrics/self
+  name: kube-state-metrics-self
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics" "additional-configs-for-prometheus" "main")) | nindent 2 }}
 spec:


### PR DESCRIPTION
## Description
The old way to add custom endpoints to additional scrape config for Prometheus in secrets will be deprecated soon.
The new way is to use ScrapeConfig custom resourse.

## Why do we need it, and what problem does it solve?
This change solves issue #6787 and allows scrape endpoint addition after deprecation.

## What is the expected result?
Metrics still be available, but the describing method was changed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Additional scrape config format was changed from secret to custom resource.

```changes
section: prometheus
type: chore
summary: The additional scrape config format was changed from secret to custom resource.
impact_level: low
```
