### PR TITLE
[keepalived] Distroless build

### DIFF
--- a/ee/modules/450-keepalived/images/keepalived/Dockerfile
+++ b/ee/modules/450-keepalived/images/keepalived/Dockerfile
@@ -1,4 +1,0 @@
-ARG BASE_PYTHON_ALPINE
-FROM $BASE_PYTHON_ALPINE
-RUN apk add --no-cache keepalived; pip3 install pyroute2; find /var/cache/apk/ -type f -delete
-COPY prepare-config.py /

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -1,0 +1,63 @@
+{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /usr/lib64/libsqlite3.so* /usr/bin/pip3" }}
+---
+artifact: {{ .ModuleName }}/build-keepalived
+from: {{ .Images.BASE_ALPINE }}
+shell:
+  install:
+    - apk add --no-cache gcc git make binutils file-dev glib-dev ipset-dev iptables-dev libmnl-dev libnftnl-dev libnl3-dev musl-dev net-snmp-dev openssl-dev openssl-libs-static pcre2 pcre2-dev autoconf automake zlib-static alpine-sdk linux-headers libmnl-static
+    - mkdir build && cd build
+    - git clone -b v2.2.7 --single-branch --depth=1 {{ $.SOURCE_REPO }}/acassen/keepalived.git ./src
+    - cd ./src
+    - ./autogen.sh
+    - CFLAGS='-static -s' LDFLAGS=-static ./configure --disable-dynamic-linking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/share/man --enable-bfd --enable-snmp --enable-snmp-rfc --enable-nftables --enable-regex --enable-json --enable-vrrp # --enable-libnl-dynamic
+    - make
+    - DESTDIR=/opt/keepalived-static make install
+    - chown -R 64535:64535 /opt/keepalived-static
+    - chmod 0700 /opt/keepalived-static/usr/sbin/keepalived
+    - chmod 0700 /opt/keepalived-static/usr/bin/genhash
+---
+artifact: {{ $.ModuleName }}/python
+fromImage: common/alt
+shell:
+  install:
+    - apt-get update
+    - apt-get install -y python3 python3-modules-sqlite3 pip
+    - /usr/bin/pip3 install pyroute2
+    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - mkdir /empty
+    - chmod 644 /empty
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+git:
+  - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/prepare-config.py
+    to: /prepare-config.py
+import:
+  - artifact: {{ $.ModuleName }}/python
+    add: /relocate
+    to: /
+    before: install
+  - artifact: {{ $.ModuleName }}/python
+    add: /usr/lib64/python3
+    to: /usr/lib64/python3
+    before: install
+  - artifact: {{ $.ModuleName }}/python
+    add: /usr/local/lib/python3/site-packages
+    to: /usr/local/lib/python3/site-packages
+    before: install
+  - artifact: {{ $.ModuleName }}/python
+    add: /usr/lib64/python3.9
+    to: /usr/lib64/python3.9
+    before: install
+  - artifact: {{ $.ModuleName }}/build-keepalived
+    add: /opt/keepalived-static/usr/sbin/keepalived
+    to: /usr/sbin/keepalived
+    before: install
+  - artifact: {{ $.ModuleName }}/build-keepalived
+    add: /opt/keepalived-static/usr/bin/genhash
+    to: /usr/bin/genhash
+    before: install
+  - artifact: {{ $.ModuleName }}/python
+    add: /empty
+    to: /run
+    before: setup

--- a/ee/modules/450-keepalived/templates/statefulset.yaml
+++ b/ee/modules/450-keepalived/templates/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
       initContainers:
       - name: init
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" $ | nindent 8 }}
-        command: ['/prepare-config.py']
+        command: ['/usr/bin/python3', '/prepare-config.py']
         image: {{ include "helm_lib_module_image" (list $ "keepalived") }}
         env:
         - name: POD_NAME


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Keepalived is now built from source and runs on a distroless image.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We want our images to be distroless-based.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: keepalived
type: chore
summary: keepalived is now based on a distroless image.
impact: keepalived pods will restart during the update.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
