### PR TITLE
[deckhouse-controller] module config validator

### DIFF
--- a/go_lib/deckhouse-config/validator.go
+++ b/go_lib/deckhouse-config/validator.go
@@ -153,7 +153,7 @@ func (c *ConfigValidator) ConvertToLatest(cfg *v1alpha1.ModuleConfig) Validation
 // TODO(future) return cfg, error. Put cfg.Spec into result cfg.
 func (c *ConfigValidator) Validate(cfg *v1alpha1.ModuleConfig) ValidationResult {
 	result := c.ConvertToLatest(cfg)
-	if result.HasError() || !hasVersionedSettings(cfg) {
+	if result.HasError() {
 		return result
 	}
 
@@ -171,12 +171,17 @@ func (c *ConfigValidator) Validate(cfg *v1alpha1.ModuleConfig) ValidationResult 
 
 // validateSettings uses ValuesValidator from ModuleManager instance to validate spec.settings.
 // cfgName arg is a kebab-cased name of the ModuleConfig resource.
-// cfgSettings is a content of spec.settings.
+// cfgSettings is a content of spec.settings and can be nil if settings field wasn't set.
 // (Note: cfgSettings map is a map with 'plain values', i.e. without camelCased module name as a root key).
 func (c *ConfigValidator) validateSettings(cfgName string, cfgSettings map[string]interface{}) error {
 	// Ignore empty validator.
 	if c.valuesValidator == nil {
 		return nil
+	}
+
+	// init cfg settings if it equals nil
+	if cfgSettings == nil {
+		cfgSettings = make(map[string]interface{})
 	}
 
 	valuesKey := valuesKeyFromObjectName(cfgName)


### PR DESCRIPTION
## Description
This pr fixes `ModuleConfig` validation in case a module config has empty settings field but there are some required parameters in its OpenApi schema.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
As of now, if a module config has empty settings field, the validation process doesn't actually validate any module values and if there are some required parameters in the module's OpenApi schema it entails a deferred error when deckhouse is trying to enable the module. Such ModuleConfigs have to be filtered at creation step.
Closes #6973
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
ModuleConfigs are get validated even if they don't have .spec.version/.spec.settings fields specified.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix ModuleConfig validation for configs with empty settings.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
