### PR TITLE
[candi] Fixed setting default value for kubelet resourceReservation

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -2027,6 +2027,7 @@ spec:
                       description: |
                         How many rotated log files to store before deleting them.
                     resourceReservation:
+                      default: {}
                       type: object
                       oneOf:
                       - properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -1467,6 +1467,8 @@ spec:
                           description: The checksum of the last applied resource.
             spec:
               type: object
+              default:
+                nodeType: Cloud
               required:
                 - nodeType
               properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -598,6 +598,7 @@ spec:
                         Enable Docker maintenance from bashible.
                 kubelet:
                   type: object
+                  default: {}
                   description: |
                     Kubelet settings for nodes.
                   properties:
@@ -1202,6 +1203,7 @@ spec:
                           - required: [automatic]
                 kubelet:
                   type: object
+                  default: {}
                   description: |
                     Kubelet settings for nodes.
                   properties:
@@ -1997,6 +1999,7 @@ spec:
                           - required: [automatic]
                 kubelet:
                   type: object
+                  default: {}
                   description: |
                     Kubelet settings for nodes.
                   properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -161,8 +161,6 @@ spec:
                       type: string
             spec:
               type: object
-              default:
-                nodeType: Static
               required:
                 - nodeType
               properties:
@@ -774,8 +772,6 @@ spec:
                       type: string
             spec:
               type: object
-              default:
-                nodeType: Static
               required:
                 - nodeType
               properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -1468,7 +1468,7 @@ spec:
             spec:
               type: object
               default:
-                nodeType: Cloud
+                nodeType: CloudEphemeral
               required:
                 - nodeType
               properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -162,7 +162,7 @@ spec:
             spec:
               type: object
               default:
-                nodeType: Cloud
+                nodeType: Static
               required:
                 - nodeType
               properties:
@@ -774,7 +774,7 @@ spec:
             spec:
               type: object
               default:
-                nodeType: Cloud
+                nodeType: Static
               required:
                 - nodeType
               properties:
@@ -1472,7 +1472,7 @@ spec:
             spec:
               type: object
               default:
-                nodeType: CloudEphemeral
+                nodeType: Static
               required:
                 - nodeType
               properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -2019,6 +2019,7 @@ spec:
                       description: |
                         How many rotated log files to store before deleting them.
                     resourceReservation:
+                      default: {}
                       type: object
                       oneOf:
                       - properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -2019,7 +2019,6 @@ spec:
                       description: |
                         How many rotated log files to store before deleting them.
                     resourceReservation:
-                      default: {}
                       type: object
                       oneOf:
                       - properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -161,6 +161,8 @@ spec:
                       type: string
             spec:
               type: object
+              default:
+                nodeType: Cloud
               required:
                 - nodeType
               properties:
@@ -771,6 +773,8 @@ spec:
                       type: string
             spec:
               type: object
+              default:
+                nodeType: Cloud
               required:
                 - nodeType
               properties:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -596,7 +596,6 @@ spec:
                         Enable Docker maintenance from bashible.
                 kubelet:
                   type: object
-                  default: {}
                   description: |
                     Kubelet settings for nodes.
                   properties:
@@ -1199,7 +1198,6 @@ spec:
                           - required: [automatic]
                 kubelet:
                   type: object
-                  default: {}
                   description: |
                     Kubelet settings for nodes.
                   properties:
@@ -1469,8 +1467,6 @@ spec:
                           description: The checksum of the last applied resource.
             spec:
               type: object
-              default:
-                nodeType: Static
               required:
                 - nodeType
               properties:

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -99,7 +99,7 @@ func configMapName(obj *unstructured.Unstructured) (go_hook.FilterResult, error)
 }
 
 func systemReserve(input *go_hook.HookInput) error {
-	if cmSnapshot := input.Snapshots["cmNew"]; len(cmSnapshot) > 0 {
+	if cmSnapshotNew := input.Snapshots["cmNew"]; len(cmSnapshotNew) > 0 {
 		log.Debug("System reserved Nodes are already migrated, skipping...")
 		return nil
 	}


### PR DESCRIPTION
## Description
Fix setting the default value for the `kubelet.resourceReservation` parameter in `NodeGroup`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix setting the default value for the `kubelet.resourceReservation` parameter in `NodeGroup`.
```
