### PR TITLE
[candi] bump cni-plugins version to 1.4.0

### DIFF
--- a/candi/bashible/common-steps/all/006_fetch_registry_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/006_fetch_registry_packages.sh.tpl
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 {{- $kubernetesVersion := printf "%s%s" (.kubernetesVersion | toString) (index .k8s .kubernetesVersion "patch" | toString) | replace "." "" }}
-{{- $kubernetesCniVersion := "1.2.0" | replace "." "" }}
+{{- $kubernetesCniVersion := "1.4.0" | replace "." "" }}
 
 bb-rp-fetch "kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) | toString }}" "kubectl:{{ index .images.registrypackages (printf "kubectl%s" $kubernetesVersion) | toString }}" "kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) | toString }}" "containerd:{{- index $.images.registrypackages "containerd1624" }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}" "toml-merge:{{ .images.registrypackages.tomlMerge01 }}"

--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $kubernetesVersion := printf "%s%s" (.kubernetesVersion | toString) (index .k8s .kubernetesVersion "patch" | toString) | replace "." "" }}
-{{- $kubernetesCniVersion := "1.2.0" | replace "." "" }}
+{{- $kubernetesCniVersion := "1.4.0" | replace "." "" }}
 bb-rp-install "kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) | toString }}" "kubectl:{{ index .images.registrypackages (printf "kubectl%s" $kubernetesVersion) | toString }}"
 
 old_kubelet_hash=""

--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Flant JSC
+# Copyright 2023 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2023 Flant JSC
+# Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/all/064_fix_permission_on_cni_files.sh.tpl
+++ b/candi/bashible/common-steps/all/064_fix_permission_on_cni_files.sh.tpl
@@ -1,0 +1,17 @@
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CIS becnhmark purposes
+find /etc/cni/net.d -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
+find /var/lib/cni/networks -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600

--- a/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
+++ b/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# CIS becnhmark purposes
+# CIS becnhmark purposes (1.1.9 and 1.1.10)
 if [ -d /etc/cni/net.d ]; then
   find /etc/cni/net.d -type f -exec chmod 600 -- {} +
 fi

--- a/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
+++ b/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
@@ -14,7 +14,7 @@
 
 # CIS becnhmark purposes
 if [ -d /etc/cni/net.d ]; then
-  find /etc/cni/net.d -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
+  find /etc/cni/net.d -type f -exec chmod 600 -- {} +
 fi
 if [ -d /var/lib/cni/networks ]; then
   find /var/lib/cni/networks -type f -exec chmod 600 -- {} +

--- a/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
+++ b/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # CIS becnhmark purposes
-if ls /etc/cni/net.d >/dev/null 2>&1; then
+if [ -d /etc/cni/net.d ]; then
   find /etc/cni/net.d -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
 fi
-if ls /var/lib/cni/networks >/dev/null 2>&1; then
-  find /var/lib/cni/networks -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
+if [ -d /var/lib/cni/networks ]; then
+  find /var/lib/cni/networks -type f -exec chmod 600 -- {} +
 fi

--- a/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
+++ b/candi/bashible/common-steps/all/066_fix_permission_on_cni_files.sh.tpl
@@ -13,5 +13,9 @@
 # limitations under the License.
 
 # CIS becnhmark purposes
-find /etc/cni/net.d -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
-find /var/lib/cni/networks -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
+if ls /etc/cni/net.d >/dev/null 2>&1; then
+  find /etc/cni/net.d -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
+fi
+if ls /var/lib/cni/networks >/dev/null 2>&1; then
+  find /var/lib/cni/networks -type f -print0 2> /dev/null | xargs -0 --no-run-if-empty chmod 600
+fi

