### PR TITLE
[runtime-audit-engine] migrate runtime-audit-engine module to distroless

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -1,17 +1,44 @@
 {{- $falcoVersion := "0.35.1" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_UBUNTU }}
+fromImage: common/alt
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /falco-package
+  to: /
+  includePaths:
+  - usr/bin/
+  - usr/share/
+  - etc/
+  before: install
 shell:
   beforeInstall:
-    - apt-get update
-    - apt-get install tar gzip curl -y
-    - curl -sfL https://download.falco.org/packages/bin/x86_64/falco-{{ $falcoVersion }}-x86_64.tar.gz --output /tmp/falco.tar.gz
-    - tar -zxvf /tmp/falco.tar.gz --strip-components 1 --directory /
-    - rm -f /tmp/falco.tar.gz
+  - rm -df /lib/modules
+  - ln -s $HOST_ROOT/lib/modules /lib/modules
   install:
-    - "sed -i 's/time_format_iso_8601: false/time_format_iso_8601: true/' /etc/falco/falco.yaml"
-    - rm -df /lib/modules
-    - ln -s $HOST_ROOT/lib/modules /lib/modules
+  - "sed -i 's/time_format_iso_8601: false/time_format_iso_8601: true/' /etc/falco/falco.yaml"
 docker:
   CMD: ["/usr/bin/falco"]
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+fromImage: common/alt
+shell:
+  beforeInstall:
+  - apt-get -y update
+  - apt-get install -y gcc gcc-c++ git make cmake autoconf automake pkg-config patch libtool elfutils-devel diffutils which perl-FindBin-libs clang15.0 llvm rpm-build bpftool perl-Pod-Usage
+  install:
+  - git clone --branch {{ $falcoVersion }} --depth 1 {{ .SOURCE_REPO }}/falcosecurity/falco.git
+  - mkdir -p /falco/build
+  - cd /falco/build
+  - git clone --branch {{ $falcoVersion }} --depth 1 {{ .SOURCE_REPO }}/falcosecurity/falco-deps.git .
+  - rm -f /usr/bin/clang
+  - ln -s /usr/bin/clang-15 /usr/bin/clang
+  - cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION="{{ $falcoVersion }}" -DUSE_BUNDLED_DEPS=ON /falco
+# clone grpc repo from SOURCE_REPO
+  - export SED_VAR=$(sed "s/\//\\\\\//g" <<< "{{ .SOURCE_REPO }}")
+  - sed -i "s/https:\/\/github.com/$SED_VAR/g" grpc-prefix/src/grpc-stamp/grpc-gitinfo.txt
+  - sed -i "s/https:\/\/github.com/$SED_VAR/g" grpc-prefix/tmp/grpc-gitclone.cmake
+  - sed -i "s/DEB;RPM;TGZ/TGZ/" ./CPackConfig.cmake
+  - make package -j4
+  - mkdir -p /falco-package
+  - tar -zxvf falco-{{ $falcoVersion }}-x86_64.tar.gz --strip-components 1 -C /falco-package

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/requirements.txt
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/requirements.txt
@@ -1,5 +1,5 @@
-dictdiffer==0.9.0
-dotmap==1.3.30
-PyYAML==6.0
-stringcase==1.2.0
-deckhouse==0.4.7
+git+${SOURCE_REPO}/python-modules/dictdiffer.git@v0.9.0
+git+${SOURCE_REPO}/python-modules/dotmap.git@c7a778a95a01a7a0fd2f816a07c62de2478260c6
+git+${SOURCE_REPO}/python-modules/pyyaml.git@6.0.1
+git+${SOURCE_REPO}/python-modules/python-stringcase.git@57aae96649f5cf7fc98e50b1d62479456d492715
+git+${SOURCE_REPO}/python-modules/lib-python.git@d87162e79f62d064a7552cd51c06dff82fb253c5

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
@@ -1,34 +1,43 @@
-{{- $falcoVersion := "0.35.1" }}
+---
+artifact: tini-artifact
+from: {{ $.Images.BASE_ALPINE }}
+shell:
+  beforeInstall:
+    - apk update && apk add git cmake gcc make musl-dev
+  install:
+    - git clone {{ .SOURCE_REPO }}/krallin/tini --branch v0.19.0
+    - cd /tini/
+    - export CFLAGS="-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
+    - cmake . && make
+    - rm -rf /var/cache/apk/*
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_UBUNTU }}
+fromImage: common/shell-operator
 import:
+- artifact: tini-artifact
+  add: /tini/tini-static
+  to: /sbin/tini
+  before: setup
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
-    - usr/bin/falco
-    - usr/share/falco
-    - usr/local/lib/python3.10
-  before: setup
-- image: common/shell-operator
-  add: /shell-operator
-  to: /shell-operator
+  - usr/bin/falco
+  - usr/share/falco
+  - usr/local/lib/python3
+  - usr/local/lib64/python3
   before: setup
 git:
-  - add: /{{ $.ModulePath }}modules/650-{{ $.ModuleName }}/images/{{ $.ImageName }}/hooks
-    to: /hooks
-    stageDependencies:
-      install:
-        - '**/*'
+- add: /{{ $.ModulePath }}modules/650-{{ $.ModuleName }}/images/{{ $.ImageName }}/hooks
+  to: /hooks
+  stageDependencies:
+    install:
+    - '**/*'
 shell:
   beforeInstall:
