### PR TITLE
[linstor] prevent Deckhouse update while Linstor module is enabled

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -61,6 +61,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/pkg/schema"
 	_ "github.com/deckhouse/deckhouse/modules/040-node-manager/requirements"
 	_ "github.com/deckhouse/deckhouse/modules/041-linstor/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/041-linstor/requirements"
 	_ "github.com/deckhouse/deckhouse/modules/042-kube-dns/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/045-snapshot-controller/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/101-cert-manager/hooks"

--- a/modules/041-linstor/hooks/requirement_release_on_module_delete.go
+++ b/modules/041-linstor/hooks/requirement_release_on_module_delete.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterDeleteHelm: &go_hook.OrderedConfig{Order: 10},
+}, resetRequirementsHandler)
+
+func resetRequirementsHandler(_ *go_hook.HookInput) error {
+	requirements.RemoveValue(linstorEnabled)
+	return nil
+}

--- a/modules/041-linstor/hooks/requirement_set_if_module_is_enabled.go
+++ b/modules/041-linstor/hooks/requirement_set_if_module_is_enabled.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const linstorEnabled = "linstor:enabled"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 99},
+}, setRequirementsHandler)
+
+func setRequirementsHandler(_ *go_hook.HookInput) error {
+	requirements.SaveValue(linstorEnabled, "true")
+	return nil
+}

--- a/modules/041-linstor/requirements/check.go
+++ b/modules/041-linstor/requirements/check.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Don't forget to add "linstorMustBeDisabled": "true" to release.yaml
+
+package requirements
+
+import (
+	"errors"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const linstorEnabled = "linstor:enabled"
+const requirementsKey = "linstorMustBeDisabled"
+
+func init() {
+	f := func(_ string, getter requirements.ValueGetter) (bool, error) {
+		if _, ok := getter.Get(linstorEnabled); ok {
+			return false, errors.New("linstor module must be disabled, switch to sds-drbd module instead")
+		}
+		return true, nil
+	}
+
+	requirements.RegisterCheck(requirementsKey, f)
+}

--- a/modules/041-linstor/requirements/check_test.go
+++ b/modules/041-linstor/requirements/check_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+func TestDisabledLinstorRequirement(t *testing.T) {
+	requirements.RemoveValue(linstorEnabled)
+
+	t.Run("linstor is disabled", func(t *testing.T) {
+		ok, err := requirements.CheckRequirement(requirementsKey, "true")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("linstor is enabled", func(t *testing.T) {
+		requirements.SaveValue(linstorEnabled, "true")
+		ok, err := requirements.CheckRequirement(requirementsKey, "true")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disable Deckhouse update while linstor module is enabled.

Ref: https://github.com/deckhouse/deckhouse/pull/7086

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

You must disable the legacy linstor module before it can be completely removed from the deckhouse.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Deckhouse will not update until the linstor module is disabled.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: linstor
type: chore
summary: Disable Deckhouse update while `legacy` linstor module is enabled.
impact: Deckhouse will not be able to perform an upgrade if `linstor` module is enabled.
impact_level: high
```
