### PR TITLE
[prometheus]  Add examples for CustomAlertmanager

### DIFF
--- a/modules/300-prometheus/docs/USAGE.md
+++ b/modules/300-prometheus/docs/USAGE.md
@@ -237,7 +237,7 @@ spec:
 
 The fields `token` in the Secret and `chatID` in the `CustomAlertmanager` custom resource must be set on your own. [Read more](https://core.telegram.org/bots) about Telegram API.
 
-## Example of sending alerts to Slack with filtres
+## Example of sending alerts to Slack with a filter
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -285,7 +285,7 @@ spec:
   type: Internal
 ```
 
-## Example of sending alerts to opsgenie
+## Example of sending alerts to Opsgenie
 
 ```yaml
 - name: opsgenie

--- a/modules/300-prometheus/docs/USAGE.md
+++ b/modules/300-prometheus/docs/USAGE.md
@@ -236,3 +236,69 @@ spec:
 ```
 
 The fields `token` in the Secret and `chatID` in the `CustomAlertmanager` custom resource must be set on your own. [Read more](https://core.telegram.org/bots) about Telegram API.
+
+## Example of sending alerts to Slack with filtres
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: CustomAlertmanager
+metadata:
+  name: slack
+spec:
+  internal:
+    receivers:
+    - name: devnull
+    - name: slack
+      slackConfigs:
+      - apiURL:
+          key: apiURL
+          name: slack-apiurl
+        channel: {{ dig .Values.werf.env .Values.slack.channel._default .Values.slack.channel }} 
+        fields:
+        - short: true
+          title: Severity
+          value: '{{`{{  .CommonLabels.severity_level }}`}}'
+        - short: true
+          title: Status
+          value: '{{`{{ .Status }}`}}'
+        - title: Summary
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.summary }}`}} {{`{{ end }}`}}'
+        - title: Description
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.description }}`}} {{`{{ end }}`}}'
+        - title: Labels
+          value: '{{`{{ range .Alerts }}`}} {{`{{ range .Labels.SortedPairs }}`}}{{`{{ printf "%s:
+            %s\n" .Name .Value }}`}}{{`{{ end }}`}}{{`{{ end }}`}}'
+        - title: Links
+          value: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+        title: '{{`{{ .CommonLabels.alertname }}`}}'
+    route:
+      groupBy:
+      - '...'  
+      receiver: devnull
+      routes:
+        - matchers:
+          - matchType: =~
+            name: severity_level
+            value: "^[4-9]$"
+          receiver: slack
+      repeatInterval: 12h
+  type: Internal
+```
+
+## Example of sending alerts to opsgenie
+
+```yaml
+- name: opsgenie
+        opsgenieConfigs:
+          - apiKey:
+              key: data
+              name: opsgenie
+            description: |
+              {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}
+              {{ range .Alerts }}{{ .Annotations.description }} {{ end }}
+            message: '{{ .CommonLabels.alertname }}'
+            priority: P1
+            responders:
+              - id: team_id
+                type: team
+```

--- a/modules/300-prometheus/docs/USAGE_RU.md
+++ b/modules/300-prometheus/docs/USAGE_RU.md
@@ -239,7 +239,8 @@ spec:
 
 ## Пример отправки алертов в Slack с фильтром
 
-```apiVersion: deckhouse.io/v1alpha1
+```yaml
+apiVersion: deckhouse.io/v1alpha1
 kind: CustomAlertmanager
 metadata:
   name: slack
@@ -286,7 +287,8 @@ spec:
 
 ## Пример отправки алертов в opsgenie
 
-```- name: opsgenie
+```yaml
+- name: opsgenie
         opsgenieConfigs:
           - apiKey:
               key: data

--- a/modules/300-prometheus/docs/USAGE_RU.md
+++ b/modules/300-prometheus/docs/USAGE_RU.md
@@ -285,7 +285,7 @@ spec:
   type: Internal
 ```
 
-## Пример отправки алертов в opsgenie
+## Пример отправки алертов в Opsgenie
 
 ```yaml
 - name: opsgenie

--- a/modules/300-prometheus/docs/USAGE_RU.md
+++ b/modules/300-prometheus/docs/USAGE_RU.md
@@ -236,3 +236,67 @@ spec:
 ```
 
 Поля `token` в Secret'е и `chatID` в ресурсе `CustomAlertmanager` необходимо поставить свои. [Подробнее](https://core.telegram.org/bots) о Telegram API.
+
+## Пример отправки алертов в Slack с фильтром
+
+```apiVersion: deckhouse.io/v1alpha1
+kind: CustomAlertmanager
+metadata:
+  name: slack
+spec:
+  internal:
+    receivers:
+    - name: devnull
+    - name: slack
+      slackConfigs:
+      - apiURL:
+          key: apiURL
+          name: slack-apiurl
+        channel: {{ dig .Values.werf.env .Values.slack.channel._default .Values.slack.channel }} 
+        fields:
+        - short: true
+          title: Severity
+          value: '{{`{{  .CommonLabels.severity_level }}`}}'
+        - short: true
+          title: Status
+          value: '{{`{{ .Status }}`}}'
+        - title: Summary
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.summary }}`}} {{`{{ end }}`}}'
+        - title: Description
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.description }}`}} {{`{{ end }}`}}'
+        - title: Labels
+          value: '{{`{{ range .Alerts }}`}} {{`{{ range .Labels.SortedPairs }}`}}{{`{{ printf "%s:
+            %s\n" .Name .Value }}`}}{{`{{ end }}`}}{{`{{ end }}`}}'
+        - title: Links
+          value: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+        title: '{{`{{ .CommonLabels.alertname }}`}}'
+    route:
+      groupBy:
+      - '...'  
+      receiver: devnull
+      routes:
+        - matchers:
+          - matchType: =~
+            name: severity_level
+            value: "^[4-9]$"
+          receiver: slack
+      repeatInterval: 12h
+  type: Internal
+```
+
+## Пример отправки алертов в opsgenie
+
+```- name: opsgenie
+        opsgenieConfigs:
+          - apiKey:
+              key: data
+              name: opsgenie
+            description: |
+              {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}
+              {{ range .Alerts }}{{ .Annotations.description }} {{ end }}
+            message: '{{ .CommonLabels.alertname }}'
+            priority: P1
+            responders:
+              - id: team_id
+                type: team
+```


### PR DESCRIPTION
## Description
Add examples of CustomAlertmanager for Slack and Opsgenie.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Add examples of CustomAlertmanager for Slack and Opsgenie.
```
