### PR TITLE
[log-shipper] add node group name to logs metadata

### DIFF
--- a/modules/460-log-shipper/docs/README.md
+++ b/modules/460-log-shipper/docs/README.md
@@ -72,6 +72,10 @@ The following metadata fields will be exposed:
 | `node`       | spec.nodeName           |
 | `pod_owner`  | metadata.ownerRef[0]    |
 
+| Label        | Node spec path                            |
+|--------------|-------------------------------------------|
+| `node_group` | metadata.labels[].node.deckhouse.io/group |
+
 {% alert -%}
 Splunk destination does not use `pod_labels`, because it is a nested object with keys and values.
 {%- endalert %}

--- a/modules/460-log-shipper/docs/README_RU.md
+++ b/modules/460-log-shipper/docs/README_RU.md
@@ -72,6 +72,10 @@ description: Описание возможностей сбора логов в 
 | `node`       | spec.nodeName           |
 | `pod_owner`  | metadata.ownerRef[0]    |
 
+| Label        | Node spec path                            |
+|--------------|-------------------------------------------|
+| `node_group` | metadata.labels[].node.deckhouse.io/group |
+
 {% alert -%}
 Для Splunk поля `pod_labels` не экспортируются, потому что это вложенный объект, который не поддерживается самим Splunk.
 {%- endalert %}

--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     },
@@ -32,6 +35,9 @@
         "pod_namespace": "namespace",
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
+      },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
       },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
@@ -74,7 +80,8 @@
         "pod_ip": "{{ pod_ip }}",
         "pod_labels_*": "{{ pod_labels }}",
         "pod_owner": "{{ pod_owner }}",
-        "stream": "{{ stream }}"
+        "stream": "{{ stream }}",
+        "node_labels_*": "{{ node_labels }}"
       },
       "remove_label_fields": true,
       "out_of_order_action": "rewrite_timestamp"

--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
@@ -81,7 +81,7 @@
         "pod_labels_*": "{{ pod_labels }}",
         "pod_owner": "{{ pod_owner }}",
         "stream": "{{ stream }}",
-        "node_labels_*": "{{ node_labels }}"
+        "node_group": "{{ node_group }}"
       },
       "remove_label_fields": true,
       "out_of_order_action": "rewrite_timestamp"

--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_2.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_2.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     },
@@ -32,6 +35,9 @@
         "pod_namespace": "namespace",
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
+      },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
       },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true

--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_4.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_4.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }

