### PR TITLE
[user-authn] OIDC allow unverified email

### DIFF
--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -152,6 +152,7 @@ spec:
         - --redis-connection-url=redis://127.0.0.1/
         - --cookie-refresh={{ $context.Values.userAuthn.idTokenTTL | default "10m" }}
         - --cookie-expire={{ $crd.spec.keepUsersLoggedInFor | default "168h" }} # 7 days
+        - --insecure-oidc-allow-unverified-email=true
         env:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:


### PR DESCRIPTION
## Description
Fix #6696 

## Why do we need it, and what problem does it solve?
It is currently not possible to configure oauth-proxy with --insecure-oidc-allow-unverified-email.
As a result, you cannot log into Deckhouse modules such as grafana or dashboard if your user has unverified email.
So you have to manually path the deployment, but this will probably work only until the next module update.

## Why do we need it in the patch release (if we do)?
We have clients who are forced to use such users in OIDC.

## What is the expected result?
A user whose email has not been verified can log into grafana.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
OIDC allow unverified email


```changes
section: user-authn
type: fix
summary: OIDC allow unverified email
impact_level: defaut
```
