### PR TITLE
[candi] Change node name to fqdn

### DIFF
--- a/candi/bashible/bashbooster/60_deckhouse.sh
+++ b/candi/bashible/bashbooster/60_deckhouse.sh
@@ -28,7 +28,7 @@ bb-deckhouse-get-disruptive-update-approval() {
     attempt=0
     until
         node_data="$(
-          bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "${DECK_NODE_HOSTNAME}" -o json | jq '
+          bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "${D8_NODE_HOSTNAME}" -o json | jq '
           {
             "resourceVersion": .metadata.resourceVersion,
             "isDisruptionApproved": (.metadata.annotations | has("update.node.deckhouse.io/disruption-approved")),
@@ -48,7 +48,7 @@ bb-deckhouse-get-disruptive-update-approval() {
           bb-kubectl \
             --kubeconfig=/etc/kubernetes/kubelet.conf \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
-            annotate node "${DECK_NODE_HOSTNAME}" update.node.deckhouse.io/rolling-update= || { bb-log-info "Retry setting update.node.deckhouse.io/rolling-update= annotation on Node in 10 sec..."; sleep 10; }
+            annotate node "${D8_NODE_HOSTNAME}" update.node.deckhouse.io/rolling-update= || { bb-log-info "Retry setting update.node.deckhouse.io/rolling-update= annotation on Node in 10 sec..."; sleep 10; }
           exit 0
         else
           bb-log-info "Disruption required, asking for approval."
@@ -56,7 +56,7 @@ bb-deckhouse-get-disruptive-update-approval() {
           bb-kubectl \
             --kubeconfig=/etc/kubernetes/kubelet.conf \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
-            annotate node "${DECK_NODE_HOSTNAME}" update.node.deckhouse.io/disruption-required= || { bb-log-info "Retry setting update.node.deckhouse.io/disruption-required= annotation on Node in 10 sec..."; sleep 10; }
+            annotate node "${D8_NODE_HOSTNAME}" update.node.deckhouse.io/disruption-required= || { bb-log-info "Retry setting update.node.deckhouse.io/disruption-required= annotation on Node in 10 sec..."; sleep 10; }
         fi
     done
 
@@ -64,7 +64,7 @@ bb-deckhouse-get-disruptive-update-approval() {
 
     attempt=0
     until
-      bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "${DECK_NODE_HOSTNAME}" -o json | \
+      bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "${D8_NODE_HOSTNAME}" -o json | \
       jq -e '.metadata.annotations | has("update.node.deckhouse.io/disruption-approved")' >/dev/null
     do
         attempt=$(( attempt + 1 ))
@@ -73,7 +73,7 @@ bb-deckhouse-get-disruptive-update-approval() {
             exit 1
         fi
         bb-log-info "Step needs to make some disruptive action. It will continue upon approval:"
-        bb-log-info "kubectl annotate node ${DECK_NODE_HOSTNAME} update.node.deckhouse.io/disruption-approved="
+        bb-log-info "kubectl annotate node ${D8_NODE_HOSTNAME} update.node.deckhouse.io/disruption-approved="
         bb-log-info "Retry in 10sec..."
         sleep 10
     done

--- a/candi/bashible/bashbooster/60_deckhouse.sh
+++ b/candi/bashible/bashbooster/60_deckhouse.sh
@@ -28,7 +28,7 @@ bb-deckhouse-get-disruptive-update-approval() {
     attempt=0
     until
         node_data="$(
-          bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "$(DECK_NODE_HOSTNAME)" -o json | jq '
+          bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "${DECK_NODE_HOSTNAME}" -o json | jq '
           {
             "resourceVersion": .metadata.resourceVersion,
             "isDisruptionApproved": (.metadata.annotations | has("update.node.deckhouse.io/disruption-approved")),
@@ -48,7 +48,7 @@ bb-deckhouse-get-disruptive-update-approval() {
           bb-kubectl \
             --kubeconfig=/etc/kubernetes/kubelet.conf \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
-            annotate node "$(DECK_NODE_HOSTNAME)" update.node.deckhouse.io/rolling-update= || { bb-log-info "Retry setting update.node.deckhouse.io/rolling-update= annotation on Node in 10 sec..."; sleep 10; }
+            annotate node "${DECK_NODE_HOSTNAME}" update.node.deckhouse.io/rolling-update= || { bb-log-info "Retry setting update.node.deckhouse.io/rolling-update= annotation on Node in 10 sec..."; sleep 10; }
           exit 0
         else
           bb-log-info "Disruption required, asking for approval."
@@ -56,7 +56,7 @@ bb-deckhouse-get-disruptive-update-approval() {
           bb-kubectl \
             --kubeconfig=/etc/kubernetes/kubelet.conf \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
-            annotate node "$(DECK_NODE_HOSTNAME)" update.node.deckhouse.io/disruption-required= || { bb-log-info "Retry setting update.node.deckhouse.io/disruption-required= annotation on Node in 10 sec..."; sleep 10; }
+            annotate node "${DECK_NODE_HOSTNAME}" update.node.deckhouse.io/disruption-required= || { bb-log-info "Retry setting update.node.deckhouse.io/disruption-required= annotation on Node in 10 sec..."; sleep 10; }
         fi
     done
 
@@ -64,7 +64,7 @@ bb-deckhouse-get-disruptive-update-approval() {
 
     attempt=0
     until
-      bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "$(DECK_NODE_HOSTNAME)" -o json | \
+      bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "${DECK_NODE_HOSTNAME}" -o json | \
       jq -e '.metadata.annotations | has("update.node.deckhouse.io/disruption-approved")' >/dev/null
     do
         attempt=$(( attempt + 1 ))
@@ -73,7 +73,7 @@ bb-deckhouse-get-disruptive-update-approval() {
             exit 1
         fi
         bb-log-info "Step needs to make some disruptive action. It will continue upon approval:"
-        bb-log-info "kubectl annotate node $(DECK_NODE_HOSTNAME) update.node.deckhouse.io/disruption-approved="
+        bb-log-info "kubectl annotate node ${DECK_NODE_HOSTNAME} update.node.deckhouse.io/disruption-approved="
         bb-log-info "Retry in 10sec..."
         sleep 10
     done

--- a/candi/bashible/bashbooster/60_deckhouse.sh
+++ b/candi/bashible/bashbooster/60_deckhouse.sh
@@ -28,7 +28,7 @@ bb-deckhouse-get-disruptive-update-approval() {
     attempt=0
     until
         node_data="$(
-          bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "$(hostname -s)" -o json | jq '
+          bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "$(DECK_NODE_HOSTNAME)" -o json | jq '
           {
             "resourceVersion": .metadata.resourceVersion,
             "isDisruptionApproved": (.metadata.annotations | has("update.node.deckhouse.io/disruption-approved")),
@@ -48,7 +48,7 @@ bb-deckhouse-get-disruptive-update-approval() {
           bb-kubectl \
             --kubeconfig=/etc/kubernetes/kubelet.conf \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
-            annotate node "$(hostname -s)" update.node.deckhouse.io/rolling-update= || { bb-log-info "Retry setting update.node.deckhouse.io/rolling-update= annotation on Node in 10 sec..."; sleep 10; }
+            annotate node "$(DECK_NODE_HOSTNAME)" update.node.deckhouse.io/rolling-update= || { bb-log-info "Retry setting update.node.deckhouse.io/rolling-update= annotation on Node in 10 sec..."; sleep 10; }
           exit 0
         else
           bb-log-info "Disruption required, asking for approval."
@@ -56,7 +56,7 @@ bb-deckhouse-get-disruptive-update-approval() {
           bb-kubectl \
             --kubeconfig=/etc/kubernetes/kubelet.conf \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
-            annotate node "$(hostname -s)" update.node.deckhouse.io/disruption-required= || { bb-log-info "Retry setting update.node.deckhouse.io/disruption-required= annotation on Node in 10 sec..."; sleep 10; }
+            annotate node "$(DECK_NODE_HOSTNAME)" update.node.deckhouse.io/disruption-required= || { bb-log-info "Retry setting update.node.deckhouse.io/disruption-required= annotation on Node in 10 sec..."; sleep 10; }
         fi
     done
 
@@ -64,7 +64,7 @@ bb-deckhouse-get-disruptive-update-approval() {
 
     attempt=0
     until
-      bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "$(hostname -s)" -o json | \
+      bb-kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get node "$(DECK_NODE_HOSTNAME)" -o json | \
       jq -e '.metadata.annotations | has("update.node.deckhouse.io/disruption-approved")' >/dev/null
     do
         attempt=$(( attempt + 1 ))
@@ -73,7 +73,7 @@ bb-deckhouse-get-disruptive-update-approval() {
             exit 1
         fi
         bb-log-info "Step needs to make some disruptive action. It will continue upon approval:"
-        bb-log-info "kubectl annotate node $(hostname -s) update.node.deckhouse.io/disruption-approved="
+        bb-log-info "kubectl annotate node $(DECK_NODE_HOSTNAME) update.node.deckhouse.io/disruption-approved="
         bb-log-info "Retry in 10sec..."
         sleep 10
     done

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -32,8 +32,8 @@ function bb-event-error-create() {
     # step is used as argument for function call.
     # If event creation failed, error from kubectl suppressed.
     step="$1"
-    eventName="$(echo -n "${DECK_NODE_HOSTNAME}")-$(echo $step | sed 's#.*/##; s/_/-/g')"
-    nodeName="${DECK_NODE_HOSTNAME}"
+    eventName="$(echo -n "${D8_NODE_HOSTNAME}")-$(echo $step | sed 's#.*/##; s/_/-/g')"
+    nodeName="${D8_NODE_HOSTNAME}"
     eventLog="/var/lib/bashible/step.log"
     kubectl_exec apply -f - <<EOF || true
         apiVersion: events.k8s.io/v1
@@ -49,29 +49,29 @@ function bb-event-error-create() {
         reason: BashibleStepFailed
         type: Warning
         reportingController: bashible
-        reportingInstance: '${DECK_NODE_HOSTNAME}'
+        reportingInstance: '${D8_NODE_HOSTNAME}'
         eventTime: '$(date -u +"%Y-%m-%dT%H:%M:%S.%6NZ")'
         action: "BashibleStepExecution"
 EOF
 }
 
 function annotate_node() {
-  echo "Annotate node ${DECK_NODE_HOSTNAME} with annotation ${@}"
+  echo "Annotate node ${D8_NODE_HOSTNAME} with annotation ${@}"
   attempt=0
-  until error=$(kubectl_exec annotate node ${DECK_NODE_HOSTNAME} --overwrite ${@} 2>&1); do
+  until error=$(kubectl_exec annotate node ${D8_NODE_HOSTNAME} --overwrite ${@} 2>&1); do
     attempt=$(( attempt + 1 ))
     if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-      >&2 echo "ERROR: Failed to annotate node ${DECK_NODE_HOSTNAME} with annotation ${@} after ${MAX_RETRIES} retries. Last error from kubectl: ${error}"
+      >&2 echo "ERROR: Failed to annotate node ${D8_NODE_HOSTNAME} with annotation ${@} after ${MAX_RETRIES} retries. Last error from kubectl: ${error}"
       exit 1
     fi
     if [ "$attempt" -gt "2" ]; then
-      >&2 echo "Failed to annotate node ${DECK_NODE_HOSTNAME} with annotation ${@} after 3 tries. Last message from kubectl: ${error}"
+      >&2 echo "Failed to annotate node ${D8_NODE_HOSTNAME} with annotation ${@} after 3 tries. Last message from kubectl: ${error}"
       >&2 echo "Retrying..."
       attempt=0
     fi
     sleep 10
   done
-  echo "Succesful annotate node ${DECK_NODE_HOSTNAME} with annotation ${@}"
+  echo "Succesful annotate node ${D8_NODE_HOSTNAME} with annotation ${@}"
 }
 
 function get_secret() {
@@ -185,13 +185,13 @@ function main() {
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
 {{- if or (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
-  export DECK_NODE_HOSTNAME=$(hostname -s)
+  export D8_NODE_HOSTNAME=$(hostname -s)
 {{- else }}
-  export DECK_NODE_HOSTNAME=$(hostname)
+  export D8_NODE_HOSTNAME=$(hostname)
 {{- end }}
 
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-    if tmp="$(kubectl_exec get node ${DECK_NODE_HOSTNAME} -o json | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
+    if tmp="$(kubectl_exec get node ${D8_NODE_HOSTNAME} -o json | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
       NODE_GROUP="$tmp"
       if [ "${NODE_GROUP}" == "null" ] ; then
         >&2 echo "failed to get node group. Forgot set label 'node.deckhouse.io/group'"

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -32,8 +32,8 @@ function bb-event-error-create() {
     # step is used as argument for function call.
     # If event creation failed, error from kubectl suppressed.
     step="$1"
-    eventName="$(echo -n "$(DECK_NODE_HOSTNAME)")-$(echo $step | sed 's#.*/##; s/_/-/g')"
-    nodeName="$(DECK_NODE_HOSTNAME)"
+    eventName="$(echo -n "${DECK_NODE_HOSTNAME}")-$(echo $step | sed 's#.*/##; s/_/-/g')"
+    nodeName="${DECK_NODE_HOSTNAME}"
     eventLog="/var/lib/bashible/step.log"
     kubectl_exec apply -f - <<EOF || true
         apiVersion: events.k8s.io/v1
@@ -49,46 +49,29 @@ function bb-event-error-create() {
         reason: BashibleStepFailed
         type: Warning
         reportingController: bashible
-        reportingInstance: '$(DECK_NODE_HOSTNAME)'
+        reportingInstance: '${DECK_NODE_HOSTNAME}'
         eventTime: '$(date -u +"%Y-%m-%dT%H:%M:%S.%6NZ")'
         action: "BashibleStepExecution"
 EOF
 }
 
-function wait_node() {
-  attempt=0
-  while true; do
-    if error=$(kubectl_exec get node $(DECK_NODE_HOSTNAME) 2>&1 >/dev/null); then
-      return 0
-    fi
-    errors+="\n$error"
-
-    attempt=$(( attempt + 1 ))
-    if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-      >&2 echo "ERROR: Failed to check existence of node $(DECK_NODE_HOSTNAME) after ${MAX_RETRIES} retries."
-      exit 1
-    fi
-    if [ "$attempt" -gt "3" ]; then
-      >&2 echo -e "Failed to check existence of node $(DECK_NODE_HOSTNAME) ... retry in 10 seconds. Errors:$errors"
-      errors=""
-    fi
-    sleep 10
-  done
-}
-
 function annotate_node() {
-  echo "Annotate node $(hostname -s) with annotation ${@}"
+  echo "Annotate node ${DECK_NODE_HOSTNAME} with annotation ${@}"
   attempt=0
-  until kubectl_exec annotate node $(DECK_NODE_HOSTNAME) --overwrite ${@} 1> /dev/null; do
+  until error=$(kubectl_exec annotate node ${DECK_NODE_HOSTNAME} --overwrite ${@} 2>&1); do
     attempt=$(( attempt + 1 ))
     if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-      >&2 echo "ERROR: Failed to annotate node $(DECK_NODE_HOSTNAME) with annotation ${@} after ${MAX_RETRIES} retries."
+      >&2 echo "ERROR: Failed to annotate node ${DECK_NODE_HOSTNAME} with annotation ${@} after ${MAX_RETRIES} retries. Last error from kubectl: ${error}"
       exit 1
     fi
-    >&2 echo "Failed to annotate node $(DECK_NODE_HOSTNAME) with annotation ${@} ... retry in 10 seconds."
+    if [ "$attempt" -gt "2" ]; then
+      >&2 echo "Failed to annotate node ${DECK_NODE_HOSTNAME} with annotation ${@} after 3 tries. Last message from kubectl: ${error}"
+      >&2 echo "Retrying..."
+      attempt=0
+    fi
     sleep 10
   done
-  echo "Succesful annotate node $(hostname -s) with annotation ${@}"
+  echo "Succesful annotate node ${DECK_NODE_HOSTNAME} with annotation ${@}"
 }
 
 function get_secret() {
@@ -208,7 +191,7 @@ function main() {
 {{- end }}
 
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-    if tmp="$(kubectl_exec get node $(DECK_NODE_HOSTNAME) -o json | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
+    if tmp="$(kubectl_exec get node ${DECK_NODE_HOSTNAME} -o json | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
       NODE_GROUP="$tmp"
       if [ "${NODE_GROUP}" == "null" ] ; then
         >&2 echo "failed to get node group. Forgot set label 'node.deckhouse.io/group'"

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -78,7 +78,7 @@ while [ "$patch_pending" = true ] ; do
       sleep 1
     done
 
-    machine_name="${DECK_NODE_HOSTNAME}"
+    machine_name="${D8_NODE_HOSTNAME}"
     if [ -f ${BOOTSTRAP_DIR}/machine-name ]; then
       machine_name="$(<${BOOTSTRAP_DIR}/machine-name)"
     fi

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -57,6 +57,11 @@ export no_proxy=${NO_PROXY}
 {{- else }}
 unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
+{{- if or (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
+export D8_NODE_HOSTNAME=$(hostname -s)
+{{- else }}
+export D8_NODE_HOSTNAME=$(hostname)
+{{- end }}
 
 # Install necessary packages.
 basic_bootstrap_${BUNDLE}

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -78,7 +78,7 @@ while [ "$patch_pending" = true ] ; do
       sleep 1
     done
 
-    machine_name="$(hostname -s)"
+    machine_name="$(DECK_NODE_HOSTNAME)"
     if [ -f ${BOOTSTRAP_DIR}/machine-name ]; then
       machine_name="$(<${BOOTSTRAP_DIR}/machine-name)"
     fi

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -78,7 +78,7 @@ while [ "$patch_pending" = true ] ; do
       sleep 1
     done
 
-    machine_name="$(DECK_NODE_HOSTNAME)"
+    machine_name="${DECK_NODE_HOSTNAME}"
     if [ -f ${BOOTSTRAP_DIR}/machine-name ]; then
       machine_name="$(<${BOOTSTRAP_DIR}/machine-name)"
     fi

--- a/candi/bashible/common-steps/all/003_set_short_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/003_set_short_hostname.sh.tpl
@@ -1,3 +1,4 @@
+{{- if or (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,3 +16,4 @@
 if [[ "$(hostname)" != "$(hostname -s)" ]]; then
   hostnamectl set-hostname $(hostname -s)
 fi
+{{ end }}

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! D8_NODE_HOSTNAME|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
+if ! grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' <<< "${D8_NODE_HOSTNAME}" > /dev/null 2>&1; then
   bb-log-error "FAIL Hostname '${D8_NODE_HOSTNAME}' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
   exit 1
 fi

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! DECK_NODE_HOSTNAME|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
-  bb-log-error "FAIL Hostname '${DECK_NODE_HOSTNAME}' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+if ! D8_NODE_HOSTNAME|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
+  bb-log-error "FAIL Hostname '${D8_NODE_HOSTNAME}' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
   exit 1
 fi

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 if ! DECK_NODE_HOSTNAME|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
-  bb-log-error "FAIL Hostname '$(DECK_NODE_HOSTNAME)' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+  bb-log-error "FAIL Hostname '${DECK_NODE_HOSTNAME}' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
   exit 1
 fi
-

--- a/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/004_check_hostname.sh.tpl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! hostname -s|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
-  bb-log-error "FAIL Hostname '$(hostname -s)' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
+if ! DECK_NODE_HOSTNAME|grep -P '^[a-z0-9]{1}(([a-z0-9\-\.]{0,61}[a-z0-9]{1})|[a-z0-9]{0,62})$' > /dev/null 2>&1; then
+  bb-log-error "FAIL Hostname '$(DECK_NODE_HOSTNAME)' should be contain no more than 63 characters, contain only lowercase alphanumeric characters, '-' or '.', start with an alphanumeric character, end with an alphanumeric character"
   exit 1
 fi
 

--- a/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
+++ b/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
@@ -34,7 +34,7 @@ if [[ "$virtualization" == "" ]]; then
   virtualization="unknown"
 fi
 max_attempts=5
-node=$(hostname -s)
+node=$(DECK_NODE_HOSTNAME)
 
 until bb-kubectl --kubeconfig $kubeconfig annotate --overwrite=true node "$node" node.deckhouse.io/virtualization="$virtualization"; do
   attempt=$(( attempt + 1 ))

--- a/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
+++ b/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
@@ -34,7 +34,7 @@ if [[ "$virtualization" == "" ]]; then
   virtualization="unknown"
 fi
 max_attempts=5
-node=${DECK_NODE_HOSTNAME}
+node=${D8_NODE_HOSTNAME}
 
 until bb-kubectl --kubeconfig $kubeconfig annotate --overwrite=true node "$node" node.deckhouse.io/virtualization="$virtualization"; do
   attempt=$(( attempt + 1 ))

--- a/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
+++ b/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
@@ -34,7 +34,7 @@ if [[ "$virtualization" == "" ]]; then
   virtualization="unknown"
 fi
 max_attempts=5
-node=$(DECK_NODE_HOSTNAME)
+node=${DECK_NODE_HOSTNAME}
 
 until bb-kubectl --kubeconfig $kubeconfig annotate --overwrite=true node "$node" node.deckhouse.io/virtualization="$virtualization"; do
   attempt=$(( attempt + 1 ))

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -86,7 +86,7 @@ while true; do
 
   bb-log-info "Setting node status to NotReady..."
 
-  url="https://127.0.0.1:6445/api/v1/nodes/$(hostname -s)"
+  url="https://127.0.0.1:6445/api/v1/nodes/$(DECK_NODE_HOSTNAME)"
   ready_condition_key=""
   if ! ready_condition_key="$(d8-curl -s -f -X GET "$url" --cacert /etc/kubernetes/pki/ca.crt \
        --cert /var/lib/kubelet/pki/kubelet-client-current.pem |

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -86,7 +86,7 @@ while true; do
 
   bb-log-info "Setting node status to NotReady..."
 
-  url="https://127.0.0.1:6445/api/v1/nodes/$(DECK_NODE_HOSTNAME)"
+  url="https://127.0.0.1:6445/api/v1/nodes/${DECK_NODE_HOSTNAME}"
   ready_condition_key=""
   if ! ready_condition_key="$(d8-curl -s -f -X GET "$url" --cacert /etc/kubernetes/pki/ca.crt \
        --cert /var/lib/kubelet/pki/kubelet-client-current.pem |

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -86,7 +86,7 @@ while true; do
 
   bb-log-info "Setting node status to NotReady..."
 
-  url="https://127.0.0.1:6445/api/v1/nodes/${DECK_NODE_HOSTNAME}"
+  url="https://127.0.0.1:6445/api/v1/nodes/${D8_NODE_HOSTNAME}"
   ready_condition_key=""
   if ! ready_condition_key="$(d8-curl -s -f -X GET "$url" --cacert /etc/kubernetes/pki/ca.crt \
        --cert /var/lib/kubelet/pki/kubelet-client-current.pem |

--- a/candi/bashible/common-steps/cluster-bootstrap/050_reset_control_plane_on_configuration_change.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/050_reset_control_plane_on_configuration_change.sh.tpl
@@ -33,7 +33,7 @@ if [ -f /etc/kubernetes/admin.conf ]; then
       sleep 1
     done
 
-  elif bb-kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o name | grep -q -v "^node/${DECK_NODE_HOSTNAME}$"; then
+  elif bb-kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o name | grep -q -v "^node/${D8_NODE_HOSTNAME}$"; then
     >&2 echo "ERROR: Trying to re-bootstrap cluster which has more than one node."
     exit 1
   fi

--- a/candi/bashible/common-steps/cluster-bootstrap/050_reset_control_plane_on_configuration_change.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/050_reset_control_plane_on_configuration_change.sh.tpl
@@ -33,7 +33,7 @@ if [ -f /etc/kubernetes/admin.conf ]; then
       sleep 1
     done
 
-  elif bb-kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o name | grep -q -v "^node/$(DECK_NODE_HOSTNAME)$"; then
+  elif bb-kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o name | grep -q -v "^node/${DECK_NODE_HOSTNAME}$"; then
     >&2 echo "ERROR: Trying to re-bootstrap cluster which has more than one node."
     exit 1
   fi

--- a/candi/bashible/common-steps/cluster-bootstrap/050_reset_control_plane_on_configuration_change.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/050_reset_control_plane_on_configuration_change.sh.tpl
@@ -33,7 +33,7 @@ if [ -f /etc/kubernetes/admin.conf ]; then
       sleep 1
     done
 
-  elif bb-kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o name | grep -q -v "^node/$(hostname -s)$"; then
+  elif bb-kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes -o name | grep -q -v "^node/$(DECK_NODE_HOSTNAME)$"; then
     >&2 echo "ERROR: Trying to re-bootstrap cluster which has more than one node."
     exit 1
   fi

--- a/candi/bashible/common-steps/node-group/001_waiting_approval_annotations.sh.tpl
+++ b/candi/bashible/common-steps/node-group/001_waiting_approval_annotations.sh.tpl
@@ -22,7 +22,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   attempt=0
   until
     node_data="$(
-      kubectl_exec get node "$(hostname -s)" -o json | jq '
+      kubectl_exec get node "$(DECK_NODE_HOSTNAME)" -o json | jq '
       {
         "resourceVersion": .metadata.resourceVersion,
         "isApproved": (.metadata.annotations | has("update.node.deckhouse.io/approved")),
@@ -36,7 +36,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
       >&2 echo "ERROR: Can't set update.node.deckhouse.io/waiting-for-approval= annotation on our Node."
       exit 1
     fi
-    kubectl_exec annotate node "$(hostname -s)" \
+    kubectl_exec annotate node "$(DECK_NODE_HOSTNAME)" \
       --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
       update.node.deckhouse.io/waiting-for-approval= node.deckhouse.io/configuration-checksum- \
       || { echo "Retry setting update.node.deckhouse.io/waiting-for-approval= annotation on our Node in 10sec..."; sleep 10; }
@@ -45,7 +45,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   >&2 echo "Waiting for update.node.deckhouse.io/approved= annotation on our Node..."
   attempt=0
   until
-    kubectl_exec get node "$(hostname -s)" -o json | \
+    kubectl_exec get node "$(DECK_NODE_HOSTNAME)" -o json | \
     jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' >/dev/null
   do
     attempt=$(( attempt + 1 ))
@@ -55,7 +55,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
     fi
     echo "Steps are waiting for approval to start."
     echo "Note: Deckhouse is performing a rolling update. If you want to force an update, use the following command."
-    echo "kubectl annotate node $(hostname -s) update.node.deckhouse.io/approved="
+    echo "kubectl annotate node $(DECK_NODE_HOSTNAME) update.node.deckhouse.io/approved="
     echo "Retry in 10sec..."
     sleep 10
   done

--- a/candi/bashible/common-steps/node-group/001_waiting_approval_annotations.sh.tpl
+++ b/candi/bashible/common-steps/node-group/001_waiting_approval_annotations.sh.tpl
@@ -22,7 +22,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   attempt=0
   until
     node_data="$(
-      kubectl_exec get node "${DECK_NODE_HOSTNAME}" -o json | jq '
+      kubectl_exec get node "${D8_NODE_HOSTNAME}" -o json | jq '
       {
         "resourceVersion": .metadata.resourceVersion,
         "isApproved": (.metadata.annotations | has("update.node.deckhouse.io/approved")),
@@ -36,7 +36,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
       >&2 echo "ERROR: Can't set update.node.deckhouse.io/waiting-for-approval= annotation on our Node."
       exit 1
     fi
-    kubectl_exec annotate node "${DECK_NODE_HOSTNAME}" \
+    kubectl_exec annotate node "${D8_NODE_HOSTNAME}" \
       --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
       update.node.deckhouse.io/waiting-for-approval= node.deckhouse.io/configuration-checksum- \
       || { echo "Retry setting update.node.deckhouse.io/waiting-for-approval= annotation on our Node in 10sec..."; sleep 10; }
@@ -45,7 +45,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   >&2 echo "Waiting for update.node.deckhouse.io/approved= annotation on our Node..."
   attempt=0
   until
-    kubectl_exec get node "${DECK_NODE_HOSTNAME}" -o json | \
+    kubectl_exec get node "${D8_NODE_HOSTNAME}" -o json | \
     jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' >/dev/null
   do
     attempt=$(( attempt + 1 ))
@@ -55,7 +55,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
     fi
     echo "Steps are waiting for approval to start."
     echo "Note: Deckhouse is performing a rolling update. If you want to force an update, use the following command."
-    echo "kubectl annotate node ${DECK_NODE_HOSTNAME} update.node.deckhouse.io/approved="
+    echo "kubectl annotate node ${D8_NODE_HOSTNAME} update.node.deckhouse.io/approved="
     echo "Retry in 10sec..."
     sleep 10
   done

--- a/candi/bashible/common-steps/node-group/001_waiting_approval_annotations.sh.tpl
+++ b/candi/bashible/common-steps/node-group/001_waiting_approval_annotations.sh.tpl
@@ -22,7 +22,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   attempt=0
   until
     node_data="$(
-      kubectl_exec get node "$(DECK_NODE_HOSTNAME)" -o json | jq '
+      kubectl_exec get node "${DECK_NODE_HOSTNAME}" -o json | jq '
       {
         "resourceVersion": .metadata.resourceVersion,
         "isApproved": (.metadata.annotations | has("update.node.deckhouse.io/approved")),
@@ -36,7 +36,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
       >&2 echo "ERROR: Can't set update.node.deckhouse.io/waiting-for-approval= annotation on our Node."
       exit 1
     fi
-    kubectl_exec annotate node "$(DECK_NODE_HOSTNAME)" \
+    kubectl_exec annotate node "${DECK_NODE_HOSTNAME}" \
       --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
       update.node.deckhouse.io/waiting-for-approval= node.deckhouse.io/configuration-checksum- \
       || { echo "Retry setting update.node.deckhouse.io/waiting-for-approval= annotation on our Node in 10sec..."; sleep 10; }
@@ -45,7 +45,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   >&2 echo "Waiting for update.node.deckhouse.io/approved= annotation on our Node..."
   attempt=0
   until
-    kubectl_exec get node "$(DECK_NODE_HOSTNAME)" -o json | \
+    kubectl_exec get node "${DECK_NODE_HOSTNAME}" -o json | \
     jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' >/dev/null
   do
     attempt=$(( attempt + 1 ))
@@ -55,7 +55,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
     fi
     echo "Steps are waiting for approval to start."
     echo "Note: Deckhouse is performing a rolling update. If you want to force an update, use the following command."
-    echo "kubectl annotate node $(DECK_NODE_HOSTNAME) update.node.deckhouse.io/approved="
+    echo "kubectl annotate node ${DECK_NODE_HOSTNAME} update.node.deckhouse.io/approved="
     echo "Retry in 10sec..."
     sleep 10
   done


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Issue #5594 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Node with short name works well. Node with fqdn names works well, also on centos-based distros. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Node named with fqdn
impact: New nodes have fqdn
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
