### PR TITLE
[modules docs] Fix rendering of resources to avoid overlapping with the TOC

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -370,7 +370,7 @@ module Jekyll
                 lengthValue = "#{attributes['maxLength'].to_json}"
             end
             unless attributes['type'] == 'string' && caption == 'min_length'
-                description = %Q(<p class="resources__attrs"><span class="resources__attrs_name">#{get_i18n_term(caption).capitalize}</span>: <span class="resources__attrs_content"><code>#{lengthValue}</code></span></p>)
+                description = %Q(<p class="resources__attrs"><span class="resources__attrs_name">#{get_i18n_term(caption).capitalize}:</span> <span class="resources__attrs_content"><code>#{lengthValue}</code></span></p>)
                 result.push(CONVERTER.convert(description.to_s))
             end
         end

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
@@ -88,7 +88,7 @@
   {{ $lengthValue = ( .maxLength | jsonify ) }}
 {{ end }}
 <p class="resources__attrs">
-  <span class="resources__attrs_name">{{ T $caption | humanize }}</span>: <span class="resources__attrs_content"><code>{{ $lengthValue }}</code></span>
+  <span class="resources__attrs_name">{{ T $caption | humanize }}:</span> <span class="resources__attrs_content"><code>{{ $lengthValue }}</code></span>
 </p>
 {{ end }}
 

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -25,8 +25,10 @@
       padding: 0;
     }
 
-    &_name > .ancestors, &_title > .ancestors {
+    &_name > .ancestors,
+    &_title > .ancestors {
       opacity: 55%;
+      word-break: break-all;
     }
 
     &_type {
@@ -59,6 +61,9 @@
   &__attrs {
     margin-top: rem(7px);
     margin-bottom: 0;
+    display: flex;
+    gap: 7px;
+    overflow-x: hidden;
 
     &_name {
       font-weight: $font-weight-regular;
@@ -73,6 +78,7 @@
     &_content {
       line-height: 1.2rem;
       font-size: 0.9rem;
+      overflow: auto;
     }
   }
 }


### PR DESCRIPTION
Fix the rendering of OpenAPi specs to avoid overlapping with the TOC in the documentation on the site.