### PR TITLE
[istio] Check deprecated versions based on mc and iop in cluster

### DIFF
--- a/modules/110-istio/hooks/deprecated_versions_monitoring.go
+++ b/modules/110-istio/hooks/deprecated_versions_monitoring.go
@@ -30,23 +30,21 @@ var (
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue:        lib.Queue("monitoring"),
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10}, // The hook relies on operatorVersionsToInstall value discovered in discovery_operator_versions_to_install.go before.
 }, versionMonitoringHook)
 
 func versionMonitoringHook(input *go_hook.HookInput) error {
-	if !input.Values.Get("istio.globalVersion").Exists() {
+	if !input.Values.Get("istio.internal.operatorVersionsToInstall").Exists() {
 		return nil
 	}
 
 	input.MetricsCollector.Expire(versionsMonitoringMetricsGroup)
-	globalVersion := input.Values.Get("istio.globalVersion").String()
-	additionalVersions := input.Values.Get("istio.additionalVersions").Array()
+	istioVersions := input.Values.Get("istio.internal.operatorVersionsToInstall").Array()
 	deprecatedVersions := input.Values.Get("istio.internal.deprecatedVersions").Array()
 	istioVersionsMap := make(map[string]struct{}, 0)
 
-	istioVersionsMap[globalVersion] = struct{}{}
-	for _, additionalVersion := range additionalVersions {
-		istioVersionsMap[additionalVersion.String()] = struct{}{}
+	for _, istioVersion := range istioVersions {
+		istioVersionsMap[istioVersion.String()] = struct{}{}
 	}
 
 	for _, deprecatedVersion := range deprecatedVersions {

--- a/modules/110-istio/hooks/deprecated_versions_monitoring_test.go
+++ b/modules/110-istio/hooks/deprecated_versions_monitoring_test.go
@@ -42,14 +42,8 @@ var _ = Describe("Istio hooks :: versions_monitoring ::", func() {
 	})
 
 	Context("There are no deprecated versions", func() {
-		var noDeprecatedVersions = `
-globalVersion: 1.1.1
-additionalVersions:
-- 1.2.0
-- 1.3.0
-`
 		BeforeEach(func() {
-			f.ValuesSetFromYaml("istio", []byte(noDeprecatedVersions))
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.1", "1.2", "1.3"]`))
 			f.RunHook()
 		})
 		It("Hook must execute successfully", func() {
@@ -66,18 +60,13 @@ additionalVersions:
 	})
 
 	Context("There are no deprecated version installed", func() {
-		var noDeprecatedVersions = `
-globalVersion: 1.1.1
-additionalVersions:
-- 1.2.0
-- 1.3.0
-internal:
-   deprecatedVersions:
-   - version: 1.1.9
-     alertSeverity: 4
+		var deprecatedVersions = `
+- version: "1.0"
+  alertSeverity: 4
 `
 		BeforeEach(func() {
-			f.ValuesSetFromYaml("istio", []byte(noDeprecatedVersions))
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.1", "1.2", "1.3"]`))
+			f.ValuesSetFromYaml("istio.internal.deprecatedVersions", []byte(deprecatedVersions))
 			f.RunHook()
 		})
 		It("Hook must execute successfully", func() {
@@ -94,18 +83,13 @@ internal:
 	})
 
 	Context("There is one deprecated version installed", func() {
-		var noDeprecatedVersions = `
-globalVersion: 1.1.1
-additionalVersions:
-- 1.2.0
-- 1.3.0
-internal:
-   deprecatedVersions:
-   - version: 1.1.1
-     alertSeverity: 4
+		var deprecatedVersions = `
+- version: "1.1"
+  alertSeverity: 4
 `
 		BeforeEach(func() {
-			f.ValuesSetFromYaml("istio", []byte(noDeprecatedVersions))
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.1", "1.2", "1.3"]`))
+			f.ValuesSetFromYaml("istio.internal.deprecatedVersions", []byte(deprecatedVersions))
 			f.RunHook()
 		})
 		It("Hook must execute successfully", func() {
@@ -124,7 +108,7 @@ internal:
 				Action: "set",
 				Value:  pointer.Float64(1.0),
 				Labels: map[string]string{
-					"version":        "1.1.1",
+					"version":        "1.1",
 					"alert_severity": "4",
 				},
 			}))
@@ -132,21 +116,15 @@ internal:
 	})
 
 	Context("There are several deprecated version installed", func() {
-		var noDeprecatedVersions = `
-globalVersion: 1.1.1
-additionalVersions:
-- 1.2.0
-- 1.3.0
-internal:
-   deprecatedVersions:
-   - version: 1.2.0
-     alertSeverity: 8
-   - version: 1.3.0
-     alertSeverity: 9
-
+		var deprecatedVersions = `
+- version: "1.2"
+  alertSeverity: 8
+- version: "1.3"
+  alertSeverity: 9
 `
 		BeforeEach(func() {
-			f.ValuesSetFromYaml("istio", []byte(noDeprecatedVersions))
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", []byte(`["1.1", "1.2", "1.3"]`))
+			f.ValuesSetFromYaml("istio.internal.deprecatedVersions", []byte(deprecatedVersions))
 			f.RunHook()
 		})
 		It("Hook must execute successfully", func() {
@@ -165,7 +143,7 @@ internal:
 				Action: "set",
 				Value:  pointer.Float64(1.0),
 				Labels: map[string]string{
-					"version":        "1.2.0",
+					"version":        "1.2",
 					"alert_severity": "8",
 				},
 			}))
@@ -175,7 +153,7 @@ internal:
 				Action: "set",
 				Value:  pointer.Float64(1.0),
 				Labels: map[string]string{
-					"version":        "1.3.0",
+					"version":        "1.3",
 					"alert_severity": "9",
 				},
 			}))


### PR DESCRIPTION
## Description

Improved checking for currently running deprecated versions of Istio in the cluster.

## Why do we need it, and what problem does it solve?

Previously, if a deprecated version was used in a cluster, but was not explicitly described in the moduleconfig, no alert would be generated. For example, the control-plane was setupped from custom IstioOperator CR.

Fixes https://github.com/deckhouse/deckhouse/issues/6374.

## What is the expected result?

The alert D8IstioDeprecatedIstioVersionInstalled will be generated if a deprecated version of istio is described in the moduleconfig or running in the cluster (being setupped from custom IstioOperator CR).

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Improved checking for currently running deprecated versions of Istio in the cluster.
impact_level: default
```
