### PR TITLE
[operator-trivy] cis benchmark job startup

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -21,11 +21,13 @@ COPY patches/001-add-registry-secret-as-dockerconfigjson.patch /src
 COPY patches/002-skip-some-checks.patch /src
 COPY patches/003-aws-ecr.patch /src
 COPY patches/004-scan-job-registry-ca.patch /src
+COPY patches/005-cis-benchmark-on-startup.patch /src
 
 RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
     patch -p1 < 002-skip-some-checks.patch && \
     patch -p1 < 003-aws-ecr.patch && \
-    patch -p1 < 004-scan-job-registry-ca.patch
+    patch -p1 < 004-scan-job-registry-ca.patch && \
+    patch -p1 < 005-cis-benchmark-on-startup.patch
 
 RUN go get -u golang.org/x/net@v0.17.0 && go mod tidy && go mod vendor
 RUN go build -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go

--- a/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/compliance/clustercompliancereport.go b/pkg/compliance/clustercompliancereport.go
-index 5878a5d6..8685b87f 100644
+index 5878a5d6..e7b355ce 100644
 --- a/pkg/compliance/clustercompliancereport.go
 +++ b/pkg/compliance/clustercompliancereport.go
 @@ -3,6 +3,7 @@ package compliance
@@ -20,11 +20,16 @@ index 5878a5d6..8685b87f 100644
  }
  
  // +kubebuilder:rbac:groups=aquasecurity.github.io,resources=clustercompliancereports,verbs=get;list;watch;create;update;patch;delete
