### PR TITLE
[deckhouse-controller] Fix auth data handling in change-registry helper

### DIFF
--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -1,6 +1,6 @@
 {!{ define "unit_run_args" }!}
 # <template: unit_run_args>
-args: 'make tests-modules'
+args: 'make tests-controller tests-modules'
 docker_options: '-w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg'
 # <template: unit_run_args>
 {!{- end -}!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -928,7 +928,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make tests-modules
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make tests-controller tests-modules
     # </template: tests_before_build_template>
 
   matrix_tests:

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -695,7 +695,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make tests-modules
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make tests-controller tests-modules
     # </template: tests_before_build_template>
 
   matrix_tests:

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -1567,7 +1567,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make tests-modules
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make tests-controller tests-modules
     # </template: tests_before_build_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ bin/gator: bin/gator-${GATOR_VERSION}/gator
 	rm -f bin/gator
 	ln -s /deckhouse/bin/gator-${GATOR_VERSION}/gator bin/gator
 
-.PHONY: tests-modules tests-matrix tests-openapi tests-prometheus
+.PHONY: tests-modules tests-matrix tests-openapi tests-prometheus tests-controller
 tests-modules: ## Run unit tests for modules hooks and templates.
   ##~ Options: FOCUS=module-name
 	go test -timeout=${TESTS_TIMEOUT} -vet=off ${TESTS_PATH}
@@ -135,6 +135,9 @@ tests-matrix: bin/promtool bin/gator ## Test how helm templates are rendered wit
 
 tests-openapi: ## Run tests against modules openapi values schemas.
 	go test -vet=off ./testing/openapi_cases/
+
+tests-controller: ## Run deckhouse-controller unit tests.
+	go test ./deckhouse-controller/... -v
 
 .PHONY: tests-doc-links
 tests-doc-links: ## Build documentation and run checker of html links.

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
@@ -143,7 +143,7 @@ func TestNewImagePullSecretData(t *testing.T) {
 			newRepo:   "registry.example.com/deckhouse",
 			caContent: testCaContent,
 			want: map[string]string{
-				".dockerconfigjson": `{"auths":{"registry.example.com":{"auth":"dGVzdDp0ZXN0"}}}`,
+				".dockerconfigjson": `{"auths":{"registry.example.com":{"username":"test","password":"test","auth":"dGVzdDp0ZXN0"}}}`,
 				"address":           "registry.example.com",
 				"path":              "/deckhouse",
 				"scheme":            "https",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed a bug where helper would not properly marshal provided credentials for registry into the secret. Unit tests of `deckhouse-controller` are now enabled as part of CI pipeline.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes a reported bug introduced with a `go-containerregistry` update.

## Why do we need it in the patch release (if we do)?

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix for `change-registry` helper's handling of registry credentials.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
