### PR TITLE
return "[prometheus]  Add examples for CustomAlertmanager (#7030)"

### DIFF
--- a/modules/300-prometheus/docs/USAGE.md
+++ b/modules/300-prometheus/docs/USAGE.md
@@ -5,6 +5,8 @@ type:
 search: prometheus remote write, how to connect to Prometheus, custom Grafana, prometheus remote write
 ---
 
+{% raw %}
+
 ## An example of the module configuration
 
 ```yaml
@@ -236,3 +238,71 @@ spec:
 ```
 
 The fields `token` in the Secret and `chatID` in the `CustomAlertmanager` custom resource must be set on your own. [Read more](https://core.telegram.org/bots) about Telegram API.
+
+## Example of sending alerts to Slack with a filter
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: CustomAlertmanager
+metadata:
+  name: slack
+spec:
+  internal:
+    receivers:
+    - name: devnull
+    - name: slack
+      slackConfigs:
+      - apiURL:
+          key: apiURL
+          name: slack-apiurl
+        channel: {{ dig .Values.werf.env .Values.slack.channel._default .Values.slack.channel }} 
+        fields:
+        - short: true
+          title: Severity
+          value: '{{`{{  .CommonLabels.severity_level }}`}}'
+        - short: true
+          title: Status
+          value: '{{`{{ .Status }}`}}'
+        - title: Summary
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.summary }}`}} {{`{{ end }}`}}'
+        - title: Description
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.description }}`}} {{`{{ end }}`}}'
+        - title: Labels
+          value: '{{`{{ range .Alerts }}`}} {{`{{ range .Labels.SortedPairs }}`}}{{`{{ printf "%s:
+            %s\n" .Name .Value }}`}}{{`{{ end }}`}}{{`{{ end }}`}}'
+        - title: Links
+          value: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+        title: '{{`{{ .CommonLabels.alertname }}`}}'
+    route:
+      groupBy:
+      - '...'  
+      receiver: devnull
+      routes:
+        - matchers:
+          - matchType: =~
+            name: severity_level
+            value: "^[4-9]$"
+          receiver: slack
+      repeatInterval: 12h
+  type: Internal
+```
+
+## Example of sending alerts to Opsgenie
+
+```yaml
+- name: opsgenie
+        opsgenieConfigs:
+          - apiKey:
+              key: data
+              name: opsgenie
+            description: |
+              {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}
+              {{ range .Alerts }}{{ .Annotations.description }} {{ end }}
+            message: '{{ .CommonLabels.alertname }}'
+            priority: P1
+            responders:
+              - id: team_id
+                type: team
+```
+
+{% endraw %}

--- a/modules/300-prometheus/docs/USAGE_RU.md
+++ b/modules/300-prometheus/docs/USAGE_RU.md
@@ -5,6 +5,8 @@ type:
 search: prometheus remote write, как подключиться к Prometheus, пользовательская Grafana, prometheus remote write
 ---
 
+{% raw %}
+
 ## Пример конфигурации модуля
 
 ```yaml
@@ -236,3 +238,71 @@ spec:
 ```
 
 Поля `token` в Secret'е и `chatID` в ресурсе `CustomAlertmanager` необходимо поставить свои. [Подробнее](https://core.telegram.org/bots) о Telegram API.
+
+## Пример отправки алертов в Slack с фильтром
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: CustomAlertmanager
+metadata:
+  name: slack
+spec:
+  internal:
+    receivers:
+    - name: devnull
+    - name: slack
+      slackConfigs:
+      - apiURL:
+          key: apiURL
+          name: slack-apiurl
+        channel: {{ dig .Values.werf.env .Values.slack.channel._default .Values.slack.channel }} 
+        fields:
+        - short: true
+          title: Severity
+          value: '{{`{{  .CommonLabels.severity_level }}`}}'
+        - short: true
+          title: Status
+          value: '{{`{{ .Status }}`}}'
+        - title: Summary
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.summary }}`}} {{`{{ end }}`}}'
+        - title: Description
+          value: '{{`{{ range .Alerts }}`}}{{`{{ .Annotations.description }}`}} {{`{{ end }}`}}'
+        - title: Labels
+          value: '{{`{{ range .Alerts }}`}} {{`{{ range .Labels.SortedPairs }}`}}{{`{{ printf "%s:
+            %s\n" .Name .Value }}`}}{{`{{ end }}`}}{{`{{ end }}`}}'
+        - title: Links
+          value: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+        title: '{{`{{ .CommonLabels.alertname }}`}}'
+    route:
+      groupBy:
+      - '...'  
+      receiver: devnull
+      routes:
+        - matchers:
+          - matchType: =~
+            name: severity_level
+            value: "^[4-9]$"
+          receiver: slack
+      repeatInterval: 12h
+  type: Internal
+```
+
+## Пример отправки алертов в Opsgenie
+
+```yaml
+- name: opsgenie
+        opsgenieConfigs:
+          - apiKey:
+              key: data
+              name: opsgenie
+            description: |
+              {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}
+              {{ range .Alerts }}{{ .Annotations.description }} {{ end }}
+            message: '{{ .CommonLabels.alertname }}'
+            priority: P1
+            responders:
+              - id: team_id
+                type: team
+```
+
+{% endraw %}


### PR DESCRIPTION
## Description

This returns https://github.com/deckhouse/deckhouse/pull/7030 (was reverted in https://github.com/deckhouse/deckhouse/pull/7050).

The return of values became possible after https://github.com/deckhouse/deckhouse/pull/7052.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Return https://github.com/deckhouse/deckhouse/pull/7030 (was reverted in https://github.com/deckhouse/deckhouse/pull/7050).
impact_level: low
```
