### PR TITLE
[ci] Exclude go files from deckhouse-controller image

### DIFF
--- a/tools/build.go
+++ b/tools/build.go
@@ -48,6 +48,8 @@ var defaultModulesExcludes = []string{
 	"images",
 	"hooks/**/*.go",
 	"hooks/*.go",
+	"*.go",
+	"hack",
 	"template_tests",
 	".namespace",
 	"values_matrix_test.yaml",

--- a/tools/build.go
+++ b/tools/build.go
@@ -48,7 +48,6 @@ var defaultModulesExcludes = []string{
 	"images",
 	"hooks/**/*.go",
 	"hooks/*.go",
-	"*.go",
 	"hack",
 	"template_tests",
 	".namespace",
@@ -111,7 +110,7 @@ func writeSections(settings writeSettings) {
 		log.Fatalf("globbing: %v", err)
 	}
 	addNewFileEntry := func(file string) {
-		hooksPathRegex := regexp.MustCompile(`\d+-\w+\/hooks`)
+		hooksPathRegex := regexp.MustCompile(`\d+-[\w\-]+\/hooks`)
 		// we do not want to add hooks to the modules-with-exclude include
 		// this include is used in the dev-prebuild image, which does not use the hooks folder
 		if settings.SaveTo == modulesWithExcludeFileName && hooksPathRegex.Match([]byte(file)) {

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -7,7 +7,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -21,7 +20,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -35,7 +33,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -49,7 +46,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -63,7 +59,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -77,7 +72,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -91,7 +85,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -105,7 +98,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -119,7 +111,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -133,7 +124,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -147,7 +137,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -161,7 +150,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -175,7 +163,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -189,7 +176,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -203,7 +189,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -217,7 +202,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -231,7 +215,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -245,7 +228,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -259,7 +241,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -273,49 +254,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
-- add: /ee/modules/150-user-authn/hooks/common_test.go
-  to: /deckhouse/modules/150-user-authn/hooks/common_test.go
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - '*.go'
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
-- add: /ee/modules/150-user-authn/hooks/custom_logo.go
-  to: /deckhouse/modules/150-user-authn/hooks/custom_logo.go
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - '*.go'
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
-- add: /ee/modules/150-user-authn/hooks/custom_logo_test.go
-  to: /deckhouse/modules/150-user-authn/hooks/custom_logo_test.go
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -329,7 +267,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -343,7 +280,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -357,7 +293,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -371,7 +306,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -385,7 +319,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -399,7 +332,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -413,7 +345,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -427,7 +358,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -441,7 +371,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -7,6 +7,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -19,6 +21,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -31,6 +35,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -43,6 +49,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -55,6 +63,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -67,6 +77,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -79,6 +91,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -91,6 +105,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -103,6 +119,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -115,6 +133,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -127,6 +147,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -139,6 +161,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -151,6 +175,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -163,6 +189,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -175,6 +203,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -187,6 +217,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -199,6 +231,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -211,6 +245,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -223,6 +259,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -235,6 +273,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -247,6 +287,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -259,6 +301,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -271,6 +315,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -283,6 +329,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -295,6 +343,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -307,6 +357,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -319,6 +371,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -331,6 +385,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -343,6 +399,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -355,6 +413,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -367,6 +427,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -379,6 +441,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -7,7 +7,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -21,7 +20,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -35,7 +33,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -49,7 +46,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -63,7 +59,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -77,7 +72,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -91,7 +85,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -105,7 +98,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -119,7 +111,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -133,7 +124,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -147,7 +137,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -161,7 +150,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -175,7 +163,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -189,7 +176,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -203,7 +189,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -217,7 +202,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -231,7 +215,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -245,7 +228,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -259,7 +241,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -273,7 +254,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -287,7 +267,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -301,49 +280,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
-- add: /ee/modules/150-user-authn/hooks/common_test.go
-  to: /deckhouse/modules/150-user-authn/hooks/common_test.go
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - '*.go'
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
-- add: /ee/modules/150-user-authn/hooks/custom_logo.go
-  to: /deckhouse/modules/150-user-authn/hooks/custom_logo.go
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - '*.go'
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
-- add: /ee/modules/150-user-authn/hooks/custom_logo_test.go
-  to: /deckhouse/modules/150-user-authn/hooks/custom_logo_test.go
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -357,7 +293,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -371,7 +306,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -385,7 +319,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -399,7 +332,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -413,7 +345,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -427,7 +358,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -441,7 +371,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -455,7 +384,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace
@@ -469,7 +397,6 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
-    - '*.go'
     - hack
     - template_tests
     - .namespace

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -7,6 +7,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -19,6 +21,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -31,6 +35,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -43,6 +49,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -55,6 +63,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -67,6 +77,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -79,6 +91,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -91,6 +105,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -103,6 +119,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -115,6 +133,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -127,6 +147,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -139,6 +161,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -151,6 +175,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -163,6 +189,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -175,6 +203,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -187,6 +217,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -199,6 +231,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -211,6 +245,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -223,6 +259,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -235,6 +273,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -247,6 +287,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -259,6 +301,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -271,6 +315,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -283,6 +329,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -295,6 +343,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -307,6 +357,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -319,6 +371,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -331,6 +385,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -343,6 +399,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -355,6 +413,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -367,6 +427,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -379,6 +441,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -391,6 +455,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml
@@ -403,6 +469,8 @@
     - images
     - hooks/**/*.go
     - hooks/*.go
+    - '*.go'
+    - hack
     - template_tests
     - .namespace
     - values_matrix_test.yaml


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Exclude go files from deckhouse-controller image

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Deckhouse image should not contain *.go files

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/deckhouse/deckhouse/assets/30695496/cc5902c5-9cb2-4366-a772-34b61fefdb69)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Exclude go files from deckhouse-controller image
impact_level: ow
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
