### PR TITLE
[istio] Generate only requested mutating and validating webhooks

### DIFF
--- a/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
@@ -23,7 +23,7 @@
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- range $version := (keys .Values.istio.internal.operatorVersionsToInstall) }}
+{{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
 {{- $baseArg := (list $ $version) }}
 ---
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}

--- a/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
@@ -23,7 +23,7 @@
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- range $version := (keys .Values.istio.internal.versionMap) }}
+{{- range $version := (keys .Values.istio.internal.operatorVersionsToInstall) }}
 {{- $baseArg := (list $ $version) }}
 ---
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}

--- a/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
@@ -1,4 +1,4 @@
-{{- range $version := (keys .Values.istio.internal.operatorVersionsToInstall) }}
+{{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
 {{- $revision := get $versionInfo "revision" }}
 ---

--- a/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
@@ -1,4 +1,4 @@
-{{- range $version := (keys .Values.istio.internal.versionMap) }}
+{{- range $version := (keys .Values.istio.internal.operatorVersionsToInstall) }}
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
 {{- $revision := get $versionInfo "revision" }}
 ---


### PR DESCRIPTION
## Description

Generate only requested mutating and validating webhooks.

## Why do we need it, and what problem does it solve?

Previously, `MutatingWebhookConfigurations` and `ValidatingWebhookConfigurations` were created for all supported versions of Istio.

It could be confusing.

## What is the expected result?

`MutatingWebhookConfigurations` and `ValidatingWebhookConfigurations` will only be created for the versions used in the cluster (globalVersion and additionalVersions).

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Generate only requested mutating and validating webhooks.
impact_level: default
```
