### PR TITLE
[prometheus] Set .spec.externalURL in alermanager manifest

### DIFF
--- a/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
@@ -71,6 +71,9 @@ spec:
             alertmanager: {{ .name }}
         topologyKey: kubernetes.io/hostname
   {{- end }}
+{{- if $.Values.global.modules.publicDomainTemplate }}
+  externalUrl: {{ include "helm_lib_module_uri_scheme" $ }}://{{ include "helm_lib_module_public_domain" (list $ "grafana") }}/alertmanager/{{ .name }}
+{{- end }}
   {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" $ | nindent 2 }}
   {{- include "helm_lib_node_selector" (tuple $ "monitoring") | nindent 2 }}
   {{- include "helm_lib_tolerations" (tuple $ "monitoring") | nindent 2 }}


### PR DESCRIPTION
## Description

When a public domain is configured the `.spec.externalURL` parameter must be set in the `Alertmanager` manifest [similar](https://github.com/deckhouse/deckhouse/blob/fdc2a2bc3072f5acae424b85eeacd053ec5eb81e/modules/300-prometheus/templates/prometheus/prometheus.yaml#L271-L273) to the Prometheus manifest

This PR fix part of problem with internal alertmanager in #7041 issue

## Why do we need it, and what problem does it solve?

Currently the `.spec.externalURL` parameter is absent, and as a result, in notifications where `externalURL` is used in templates, the link contains the URL of the internal k8s service

## Why do we need it in the patch release (if we do)?

This is a minor fix, so there's no need to wait for a minor release

## What is the expected result?

When a public domain is specified the `.spec.externalURL` parameter in the Alertmanager manifest should appear with the corresponding value

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: chore
summary: Set .spec.externalURL in alermanager manifest when a public domain is specified
