### PR TITLE
[istio] Improved `hack_iop_reconciling` hook

### DIFF
--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -133,8 +133,10 @@ func hackIopReconcilingHook(input *go_hook.HookInput) error {
 		input.LogEntry.Infof("Operator_pod Name: %s, CreationTimestamp: %s", operatorPod.Name, operatorPod.CreationTimestamp.Format(time.RFC3339))
 		input.LogEntry.Infof("Operator_pod Name: %s, CreationTimestamp+5m: %s", operatorPod.Name, operatorPod.CreationTimestamp.Add(time.Minute*5).Format(time.RFC3339))
 		input.LogEntry.Infof("Current Timestamp: %s", time.Now().Format(time.RFC3339))
-		input.LogEntry.Infof("Operator_pod Name: %s, calc AllowedToPunch %t", operatorPod.Name, time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)))
-		input.LogEntry.Infof("Operator_pod Name: %s, Status", operatorPod.podStatusPhase)
+		input.LogEntry.Infof("Operator_pod Name: %s, Status %s", operatorPod.Name, operatorPod.podStatusPhase)
+		input.LogEntry.Infof("Operator_pod Name: %s, calc time in AllowedToPunch %t", operatorPod.Name, time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)))
+		input.LogEntry.Infof("Operator_pod Name: %s, calc status in AllowedToPunch %t", operatorPod.Name, operatorPod.podStatusPhase == v1.PodRunning)
+		input.LogEntry.Infof("Operator_pod Name: %s, calc AllowedToPunch %t", operatorPod.Name, time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)) && operatorPod.podStatusPhase == v1.PodRunning)
 		if operatorPod.AllowedToPunch {
 			operatorPodMap[operatorPod.Revision] = operatorPod.Name
 		}