--- a/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
@@ -64,16 +64,16 @@ func NewLoki(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Loki {
 	// See https://github.com/vectordotdev/vector/pull/12041
 	labels := map[string]string{
 		// Kubernetes logs labels
-		"namespace":     "{{ namespace }}",
-		"container":     "{{ container }}",
-		"image":         "{{ image }}",
-		"pod":           "{{ pod }}",
-		"node":          "{{ node }}",
-		"pod_ip":        "{{ pod_ip }}",
-		"stream":        "{{ stream }}",
-		"pod_labels_*":  "{{ pod_labels }}",
-		"node_labels_*": "{{ node_labels }}",
-		"pod_owner":     "{{ pod_owner }}",
+		"namespace":    "{{ namespace }}",
+		"container":    "{{ container }}",
+		"image":        "{{ image }}",
+		"pod":          "{{ pod }}",
+		"node":         "{{ node }}",
+		"pod_ip":       "{{ pod_ip }}",
+		"stream":       "{{ stream }}",
+		"pod_labels_*": "{{ pod_labels }}",
+		"node_group":   "{{ node_group }}",
+		"pod_owner":    "{{ pod_owner }}",
 		// File labels
 		// TODO(nabokihms): think about removing this label and always use the `node` labels.
 		//   If we do this right now, it will break already working setups.

--- a/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
@@ -64,15 +64,16 @@ func NewLoki(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Loki {
 	// See https://github.com/vectordotdev/vector/pull/12041
 	labels := map[string]string{
 		// Kubernetes logs labels
-		"namespace":    "{{ namespace }}",
-		"container":    "{{ container }}",
-		"image":        "{{ image }}",
-		"pod":          "{{ pod }}",
-		"node":         "{{ node }}",
-		"pod_ip":       "{{ pod_ip }}",
-		"stream":       "{{ stream }}",
-		"pod_labels_*": "{{ pod_labels }}",
-		"pod_owner":    "{{ pod_owner }}",
+		"namespace":     "{{ namespace }}",
+		"container":     "{{ container }}",
+		"image":         "{{ image }}",
+		"pod":           "{{ pod }}",
+		"node":          "{{ node }}",
+		"pod_ip":        "{{ pod_ip }}",
+		"stream":        "{{ stream }}",
+		"pod_labels_*":  "{{ pod_labels }}",
+		"node_labels_*": "{{ node_labels }}",
+		"pod_owner":     "{{ pod_owner }}",
 		// File labels
 		// TODO(nabokihms): think about removing this label and always use the `node` labels.
 		//   If we do this right now, it will break already working setups.

--- a/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
@@ -51,8 +51,8 @@ type Kubernetes struct {
 	namespaceLabelSelector string
 
 	annotationFields     KubernetesAnnotationFields
+	nodeAnnotationFields NodeAnnotationFields
 	globCooldownMs       int
-	nodeAnnotationFields string
 }
 
 // KubernetesAnnotationFields are supported fields for the following vector options
@@ -66,7 +66,10 @@ type KubernetesAnnotationFields struct {
 	PodNamespace   string `json:"pod_namespace,omitempty"`
 	PodNodeName    string `json:"pod_node_name,omitempty"`
 	PodOwner       string `json:"pod_owner,omitempty"`
-	NodeLabels     string `json:"node_labels,omitempty"`
+}
+
+type NodeAnnotationFields struct {
+	NodeLabels string `json:"node_labels,omitempty"`
 }
 
 // rawKubernetesLogs represents `kubernetes_logs` vector source
@@ -74,12 +77,13 @@ type KubernetesAnnotationFields struct {
 type rawKubernetesLogs struct {
 	commonSource
 
-	Labels             string                     `json:"extra_label_selector,omitempty"`
-	Fields             string                     `json:"extra_field_selector,omitempty"`
-	NamespaceLabels    string                     `json:"extra_namespace_label_selector,omitempty"`
-	AnnotationFields   KubernetesAnnotationFields `json:"annotation_fields,omitempty"`
-	GlobCooldownMs     int                        `json:"glob_minimum_cooldown_ms,omitempty"`
-	UserAPIServerCache bool                       `json:"use_apiserver_cache,omitempty"`
+	Labels               string                     `json:"extra_label_selector,omitempty"`
+	Fields               string                     `json:"extra_field_selector,omitempty"`
+	NamespaceLabels      string                     `json:"extra_namespace_label_selector,omitempty"`
+	AnnotationFields     KubernetesAnnotationFields `json:"annotation_fields,omitempty"`
+	NodeAnnotationFields NodeAnnotationFields       `json:"node_annotation_fields"`
+	GlobCooldownMs       int                        `json:"glob_minimum_cooldown_ms,omitempty"`
+	UserAPIServerCache   bool                       `json:"use_apiserver_cache,omitempty"`
 }
 
 func (k *rawKubernetesLogs) BuildSources() []apis.LogSource {
@@ -141,7 +145,9 @@ func NewKubernetes(name string, spec v1alpha1.KubernetesPodsSpec, namespaced boo
 			ContainerName:  "container",
 			PodNodeName:    "node",
 			PodOwner:       "pod_owner",
-			NodeLabels:     "node_labels",
+		},
+		nodeAnnotationFields: NodeAnnotationFields{
+			NodeLabels: "node_labels",
 		},
 		globCooldownMs: defaultGlobCooldownMs,
 	}

--- a/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
@@ -66,7 +66,7 @@ type KubernetesAnnotationFields struct {
 	PodNamespace   string `json:"pod_namespace,omitempty"`
 	PodNodeName    string `json:"pod_node_name,omitempty"`
 	PodOwner       string `json:"pod_owner,omitempty"`
-	NodeLabels     string `json:"node_annotation_fields,omitempty"`
+	NodeLabels     string `json:"node_labels,omitempty"`
 }
 
 // rawKubernetesLogs represents `kubernetes_logs` vector source

--- a/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
@@ -81,7 +81,7 @@ type rawKubernetesLogs struct {
 	Fields               string                     `json:"extra_field_selector,omitempty"`
 	NamespaceLabels      string                     `json:"extra_namespace_label_selector,omitempty"`
 	AnnotationFields     KubernetesAnnotationFields `json:"annotation_fields,omitempty"`
-	NodeAnnotationFields NodeAnnotationFields       `json:"node_annotation_fields"`
+	NodeAnnotationFields NodeAnnotationFields       `json:"node_annotation_fields,omitempty"`
 	GlobCooldownMs       int                        `json:"glob_minimum_cooldown_ms,omitempty"`
 	UserAPIServerCache   bool                       `json:"use_apiserver_cache,omitempty"`
 }

--- a/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
@@ -50,8 +50,9 @@ type Kubernetes struct {
 	labelSelector          string
 	namespaceLabelSelector string
 
-	annotationFields KubernetesAnnotationFields
-	globCooldownMs   int
+	annotationFields     KubernetesAnnotationFields
+	globCooldownMs       int
+	nodeAnnotationFields string
 }
 
 // KubernetesAnnotationFields are supported fields for the following vector options
@@ -65,6 +66,7 @@ type KubernetesAnnotationFields struct {
 	PodNamespace   string `json:"pod_namespace,omitempty"`
 	PodNodeName    string `json:"pod_node_name,omitempty"`
 	PodOwner       string `json:"pod_owner,omitempty"`
+	NodeLabels     string `json:"node_annotation_fields,omitempty"`
 }
 
 // rawKubernetesLogs represents `kubernetes_logs` vector source
@@ -139,6 +141,7 @@ func NewKubernetes(name string, spec v1alpha1.KubernetesPodsSpec, namespaced boo
 			ContainerName:  "container",
 			PodNodeName:    "node",
 			PodOwner:       "pod_owner",
+			NodeLabels:     "node_labels",
 		},
 		globCooldownMs: defaultGlobCooldownMs,
 	}

--- a/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
@@ -159,12 +159,13 @@ func (k *Kubernetes) newRawSource(name string, fields []string) *rawKubernetesLo
 			Type: k.Type,
 			Name: name,
 		},
-		Fields:             strings.Join(fields, ","),
-		Labels:             k.labelSelector,
-		NamespaceLabels:    k.namespaceLabelSelector,
-		AnnotationFields:   k.annotationFields,
-		GlobCooldownMs:     k.globCooldownMs,
-		UserAPIServerCache: true,
+		Fields:               strings.Join(fields, ","),
+		Labels:               k.labelSelector,
+		NamespaceLabels:      k.namespaceLabelSelector,
+		AnnotationFields:     k.annotationFields,
+		NodeAnnotationFields: k.nodeAnnotationFields,
+		GlobCooldownMs:       k.globCooldownMs,
+		UserAPIServerCache:   true,
 	}
 }
 

--- a/modules/460-log-shipper/hooks/internal/vrl/cleanup.go
+++ b/modules/460-log-shipper/hooks/internal/vrl/cleanup.go
@@ -31,4 +31,8 @@ if exists(.kubernetes) {
 if exists(.file) {
     del(.file)
 }
+if exists(.node_labels."node.deckhouse.io/group") {
+	.node_group = (.node_labels."node.deckhouse.io/group")
+	del(.node_labels)
+}
 `

--- a/modules/460-log-shipper/hooks/internal/vrl/cleanup.go
+++ b/modules/460-log-shipper/hooks/internal/vrl/cleanup.go
@@ -33,6 +33,6 @@ if exists(.file) {
 }
 if exists(.node_labels."node.deckhouse.io/group") {
 	.node_group = (.node_labels."node.deckhouse.io/group")
-	del(.node_labels)
 }
+del(.node_labels)
 `

--- a/modules/460-log-shipper/hooks/testdata/es-5x/result.json
+++ b/modules/460-log-shipper/hooks/testdata/es-5x/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -57,7 +60,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-elastic/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-elastic/result.json
@@ -29,7 +29,7 @@
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/01_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
@@ -21,7 +21,7 @@
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/01_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
@@ -13,7 +13,7 @@
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/01_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-loki/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-loki/result.json
@@ -21,7 +21,7 @@
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/01_local_timezone": {
@@ -68,6 +68,7 @@
         "image": "{{ image }}",
         "namespace": "{{ namespace }}",
         "node": "{{ node }}",
+        "node_group": "{{ node_group }}",
         "pod": "{{ pod }}",
         "pod_ip": "{{ pod_ip }}",
         "pod_labels_*": "{{ pod_labels }}",

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
@@ -21,7 +21,7 @@
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/01_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-vector/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-vector/result.json
@@ -21,7 +21,7 @@
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/01_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/many-to-one/result.json
+++ b/modules/460-log-shipper/hooks/testdata/many-to-one/result.json
@@ -21,6 +21,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -40,7 +43,7 @@
       "inputs": [
         "cluster_logging_config/test-file"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-file/01_local_timezone": {
@@ -64,7 +67,7 @@
       "inputs": [
         "transform/source/test-kubernetes/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-kubernetes/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/multiline-custom-pods/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline-custom-pods/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -57,7 +60,7 @@
       "inputs": [
         "transform/source/tests-whispers-pods_whispers-logs-pods/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/tests-whispers-pods_whispers-logs-pods/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/multiline-custom/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline-custom/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -57,7 +60,7 @@
       "inputs": [
         "transform/source/whispers-logs/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/whispers-logs/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/multiline/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -57,7 +60,7 @@
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/tests-whispers_whispers-logs/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -89,7 +92,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {
@@ -299,6 +302,7 @@
         "image": "{{ image }}",
         "namespace": "{{ namespace }}",
         "node": "{{ node }}",
+        "node_group": "{{ node_group }}",
         "pod": "{{ pod }}",
         "pod_ip": "{{ pod_ip }}",
         "pod_labels_*": "{{ pod_labels }}",

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -65,7 +68,7 @@
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/tests-whispers_whispers-logs/02_local_timezone": {
@@ -155,6 +158,7 @@
         "image": "{{ image }}",
         "namespace": "{{ namespace }}",
         "node": "{{ node }}",
+        "node_group": "{{ node_group }}",
         "pod": "{{ pod }}",
         "pod_ip": "{{ pod_ip }}",
         "pod_labels_*": "{{ pod_labels }}",

--- a/modules/460-log-shipper/hooks/testdata/one-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/one-dest/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     },
@@ -32,6 +35,9 @@
         "pod_namespace": "namespace",
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
+      },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
       },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
@@ -76,7 +82,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/pair-datastream/result.json
+++ b/modules/460-log-shipper/hooks/testdata/pair-datastream/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -65,7 +68,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/simple-pair/result.json
+++ b/modules/460-log-shipper/hooks/testdata/simple-pair/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -57,7 +60,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/throttle-with-filter/result.json
+++ b/modules/460-log-shipper/hooks/testdata/throttle-with-filter/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -62,7 +65,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {

--- a/modules/460-log-shipper/hooks/testdata/throttle/result.json
+++ b/modules/460-log-shipper/hooks/testdata/throttle/result.json
@@ -15,6 +15,9 @@
         "pod_node_name": "node",
         "pod_owner": "pod_owner"
       },
+      "node_annotation_fields": {
+        "node_labels": "node_labels"
+      },
       "glob_minimum_cooldown_ms": 1000,
       "use_apiserver_cache": true
     }
@@ -58,7 +61,7 @@
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-source/02_local_timezone": {


### PR DESCRIPTION
## Description
Add node labels to vector log metadata. 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Now it's possible to filter logs also by a node group name. We can choose different log destinations depending on a node group name for example.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Log shipper collects node labels
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: feature
summary: New labels for log filtering.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
