### PR TITLE
[cni-cilium] change cilium dashboard 

### DIFF
--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
@@ -23,9 +23,8 @@
   },
   "description": "Dashboard for Cilium (https://cilium.io/) metrics",
   "editable": true,
-  "gnetId": 15513,
+  "gnetId": null,
   "graphTooltip": 1,
-  "id": 36,
   "iteration": 1606309591568,
   "links": [],
   "liveNow": false,
@@ -3554,7 +3553,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",pod=~\"$pod\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3562,28 +3561,28 @@
           "refId": "A"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",pod=~\"$pod\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
           "refId": "B"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",pod=~\"$pod\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",pod=~\"$pod\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
           "refId": "D"
         },
         {
-          "expr": "max(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",pod=~\"$pod\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{job=\"cilium-agent\",status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -5819,7 +5818,7 @@
       "aliasColors": {
         "max": "#f2c96d",
         "policy errors": "#bf1b00",
-        "policy import errors": "#bf1b00"
+        "policy change errors": "#bf1b00"
       },
       "bars": false,
       "dashLength": 10,
@@ -5883,7 +5882,7 @@
           "lines": false
         },
         {
-          "alias": "policy import errors",
+          "alias": "policy change errors",
           "yaxis": 2
         }
       ],
@@ -5913,10 +5912,10 @@
           "refId": "C"
         },
         {
-          "expr": "sum(cilium_policy_import_errors_total{job=\"cilium-agent\",pod=~\"$pod\"}) by (pod)",
+          "expr": "sum(cilium_policy_change_total{job=\"cilium-agent\",pod=~\"$pod\"}, outcome=\"fail\") by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "policy import errors",
+          "legendFormat": "policy change errors",
           "refId": "D"
         }
       ],
@@ -6282,7 +6281,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{job=\"cilium-agent\",pod=~\"$pod\", scope!=\"total\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{job=\"cilium-agent\", scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6386,7 +6385,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{job=\"cilium-agent\",pod=~\"$pod\", scope!=\"total\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{job=\"cilium-agent\",scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -7423,7 +7422,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",pod=~\"$pod\", equal=\"true\", valid=\"true\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",equal=\"true\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7526,7 +7525,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",pod=~\"$pod\", equal=\"true\", valid=\"false\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",equal=\"true\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7629,7 +7628,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",pod=~\"$pod\", equal=\"false\", valid=\"true\"}[5m])) by (pod, scope, action, valid)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",equal=\"false\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action, valid)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7731,7 +7730,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",pod=~\"$pod\", equal=\"false\", valid=\"false\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{job=\"cilium-agent\",equal=\"false\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7834,7 +7833,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"CiliumNetworkPolicy\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7941,7 +7940,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"NetworkPolicy\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"NetworkPolicy\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -8048,7 +8047,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"Pod\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"Pod\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -8155,7 +8154,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"Node\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"Node\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -8258,7 +8257,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"Service\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"Service\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8361,7 +8360,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"Endpoint\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"Endpoint\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8464,7 +8463,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",pod=~\"$pod\", scope=\"Namespace\"}[$__interval_sx4])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{job=\"cilium-agent\",scope=\"Namespace\", pod=~\"$pod\"}[$__interval_sx4])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8530,7 +8529,7 @@
           "type": "prometheus",
           "uid": "P0D6E4079E36703EB"
         },
-        "definition": "label_values(kube_pod_created{pod=~\"agent.*\",namespace=\"d8-cni-cilium\"},pod)",
+        "definition": "label_values(cilium_version, pod)",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -8538,7 +8537,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_created{pod=~\"agent.*\",namespace=\"d8-cni-cilium\"},pod)",
+          "query": "label_values(cilium_version, pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -8582,7 +8581,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Cilium Agent Metrics",
+  "title": "Cilium Metrics",
   "uid": "vtuWtdumz",
   "version": 1,
   "weekStart": ""

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
@@ -23,7 +23,7 @@
   },
   "description": "Dashboard for Cilium (https://cilium.io/) metrics",
   "editable": true,
-  "gnetId": null,
+  "gnetId": 15513,
   "graphTooltip": 1,
   "iteration": 1606309591568,
   "links": [],

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
@@ -8582,7 +8582,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Cilium v1.12 Agent Metrics",
+  "title": "Cilium Agent Metrics",
   "uid": "vtuWtdumz",
   "version": 1,
   "weekStart": ""


### PR DESCRIPTION
## Description

Refresh dashboard for cni-cilium

## Why do we need it, and what problem does it solve?

We want to have an up-to-date dashboard.

## What is the expected result?
The dashboard is fresh (i.e. the title is Cilium Metrics, not Cilium 1.12 Metrics).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: Refresh dashboard for cni-cilium
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
