### PR TITLE
[grafana] Dashboard linter

### DIFF
--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -578,6 +578,7 @@ module.exports.checkValidationLabels = ({ core, labels }) => {
       core.setOutput(`label_${validation_name}`, name);
     });
   core.setCommandEcho(false);
+  core.setOutput('run_grafana_dashboard', 'true');
   core.endGroup();
 };
 

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -578,8 +578,6 @@ module.exports.checkValidationLabels = ({ core, labels }) => {
       core.setOutput(`label_${validation_name}`, name);
     });
   core.setCommandEcho(false);
-  core.setOutput('run_grafana_dashboard', 'true');
-  core.setOutput('label_grafana_dashboard', 'grafana_dashboard');
   core.endGroup();
 };
 

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -579,6 +579,7 @@ module.exports.checkValidationLabels = ({ core, labels }) => {
     });
   core.setCommandEcho(false);
   core.setOutput('run_grafana_dashboard', 'true');
+  core.setOutput('label_grafana_dashboard', 'grafana_dashboard');
   core.endGroup();
 };
 

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -22,7 +22,7 @@ const labels = {
   'skip/no-cyrillic-validation': { type: 'skip-validation', validation_name: 'no_cyrillic' },
   'skip/documentation-validation': { type: 'skip-validation', validation_name: 'doc_changes' },
   'skip/copyright-validation': { type: 'skip-validation', validation_name: 'copyright' },
-  'skip/grafana-dashboard': { type: 'skip-validation', validation_name: 'grafana_dashboard'},
+  'skip/grafana-dashboard': { type: 'skip-validation', validation_name: 'grafana_dashboard' },
   'skip/markdown-validation': { type: 'skip-validation', validation_name: 'markdown' },
   'skip/actionlint': { type: 'skip-validation', validation_name: 'actionlint' },
 

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -22,6 +22,7 @@ const labels = {
   'skip/no-cyrillic-validation': { type: 'skip-validation', validation_name: 'no_cyrillic' },
   'skip/documentation-validation': { type: 'skip-validation', validation_name: 'doc_changes' },
   'skip/copyright-validation': { type: 'skip-validation', validation_name: 'copyright' },
+  'skip/grafana-dashboard': { type: 'skip-validation', validation_name: 'grafana_dashboard'},
   'skip/markdown-validation': { type: 'skip-validation', validation_name: 'markdown' },
   'skip/actionlint': { type: 'skip-validation', validation_name: 'actionlint' },
 

--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -84,6 +84,8 @@ jobs:
       label_copyright: ${{ steps.check_labels.outputs.label_copyright }}
       run_markdown: ${{ steps.check_labels.outputs.run_markdown }}
       label_markdown: ${{ steps.check_labels.outputs.label_markdown }}
+      run_grafana_dashboard: ${{ steps.check_labels.outputs.run_grafana_dashboard }}
+      label_grafana_dashboard: ${{ steps.check_labels.outputs.label_grafana_dashboard }}
     steps:
 {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
       - id: check_labels
@@ -126,6 +128,10 @@ jobs:
   copyright_validation:
     name: Copyright Validation
 {!{ tmpl.Exec "validation_template" (slice $ctx "copyright") | strings.Indent 4 }!}
+
+  grafana_dashboard_validation:
+    name: Grafana Dashboard Validation
+{!{ tmpl.Exec "validation_template" (slice $ctx "grafana_dashboard") | strings.Indent 4 }!}
 
   markdown_linter:
     name: Markdown Linter

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -304,6 +304,8 @@ jobs:
       label_copyright: ${{ steps.check_labels.outputs.label_copyright }}
       run_markdown: ${{ steps.check_labels.outputs.run_markdown }}
       label_markdown: ${{ steps.check_labels.outputs.label_markdown }}
+      run_grafana_dashboard: ${{ steps.check_labels.outputs.run_grafana_dashboard }}
+      label_grafana_dashboard: ${{ steps.check_labels.outputs.label_grafana_dashboard }}
     steps:
 
       # <template: checkout_step>
@@ -427,6 +429,35 @@ jobs:
           SKIP_LABEL_NAME: ${{ needs.discover.outputs.label_copyright }}
         run: |
           ./.github/scripts/validation_run.sh ./testing/validate_copyright.sh
+
+  grafana_dashboard_validation:
+    name: Grafana Dashboard Validation
+
+    needs:
+      - discover
+      - pull_request_info
+    if: needs.discover.outputs.run_grafana_dashboard == 'true'
+    runs-on: ubuntu-latest
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
+
+      - name: Restore diff artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: pr_diff
+
+      - name: Run check
+        env:
+          DIFF_PATH: ./pr.diff
+          SKIP_LABEL_NAME: ${{ needs.discover.outputs.label_grafana_dashboard }}
+        run: |
+          ./.github/scripts/validation_run.sh ./testing/validate_grafana_dashboard.sh
 
   markdown_linter:
     name: Markdown Linter

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -436,7 +436,7 @@ jobs:
     needs:
       - discover
       - pull_request_info
-    #if: needs.discover.outputs.run_grafana_dashboard == 'true'
+    if: needs.discover.outputs.run_grafana_dashboard == 'true'
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -436,7 +436,7 @@ jobs:
     needs:
       - discover
       - pull_request_info
-    if: needs.discover.outputs.run_grafana_dashboard == 'true'
+    #if: needs.discover.outputs.run_grafana_dashboard == 'true'
     runs-on: ubuntu-latest
     steps:
 

--- a/testing/validate_grafana_dashboard.sh
+++ b/testing/validate_grafana_dashboard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/validate_grafana_dashboard.sh
+++ b/testing/validate_grafana_dashboard.sh
@@ -14,16 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Example usage:
-# source ./tools/validation/run_env
-# validation_go_run ./tools/validation --type copyright --file "$1"
+source ./tools/validation/run_env
 
-# This snippet is needed because 'go run' still not in sync
-# with other Go tools and considered a toy.
-# See https://github.com/golang/go/issues/13440#issuecomment-218353305
-
-function validation_go_run() {
-  validationDir="$1"
-  shift
-  go run ${validationDir}/{main,messages,diff,copyright,no_cyrillic,doc_changes,grafana_dashboard}.go "$@"
-}
+validation_go_run ./tools/validation \
+  --type grafana-dashboard \
+  --file "$1"

--- a/tools/validation/grafana_dashboard.go
+++ b/tools/validation/grafana_dashboard.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import (
 )
 
 func RunGrafanaDashboardValidation(info *DiffInfo) (exitCode int) {
-	fmt.Printf("Run 'grafana dashboards' validation ...\n")
+	fmt.Println("Run 'grafana dashboards' validation...")
 
 	if len(info.Files) == 0 {
-		fmt.Printf("Nothing to validate, diff is empty\n")
+		fmt.Println("Nothing to validate, diff is empty.")
 		return 0
 	}
 
@@ -68,8 +68,7 @@ func RunGrafanaDashboardValidation(info *DiffInfo) (exitCode int) {
 
 func isGrafanaDashboard(fileName string) bool {
 	fileName = strings.ToLower(fileName)
-	return strings.Contains(fileName, "grafana") &&
-		strings.Contains(fileName, "dashboard") &&
+	return strings.Contains(fileName, "grafana-dashboards") &&
 		strings.HasSuffix(fileName, ".json")
 }
 

--- a/tools/validation/grafana_dashboard.go
+++ b/tools/validation/grafana_dashboard.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+func RunGrafanaDashboardValidation(info *DiffInfo) (exitCode int) {
+	fmt.Printf("Run 'grafana dashboards' validation ...\n")
+
+	if len(info.Files) == 0 {
+		fmt.Printf("Nothing to validate, diff is empty\n")
+		return 0
+	}
+
+	exitCode = 0
+	msgs := NewMessages()
+	for _, fileInfo := range info.Files {
+		if !fileInfo.HasContent() {
+			continue
+		}
+
+		fileName := fileInfo.NewFileName
+		if !isGrafanaDashboard(fileName) {
+			continue
+		}
+
+		fileContent, err := os.ReadFile(fileName)
+		if err != nil {
+			msgs.Add(
+				NewError(
+					fileName,
+					"failed to open file",
+					err.Error(),
+				))
+			continue
+		}
+
+		msgs.Join(validateGrafanaDashboardFile(fileName, fileContent))
+	}
+
+	msgs.PrintReport()
+	if msgs.CountErrors() > 0 {
+		exitCode = 1
+	}
+
+	return exitCode
+}
+
+func isGrafanaDashboard(fileName string) bool {
+	fileName = strings.ToLower(fileName)
+	return strings.Contains(fileName, "grafana") &&
+		strings.Contains(fileName, "dashboard") &&
+		strings.HasSuffix(fileName, ".json")
+}
+
+func validateGrafanaDashboardFile(fileName string, fileContent []byte) *Messages {
+	msgs := NewMessages()
+
+	dashboard := gjson.ParseBytes(fileContent)
+	dashboardPanels := make([]gjson.Result, 0)
+	dashboardRows := dashboard.Get("rows").Array()
+
+	for _, dashboardRow := range dashboardRows {
+		rowPanels := dashboardRow.Get("panels").Array()
+		dashboardPanels = append(dashboardPanels, rowPanels...)
+	}
+	panels := dashboard.Get("panels").Array()
+	dashboardPanels = append(dashboardPanels, panels...)
+
+	for _, panel := range dashboardPanels {
+		panelTitle := panel.Get("title").String()
+		intervals := evaluateDeprecatedIntervals(panel)
+		for _, interval := range intervals {
+			msgs.Add(
+				NewError(
+					fileName,
+					"deprecated interval",
+					fmt.Sprintf("Panel %s contains deprecated interval: '%s', consider using '$__rate_interval'",
+						panelTitle, interval),
+				),
+			)
+		}
+		alertRule := panel.Get("alert")
+		if alertRule.Exists() {
+			alertRuleName := alertRule.Get("name").String()
+			msgs.Add(
+				NewError(
+					fileName,
+					"legacy alert rule",
+					fmt.Sprintf("Panel %s contains legacy alert rule: '%s', consider using external alertmanager",
+						panelTitle, alertRuleName),
+				),
+			)
+		}
+		datasourceUIDs := evaluateHardcodedDatasourceUIDs(panel)
+		for _, datasourceUID := range datasourceUIDs {
+			msgs.Add(
+				NewError(
+					fileName,
+					"hardcoded datasource uid",
+					fmt.Sprintf("Panel %s contains hardcoded datasource uid: '%s', consider using grafana variable of type 'Datasource'",
+						panelTitle, datasourceUID),
+				),
+			)
+		}
+	}
+	return msgs
+}
+
+func evaluateHardcodedDatasourceUIDs(panel gjson.Result) []string {
+	targets := panel.Get("targets").Array()
+	datasourceUIDs := make([]string, 0)
+	for _, target := range targets {
+		datasource := target.Get("datasource")
+		if datasource.Exists() {
+			uid := datasource.Get("uid").String()
+			if !strings.HasPrefix(uid, "$") {
+				datasourceUIDs = append(datasourceUIDs, uid)
+			}
+		}
+	}
+	return datasourceUIDs
+}
+
+var (
+	deprecatedIntervals = []string{
+		"interval_rv",
+		"interval_sx3",
+		"interval_sx4",
+	}
+)
+
+func evaluateDeprecatedIntervals(panel gjson.Result) []string {
+	targets := panel.Get("targets").Array()
+	intervals := make([]string, 0)
+	for _, target := range targets {
+		expr := target.Get("expr").String()
+		if deprecatedInterval, ok := evaluateDeprecatedInterval(expr); ok {
+			intervals = append(intervals, deprecatedInterval)
+		}
+	}
+	return intervals
+}
+
+func evaluateDeprecatedInterval(expression string) (string, bool) {
+	for _, deprecatedInterval := range deprecatedIntervals {
+		if strings.Contains(expression, deprecatedInterval) {
+			return deprecatedInterval, true
+		}
+	}
+	return "", false
+}

--- a/tools/validation/grafana_dashboard_test.go
+++ b/tools/validation/grafana_dashboard_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func Test_validateGrafanaDashboardFile(t *testing.T) {
+func TestValidateGrafanaDashboardFile(t *testing.T) {
 	// Dashboard with deprecated components
 	in := `
 {

--- a/tools/validation/grafana_dashboard_test.go
+++ b/tools/validation/grafana_dashboard_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_validateGrafanaDashboardFile(t *testing.T) {
+	// Dashboard with deprecated components
+	in := `
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 77,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                null
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Alert Rule Inside Single Panel",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus_datasource_uid"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus_datasource_uid"
+          },
+          "expr": "rate(metric_name[$__interval_rv])",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "visible": true
+        }
+      ],
+      "title": "Single Panel",
+      "type": "timeseries"
+    },
+    {
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus_datasource_uid"
+          },
+          "expr": "rate(metric_name[$__interval_rv])",
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Single Panel",
+      "type": "unknown_plugin",
+      "version": 1
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "title": "Row With Panel",
+      "type": "row"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                null
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Panel Inside Row Alert Rule",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus_datasource_uid"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus_datasource_uid"
+          },
+          "expr": "rate(metric_name[$__interval_sx3])",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "visible": true
+        }
+      ],
+      "title": "Panel Inside Row",
+      "type": "timeseries"
+    },
+    {
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus_datasource_uid"
+          },
+          "expr": "rate(metric_name[$__interval_sx4])",
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Panel Inside Row",
+      "type": "unknown_plugin",
+      "version": 1
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Test",
+  "uid": "test",
+  "version": 1,
+  "weekStart": ""
+}`
+	expected := &Messages{[]Message{
+		NewError("dashboard.json", "deprecated interval", "Panel Single Panel contains deprecated interval: 'interval_rv', consider using '$__rate_interval'"),
+		NewError("dashboard.json", "legacy alert rule", "Panel Single Panel contains legacy alert rule: 'Alert Rule Inside Single Panel', consider using external alertmanager"),
+		NewError("dashboard.json", "hardcoded datasource uid", "Panel Single Panel contains hardcoded datasource uid: 'prometheus_datasource_uid', consider using grafana variable of type 'Datasource'"),
+		NewError("dashboard.json", "deprecated interval", "Panel Plugin Single Panel contains deprecated interval: 'interval_rv', consider using '$__rate_interval'"),
+		NewError("dashboard.json", "hardcoded datasource uid", "Panel Plugin Single Panel contains hardcoded datasource uid: 'prometheus_datasource_uid', consider using grafana variable of type 'Datasource'"),
+		NewError("dashboard.json", "deprecated interval", "Panel Panel Inside Row contains deprecated interval: 'interval_sx3', consider using '$__rate_interval'"),
+		NewError("dashboard.json", "legacy alert rule", "Panel Panel Inside Row contains legacy alert rule: 'Panel Inside Row Alert Rule', consider using external alertmanager"),
+		NewError("dashboard.json", "hardcoded datasource uid", "Panel Panel Inside Row contains hardcoded datasource uid: 'prometheus_datasource_uid', consider using grafana variable of type 'Datasource'"),
+		NewError("dashboard.json", "deprecated interval", "Panel Plugin Panel Inside Row contains deprecated interval: 'interval_sx4', consider using '$__rate_interval'"),
+		NewError("dashboard.json", "hardcoded datasource uid", "Panel Plugin Panel Inside Row contains hardcoded datasource uid: 'prometheus_datasource_uid', consider using grafana variable of type 'Datasource'"),
+	}}
+
+	actual := validateGrafanaDashboardFile("dashboard.json", []byte(in))
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expect \n%s\n, got \n%s\n", expected, actual)
+	}
+}

--- a/tools/validation/main.go
+++ b/tools/validation/main.go
@@ -62,6 +62,8 @@ func main() {
 		exitCode = RunNoCyrillicValidation(diffInfo, title, description)
 	case "doc-changes":
 		exitCode = RunDocChangesValidation(diffInfo)
+	case "grafana-dashboard":
+		exitCode = RunGrafanaDashboardValidation(diffInfo)
 	case "dump":
 		fmt.Printf("%s\n", diffInfo.Dump())
 	default:

--- a/tools/validation/messages.go
+++ b/tools/validation/messages.go
@@ -95,6 +95,15 @@ func (m *Messages) Add(msg Message) {
 	m.messages = append(m.messages, msg)
 }
 
+func (m *Messages) Join(msgs *Messages) {
+	if msgs == nil {
+		return
+	}
+	for _, message := range msgs.messages {
+		m.Add(message)
+	}
+}
+
 func (m *Messages) CountOK() int {
 	res := 0
 	for _, msg := range m.messages {


### PR DESCRIPTION
## Description
Grafana dashboard linter

## Why do we need it, and what problem does it solve?
Closes #7081
Related to #7018 and #7027

## What is the expected result?
CI fail when:

- Dashboard contains a deprecated query interval (deprecated intervals: `$__interval_rv`, `$__interval_sx3` and `$__interval_sx4`)
- Dashboard contains a legacy alert rule (alert rule that is configured on dashboard table and uses Grafana < 9.x internal alerting)
- Dashboard contains a hard-coded datasource uid (uid is copied as-is, without using Grafana variable of `Datasource` type)

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools | testing
type: chore
summary: Grafana dashboard linter
impact_level: low
```