--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -131,10 +131,9 @@ func hackIopReconcilingHook(input *go_hook.HookInput) error {
 
 	for _, iopRaw := range input.Snapshots["istio_operators"] {
 		iop := iopRaw.(IstioOperatorCrdSnapshot)
-		input.LogEntry.Infof("iop_rev %s, needs to punch: %t", iop.Revision, iop.NeedPunch)
 		if iop.NeedPunch {
 			if podName, ok := operatorPodMap[iop.Revision]; ok {
-				input.LogEntry.Infof("Pod %s needs to punch and it's allowed", podName)
+				input.LogEntry.Infof("iop_rev %s needs to punch and pod %s is allowed to punch", iop.Revision, podName)
 				input.PatchCollector.Delete("v1", "Pod", "d8-istio", podName, object_patch.InBackground())
 				input.LogEntry.Infof("Pod %s deleted", podName)
 			}

--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -132,8 +132,9 @@ func hackIopReconcilingHook(input *go_hook.HookInput) error {
 	for _, iopRaw := range input.Snapshots["istio_operators"] {
 		iop := iopRaw.(IstioOperatorCrdSnapshot)
 		if iop.NeedPunch {
+			input.LogEntry.Infof("iop_rev %s needs to punch.", iop.Revision)
 			if podName, ok := operatorPodMap[iop.Revision]; ok {
-				input.LogEntry.Infof("iop_rev %s needs to punch and pod %s is allowed to punch", iop.Revision, podName)
+				input.LogEntry.Infof("Pod %s is allowed to punch", podName)
 				input.PatchCollector.Delete("v1", "Pod", "d8-istio", podName, object_patch.InBackground())
 				input.LogEntry.Infof("Pod %s deleted", podName)
 			}

--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -126,14 +126,6 @@ func hackIopReconcilingHook(input *go_hook.HookInput) error {
 
 	for _, operatorPodRaw := range input.Snapshots["istio_operator_pods"] {
 		operatorPod := operatorPodRaw.(IstioOperatorPodSnapshot)
-		input.LogEntry.Infof("Operator_pod Name: %s, Revision: %s", operatorPod.Name, operatorPod.Revision)
-		input.LogEntry.Infof("Operator_pod Name: %s, Status %s", operatorPod.Name, operatorPod.Phase)
-		input.LogEntry.Infof("Operator_pod Name: %s, CreationTimestamp: %s", operatorPod.Name, operatorPod.CreationTimestamp.Format(time.RFC3339))
-		input.LogEntry.Infof("Operator_pod Name: %s, CreationTimestamp+5m: %s", operatorPod.Name, operatorPod.CreationTimestamp.Add(time.Minute*5).Format(time.RFC3339))
-		input.LogEntry.Infof("Current Timestamp: %s", time.Now().Format(time.RFC3339))
-		input.LogEntry.Infof("Operator_pod Name: %s, calc time in AllowedToPunch %t", operatorPod.Name, time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)))
-		input.LogEntry.Infof("Operator_pod Name: %s, calc status in AllowedToPunch %t", operatorPod.Name, operatorPod.Phase == v1.PodRunning)
-		input.LogEntry.Infof("Operator_pod Name: %s, calc AllowedToPunch %t", operatorPod.Name, time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)) && operatorPod.Phase == v1.PodRunning)
 		if time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)) && operatorPod.Phase == v1.PodRunning {
 			operatorPodMap[operatorPod.Revision] = operatorPod.Name
 		}
@@ -142,12 +134,11 @@ func hackIopReconcilingHook(input *go_hook.HookInput) error {
 	for _, iopRaw := range input.Snapshots["istio_operators"] {
 		iop := iopRaw.(IstioOperatorCrdSnapshot)
 		if iop.NeedPunch {
-			input.LogEntry.Infof("iop_rev %s needs to punch.", iop.Revision)
-			input.LogEntry.Infof("Pod name to punch is %s", operatorPodMap[iop.Revision])
+			input.LogEntry.Infof("iop with rev %s needs to punch.", iop.Revision)
 			if podName, ok := operatorPodMap[iop.Revision]; ok {
-				input.LogEntry.Infof("Pod %s is allowed to punch", podName)
+				input.LogEntry.Infof("Pod %s is allowed to punch.", podName)
 				input.PatchCollector.Delete("v1", "Pod", "d8-istio", podName, object_patch.InBackground())
-				input.LogEntry.Infof("Pod %s deleted", podName)
+				input.LogEntry.Infof("Pod %s deleted.", podName)
 			}
 		}
 	}

--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -38,7 +38,7 @@ import (
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/crd"
 )
 
-const validatingErrorStr = `failed calling webhook "validation.istio.io"`
+const validatingErrorStr = `failed calling webhook`
 
 type IstioOperatorCrdSnapshot struct {
 	Revision  string

--- a/modules/110-istio/hooks/hack_iop_reconciling_test.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Istio hooks :: hack iop reconciling ::", func() {
 				Name:      "errored-operator",
 				Phase:     "Running",
 				Revision:  "v1x33",
-				Timestamp: time.Now().Add(time.Minute * 6),
+				Timestamp: time.Now().Add(-time.Minute * 6),
 			})))
 			f.RunHook()
 		})
@@ -206,7 +206,7 @@ var _ = Describe("Istio hooks :: hack iop reconciling ::", func() {
 				Name:      "errored-operator",
 				Phase:     "Pending",
 				Revision:  "v1x33",
-				Timestamp: time.Now().Add(time.Minute * 6),
+				Timestamp: time.Now().Add(-time.Minute * 6),
 			})))
 			f.RunHook()
 		})
@@ -257,7 +257,7 @@ var _ = Describe("Istio hooks :: hack iop reconciling ::", func() {
 				Name:      "errored-operator",
 				Phase:     "Running",
 				Revision:  "v1x33",
-				Timestamp: time.Now().Add(time.Minute * 6),
+				Timestamp: time.Now().Add(-time.Minute * 6),
 			}),
 			))
 			f.RunHook()


### PR DESCRIPTION
## Description

Improved `hack_iop_reconciling` hook

## Why do we need it, and what problem does it solve?

Previously, this hook didn't trigger on errors contain `rev.validation.istio.io`.

## What is the expected result?

This hook should be triggered for errors that contain `validation.istio.io` or `*.validation.istio.io`.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Improved hack_iop_reconciling hook to prevent istio-operator stucking
impact_level: default
```