-    - apt update -y
-    - apt install -yq curl tini python3='3.10.6-1~22.04'
-    # cleanup
-    - apt-get clean autoclean
-    - apt-get autoremove -y
-    - rm -rf /var/lib/{apt,dpkg,cache,log}/
+  - apt-get update
+  - apt-get install python3 -y
+  - rm -rf /var/cache/apt /var/lib/apt /var/lib/rpm
 docker:
   ENV:
     SHELL_OPERATOR_HOOKS_DIR: "/hooks"
@@ -38,24 +47,26 @@ docker:
   CMD: ["start"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_UBUNTU }}
+fromImage: common/alt
 git:
 - add: /{{ $.ModulePath }}modules/650-{{ $.ModuleName }}/images/{{ $.ImageName }}/requirements.txt
-  to: /requirements.txt
+  to: /tmp/requirements.txt
   stageDependencies:
     install:
       - '**/*'
+import:
+- artifact: {{ $.ModuleName }}/falco-artifact
+  add: /falco-package
+  to: /
+  includePaths:
+  - usr/bin/
+  - usr/share/
+  before: install
 shell:
   beforeInstall:
-  - apt update -y
-  - apt install -yq curl python3='3.10.6-1~22.04' python3-pip
-  - curl -sSfL https://download.falco.org/packages/bin/x86_64/falco-{{ $falcoVersion }}-x86_64.tar.gz | tar -C /tmp -xzvf -
-  - cp -f /tmp/falco-{{ $falcoVersion }}-x86_64/usr/bin/falco /usr/bin/falco
-  - cp -rf /tmp/falco-{{ $falcoVersion }}-x86_64/usr/share/falco /usr/share/falco
-  # cleanup
-  - apt-get clean autoclean
-  - apt-get autoremove -y
-  - rm -rf /var/lib/{apt,dpkg,cache,log}/
-  - rm -rf /tmp/falco-*
+  - apt-get update
+  - apt-get install python3 pip git -y
+  - rm -rf /var/cache/apt /var/lib/apt /var/lib/rpm
   install:
-  - pip3 install -r /requirements.txt
+  - export SOURCE_REPO={{ .SOURCE_REPO }}
+  - pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`runtime-audit-engine` images are now based on a distroless image.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We'd like to base our images on a distroless image.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: feature
summary: Docker images are based on a distroless image.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
