### PR TITLE
[common] Fix CVEs in csi livenessprobe and node-driver-registrar

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -36,7 +36,7 @@ k8s:
       resizer: v1.7.0
       registrar: v2.7.0
       snapshotter: v6.3.1
-      livenessprobe: v2.9.0
+      livenessprobe: v2.11.0
   '1.25':
     status: available
     patch: 16
@@ -56,7 +56,7 @@ k8s:
       resizer: v1.7.0
       registrar: v2.7.0
       snapshotter: v6.3.1
-      livenessprobe: v2.9.0
+      livenessprobe: v2.11.0
   '1.26':
     status: available
     patch: 11
@@ -76,7 +76,7 @@ k8s:
       resizer: v1.7.0
       registrar: v2.7.0
       snapshotter: v6.3.1
-      livenessprobe: v2.9.0
+      livenessprobe: v2.11.0
   '1.27':
     status: available
     patch: 8
@@ -96,7 +96,7 @@ k8s:
       resizer: v1.8.0
       registrar: v2.8.0
       snapshotter: v6.3.1
-      livenessprobe: v2.10.0
+      livenessprobe: v2.11.0
   '1.28':
     status: preview
     patch: 4

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -9,8 +9,6 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /livenessprobe
     to: /livenessprobe
-    includePaths:
-      - livenessprobe
     before: setup
 docker:
   ENTRYPOINT: ["/livenessprobe"]
@@ -25,6 +23,9 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u google.golang.org/grpc@v1.56.3
+    - go mod vendor
     - make build
     - cp bin/livenessprobe /livenessprobe
     - chown 64535:64535 /livenessprobe

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -9,8 +9,6 @@ import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /csi-node-driver-registrar
     to: /csi-node-driver-registrar
-    includePaths:
-      - csi-node-driver-registrar
     before: setup
 docker:
   ENTRYPOINT: ["/csi-node-driver-registrar"]

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -25,6 +25,9 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
+    - go get -u golang.org/x/net@v0.17.0
+    - go get -u google.golang.org/grpc@v1.56.3
+    - go mod vendor
     - make build
     - cp bin/csi-node-driver-registrar /csi-node-driver-registrar
     - chown 64535:64535 /csi-node-driver-registrar


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed vulnerabilities:

- CVE-2022-41723
- CVE-2023-39325
- GHSA-m425-mq94-257g

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Info

<details><summary>before</summary>

```shell
csi-node-driver-registrar (gobinary)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                            Title                             │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2023-39325      │ HIGH     │ v0.8.0            │ 0.17.0                 │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                        │                     │          │                   │                        │ excessive work (CVE-2023-44487)                              │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.54.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability                     │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g            │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴──────────────────────────────────────────────────────────────┘
livenessprobe (gobinary)

Total: 3 (HIGH: 3, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Installed Version │     Fixed Version      │                            Title                             │
├────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net       │ CVE-2022-41723      │ HIGH     │ v0.4.0            │ 0.7.0                  │ net/http, golang.org/x/net/http2: avoid quadratic complexity │
│                        │                     │          │                   │                        │ in HPACK decoding                                            │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-41723                   │
│                        ├─────────────────────┤          │                   ├────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2023-39325      │          │                   │ 0.17.0                 │ golang: net/http, x/net/http2: rapid stream resets can cause │
│                        │                     │          │                   │                        │ excessive work (CVE-2023-44487)                              │
│                        │                     │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-39325                   │
├────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │          │ v1.49.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability                     │
│                        │                     │          │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g            │
└────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────┴──────────────────────────────────────────────────────────────┘
```

</details>


<details><summary>after</summary>

