### PR TITLE
[docs][getting-started] Fix snippet for the bare metal

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
@@ -65,7 +65,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
@@ -63,7 +63,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
@@ -63,7 +63,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
@@ -68,7 +68,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
@@ -58,7 +58,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
@@ -56,7 +56,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ce.inc
@@ -40,7 +40,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/existing/partials/config.ru.yml.ee.inc
@@ -38,7 +38,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
@@ -63,7 +63,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
@@ -63,7 +63,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ee.inc
@@ -59,7 +59,7 @@ metadata:
   name: global
 spec:
   version: 1
-  settings: # <-- Параметры модуля из раздела "Параметры" ниже.
+  settings:
     modules:
       # [<en>] Template that will be used for system apps domains within the cluster.
       # [<en>] E.g., Grafana for %s.example.com will be available as 'grafana.example.com'.

--- a/docs/site/js/getting-started-private.js
+++ b/docs/site/js/getting-started-private.js
@@ -23,7 +23,7 @@ $(document).ready(function () {
           delete_elements($(this), 2);
           parent.html(parent.html().replaceAll(/\n\s+\n/g, "\n"));
         });
-        updateTextInSnippet('[config-yml]', /\n\s+httpProxy: <HTTP_PROXY_ADDRESS>\n/, "\n");
+        updateTextInSnippet('[config-yml]', /\n\s+httpProxy: \<HTTP_PROXY_ADDRESS\>\n/, "\n");
       }
     }
 
@@ -38,7 +38,7 @@ $(document).ready(function () {
           delete_elements($(this), 2);
           parent.html(parent.html().replaceAll(/\n\s+\n/g, "\n"));
         });
-        updateTextInSnippet('[config-yml]', /\n\s+httpsProxy: <HTTPS_PROXY_ADDRESS>\n/, "\n");
+        updateTextInSnippet('[config-yml]', /\n\s+httpsProxy: \<HTTPS_PROXY_ADDRESS\>\n/, "\n");
       }
     }
 
@@ -55,7 +55,10 @@ $(document).ready(function () {
       delete_elements($(this).prev(), 11);
       parent.html(parent.html().replaceAll(/\n\s+\n/g, "\n"));
     });
-    updateTextInSnippet('[config-yml]', /\n\s+#[^#]+\n\s+proxy:\n\s+httpProxy: <HTTP_PROXY_ADDRESS>\n\s+httpsProxy: <HTTPS_PROXY_ADDRESS>\n\s+noProxy: <NO_PROXY_LIST>\n/, "\n");
+    updateTextInSnippet('[config-yml]', /\n\s*#[^#]+\n\s*proxy:\n/, "\n");
+    updateTextInSnippet('[config-yml]', /\n\s+httpProxy: \<HTTP_PROXY_ADDRESS\>\n/, "\n");
+    updateTextInSnippet('[config-yml]', /\n\s+httpsProxy: \<HTTPS_PROXY_ADDRESS\>\n/, "\n");
+    updateTextInSnippet('[config-yml]', /\n\s+noProxy: \<NO_PROXY_LIST\>\n/, "\n");
   }
 
   if (!(noProxyAddressList && noProxyAddressList.length > 0)) {
@@ -67,7 +70,7 @@ $(document).ready(function () {
       delete_elements($(this), 2);
       parent.html(parent.html().replaceAll(/\n\s+\n/g, "\n"));
     });
-    updateTextInSnippet('[config-yml]', /\n\s+noProxy: <NO_PROXY_LIST>\n/, "\n");
+    updateTextInSnippet('[config-yml]', /\n\s+noProxy: \<NO_PROXY_LIST\>\n/, "\n");
   }
 
   if (registryImagesRepo && registryImagesRepo.length > 0) {
@@ -88,10 +91,11 @@ $(document).ready(function () {
         return (this.innerText === "registryScheme");
       }).each(function (index) {
         delete_elements($(this).next().next().next(), 3);
-        updateTextInSnippet('[config-yml]', /(registryScheme: HTTP[S]?).+\n---/s, "$1\n---");
+        updateTextInSnippet('[config-yml]', /(registryScheme: HTTP[S]?).+\<REGISTRY_CA\>\n---/s, "$1\n---");
       });
 
     }
+
     $('.highlight code').filter(function () {
       return this.innerText.match('<IMAGES_REPO_URI>');
     }).each(function () {


### PR DESCRIPTION
## Description
Fix snippet modification logic for the bare metal installation.

## Why do we need it, and what problem does it solve?
There are some cases, when code in the clipboard does not reflect actual config on a page in the getting started for bare metal installation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix snippet modification logic for the bare metal installation.
impact_level: low
```
