### PR TITLE
[dhctl] mirror: tag release channels images with their versions

### DIFF
--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -123,7 +123,7 @@ func mirrorPullDeckhouseToLocalFilesystem() error {
 		return fmt.Errorf("Source registry access validation failure: %w", err)
 	}
 
-	var versionsToMirror []*semver.Version
+	var versionsToMirror []semver.Version
 	var err error
 	err = log.Process("mirror", "Looking for required Deckhouse releases", func() error {
 		versionsToMirror, err = mirror.VersionsToCopy(mirrorCtx)

--- a/dhctl/pkg/operations/mirror.go
+++ b/dhctl/pkg/operations/mirror.go
@@ -34,7 +34,7 @@ import (
 
 func MirrorDeckhouseToLocalFS(
 	mirrorCtx *mirror.Context,
-	versions []*semver.Version,
+	versions []semver.Version,
 ) error {
 	log.InfoF("Fetching Deckhouse modules list...\t")
 	modules, err := mirror.GetDeckhouseExternalModules(mirrorCtx)

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -143,7 +143,7 @@ type ociLayout struct {
 	ImageLayoutVersion string `json:"imageLayoutVersion"`
 }
 
-func FillLayoutsImages(mirrorCtx *Context, layouts *ImageLayouts, deckhouseVersions []*semver.Version) {
+func FillLayoutsImages(mirrorCtx *Context, layouts *ImageLayouts, deckhouseVersions []semver.Version) {
 	layouts.DeckhouseImages = map[string]struct{}{
 		mirrorCtx.DeckhouseRegistryRepo + ":alpha":        {},
 		mirrorCtx.DeckhouseRegistryRepo + ":beta":         {},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Release channel images of deckhouse controller and installer will now be pushed into the registry with both release channel and version tags.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes installation from mirrored registries where release channel was not of latest patch in release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: dhctl mirror will tag release channels images with their versions as well.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
