### PR TITLE
[kube-dns] Change D8KubeDnsServiceWithDeprecatedAnnotation alert name

### DIFF
--- a/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
+++ b/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
@@ -17,7 +17,7 @@
       summary: CoreDNS has critical errors.
 - name: deckhouse.kube-dns.legacy-services
   rules:
-  - alert: D8KubeDnsServiceWithDeprecatedAnnotation
+  - alert: KubeDnsServiceWithDeprecatedAnnotation
     expr: max by (service_namespace, service_name) (d8_kube_dns_deprecated_service_annotation) == 1
     for: 5m
     labels:
@@ -25,8 +25,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
-      plk_grouped_by__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
+      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
+      plk_grouped_by__d8_kube_dns_deprecated_resources: KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
       summary: Deprecated Service annotation found.
       description: |
         Replace deprecated Service annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` with `spec.publishNotReadyAddresses: true`.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change alert name to send alert directly to cluster owner instead of d8 support

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Alert should send to cluster support command. D8 support can't resolve this alert

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Alert send to cluster support team

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: fix
summary: Change D8KubeDnsServiceWithDeprecatedAnnotation alert name
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
