### PR TITLE
[prometheus] Support setting custom CA for remote_write

### DIFF
--- a/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
@@ -63,6 +63,8 @@ spec:
                   properties:
                     insecureSkipVerify:
                       description: Отключить проверку сертификата.
+                    ca:
+                      description: СA cертификат для проверки сертификата API сервера.
       additionalPrinterColumns: &additionalPrinterColumns
         - name: URL
           type: string

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -109,6 +109,10 @@ spec:
                       description: Disable target certificate validation.
                       type: boolean
                       x-doc-default: false
+                    ca:
+                      description: CA certificate to validate API server certificate with.
+                      type: string
+                      x-doc-default: ""
       additionalPrinterColumns: &additionalPrinterColumns
         - name: URL
           type: string

--- a/modules/300-prometheus/openapi/values.yaml
+++ b/modules/300-prometheus/openapi/values.yaml
@@ -265,6 +265,8 @@ properties:
                   properties:
                     insecureSkipVerify:
                       type: boolean
+                    ca:
+                      type: string
         default: []
         x-examples:
           -

--- a/modules/300-prometheus/template_tests/prometheus_cr_test.go
+++ b/modules/300-prometheus/template_tests/prometheus_cr_test.go
@@ -88,6 +88,11 @@ internal:
     spec:
       url: https://test-remote-write-bearer-token.domain.com/api/v1/write
       bearerToken: xxx
+  - name: test-remote-write-custom-ca
+    spec:
+      url: https://test-remote-write-custom-ca.domain.com/api/v1/write
+      tlsConfig:
+        ca: CRTCRTCRT
   vpa:
     longtermMaxCPU: 2933m
     longtermMaxMemory: 2200Mi
@@ -123,11 +128,21 @@ scrapeInterval: 30s
       key: password
 - url: https://test-remote-write-bearer-token.domain.com/api/v1/write
   bearerToken: xxx
+- url: https://test-remote-write-custom-ca.domain.com/api/v1/write
+  tlsConfig:
+    ca:
+      configMap:
+        key: ca.crt
+        name: d8-prometheus-remote-write-ca-test-remote-write-custom-ca
 `))
 			rwSecret := f.KubernetesResource("Secret", "d8-monitoring", "d8-prometheus-remote-write-test-remote-write-basic-auth")
 			Expect(rwSecret.Exists()).To(BeTrue())
 			Expect(rwSecret.Field("data.username").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("user"))))
 			Expect(rwSecret.Field("data.password").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("pass"))))
+
+			rwCAConfigMap := f.KubernetesResource("ConfigMap", "d8-monitoring", "d8-prometheus-remote-write-ca-test-remote-write-custom-ca")
+			Expect(rwCAConfigMap.Exists()).To(BeTrue())
+			Expect(rwCAConfigMap.Field("ca.crt").String()).To(Equal("CRTCRTCRT"))
 		})
 	})
 })

--- a/modules/300-prometheus/template_tests/prometheus_cr_test.go
+++ b/modules/300-prometheus/template_tests/prometheus_cr_test.go
@@ -142,7 +142,7 @@ scrapeInterval: 30s
 
 			rwCAConfigMap := f.KubernetesResource("ConfigMap", "d8-monitoring", "d8-prometheus-remote-write-ca-test-remote-write-custom-ca")
 			Expect(rwCAConfigMap.Exists()).To(BeTrue())
-			Expect(rwCAConfigMap.Field("ca.crt").String()).To(Equal("CRTCRTCRT"))
+			Expect(rwCAConfigMap.Field("data").String()).To(Equal(`{"ca.crt":"CRTCRTCRT"}`))
 		})
 	})
 })

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,13 +218,13 @@ spec:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
     {{- end }}
     {{- if .spec.tlsConfig }}
-      {{- if .spec.tlsConfig.ca }}
       {{- $tlsConfig := .spec.tlsConfig | deepCopy }}
-      {{- $_ := unset $tlsConfig "ca" }}
-      {{- $_ = set $tlsConfig "ca" (dict "configMap" (dict "name" (printf "d8-prometheus-remote-write-ca-%s" .name) "key" "ca.crt")) }}
+      {{- if .spec.tlsConfig.ca }}
+        {{- $_ := unset $tlsConfig "ca" }}
+        {{- $_ = set $tlsConfig "ca" (dict "configMap" (dict "name" (printf "d8-prometheus-remote-write-ca-%s" .name) "key" "ca.crt")) }}
+      {{- end }}
     tlsConfig:
       {{- $tlsConfig | toYaml | nindent 6 }}
-      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,8 +218,13 @@ spec:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
     {{- end }}
     {{- if .spec.tlsConfig }}
+      {{- if .spec.tlsConfig.ca }}
+      {{- $tlsConfig := .spec.tlsConfig | deepCopy }}
+      {{- $_ := unset $tlsConfig "ca" }}
+      {{- $_ = set $tlsConfig "ca" (dict "configMap" (dict "name" (printf "d8-prometheus-remote-write-ca-%s" .name) "key" "ca.crt")) }}
     tlsConfig:
-      {{- .spec.tlsConfig | toYaml | nindent 6 }}
+      {{- $tlsConfig | toYaml | nindent 6 }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/remote-write-secrets.yaml
+++ b/modules/300-prometheus/templates/prometheus/remote-write-secrets.yaml
@@ -14,6 +14,20 @@ data:
   username: {{ .spec.basicAuth.username | b64enc | quote }}
   password: {{ .spec.basicAuth.password | b64enc | quote }}
       {{- end }}
+
+      {{- if .spec.tlsConfig }}
+        {{  if .spec.tlsConfig.ca }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-prometheus-remote-write-ca-{{ .name }}
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "prometheus")) | nindent 2 }}
+data:
+  ca.crt: {{ .spec.tlsConfig.ca | quote }}
+        {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Implement CA property in D8's PrometheusRemoteWrite CRD.

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/3572

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: feat
summary: Implement CA property in D8's PrometheusRemoteWrite.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
