### PR TITLE
[external-module-manager] Fix default overrite

### DIFF
--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -15,6 +15,8 @@
 package hooks
 
 import (
+	"strings"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
@@ -87,6 +89,12 @@ func createDeckhouseModuleSourceAndPolicy(input *go_hook.HookInput) error {
 		return nil
 	}
 
+	// get scheme from values
+	scheme := strings.ToUpper(input.Values.Get("global.modulesImages.registry.scheme").String())
+	if scheme == "" {
+		scheme = "HTTPS"
+	}
+
 	newms := v1alpha1.ModuleSource{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ModuleSource",
@@ -101,7 +109,7 @@ func createDeckhouseModuleSourceAndPolicy(input *go_hook.HookInput) error {
 		Spec: v1alpha1.ModuleSourceSpec{
 			ReleaseChannel: ms.Spec.ReleaseChannel,
 			Registry: v1alpha1.ModuleSourceSpecRegistry{
-				Scheme:    "HTTPS",
+				Scheme:    scheme,
 				Repo:      deckhouseRepo,
 				DockerCFG: deckhouseDockerCfg,
 				CA:        deckhouseCA,

--- a/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
+++ b/modules/005-external-module-manager/hooks/create_deckhouse_modules_source.go
@@ -91,7 +91,11 @@ func createDeckhouseModuleSourceAndPolicy(input *go_hook.HookInput) error {
 
 	// get scheme from values
 	scheme := strings.ToUpper(input.Values.Get("global.modulesImages.registry.scheme").String())
-	if scheme == "" {
+	switch scheme {
+	case "HTTP", "HTTPS":
+	// pass
+
+	default:
 		scheme = "HTTPS"
 	}
 


### PR DESCRIPTION
## Description
Get scheme from default `deckhouse` ModuleSource from values

## Why do we need it, and what problem does it solve?
If user has changed scheme in ModuleSource and then change some other registry field, scheme will be resetted. It can lead to non-obvious errors and error messages, like [here](https://flant.slack.com/archives/CML93AWG2/p1704962889578619)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Get scheme for `deckhouse` ModuleSource from the deckhouse values
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
