### PR TITLE
[linstor] add validating webhook to disable module

### DIFF
--- a/modules/002-deckhouse/webhooks/validating/disable_virtualization_module
+++ b/modules/002-deckhouse/webhooks/validating/disable_virtualization_module
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: You should remove this hook as soon as the linstor module is removed from deckhouse.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetesValidating:
+- name: disable-linstor-module.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["moduleconfigs"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+  mcName=$(context::jq -r '.review.request.object.metadata.name')
+  if [[ "$mcName" == "linstor" ]]; then
+    if context::jq -e '.review.request.object.spec.enabled' >/dev/null; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"moduleconfigs.deckhouse.io \"linstor\" is deprecated, please use sds-drbd module instead (https://deckhouse.io/modules/)." }
+EOF
+    return 0
+    fi
+  fi
+  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+}
+
+hook::run "$@"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add a validating webhook to prevent the linstor module from being enabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The linstor module should not be allowed to be enabled because we are moving to sds-drbd module.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

It will not be possible to enable the module if it has not been enabled before, alas to change module config.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: chore
summary: Add a validating webhook to prevent the linstor module from being enabled.
impact: The `linstor` module is deprecated. Please switch to [sds-drbd](https://deckhouse.io/modules/sds-drbd/stable/) module ASAP. The `linstor` module cannot be enabled but will continue to work if it was already enabled before.
impact_level: high
```
