### PR TITLE
[istio] Add a minimum version of istio to the D8 update requirements.

### DIFF
--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Don't forget to add the requirement to release.yaml in next release
-
 package requirements
 
 import (

--- a/modules/110-istio/requirements/check_test.go
+++ b/modules/110-istio/requirements/check_test.go
@@ -40,4 +40,11 @@ func TestIstioOperatorVersionRequirement(t *testing.T) {
 		assert.False(t, ok)
 		require.Error(t, err)
 	})
+
+	t.Run("Istio is not installed on the cluster", func(t *testing.T) {
+		requirements.RemoveValue(minVersionValuesKey)
+		ok, err := requirements.CheckRequirement("istioVer", "1.16")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
 }

--- a/release.yaml
+++ b/release.yaml
@@ -27,6 +27,7 @@ requirements:
   "ingressNginx": "1.1" # modules/402-ingress-nginx/requirements/check.go
   "nodesMinimalOSVersionUbuntu": "18.04" # modules/040-node-manager/requirements/check.go
   "containerdOnAllNodes": "true" # modules/040-node-manager/requirements/check.go
+  "istioVer": "1.16" # modules/110-istio/requirements/check.go
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:


### PR DESCRIPTION
## Description

Add a minimum version of istio to the D8 update requirements.

## Why do we need it, and what problem does it solve?

If the istio version and versions of other component are not compatible, they may not function correctly together.

## What is the expected result?

D8 can't upgrade to next version If istio installed in cluster and it version lower then 1.16 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Add a minimum version of istio to the D8 update requirements.
impact: D8 can't upgrade to next version If istio installed in cluster and it version lower then 1.16 
impact_level: default
```
