### PR TITLE
[testing] Change worker node bootstrap from manual to CAPS

### DIFF
--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -14,6 +14,26 @@ spec:
     - effect: NoExecute
       key: dedicated.deckhouse.io
       value: system
+
+
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SSHCredentials
+metadata:
+  name: caps_id
+spec:
+  privateSSHKey: '${b64_SSH_KEY}'
+  user: '${WORKER_USER}'
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static
+spec:
+  address: '${WORKER_IP}'
+  credentialsRef:
+    kind: SSHCredentials
+    name: caps_id
 ---
 apiVersion: deckhouse.io/v1
 kind: NodeGroup
@@ -21,6 +41,8 @@ metadata:
   name: worker
 spec:
   nodeType: Static
+  staticInstances:
+    count: 1
   disruptions:
     approvalMode: Manual
   nodeTemplate:

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -20,7 +20,7 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: SSHCredentials
 metadata:
-  name: caps_id
+  name: caps-id
 spec:
   privateSSHKey: '${b64_SSH_KEY}'
   user: '${WORKER_USER}'
@@ -33,7 +33,7 @@ spec:
   address: '${WORKER_IP}'
   credentialsRef:
     kind: SSHCredentials
-    name: caps_id
+    name: caps-id
 ---
 apiVersion: deckhouse.io/v1
 kind: NodeGroup

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -568,7 +568,7 @@ ENDSSH
   # shellcheck disable=SC2016
   env b64_SSH_KEY="$(base64 -w0 "$ssh_private_key_path")" WORKER_USER="$ssh_user_worker" WORKER_IP="$worker_ip" \
       envsubst '${b64_SSH_KEY} ${WORKER_USER} ${WORKER_IP}' \
-      <"$cwd/resources.tpl.yaml" "$cwd/resources.yaml"
+      <"$cwd/resources.tpl.yaml" >"$cwd/resources.yaml"
 
   # Bootstrap
   >&2 echo "Run dhctl bootstrap ..."

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -564,6 +564,12 @@ ENDSSH
     return 1
   fi
 
+  # Prepare resources.yaml for starting working node with CAPS
+  # shellcheck disable=SC2016
+  env b64_SSH_KEY="$(base64 -w0 "$ssh_private_key_path")" WORKER_USER="$ssh_user_worker" WORKER_IP="$worker_ip" \
+      envsubst '${b64_SSH_KEY} ${WORKER_USER} ${WORKER_IP}' \
+      <"$cwd/resources.tpl.yaml" "$cwd/resources.yaml"
+
   # Bootstrap
   >&2 echo "Run dhctl bootstrap ..."
   dhctl bootstrap --resources-timeout="30m" --yes-i-want-to-drop-cache --ssh-bastion-host "$bastion_ip" --ssh-bastion-user="$ssh_user" --ssh-host "$master_ip" --ssh-agent-private-keys "$ssh_private_key_path" --ssh-user "$ssh_user" \
@@ -597,23 +603,6 @@ ENDSSH
     return 1
   fi
 
-  for ((i=0; i<10; i++)); do
-    bootstrap_worker="$($ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash << "ENDSSH"
-export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-export LANG=C
-set -Eeuo pipefail
-kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq -r '.data."bootstrap.sh"'
-ENDSSH
-)" && break
-    >&2 echo "Attempt to get secret manual-bootstrap-for-worker in d8-cloud-instance-manager namespace #$i failed. Sleeping 30 seconds..."
-    sleep 30
-  done
-
-  if [[ -z "$bootstrap_worker" ]]; then
-    >&2 echo "Couldn't get secret manual-bootstrap-for-worker in d8-cloud-instance-manager namespace."
-    return 1
-  fi
-
   # shellcheck disable=SC2087
   # Node reboots in bootstrap process, so ssh exits with error code 255. It's normal, so we use || true to avoid script fail.
   $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user_system@$system_ip" sudo su -c /bin/bash <<ENDSSH || true
@@ -621,13 +610,6 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 base64 -d <<< "$bootstrap_system" | bash
-ENDSSH
-
-  $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user_worker@$worker_ip" sudo su -c /bin/bash <<ENDSSH || true
-export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-export LANG=C
-set -Eeuo pipefail
-base64 -d <<< "$bootstrap_worker" | bash
 ENDSSH
 
   registration_failed=


### PR DESCRIPTION
## Description
In current static e2e tests, all static nodes bootstrapped manually, sending bash script to the node. Recently, we added Cluster API Provider Static (CAPS) for managing static nodes. We need to add this kind of node to e2e Static tests.

## Why do we need it, and what problem does it solve?
It is needed to bootstrap nodes with Cluster API Provider Static (CAPS) in e2e static tests. 

## What is the expected result?
Worker node bootstraps using CAPS.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: feature
summary: Change worker node bootstrap from manual to CAPS.
impact_level: low
```