-@@ -58,6 +62,12 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
+@@ -58,6 +62,17 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
  			}
  			return fmt.Errorf("getting report from cache: %w", err)
  		}
 +		r.onStartup(namespaceName).Do(func() {
++			var emptyStatus v1alpha1.ReportStatus
++			if report.Status != emptyStatus {
++				return
++			}
++
 +			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
 +			if err != nil {
 +				log.Error(err, "failed to generate compliance report")
@@ -33,7 +38,7 @@ index 5878a5d6..8685b87f 100644
  		durationToNextGeneration, err := utils.NextCronDuration(report.Spec.Cron, r.reportLastUpdatedTime(&report), r.Clock)
  		if err != nil {
  			return fmt.Errorf("failed to check report cron expression %w", err)
-@@ -87,3 +97,18 @@ func (r *ClusterComplianceReportReconciler) reportLastUpdatedTime(report *v1alph
+@@ -87,3 +102,18 @@ func (r *ClusterComplianceReportReconciler) reportLastUpdatedTime(report *v1alph
  	}
  	return lastUpdated
  }

--- a/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/compliance/clustercompliancereport.go b/pkg/compliance/clustercompliancereport.go
-index 5878a5d6..e7b355ce 100644
+index 5878a5d6..d6c293ed 100644
 --- a/pkg/compliance/clustercompliancereport.go
 +++ b/pkg/compliance/clustercompliancereport.go
 @@ -3,6 +3,7 @@ package compliance
@@ -20,13 +20,12 @@ index 5878a5d6..e7b355ce 100644
  }
  
  // +kubebuilder:rbac:groups=aquasecurity.github.io,resources=clustercompliancereports,verbs=get;list;watch;create;update;patch;delete
-@@ -58,6 +62,17 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
+@@ -58,6 +62,16 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
  			}
  			return fmt.Errorf("getting report from cache: %w", err)
  		}
 +		r.onStartup(namespaceName).Do(func() {
-+			var emptyStatus v1alpha1.ReportStatus
-+			if report.Status != emptyStatus {
++			if report.Status.SummaryReport != nil || report.Status.DetailReport != nil {
 +				return
 +			}
 +
@@ -38,7 +37,7 @@ index 5878a5d6..e7b355ce 100644
  		durationToNextGeneration, err := utils.NextCronDuration(report.Spec.Cron, r.reportLastUpdatedTime(&report), r.Clock)
  		if err != nil {
  			return fmt.Errorf("failed to check report cron expression %w", err)
-@@ -87,3 +102,18 @@ func (r *ClusterComplianceReportReconciler) reportLastUpdatedTime(report *v1alph
+@@ -87,3 +101,18 @@ func (r *ClusterComplianceReportReconciler) reportLastUpdatedTime(report *v1alph
  	}
  	return lastUpdated
  }

--- a/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/compliance/clustercompliancereport.go b/pkg/compliance/clustercompliancereport.go
-index 5878a5d6..5199b2d9 100644
+index 5878a5d6..8685b87f 100644
 --- a/pkg/compliance/clustercompliancereport.go
 +++ b/pkg/compliance/clustercompliancereport.go
 @@ -3,6 +3,7 @@ package compliance
@@ -10,19 +10,21 @@ index 5878a5d6..5199b2d9 100644
  	"time"
  
  	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
-@@ -24,6 +25,7 @@ type ClusterComplianceReportReconciler struct {
+@@ -24,6 +25,9 @@ type ClusterComplianceReportReconciler struct {
  	etc.Config
  	Mgr
  	ext.Clock
-+	onStartup sync.Once
++
++	onStartupOnce map[types.NamespacedName]*sync.Once
++	mu            sync.Mutex
  }
  
  // +kubebuilder:rbac:groups=aquasecurity.github.io,resources=clustercompliancereports,verbs=get;list;watch;create;update;patch;delete
-@@ -58,6 +60,12 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
+@@ -58,6 +62,12 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
  			}
  			return fmt.Errorf("getting report from cache: %w", err)
  		}
-+		r.onStartup.Do(func() {
++		r.onStartup(namespaceName).Do(func() {
 +			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
 +			if err != nil {
 +				log.Error(err, "failed to generate compliance report")
@@ -31,3 +33,22 @@ index 5878a5d6..5199b2d9 100644
  		durationToNextGeneration, err := utils.NextCronDuration(report.Spec.Cron, r.reportLastUpdatedTime(&report), r.Clock)
  		if err != nil {
  			return fmt.Errorf("failed to check report cron expression %w", err)
+@@ -87,3 +97,18 @@ func (r *ClusterComplianceReportReconciler) reportLastUpdatedTime(report *v1alph
+ 	}
+ 	return lastUpdated
+ }
++
++func (r *ClusterComplianceReportReconciler) onStartup(nn types.NamespacedName) *sync.Once {
++	r.mu.Lock()
++	defer r.mu.Unlock()
++
++	if r.onStartupOnce == nil {
++		r.onStartupOnce = make(map[types.NamespacedName]*sync.Once)
++	}
++
++	if _, ok := r.onStartupOnce[nn]; !ok {
++		r.onStartupOnce[nn] = new(sync.Once)
++	}
++
++	return r.onStartupOnce[nn]
++}

--- a/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/005-cis-benchmark-on-startup.patch
@@ -1,0 +1,33 @@
+diff --git a/pkg/compliance/clustercompliancereport.go b/pkg/compliance/clustercompliancereport.go
+index 5878a5d6..5199b2d9 100644
+--- a/pkg/compliance/clustercompliancereport.go
++++ b/pkg/compliance/clustercompliancereport.go
+@@ -3,6 +3,7 @@ package compliance
+ import (
+ 	"context"
+ 	"fmt"
++	"sync"
+ 	"time"
+ 
+ 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
+@@ -24,6 +25,7 @@ type ClusterComplianceReportReconciler struct {
+ 	etc.Config
+ 	Mgr
+ 	ext.Clock
++	onStartup sync.Once
+ }
+ 
+ // +kubebuilder:rbac:groups=aquasecurity.github.io,resources=clustercompliancereports,verbs=get;list;watch;create;update;patch;delete
+@@ -58,6 +60,12 @@ func (r *ClusterComplianceReportReconciler) generateComplianceReport(ctx context
+ 			}
+ 			return fmt.Errorf("getting report from cache: %w", err)
+ 		}
++		r.onStartup.Do(func() {
++			err = r.Mgr.GenerateComplianceReport(ctx, report.Spec)
++			if err != nil {
++				log.Error(err, "failed to generate compliance report")
++			}
++		})
+ 		durationToNextGeneration, err := utils.NextCronDuration(report.Spec.Cron, r.reportLastUpdatedTime(&report), r.Clock)
+ 		if err != nil {
+ 			return fmt.Errorf("failed to check report cron expression %w", err)

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -23,3 +23,10 @@ This patch is fixing this behaviour.
 This patch adds the ability to specify CA for scan jobs via environment variables.
 
 [Issue](https://github.com/deckhouse/deckhouse/issues/4950)
+
+
+### 005-cis-benchmark-on-startup.patch
+
+The first check begins instantly when the operator starts
+
+[Issue](https://github.com/deckhouse/deckhouse/issues/5174)


### PR DESCRIPTION
## Description
The first check begins instantly when the operator starts
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
https://github.com/deckhouse/deckhouse/issues/5174
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---
## Why do we need it in the patch release (if we do)?

Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
<!---
## What is the expected result?

  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: fix
summary: CIS compliance checks are now available immediately after activating the module
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
