### PR TITLE
[network-gateway] migrate network-gateway module to distroless

### DIFF
--- a/ee/modules/450-network-gateway/images/dnsmasq/Dockerfile
+++ b/ee/modules/450-network-gateway/images/dnsmasq/Dockerfile
@@ -1,6 +1,0 @@
-ARG BASE_PYTHON_ALPINE
-FROM $BASE_PYTHON_ALPINE
-
-RUN apk add --no-cache dnsmasq; pip3 install pyroute2 six ipcalc; find /var/cache/apk/ -type f -delete
-
-COPY prepare-config.py /

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -1,0 +1,30 @@
+{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /usr/lib64/libsqlite3.so* /usr/sbin/dnsmasq /lib64/libnss_*" }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+fromImage: common/alt
+shell:
+  install:
+    - apt-get update
+    - apt-get install -y python3 python3-modules-sqlite3 pip dnsmasq
+    - /usr/bin/pip3 install pyroute2 six ipcalc
+    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+git:
+  - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/prepare-config.py
+    to: /prepare-config.py
+import:
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /relocate
+    to: /
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3.9
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/local/lib/python3/site-packages
+    before: install

--- a/ee/modules/450-network-gateway/images/snat/Dockerfile
+++ b/ee/modules/450-network-gateway/images/snat/Dockerfile
@@ -1,6 +1,0 @@
-ARG BASE_PYTHON_ALPINE
-FROM $BASE_PYTHON_ALPINE
-
-RUN apk --no-cache add iptables; find /var/cache/apk/ -type f -delete
-
-COPY iptables-loop.py /

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -1,0 +1,42 @@
+{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /bin/grep /bin/sed /bin/sh /sbin/xtables-nft-multi /sbin/ip6tables-nft /sbin/ip6tables-nft-restore /sbin/ip6tables-nft-save /sbin/iptables-nft /sbin/iptables-nft-restore /sbin/iptables-nft-save /sbin/xtables-legacy-multi /sbin/iptables /sbin/iptables-restore /sbin/iptables-save /sbin/iptables-legacy /sbin/iptables-legacy-restore /sbin/iptables-legacy-save /sbin/ip6tables /sbin/ip6tables-restore /sbin/ip6tables-save /sbin/ip6tables-legacy /sbin/ip6tables-legacy-restore /sbin/ip6tables-legacy-save /usr/lib64/libnetfilter_conntrack.so*" }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+fromImage: common/alt
+shell:
+  install:
+    - apt-get update
+    - apt-get install -y python3 iptables iptables-nft
+    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - |
+      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore ip6tables-nft ip6tables-nft-restore ip6tables-nft-save iptables-nft iptables-nft-restore iptables-nft-save; do
+        ln -f -s /iptables-wrapper "/relocate/sbin/${cmd}"
+      done
+      # broken symlinks are not imported from the artifact
+      touch /iptables-wrapper
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+git:
+  - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/iptables-loop.py
+    to: /iptables-loop.py
+import:
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /relocate
+    to: /
+    before: setup
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3
+    to: /usr/lib64/python3
+    before: setup
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3.9
+    to: /usr/lib64/python3.9
+    before: setup
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /lib64/iptables
+    to: /lib64/iptables
+    before: setup
+  - image: common/iptables-wrapper
+    add: /iptables-wrapper
+    to: /iptables-wrapper
+    before: setup

--- a/ee/modules/450-network-gateway/templates/dhcp-statefulset.yaml
+++ b/ee/modules/450-network-gateway/templates/dhcp-statefulset.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
       - name: init
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
-        command: ['/prepare-config.py']
+        command: ['/usr/bin/python3', '/prepare-config.py']
         image: {{ include "helm_lib_module_image" (list . "dnsmasq") }}
         volumeMounts:
         - name: dhcp-config

--- a/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
+++ b/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
@@ -57,9 +57,9 @@ spec:
       - name: deckhouse-registry
       containers:
       - name: snat
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add"  (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_privileged" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "snat") }}
-        command: ["/iptables-loop.py"]
+        command: ["/usr/bin/python3", "/iptables-loop.py"]
         env:
         - name: POD_SUBNET
           value: {{ .Values.global.discovery.podSubnet }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`network-gateway` module is based on a distroless image.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We'd like to base our images on a distroless image.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: network-gateway
type: feature
summary: network-gateway module is based on a distroless image.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