--- a/candi/bashible/common-steps/cluster-bootstrap/035_install_kubeadm.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/035_install_kubeadm.sh.tpl
@@ -13,5 +13,5 @@
 # limitations under the License.
 {{- $kubernetesVersion := printf "%s%s" (.kubernetesVersion | toString) (index .k8s .kubernetesVersion "patch" | toString) | replace "." "" }}
 {{- $kubernetesMajorVersion := .kubernetesVersion | toString | replace "." "" }}
-{{- $kubernetesCniVersion := "1.2.0" | replace "." "" }}
+{{- $kubernetesCniVersion := "1.4.0" | replace "." "" }}
 bb-rp-install "kubeadm:{{ index .images.registrypackages (printf "kubeadm%s" $kubernetesVersion) }}" "kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" "kubectl:{{ index .images.registrypackages (printf "kubectl%s" $kubernetesVersion) }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" "kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}"

--- a/candi/bashible/common-steps/cluster-bootstrap/035_install_kubeadm.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/035_install_kubeadm.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Flant JSC
+# Copyright 2023 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/cluster-bootstrap/035_install_kubeadm.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/035_install_kubeadm.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2023 Flant JSC
+# Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/007-registrypackages/images/kubernetes-cni/scripts/install
+++ b/modules/007-registrypackages/images/kubernetes-cni/scripts/install
@@ -15,4 +15,4 @@
 
 set -Eeo pipefail
 mkdir -p /opt/cni/bin
-cp -f bandwidth bridge dhcp dummy firewall host-device host-local ipvlan loopback macvlan portmap ptp sbr static tuning vlan vrf flannel /opt/cni/bin
+cp -f bandwidth bridge dhcp dummy firewall host-device host-local ipvlan loopback macvlan portmap ptp sbr static tap tuning vlan vrf flannel /opt/cni/bin

--- a/modules/007-registrypackages/images/kubernetes-cni/scripts/uninstall
+++ b/modules/007-registrypackages/images/kubernetes-cni/scripts/uninstall
@@ -15,4 +15,4 @@
 
 set -Eeo pipefail
 cd /opt/cni/bin
-rm -f bandwidth bridge dhcp dummy firewall host-device host-local ipvlan loopback macvlan portmap ptp sbr static tuning vlan vrf flannel
+rm -f bandwidth bridge dhcp dummy firewall host-device host-local ipvlan loopback macvlan portmap ptp sbr static tap tuning vlan vrf flannel

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $cni_version := "1.2.0" }}
+{{- $cni_version := "1.4.0" }}
 {{- $flannel_version := "1.1.2" }}
 {{- $image_version := $cni_version | replace "." "-" }}
 ---
@@ -23,6 +23,7 @@ import:
   - ptp
   - sbr
   - static
+  - tap
   - tuning
   - vlan
   - vrf
@@ -38,7 +39,7 @@ docker:
     flannel: {{ $flannel_version }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
-from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+from: {{ $.Images.BASE_GOLANG_21_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -360,7 +360,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"kubelet12612":     "imageHash-registrypackages-kubelet12612",
 		"kubelet1279":      "imageHash-registrypackages-kubelet1279",
 		"kubelet1285":      "imageHash-registrypackages-kubelet1285",
-		"kubernetesCni120": "imageHash-registrypackages-kubernetesCni120",
+		"kubernetesCni140": "imageHash-registrypackages-kubernetesCni140",
 		"tomlMerge01":      "imageHash-registrypackages-tomlMerge01",
 	},
 	"runtimeAuditEngine": map[string]interface{}{


### PR DESCRIPTION
## Description

Updating cni-plugins to version 1.4.0

## Why do we need it, and what problem does it solve?

Using the most recent stable version.
Partial solution of issue https://github.com/deckhouse/deckhouse/issues/6454

## What is the expected result?

The version of cni-plugins (located in /opt/cni/bin/) is 1.4.0
New ipam host-local files (located in /var/lib/cni/networks) are created with a permission 600

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: chore
summary: Update `cni-plugins` to version `1.4.0`.
impact: "cni-plugins will be recreated during the upgrade."
impact_level: default
```

