### PR TITLE
[ingress-nginx] fix cleanup temp dir path

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
@@ -8,6 +8,7 @@ COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
 COPY patches/metrics-SetSSLExpireTime.patch /
 COPY patches/endpointslice-missing-conditions.patch /
+COPY patches/fix-cleanup.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v1.6.4 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -16,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /healthcheck.patch && \
     patch -p1 < /metrics-SetSSLExpireTime.patch && \
     patch -p1 < /endpointslice-missing-conditions.patch && \
+    patch -p1 < /fix-cleanup.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
@@ -43,6 +43,11 @@ https://github.com/kubernetes/ingress-nginx/pull/8213
 
 ### Endpointslice missing ready conditions
 
-Ingress controller panics if there is an ingress, pointing to a service with the endpointslice lacking 'condtitions.ready' field. Fixex in 1.7.
+Ingress controller panics if there is an ingress, pointing to a service with the endpointslice lacking 'condtitions.ready' field. Fixed in 1.7.
 
 https://github.com/kubernetes/ingress-nginx/pull/9550/files
+
+
+###Fix cleanup
+
+Fix tmpDir path for the cleanup procedure.

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/fix-cleanup.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/fix-cleanup.patch
@@ -1,0 +1,35 @@
+diff --git a/internal/ingress/controller/nginx.go b/internal/ingress/controller/nginx.go
+index 5575009ea..e931706c8 100644
+--- a/internal/ingress/controller/nginx.go
++++ b/internal/ingress/controller/nginx.go
+@@ -70,6 +70,8 @@ const (
+ 	emptyUID         = "-1"
+ )
+ 
++var tmpDir = os.TempDir() + "/nginx"
++
+ // NewNGINXController creates a new NGINX Ingress controller.
+ func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXController {
+ 	eventBroadcaster := record.NewBroadcaster()
+@@ -628,7 +630,6 @@ func (n NGINXController) testTemplate(cfg []byte) error {
+ 	if len(cfg) == 0 {
+ 		return fmt.Errorf("invalid NGINX configuration (empty)")
+ 	}
+-	tmpDir := os.TempDir() + "/nginx"
+ 	tmpfile, err := os.CreateTemp(tmpDir, tempNginxPattern)
+ 	if err != nil {
+ 		return err
+@@ -1094,11 +1095,11 @@ func createOpentracingCfg(cfg ngx_config.Configuration) error {
+ func cleanTempNginxCfg() error {
+ 	var files []string
+ 
+-	err := filepath.Walk(os.TempDir(), func(path string, info os.FileInfo, err error) error {
++	err := filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+ 		if err != nil {
+ 			return err
+ 		}
+-		if info.IsDir() && os.TempDir() != path {
++		if info.IsDir() && tmpDir != path {
+ 			return filepath.SkipDir
+ 		}
+ 

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -8,6 +8,7 @@ COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
 COPY patches/metrics-SetSSLExpireTime.patch /
 COPY patches/util.patch /
+COPY patches/fix-cleanup.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v1.9.4 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -16,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /healthcheck.patch && \
     patch -p1 < /metrics-SetSSLExpireTime.patch && \
     patch -p1 < /util.patch && \
+    patch -p1 < /fix-cleanup.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
@@ -44,3 +44,7 @@ https://github.com/kubernetes/ingress-nginx/pull/8213
 ### Util patch
 
 Adds "-e /dev/null" flags to the "nginx -t" invocations so that "nginx -t" logs aren't got saved to /var/log/nginx/error.log file, preventing fs bloating.
+
+###Fix cleanup
+
+Fix tmpDir path for the cleanup procedure.

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/fix-cleanup.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/fix-cleanup.patch
@@ -1,0 +1,35 @@
+diff --git a/internal/ingress/controller/nginx.go b/internal/ingress/controller/nginx.go
+index 30f785586..4889e0e34 100644
+--- a/internal/ingress/controller/nginx.go
++++ b/internal/ingress/controller/nginx.go
+@@ -70,6 +70,8 @@ const (
+ 	emptyUID         = "-1"
+ )
+ 
++var tmpDir = os.TempDir() + "/nginx"
++
+ // NewNGINXController creates a new NGINX Ingress controller.
+ func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXController {
+ 	eventBroadcaster := record.NewBroadcaster()
+@@ -629,7 +631,6 @@ func (n *NGINXController) testTemplate(cfg []byte) error {
+ 	if len(cfg) == 0 {
+ 		return fmt.Errorf("invalid NGINX configuration (empty)")
+ 	}
+-	tmpDir := os.TempDir() + "/nginx"
+ 	tmpfile, err := os.CreateTemp(tmpDir, tempNginxPattern)
+ 	if err != nil {
+ 		return err
+@@ -1127,11 +1128,11 @@ func createOpentelemetryCfg(cfg *ngx_config.Configuration) error {
+ func cleanTempNginxCfg() error {
+ 	var files []string
+ 
+-	err := filepath.Walk(os.TempDir(), func(path string, info os.FileInfo, err error) error {
++	err := filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+ 		if err != nil {
+ 			return err
+ 		}
+-		if info.IsDir() && os.TempDir() != path {
++		if info.IsDir() && tmpDir != path {
+ 			return filepath.SkipDir
+ 		}
+ 


### PR DESCRIPTION
## Description
Fix tempDir path for the cleanup routine.
https://github.com/kubernetes/ingress-nginx/pull/10797
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The cleanup routine searches tmp files in a wrong place, so temp configs don't get deleted at all.
Close #6868 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Temp files older than 5min get deleted every 5 minutes.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix ingress controller clean up routine.
impact: All pods of ingress nginx controllers of versions 1.6 and 1.9 will be recreated.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
