### PR TITLE
[dhctl] mirror: skip registry tls certificate validation flag

### DIFF
--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -54,6 +54,7 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 func mirrorPushDeckhouseToPrivateRegistry() error {
 	mirrorCtx := &mirror.Context{
 		Insecure:              app.MirrorInsecure,
+		TLSVerification:       !app.MirrorTLSSkipVerify,
 		RegistryHost:          app.MirrorRegistryHost,
 		RegistryPath:          app.MirrorRegistryPath,
 		DeckhouseRegistryRepo: app.MirrorSourceRegistryRepo,
@@ -75,6 +76,7 @@ func mirrorPushDeckhouseToPrivateRegistry() error {
 		mirrorCtx.RegistryHost+mirrorCtx.RegistryPath,
 		mirrorCtx.RegistryAuth,
 		mirrorCtx.Insecure,
+		mirrorCtx.TLSVerification,
 	); err != nil {
 		return fmt.Errorf("Registry credentials validation failure: %w", err)
 	}
@@ -99,6 +101,7 @@ func mirrorPushDeckhouseToPrivateRegistry() error {
 func mirrorPullDeckhouseToLocalFilesystem() error {
 	mirrorCtx := &mirror.Context{
 		Insecure:              app.MirrorInsecure,
+		TLSVerification:       !app.MirrorTLSSkipVerify,
 		DoGOSTDigests:         app.MirrorDoGOSTDigest,
 		RegistryHost:          app.MirrorRegistryHost,
 		DeckhouseRegistryRepo: app.MirrorSourceRegistryRepo,
@@ -119,7 +122,12 @@ func mirrorPullDeckhouseToLocalFilesystem() error {
 		}
 	}
 
-	if err := mirror.ValidateReadAccessForImage(mirrorCtx.DeckhouseRegistryRepo+":rock-solid", mirrorCtx.RegistryAuth, mirrorCtx.Insecure); err != nil {
+	if err := mirror.ValidateReadAccessForImage(
+		mirrorCtx.DeckhouseRegistryRepo+":rock-solid",
+		mirrorCtx.RegistryAuth,
+		mirrorCtx.Insecure,
+		mirrorCtx.TLSVerification,
+	); err != nil {
 		return fmt.Errorf("Source registry access validation failure: %w", err)
 	}
 

--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -54,7 +54,7 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 func mirrorPushDeckhouseToPrivateRegistry() error {
 	mirrorCtx := &mirror.Context{
 		Insecure:              app.MirrorInsecure,
-		TLSVerification:       !app.MirrorTLSSkipVerify,
+		SkipTLSVerification:   app.MirrorTLSSkipVerify,
 		RegistryHost:          app.MirrorRegistryHost,
 		RegistryPath:          app.MirrorRegistryPath,
 		DeckhouseRegistryRepo: app.MirrorSourceRegistryRepo,
@@ -76,7 +76,7 @@ func mirrorPushDeckhouseToPrivateRegistry() error {
 		mirrorCtx.RegistryHost+mirrorCtx.RegistryPath,
 		mirrorCtx.RegistryAuth,
 		mirrorCtx.Insecure,
-		mirrorCtx.TLSVerification,
+		mirrorCtx.SkipTLSVerification,
 	); err != nil {
 		return fmt.Errorf("Registry credentials validation failure: %w", err)
 	}
@@ -101,7 +101,7 @@ func mirrorPushDeckhouseToPrivateRegistry() error {
 func mirrorPullDeckhouseToLocalFilesystem() error {
 	mirrorCtx := &mirror.Context{
 		Insecure:              app.MirrorInsecure,
-		TLSVerification:       !app.MirrorTLSSkipVerify,
+		SkipTLSVerification:   app.MirrorTLSSkipVerify,
 		DoGOSTDigests:         app.MirrorDoGOSTDigest,
 		RegistryHost:          app.MirrorRegistryHost,
 		DeckhouseRegistryRepo: app.MirrorSourceRegistryRepo,
@@ -126,7 +126,7 @@ func mirrorPullDeckhouseToLocalFilesystem() error {
 		mirrorCtx.DeckhouseRegistryRepo+":rock-solid",
 		mirrorCtx.RegistryAuth,
 		mirrorCtx.Insecure,
-		mirrorCtx.TLSVerification,
+		mirrorCtx.SkipTLSVerification,
 	); err != nil {
 		return fmt.Errorf("Source registry access validation failure: %w", err)
 	}

--- a/dhctl/cmd/dhctl/commands/mirror_modules.go
+++ b/dhctl/cmd/dhctl/commands/mirror_modules.go
@@ -38,12 +38,12 @@ func DefineMirrorModulesCommand(parent *kingpin.Application) *kingpin.CmdClause 
 			}
 
 			return log.Process("mirror", "Push Modules to registry", func() error {
-				return operations.PushModulesToRegistry(app.MirrorModuleDirectory, app.MirrorRegistry, authProvider, app.MirrorInsecure, !app.MirrorTLSSkipVerify)
+				return operations.PushModulesToRegistry(app.MirrorModuleDirectory, app.MirrorRegistry, authProvider, app.MirrorInsecure, app.MirrorTLSSkipVerify)
 			})
 		}
 
 		return log.Process("mirror", "Pull Modules to local filesystem", func() error {
-			return operations.PullExternalModulesToLocalFS(app.MirrorModuleSourcePath, app.MirrorModuleDirectory, !app.MirrorTLSSkipVerify)
+			return operations.PullExternalModulesToLocalFS(app.MirrorModuleSourcePath, app.MirrorModuleDirectory, app.MirrorTLSSkipVerify)
 		})
 	})
 

--- a/dhctl/cmd/dhctl/commands/mirror_modules.go
+++ b/dhctl/cmd/dhctl/commands/mirror_modules.go
@@ -38,12 +38,12 @@ func DefineMirrorModulesCommand(parent *kingpin.Application) *kingpin.CmdClause 
 			}
 
 			return log.Process("mirror", "Push Modules to registry", func() error {
-				return operations.PushModulesToRegistry(app.MirrorModuleDirectory, app.MirrorRegistry, authProvider, app.MirrorInsecure)
+				return operations.PushModulesToRegistry(app.MirrorModuleDirectory, app.MirrorRegistry, authProvider, app.MirrorInsecure, !app.MirrorTLSSkipVerify)
 			})
 		}
 
 		return log.Process("mirror", "Pull Modules to local filesystem", func() error {
-			return operations.PullExternalModulesToLocalFS(app.MirrorModuleSourcePath, app.MirrorModuleDirectory)
+			return operations.PullExternalModulesToLocalFS(app.MirrorModuleSourcePath, app.MirrorModuleDirectory, !app.MirrorTLSSkipVerify)
 		})
 	})
 

--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -118,7 +118,7 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 		BoolVar(&MirrorDoGOSTDigest)
 	cmd.Flag("no-pull-resume", "Do not continue last unfinished pull operation.").
 		BoolVar(&MirrorDontContinuePartialPull)
-	cmd.Flag("tls-skip-verify", "TLS certificate validation.").
+	cmd.Flag("tls-skip-verify", "Disable TLS certificate validation.").
 		BoolVar(&MirrorTLSSkipVerify)
 	cmd.Flag("insecure", "Interact with registries over HTTP.").
 		BoolVar(&MirrorInsecure)

--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -47,6 +47,7 @@ var (
 	MirrorRegistryPassword = ""
 
 	MirrorInsecure       = false
+	MirrorTLSSkipVerify  = false
 	MirrorDHLicenseToken = ""
 	MirrorTarBundlePath  = ""
 
@@ -117,6 +118,8 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 		BoolVar(&MirrorDoGOSTDigest)
 	cmd.Flag("no-pull-resume", "Do not continue last unfinished pull operation.").
 		BoolVar(&MirrorDontContinuePartialPull)
+	cmd.Flag("tls-skip-verify", "TLS certificate validation.").
+		BoolVar(&MirrorTLSSkipVerify)
 	cmd.Flag("insecure", "Interact with registries over HTTP.").
 		BoolVar(&MirrorInsecure)
 

--- a/dhctl/pkg/app/mirror_modules.go
+++ b/dhctl/pkg/app/mirror_modules.go
@@ -53,6 +53,8 @@ func DefineMirrorModulesFlags(cmd *kingpin.CmdClause) {
 		PlaceHolder("PASSWORD").
 		Envar(configEnvName("MIRROR_PASS")).
 		StringVar(&MirrorRegistryPassword)
+	cmd.Flag("tls-skip-verify", "TLS certificate validation.").
+		BoolVar(&MirrorTLSSkipVerify)
 	cmd.Flag("insecure", "Interact with registries over HTTP.").
 		BoolVar(&MirrorInsecure)
 

--- a/dhctl/pkg/operations/mirror/auth.go
+++ b/dhctl/pkg/operations/mirror/auth.go
@@ -16,7 +16,9 @@ package mirror
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -25,8 +27,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-func ValidateReadAccessForImage(imageTag string, authProvider authn.Authenticator, insecure bool) error {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+func ValidateReadAccessForImage(imageTag string, authProvider authn.Authenticator, insecure, verifyTLS bool) error {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
 	ref, err := name.ParseReference(imageTag, nameOpts...)
 	if err != nil {
 		return fmt.Errorf("Parse registry address: %w", err)
@@ -43,8 +45,8 @@ func ValidateReadAccessForImage(imageTag string, authProvider authn.Authenticato
 	return nil
 }
 
-func ValidateWriteAccessForRepo(repo string, authProvider authn.Authenticator, insecure bool) error {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+func ValidateWriteAccessForRepo(repo string, authProvider authn.Authenticator, insecure, verifyTLS bool) error {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
 	ref, err := name.NewTag(repo+":dhctlWriteCheck", nameOpts...)
 	if err != nil {
 		return err
@@ -62,7 +64,7 @@ func ValidateWriteAccessForRepo(repo string, authProvider authn.Authenticator, i
 	return nil
 }
 
-func MakeRemoteRegistryRequestOptions(authProvider authn.Authenticator, insecure bool) ([]name.Option, []remote.Option) {
+func MakeRemoteRegistryRequestOptions(authProvider authn.Authenticator, insecure, verifyTLS bool) ([]name.Option, []remote.Option) {
 	n, r := make([]name.Option, 0), make([]remote.Option, 0)
 	if insecure {
 		n = append(n, name.Insecure)
@@ -70,10 +72,15 @@ func MakeRemoteRegistryRequestOptions(authProvider authn.Authenticator, insecure
 	if authProvider != nil && authProvider != authn.Anonymous {
 		r = append(r, remote.WithAuth(authProvider))
 	}
+	if !verifyTLS {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		r = append(r, remote.WithTransport(transport))
+	}
 
 	return n, r
 }
 
 func MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx *Context) ([]name.Option, []remote.Option) {
-	return MakeRemoteRegistryRequestOptions(mirrorCtx.RegistryAuth, mirrorCtx.Insecure)
+	return MakeRemoteRegistryRequestOptions(mirrorCtx.RegistryAuth, mirrorCtx.Insecure, mirrorCtx.TLSVerification)
 }

--- a/dhctl/pkg/operations/mirror/context.go
+++ b/dhctl/pkg/operations/mirror/context.go
@@ -21,14 +21,15 @@ import (
 
 // Context hold data related to pending registry mirroring operation.
 type Context struct {
-	Insecure      bool // --insecure
-	DoGOSTDigests bool // --gost-digest
+	Insecure        bool // --insecure
+	TLSVerification bool // --tls-verify
+	DoGOSTDigests   bool // --gost-digest
 
 	RegistryAuth authn.Authenticator // --registry-login + --registry-password (can be nil in this case) or --license depending on the operation requested
 	RegistryHost string              // --registry (FQDN with port, if one is provided)
 	RegistryPath string              // --registry (path)
 
-	DeckhouseRegistryRepo string // points to the registry.deckhouse.io with path to required edition repo, see --fe flag
+	DeckhouseRegistryRepo string // --source
 
 	TarBundlePath      string // --images
 	UnpackedImagesPath string

--- a/dhctl/pkg/operations/mirror/context.go
+++ b/dhctl/pkg/operations/mirror/context.go
@@ -21,9 +21,9 @@ import (
 
 // Context hold data related to pending registry mirroring operation.
 type Context struct {
-	Insecure        bool // --insecure
-	TLSVerification bool // --tls-verify
-	DoGOSTDigests   bool // --gost-digest
+	Insecure            bool // --insecure
+	SkipTLSVerification bool // --skip-tls-verify
+	DoGOSTDigests       bool // --gost-digest
 
 	RegistryAuth authn.Authenticator // --registry-login + --registry-password (can be nil in this case) or --license depending on the operation requested
 	RegistryHost string              // --registry (FQDN with port, if one is provided)

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -192,7 +192,7 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 			moduleData.ReleaseImages,
 			mirrorCtx.RegistryAuth,
 			mirrorCtx.Insecure,
-			mirrorCtx.TLSVerification,
+			mirrorCtx.SkipTLSVerification,
 		)
 		if err != nil {
 			return fmt.Errorf("fetch versions from %q release channels: %w", moduleName, err)
@@ -236,9 +236,9 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 func fetchVersionsFromModuleReleaseChannels(
 	releaseChannelImages map[string]struct{},
 	authProvider authn.Authenticator,
-	insecure, verifyTLS bool,
+	insecure, skipVerifyTLS bool,
 ) (map[string]string, error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
 	channelVersions := map[string]string{}
 	for imageTag := range releaseChannelImages {
 

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -188,7 +188,12 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 			mirrorCtx.DeckhouseRegistryRepo + "/modules/" + moduleName + "/release:rock-solid":   {},
 		}
 
-		channelVersions, err := fetchVersionsFromModuleReleaseChannels(moduleData.ReleaseImages, mirrorCtx.RegistryAuth, mirrorCtx.Insecure)
+		channelVersions, err := fetchVersionsFromModuleReleaseChannels(
+			moduleData.ReleaseImages,
+			mirrorCtx.RegistryAuth,
+			mirrorCtx.Insecure,
+			mirrorCtx.TLSVerification,
+		)
 		if err != nil {
 			return fmt.Errorf("fetch versions from %q release channels: %w", moduleName, err)
 		}
@@ -231,9 +236,9 @@ func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error
 func fetchVersionsFromModuleReleaseChannels(
 	releaseChannelImages map[string]struct{},
 	authProvider authn.Authenticator,
-	insecure bool,
+	insecure, verifyTLS bool,
 ) (map[string]string, error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
 	channelVersions := map[string]string{}
 	for imageTag := range releaseChannelImages {
 

--- a/dhctl/pkg/operations/mirror/modules.go
+++ b/dhctl/pkg/operations/mirror/modules.go
@@ -32,7 +32,6 @@ type Module struct {
 
 func GetDeckhouseExternalModules(mirrorCtx *Context) ([]Module, error) {
 	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
-	// modulesRepo, err := name.NewRepository(mirrorCtx.DeckhouseRegistryRepo+"/modules", nameOpts...)
 	repoPathBuildFuncForDeckhouseModule := func(repo, moduleName string) string {
 		return fmt.Sprintf("%s/modules/%s", mirrorCtx.DeckhouseRegistryRepo, moduleName)
 	}
@@ -50,8 +49,8 @@ func GetDeckhouseExternalModules(mirrorCtx *Context) ([]Module, error) {
 	return result, nil
 }
 
-func GetExternalModulesFromRepo(repo string, registryAuth authn.Authenticator, insecure bool) ([]Module, error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(registryAuth, insecure)
+func GetExternalModulesFromRepo(repo string, registryAuth authn.Authenticator, insecure, verifyTLS bool) ([]Module, error) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(registryAuth, insecure, verifyTLS)
 	repoPathBuildFuncForExternalModule := func(repo, moduleName string) string {
 		return fmt.Sprintf("%s/%s", repo, moduleName)
 	}
@@ -104,8 +103,8 @@ func getModulesForRepo(
 	return result, nil
 }
 
-func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, insecure bool) (moduleImages, releaseImages map[string]struct{}, err error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, insecure, verifyTLS bool) (moduleImages, releaseImages map[string]struct{}, err error) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
 
 	moduleImages = map[string]struct{}{}
 	releaseImages, err = getAvailableReleaseChannelsImagesForModule(mod, nameOpts, remoteOpts)
@@ -113,7 +112,7 @@ func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, ins
 		return nil, nil, fmt.Errorf("Get available release channels of module: %w", err)
 	}
 
-	releaseChannelVersions, err := fetchVersionsFromModuleReleaseChannels(releaseImages, authProvider, insecure)
+	releaseChannelVersions, err := fetchVersionsFromModuleReleaseChannels(releaseImages, authProvider, insecure, verifyTLS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Fetch versions from %q release channels: %w", mod.Name, err)
 	}

--- a/dhctl/pkg/operations/mirror/modules.go
+++ b/dhctl/pkg/operations/mirror/modules.go
@@ -49,8 +49,8 @@ func GetDeckhouseExternalModules(mirrorCtx *Context) ([]Module, error) {
 	return result, nil
 }
 
-func GetExternalModulesFromRepo(repo string, registryAuth authn.Authenticator, insecure, verifyTLS bool) ([]Module, error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(registryAuth, insecure, verifyTLS)
+func GetExternalModulesFromRepo(repo string, registryAuth authn.Authenticator, insecure, skipVerifyTLS bool) ([]Module, error) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(registryAuth, insecure, skipVerifyTLS)
 	repoPathBuildFuncForExternalModule := func(repo, moduleName string) string {
 		return fmt.Sprintf("%s/%s", repo, moduleName)
 	}
@@ -103,8 +103,8 @@ func getModulesForRepo(
 	return result, nil
 }
 
-func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, insecure, verifyTLS bool) (moduleImages, releaseImages map[string]struct{}, err error) {
-	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
+func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, insecure, skipVerifyTLS bool) (moduleImages, releaseImages map[string]struct{}, err error) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
 
 	moduleImages = map[string]struct{}{}
 	releaseImages, err = getAvailableReleaseChannelsImagesForModule(mod, nameOpts, remoteOpts)
@@ -112,7 +112,7 @@ func FindExternalModuleImages(mod *Module, authProvider authn.Authenticator, ins
 		return nil, nil, fmt.Errorf("Get available release channels of module: %w", err)
 	}
 
-	releaseChannelVersions, err := fetchVersionsFromModuleReleaseChannels(releaseImages, authProvider, insecure, verifyTLS)
+	releaseChannelVersions, err := fetchVersionsFromModuleReleaseChannels(releaseImages, authProvider, insecure, skipVerifyTLS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Fetch versions from %q release channels: %w", mod.Name, err)
 	}

--- a/dhctl/pkg/operations/mirror/pull.go
+++ b/dhctl/pkg/operations/mirror/pull.go
@@ -36,7 +36,7 @@ func PullInstallers(mirrorCtx *Context, layouts *ImageLayouts) error {
 		layouts.Install,
 		layouts.InstallImages,
 		mirrorCtx.Insecure,
-		mirrorCtx.TLSVerification,
+		mirrorCtx.SkipTLSVerification,
 		false,
 	); err != nil {
 		return err
@@ -52,7 +52,7 @@ func PullDeckhouseReleaseChannels(mirrorCtx *Context, layouts *ImageLayouts) err
 		layouts.ReleaseChannel,
 		layouts.ReleaseChannelImages,
 		mirrorCtx.Insecure,
-		mirrorCtx.TLSVerification,
+		mirrorCtx.SkipTLSVerification,
 		false,
 	); err != nil {
 		return err
@@ -68,7 +68,7 @@ func PullDeckhouseImages(mirrorCtx *Context, layouts *ImageLayouts) error {
 		layouts.Deckhouse,
 		layouts.DeckhouseImages,
 		mirrorCtx.Insecure,
-		mirrorCtx.TLSVerification,
+		mirrorCtx.SkipTLSVerification,
 		false,
 	); err != nil {
 		return err
@@ -81,7 +81,7 @@ func PullImageSet(
 	authProvider authn.Authenticator,
 	targetLayout layout.Path,
 	imageSet map[string]struct{},
-	insecure, verifyTLS, allowMissingTags bool,
+	insecure, skipVerifyTLS, allowMissingTags bool,
 ) error {
 	pullCount := 1
 	totalCount := len(imageSet)
@@ -131,10 +131,10 @@ func PullImageSet(
 func PullModules(mirrorCtx *Context, layouts *ImageLayouts) error {
 	log.InfoLn("Beginning to pull Deckhouse modules")
 	for moduleName, moduleData := range layouts.Modules {
-		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ModuleLayout, moduleData.ModuleImages, mirrorCtx.Insecure, mirrorCtx.TLSVerification, false); err != nil {
+		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ModuleLayout, moduleData.ModuleImages, mirrorCtx.Insecure, mirrorCtx.SkipTLSVerification, false); err != nil {
 			return fmt.Errorf("pull %q module: %w", moduleName, err)
 		}
-		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ReleasesLayout, moduleData.ReleaseImages, mirrorCtx.Insecure, mirrorCtx.TLSVerification, true); err != nil {
+		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ReleasesLayout, moduleData.ReleaseImages, mirrorCtx.Insecure, mirrorCtx.SkipTLSVerification, true); err != nil {
 			return fmt.Errorf("pull %q module release information: %w", moduleName, err)
 		}
 	}

--- a/dhctl/pkg/operations/mirror/pull.go
+++ b/dhctl/pkg/operations/mirror/pull.go
@@ -31,7 +31,14 @@ import (
 
 func PullInstallers(mirrorCtx *Context, layouts *ImageLayouts) error {
 	log.InfoLn("Beginning to pull installers")
-	if err := PullImageSet(mirrorCtx.RegistryAuth, layouts.Install, layouts.InstallImages, mirrorCtx.Insecure, false); err != nil {
+	if err := PullImageSet(
+		mirrorCtx.RegistryAuth,
+		layouts.Install,
+		layouts.InstallImages,
+		mirrorCtx.Insecure,
+		mirrorCtx.TLSVerification,
+		false,
+	); err != nil {
 		return err
 	}
 	log.InfoLn("✅ All required installers are pulled!")
@@ -40,7 +47,14 @@ func PullInstallers(mirrorCtx *Context, layouts *ImageLayouts) error {
 
 func PullDeckhouseReleaseChannels(mirrorCtx *Context, layouts *ImageLayouts) error {
 	log.InfoLn("Beginning to pull Deckhouse release channels information")
-	if err := PullImageSet(mirrorCtx.RegistryAuth, layouts.ReleaseChannel, layouts.ReleaseChannelImages, mirrorCtx.Insecure, false); err != nil {
+	if err := PullImageSet(
+		mirrorCtx.RegistryAuth,
+		layouts.ReleaseChannel,
+		layouts.ReleaseChannelImages,
+		mirrorCtx.Insecure,
+		mirrorCtx.TLSVerification,
+		false,
+	); err != nil {
 		return err
 	}
 	log.InfoLn("✅ Deckhouse release channels are pulled!")
@@ -49,7 +63,14 @@ func PullDeckhouseReleaseChannels(mirrorCtx *Context, layouts *ImageLayouts) err
 
 func PullDeckhouseImages(mirrorCtx *Context, layouts *ImageLayouts) error {
 	log.InfoLn("Beginning to pull Deckhouse, this may take a while")
-	if err := PullImageSet(mirrorCtx.RegistryAuth, layouts.Deckhouse, layouts.DeckhouseImages, mirrorCtx.Insecure, false); err != nil {
+	if err := PullImageSet(
+		mirrorCtx.RegistryAuth,
+		layouts.Deckhouse,
+		layouts.DeckhouseImages,
+		mirrorCtx.Insecure,
+		mirrorCtx.TLSVerification,
+		false,
+	); err != nil {
 		return err
 	}
 	log.InfoLn("✅ All required Deckhouse images are pulled!")
@@ -60,8 +81,7 @@ func PullImageSet(
 	authProvider authn.Authenticator,
 	targetLayout layout.Path,
 	imageSet map[string]struct{},
-	insecure bool,
-	allowMissingTags bool,
+	insecure, verifyTLS, allowMissingTags bool,
 ) error {
 	pullCount := 1
 	totalCount := len(imageSet)
@@ -111,10 +131,10 @@ func PullImageSet(
 func PullModules(mirrorCtx *Context, layouts *ImageLayouts) error {
 	log.InfoLn("Beginning to pull Deckhouse modules")
 	for moduleName, moduleData := range layouts.Modules {
-		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ModuleLayout, moduleData.ModuleImages, mirrorCtx.Insecure, false); err != nil {
+		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ModuleLayout, moduleData.ModuleImages, mirrorCtx.Insecure, mirrorCtx.TLSVerification, false); err != nil {
 			return fmt.Errorf("pull %q module: %w", moduleName, err)
 		}
-		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ReleasesLayout, moduleData.ReleaseImages, mirrorCtx.Insecure, true); err != nil {
+		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ReleasesLayout, moduleData.ReleaseImages, mirrorCtx.Insecure, mirrorCtx.TLSVerification, true); err != nil {
 			return fmt.Errorf("pull %q module release information: %w", moduleName, err)
 		}
 	}

--- a/dhctl/pkg/operations/mirror/pull.go
+++ b/dhctl/pkg/operations/mirror/pull.go
@@ -86,7 +86,7 @@ func PullImageSet(
 	pullCount := 1
 	totalCount := len(imageSet)
 	for imageTag := range imageSet {
-		pullOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure)
+		pullOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
 		ref, err := name.ParseReference(imageTag, pullOpts...)
 		if err != nil {
 			return fmt.Errorf("parse image reference %q: %w", imageTag, err)

--- a/dhctl/pkg/operations/mirror_module.go
+++ b/dhctl/pkg/operations/mirror_module.go
@@ -36,7 +36,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/mirror"
 )
 
-func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string, verifyTLS bool) error {
+func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string, skipVerifyTLS bool) error {
 	src, err := loadModuleSourceFromPath(sourceYmlPath)
 	if err != nil {
 		return fmt.Errorf("Read ModuleSource: %w", err)
@@ -48,7 +48,7 @@ func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string, ver
 		return fmt.Errorf("Parse dockerCfg: %w", err)
 	}
 
-	modules, err := mirror.GetExternalModulesFromRepo(src.Spec.Registry.Repo, authProvider, insecure, verifyTLS)
+	modules, err := mirror.GetExternalModulesFromRepo(src.Spec.Registry.Repo, authProvider, insecure, skipVerifyTLS)
 	if err != nil {
 		return fmt.Errorf("Get external modules from %q: %w", src.Spec.Registry.Repo, err)
 	}
@@ -70,20 +70,20 @@ func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string, ver
 			return fmt.Errorf("Create module OCI Layouts: %w", err)
 		}
 
-		moduleImageSet, releasesImageSet, err := mirror.FindExternalModuleImages(&module, authProvider, insecure, verifyTLS)
+		moduleImageSet, releasesImageSet, err := mirror.FindExternalModuleImages(&module, authProvider, insecure, skipVerifyTLS)
 		if err != nil {
 			return fmt.Errorf("Find external module images`: %w", err)
 		}
 
 		log.InfoLn("Beginning to pull module contents")
-		err = mirror.PullImageSet(authProvider, moduleLayout, moduleImageSet, insecure, verifyTLS, false)
+		err = mirror.PullImageSet(authProvider, moduleLayout, moduleImageSet, insecure, skipVerifyTLS, false)
 		if err != nil {
 			return fmt.Errorf("Pull images: %w", err)
 		}
 		log.InfoLn("✅ Module contents pulled successfully")
 
 		log.InfoLn("Beginning to pull module releases")
-		err = mirror.PullImageSet(authProvider, moduleReleasesLayout, releasesImageSet, insecure, verifyTLS, false)
+		err = mirror.PullImageSet(authProvider, moduleReleasesLayout, releasesImageSet, insecure, skipVerifyTLS, false)
 		if err != nil {
 			return fmt.Errorf("Pull images: %w", err)
 		}
@@ -161,14 +161,14 @@ func PushModulesToRegistry(
 	modulesDir string,
 	registryPath string,
 	authProvider authn.Authenticator,
-	insecure, verifyTLS bool,
+	insecure, skipVerifyTLS bool,
 ) error {
 	dirEntries, err := os.ReadDir(modulesDir)
 	if err != nil {
 		return fmt.Errorf("Read modules directory: %w", err)
 	}
 
-	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
+	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
 
 	for i, entry := range dirEntries {
 		if !entry.IsDir() {
@@ -190,12 +190,12 @@ func PushModulesToRegistry(
 			return fmt.Errorf("Module %s: Read OCI layout: %w", moduleName, err)
 		}
 
-		if err = pushLayoutToRepo(moduleLayout, moduleRegistryPath, authProvider, insecure, verifyTLS); err != nil {
+		if err = pushLayoutToRepo(moduleLayout, moduleRegistryPath, authProvider, insecure, skipVerifyTLS); err != nil {
 			return fmt.Errorf("Push module to registry: %w", err)
 		}
 
 		log.InfoF("Pushing releases for module %s...\n", moduleName)
-		if err = pushLayoutToRepo(moduleReleasesLayout, moduleReleasesRegistryPath, authProvider, insecure, verifyTLS); err != nil {
+		if err = pushLayoutToRepo(moduleReleasesLayout, moduleReleasesRegistryPath, authProvider, insecure, skipVerifyTLS); err != nil {
 			return fmt.Errorf("Push module to registry: %w", err)
 		}
 
@@ -225,9 +225,9 @@ func pushLayoutToRepo(
 	imagesLayout layout.Path,
 	registryRepo string,
 	authProvider authn.Authenticator,
-	insecure, verifyTLS bool,
+	insecure, skipVerifyTLS bool,
 ) error {
-	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
+	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
 
 	index, err := imagesLayout.ImageIndex()
 	if err != nil {

--- a/dhctl/pkg/operations/mirror_module.go
+++ b/dhctl/pkg/operations/mirror_module.go
@@ -36,7 +36,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/mirror"
 )
 
-func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string) error {
+func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string, verifyTLS bool) error {
 	src, err := loadModuleSourceFromPath(sourceYmlPath)
 	if err != nil {
 		return fmt.Errorf("Read ModuleSource: %w", err)
@@ -48,7 +48,7 @@ func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string) err
 		return fmt.Errorf("Parse dockerCfg: %w", err)
 	}
 
-	modules, err := mirror.GetExternalModulesFromRepo(src.Spec.Registry.Repo, authProvider, insecure)
+	modules, err := mirror.GetExternalModulesFromRepo(src.Spec.Registry.Repo, authProvider, insecure, verifyTLS)
 	if err != nil {
 		return fmt.Errorf("Get external modules from %q: %w", src.Spec.Registry.Repo, err)
 	}
@@ -70,20 +70,20 @@ func PullExternalModulesToLocalFS(sourceYmlPath, mirrorDirectoryPath string) err
 			return fmt.Errorf("Create module OCI Layouts: %w", err)
 		}
 
-		moduleImageSet, releasesImageSet, err := mirror.FindExternalModuleImages(&module, authProvider, insecure)
+		moduleImageSet, releasesImageSet, err := mirror.FindExternalModuleImages(&module, authProvider, insecure, verifyTLS)
 		if err != nil {
 			return fmt.Errorf("Find external module images`: %w", err)
 		}
 
 		log.InfoLn("Beginning to pull module contents")
-		err = mirror.PullImageSet(authProvider, moduleLayout, moduleImageSet, insecure, false)
+		err = mirror.PullImageSet(authProvider, moduleLayout, moduleImageSet, insecure, verifyTLS, false)
 		if err != nil {
 			return fmt.Errorf("Pull images: %w", err)
 		}
 		log.InfoLn("✅ Module contents pulled successfully")
 
 		log.InfoLn("Beginning to pull module releases")
-		err = mirror.PullImageSet(authProvider, moduleReleasesLayout, releasesImageSet, insecure, false)
+		err = mirror.PullImageSet(authProvider, moduleReleasesLayout, releasesImageSet, insecure, verifyTLS, false)
 		if err != nil {
 			return fmt.Errorf("Pull images: %w", err)
 		}
@@ -161,14 +161,14 @@ func PushModulesToRegistry(
 	modulesDir string,
 	registryPath string,
 	authProvider authn.Authenticator,
-	insecure bool,
+	insecure, verifyTLS bool,
 ) error {
 	dirEntries, err := os.ReadDir(modulesDir)
 	if err != nil {
 		return fmt.Errorf("Read modules directory: %w", err)
 	}
 
-	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure)
+	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
 
 	for i, entry := range dirEntries {
 		if !entry.IsDir() {
@@ -190,12 +190,12 @@ func PushModulesToRegistry(
 			return fmt.Errorf("Module %s: Read OCI layout: %w", moduleName, err)
 		}
 
-		if err = pushLayoutToRepo(moduleLayout, moduleRegistryPath, authProvider, insecure); err != nil {
+		if err = pushLayoutToRepo(moduleLayout, moduleRegistryPath, authProvider, insecure, verifyTLS); err != nil {
 			return fmt.Errorf("Push module to registry: %w", err)
 		}
 
 		log.InfoF("Pushing releases for module %s...\n", moduleName)
-		if err = pushLayoutToRepo(moduleReleasesLayout, moduleReleasesRegistryPath, authProvider, insecure); err != nil {
+		if err = pushLayoutToRepo(moduleReleasesLayout, moduleReleasesRegistryPath, authProvider, insecure, verifyTLS); err != nil {
 			return fmt.Errorf("Push module to registry: %w", err)
 		}
 
@@ -225,9 +225,9 @@ func pushLayoutToRepo(
 	imagesLayout layout.Path,
 	registryRepo string,
 	authProvider authn.Authenticator,
-	insecure bool,
+	insecure, verifyTLS bool,
 ) error {
-	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure)
+	refOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(authProvider, insecure, verifyTLS)
 
 	index, err := imagesLayout.ImageIndex()
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `--tls-skip-verify` that forces mirror to accept non-trusted registry certificates.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Users requested this.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Added a flag that forces mirror to accept non-trusted registry certificates.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
