### PR TITLE
[ingress-nginx] fix clean up for chroot images

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-6/patches/fix-cleanup.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/fix-cleanup.patch
@@ -6,7 +6,7 @@ index 5575009ea..e931706c8 100644
  	emptyUID         = "-1"
  )
  
-+var tmpDir = os.TempDir() + "/nginx"
++var tmpDir = os.TempDir() + "/nginx/"
 +
  // NewNGINXController creates a new NGINX Ingress controller.
  func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXController {

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/fix-cleanup.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/fix-cleanup.patch
@@ -6,7 +6,7 @@ index 30f785586..4889e0e34 100644
  	emptyUID         = "-1"
  )
  
-+var tmpDir = os.TempDir() + "/nginx"
++var tmpDir = os.TempDir() + "/nginx/"
 +
  // NewNGINXController creates a new NGINX Ingress controller.
  func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXController {


### PR DESCRIPTION
## Description
A quick fix on the heels of [the previous update](https://github.com/deckhouse/deckhouse/pull/6985).
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Without slash path.Walk doesn't unwrap a symlink directory (in case of a chrooted image) preventing temp files from being deleted.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Cleanup also works in a chrooted environment.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix cleanup for a chrooted environment
impact: All pods of ingress nginx controllers of versions 1.6 and 1.9 will be recreated.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
