### PR TITLE
[deckhouse-controller] update module registry settings

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
@@ -155,7 +155,7 @@ func (md *ModuleDownloader) storeModule(moduleStorePath string, img v1.Image) er
 	}
 
 	// inject registry to values
-	err = injectRegistryToModuleValues(moduleStorePath, md.ms)
+	err = InjectRegistryToModuleValues(moduleStorePath, md.ms)
 	if err != nil {
 		return fmt.Errorf("inject registry error: %v", err)
 	}
@@ -426,7 +426,7 @@ type moduleReleaseMetadata struct {
 
 // Inject registry to module values
 
-func injectRegistryToModuleValues(moduleVersionPath string, moduleSource *v1alpha1.ModuleSource) error {
+func InjectRegistryToModuleValues(moduleVersionPath string, moduleSource *v1alpha1.ModuleSource) error {
 	valuesFile := path.Join(moduleVersionPath, "openapi", "values.yaml")
 
 	valuesData, err := os.ReadFile(valuesFile)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -491,11 +491,14 @@ func (c *Controller) reconcilePendingRelease(ctx context.Context, mr *v1alpha1.M
 			}
 
 			// if policy mode manual
-			if policy.Spec.Update.Mode == "Manual" && !isReleaseApproved(release) {
-				if e := c.updateModuleReleaseStatusMessage(ctx, release, manualApprovalRequired); e != nil {
-					return ctrl.Result{Requeue: true}, e
+			if policy.Spec.Update.Mode == "Manual" {
+				if !isReleaseApproved(release) {
+					if e := c.updateModuleReleaseStatusMessage(ctx, release, manualApprovalRequired); e != nil {
+						return ctrl.Result{Requeue: true}, e
+					}
+					return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 				}
-				return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
+				release.Status.Approved = true
 			}
 
 			// if policy mode auto


### PR DESCRIPTION
## Description
The following changes are introduced:
* module release's `.status.approved` field is set to true if the module release once was approved;
* if valid registry settings are provided in a module source, their md5 checksum is calculated ad its values is stored in the `modules.deckhouse.io/registry-spec-checksum:` annotation of the module source;
* during consequent updates of the module source, `module controller` checks if registry settings were updated by means of comparison between the annotation value and the checksum of current settings;
* if a change is detected, `module controller` searches for relevant module releases in `Deployed` phase and updates their registry settings in the `/openapi/values.yaml` file so that new settings can be applied on `deckhouse` restart or the module upgrade.
* after updating relevant modules, `module controller` writes new `modules.deckhouse.io/registry-spec-checksum:` value to the module source
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Closes #5107
We should update external modules' registry settings in case the registry config of their module source is updated because registry settings might be used in the external modules' charts. 

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
If we update registry settings of a module source and the module source has some module releases deployed, the modules from these module releases should also have their values (regarding registry configuration) updated.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Update module values if the corresponding moduleSource was updated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