```shell
[deckhouse] root@c76680a01291 / # cat /deckhouse/candi/images_digests.json | grep -E "csiLivenessprobe|csiNodeDriverRegistrar" | sort
    "csiLivenessprobe124": "sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e",
    "csiLivenessprobe125": "sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e",
    "csiLivenessprobe126": "sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e",
    "csiLivenessprobe127": "sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e",
    "csiLivenessprobe128": "sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e",
    "csiNodeDriverRegistrar124": "sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c",
    "csiNodeDriverRegistrar125": "sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c",
    "csiNodeDriverRegistrar126": "sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c",
    "csiNodeDriverRegistrar127": "sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548",
    "csiNodeDriverRegistrar128": "sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33",

+ docker pull dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e: Pulling from sys/deckhouse-oss
Digest: sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e
Status: Image is up to date for dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:873300d3823c4fb633a1b2e7f39a2bbfd9a78e59ba836e63c49376cf6a4fcf9e
2024-01-11T10:06:09.556+0300    INFO    Vulnerability scanning is enabled
2024-01-11T10:06:09.556+0300    INFO    Secret scanning is enabled
2024-01-11T10:06:09.556+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-11T10:06:09.556+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2024-01-11T10:06:09.737+0300    INFO    Number of language-specific files: 1
2024-01-11T10:06:09.737+0300    INFO    Detecting gobinary vulnerabilities...
+ set +x
---
+ docker pull dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c: Pulling from sys/deckhouse-oss
Digest: sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c
Status: Image is up to date for dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:6bbb853a2561899441a34ca67ecef7e8b07cfdff84968f24ecfcafcc46353e3c
2024-01-11T10:06:51.650+0300    INFO    Vulnerability scanning is enabled
2024-01-11T10:06:51.650+0300    INFO    Secret scanning is enabled
2024-01-11T10:06:51.650+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-11T10:06:51.650+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2024-01-11T10:06:51.827+0300    INFO    Number of language-specific files: 1
2024-01-11T10:06:51.827+0300    INFO    Detecting gobinary vulnerabilities...
+ set +x
---
+ docker pull dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548: Pulling from sys/deckhouse-oss
Digest: sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548
Status: Image is up to date for dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:40fe3bb9caa311a333af4ea7132f53fac93f04ad764158584fa44251d2076548
2024-01-11T10:14:25.928+0300    INFO    Vulnerability scanning is enabled
2024-01-11T10:14:25.928+0300    INFO    Secret scanning is enabled
2024-01-11T10:14:25.928+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-11T10:14:25.928+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2024-01-11T10:14:26.122+0300    INFO    Number of language-specific files: 1
2024-01-11T10:14:26.122+0300    INFO    Detecting gobinary vulnerabilities...
+ set +x
---
+ docker pull dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33: Pulling from sys/deckhouse-oss
Digest: sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33
Status: Image is up to date for dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33
dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33
+ trivy i --severity=CRITICAL,HIGH dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:804160cafea06cc3e23eca3801b2892c417c849a6b1bf17dc21b30de02278e33
2024-01-11T10:15:04.640+0300    INFO    Vulnerability scanning is enabled
2024-01-11T10:15:04.640+0300    INFO    Secret scanning is enabled
2024-01-11T10:15:04.640+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-11T10:15:04.640+0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2024-01-11T10:15:04.839+0300    INFO    Number of language-specific files: 1
2024-01-11T10:15:04.840+0300    INFO    Detecting gobinary vulnerabilities...

csi-node-driver-registrar (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────────────────────────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│                           Library                            │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ go.opentelemetry.io/contrib/instrumentation/google.golang.o- │ CVE-2023-47108 │ HIGH     │ v0.41.0           │ 0.46.0        │ opentelemetry-go-contrib: DoS vulnerability in otelgrpc due │
│ rg/grpc/otelgrpc                                             │                │          │                   │               │ to unbound cardinality metrics                              │
│                                                              │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-47108                  │
└──────────────────────────────────────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
+ set +x
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed vulnerabilities in csi livenessprobe and node-driver-registrar: CVE-2022-41723, CVE-2023-39325, GHSA-m425-mq94-257g
impact: csi-controller pod will restart
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
