### PR TITLE
[istio] Add a metric showing istio and k8s compatibility, and an alert for it

### DIFF
--- a/modules/110-istio/hooks/compatibility_version_istio_k8s_monitoring.go
+++ b/modules/110-istio/hooks/compatibility_version_istio_k8s_monitoring.go
@@ -30,12 +30,12 @@ import (
 )
 
 var (
-	monitoringMetricsGroup = "monitoring"
+	monitoringMetricsGroup = "k8s_version_compatibility"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue:        lib.Queue(monitoringMetricsGroup),
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        lib.Queue("monitoring"),
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10}, // The hook relies on operatorVersionsToInstall value discovered in discovery_operator_versions_to_install.go before.
 }, versionCompatibilityMonitoringHook)
 
 func versionCompatibilityMonitoringHook(input *go_hook.HookInput) error {

--- a/modules/110-istio/hooks/compatibility_version_istio_k8s_monitoring.go
+++ b/modules/110-istio/hooks/compatibility_version_istio_k8s_monitoring.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/telemetry"
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+var (
+	monitoringMetricsGroup = "monitoring"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:        lib.Queue(monitoringMetricsGroup),
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+}, versionCompatibilityMonitoringHook)
+
+func versionCompatibilityMonitoringHook(input *go_hook.HookInput) error {
+	if !input.Values.Get("istio.internal.operatorVersionsToInstall").Exists() {
+		return nil
+	}
+	if !input.Values.Get("global.discovery.kubernetesVersion").Exists() {
+		return nil
+	}
+	if !input.Values.Get("istio.internal.istioToK8sCompatibilityMap").Exists() {
+		return nil
+	}
+	compatibilityMap := make(map[string][]string)
+
+	// Major.Minor
+	istioVersions := input.Values.Get("istio.internal.operatorVersionsToInstall").Array()
+	// Major.Minor.Patch
+	k8sVersion := input.Values.Get("global.discovery.kubernetesVersion").String()
+	k8sVersionSemver, err := semver.NewVersion(k8sVersion)
+	if err != nil {
+		return nil
+	}
+	k8sVersionMajorMinor := fmt.Sprintf("%d.%d", k8sVersionSemver.Major(), k8sVersionSemver.Minor())
+	compatibilityMapStr := input.Values.Get("istio.internal.istioToK8sCompatibilityMap").String()
+	_ = json.Unmarshal([]byte(compatibilityMapStr), &compatibilityMap)
+
+	input.MetricsCollector.Expire(monitoringMetricsGroup)
+
+OUTER:
+	for _, istioVersion := range istioVersions {
+		for _, k8sCompVersion := range compatibilityMap[istioVersion.String()] {
+			if k8sVersionMajorMinor == k8sCompVersion {
+				continue OUTER
+			}
+		}
+		labels := map[string]string{
+			"k8s_version":   k8sVersion,
+			"istio_version": istioVersion.String(),
+		}
+		input.MetricsCollector.Set(telemetry.WrapName("istio_version_incompatible_with_k8s_version"), 1.0, labels, metrics.WithGroup(monitoringMetricsGroup))
+	}
+
+	return nil
+}

--- a/modules/110-istio/hooks/compatibility_version_istio_k8s_monitoring_test.go
+++ b/modules/110-istio/hooks/compatibility_version_istio_k8s_monitoring_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/shell-operator/pkg/metric_storage/operation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Istio hooks :: check_istio_k8s_version_compatibility ::", func() {
+	initValues := `
+istio:
+  internal:
+    istioToK8sCompatibilityMap:
+      "1.13": ["1.20", "1.21", "1.22", "1.23"]
+      "1.16": ["1.22", "1.23", "1.24", "1.25"]
+      "1.19": ["1.25", "1.26", "1.27", "1.28"]
+`
+	f := HookExecutionConfigInit(initValues, "")
+
+	Context("Empty cluster and minimal settings", func() {
+		BeforeEach(func() {
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(0))
+
+		})
+	})
+
+	Context("Unknown version of istio", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.12", "1.16"]`))
+			f.ValuesSet("global.discovery.kubernetesVersion", "1.25.4")
+
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully and generate metric", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  monitoringMetricsGroup,
+				Action: "expire",
+			}))
+			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_telemetry_istio_version_incompatible_with_k8s_version",
+				Group:  monitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"istio_version": "1.12",
+					"k8s_version":   "1.25.4",
+				},
+			}))
+		})
+	})
+
+	Context("istio version known, but incompatible with current k8s version", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.16","1.19"]`))
+			f.ValuesSet("global.discovery.kubernetesVersion", "1.28.4")
+
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully and generate metric", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  monitoringMetricsGroup,
+				Action: "expire",
+			}))
+			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_telemetry_istio_version_incompatible_with_k8s_version",
+				Group:  monitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64(1.0),
+				Labels: map[string]string{
+					"istio_version": "1.16",
+					"k8s_version":   "1.28.4",
+				},
+			}))
+		})
+	})
+
+	Context(" the istio version is known, and it is compatible with the current version of k8s", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.16","1.19"]`))
+			f.ValuesSet("global.discovery.kubernetesVersion", "1.25.4")
+
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully and generate metric", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.LogrusOutput.Contents()).To(HaveLen(0))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  monitoringMetricsGroup,
+				Action: "expire",
+			}))
+		})
+	})
+})

--- a/modules/110-istio/hooks/deprecated_versions_monitoring.go
+++ b/modules/110-istio/hooks/deprecated_versions_monitoring.go
@@ -29,7 +29,7 @@ var (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue:        lib.Queue(versionsMonitoringMetricsGroup),
+	Queue:        lib.Queue("monitoring"),
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 }, versionMonitoringHook)
 

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -16,3 +16,21 @@
       labels:
         severity_level: "{{"{{$labels.alert_severity}}"}}"
         tier: cluster
+- name: d8.istio.k8sVersionsCompatibility
+  rules:
+    - alert: D8IstioVersionIsIncompatibleWithK8sVersion
+      annotations:
+        description: |
+          The current istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current k8s version `{{"{{$labels.k8s_version}}"}}`, because it officially  unsupported.
+          Please upgrade istio as soon as possible.
+          Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+        plk_markup_format: markdown
+        plk_labels_as_annotations: pod,instance
+        plk_protocol_version: "1"
+        summary: The installed istio version is incompatible with the k8s version
+      expr: |
+        d8_telemetry_istio_version_incompatible_with_k8s_version{}
+      for: 5m
+      labels:
+        severity_level: "3"
+        tier: cluster

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -21,7 +21,7 @@
     - alert: D8IstioVersionIsIncompatibleWithK8sVersion
       annotations:
         description: |
-          The current istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current k8s version `{{"{{$labels.k8s_version}}"}}`, because it officially  unsupported.
+          The current istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current k8s version `{{"{{$labels.k8s_version}}"}}`, because it is unsupported officially.
           Please upgrade istio as soon as possible.
           Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
         plk_markup_format: markdown


### PR DESCRIPTION
## Description

Add a metric showing istio and k8s compatibility, and an alert for it

## Why do we need it, and what problem does it solve?

If the istio version and the k8s version are not officially compatible or supported, they may not function correctly together.

## Why do we need it in the patch release (if we do)?

We removed this check previously to revise it (https://github.com/deckhouse/deckhouse/pull/6914).

## What is the expected result?

If k8s and istio versions aren't compatible, we get alert of that

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Adding alert about istio and k8s versions incompatibility
impact_level: default
```
