### PR TITLE
[user-authz] fixing ClusterRoleBinding names prefix

### DIFF
--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 		It("Should create a ClusterRoleBinding for each additionalRole", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "user-authz:testenev:additional-role:cluster-write-all")
+			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:testenev:additional-role:cluster-write-all")
 			Expect(crb.Exists()).To(BeTrue())
 
 			Expect(crb.Field("roleRef.name").String()).To(Equal("cluster-write-all"))
@@ -149,10 +149,10 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 		})
 
 		It("Should create a ClusterRoleBinding to an appropriate ClusterRole", func() {
-			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "user-authz:testenev:admin")
+			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:testenev:admin")
 			Expect(crb.Exists()).To(BeTrue())
 
-			Expect(crb.Field("roleRef.name").String()).To(Equal("user-authz:admin"))
+			Expect(crb.Field("roleRef.name").String()).To(Equal("d8:user-authz:admin"))
 			Expect(crb.Field("roleRef.kind").String()).To(Equal("ClusterRole"))
 			Expect(crb.Field("subjects.0.name").String()).To(Equal("Efrem Testenev"))
 		})
@@ -161,13 +161,13 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			rb := f.KubernetesResource("RoleBinding", "testenv", "user-authz:testenev-namespaced:editor")
 			Expect(rb.Exists()).To(BeTrue())
 
-			Expect(rb.Field("roleRef.name").String()).To(Equal("user-authz:editor"))
+			Expect(rb.Field("roleRef.name").String()).To(Equal("d8:user-authz:editor"))
 			Expect(rb.Field("roleRef.kind").String()).To(Equal("ClusterRole"))
 			Expect(rb.Field("subjects.0.name").String()).To(Equal("Namespace Testenev"))
 		})
 
 		It("Should create additional ClusterRoleBinding for each ClusterRole with the \"user-authz.deckhouse.io/access-level\" annotation", func() {
-			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "user-authz:testenev:admin:custom-cluster-role:cert-manager:user-authz:user")
+			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:testenev:admin:custom-cluster-role:cert-manager:user-authz:user")
 			Expect(crb.Exists()).To(BeTrue())
 
 			Expect(crb.Field("roleRef.name").String()).To(Equal("cert-manager:user-authz:user"))
@@ -191,10 +191,10 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			})
 
 			It("Should create a port-forward ClusterRoleBinding", func() {
-				crb := f.KubernetesGlobalResource("ClusterRoleBinding", "user-authz:testenev:port-forward")
+				crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:testenev:port-forward")
 				Expect(crb.Exists()).To(BeTrue())
 
-				Expect(crb.Field("roleRef.name").String()).To(Equal("user-authz:port-forward"))
+				Expect(crb.Field("roleRef.name").String()).To(Equal("d8:user-authz:port-forward"))
 				Expect(crb.Field("roleRef.kind").String()).To(Equal("ClusterRole"))
 				Expect(crb.Field("subjects.0.name").String()).To(Equal("Efrem Testenev"))
 			})
@@ -210,7 +210,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 				rb := f.KubernetesResource("RoleBinding", "testenv", "user-authz:testenev-namespaced:port-forward")
 				Expect(rb.Exists()).To(BeTrue())
 
-				Expect(rb.Field("roleRef.name").String()).To(Equal("user-authz:port-forward"))
+				Expect(rb.Field("roleRef.name").String()).To(Equal("d8:user-authz:port-forward"))
 				Expect(rb.Field("roleRef.kind").String()).To(Equal("ClusterRole"))
 				Expect(rb.Field("subjects.0.name").String()).To(Equal("Namespace Testenev"))
 			})
@@ -223,10 +223,10 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			})
 
 			It("Should create a scale RoleBinding", func() {
-				crb := f.KubernetesGlobalResource("ClusterRoleBinding", "user-authz:testenev:scale")
+				crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:testenev:scale")
 				Expect(crb.Exists()).To(BeTrue())
 
-				Expect(crb.Field("roleRef.name").String()).To(Equal("user-authz:scale"))
+				Expect(crb.Field("roleRef.name").String()).To(Equal("d8:user-authz:scale"))
 				Expect(crb.Field("roleRef.kind").String()).To(Equal("ClusterRole"))
 				Expect(crb.Field("subjects.0.name").String()).To(Equal("Efrem Testenev"))
 			})
@@ -242,7 +242,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 				rb := f.KubernetesResource("RoleBinding", "testenv", "user-authz:testenev-namespaced:scale")
 				Expect(rb.Exists()).To(BeTrue())
 
-				Expect(rb.Field("roleRef.name").String()).To(Equal("user-authz:scale"))
+				Expect(rb.Field("roleRef.name").String()).To(Equal("d8:user-authz:scale"))
 				Expect(rb.Field("roleRef.kind").String()).To(Equal("ClusterRole"))
 				Expect(rb.Field("subjects.0.name").String()).To(Equal("Namespace Testenev"))
 			})
@@ -255,7 +255,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			})
 
 			It("Should not create a scale RoleBinding", func() {
-				crb := f.KubernetesGlobalResource("ClusterRoleBinding", "user-authz:testenev:scale")
+				crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:testenev:scale")
 				Expect(crb.Exists()).To(BeFalse())
 			})
 		})

--- a/modules/140-user-authz/templates/cluster-role-bindings.yaml
+++ b/modules/140-user-authz/templates/cluster-role-bindings.yaml
@@ -52,7 +52,7 @@ subjects:
 
     {{- if hasKey $crd.spec "accessLevel" }}
       {{- include "rbac.check.valid.spec" (list $data.kind $crd) }}
-{{- include "rbac.binding" ( list $ $data.kind $crd ($crd.spec.accessLevel | kebabcase) (printf "user-authz:%s" ($crd.spec.accessLevel | kebabcase)) ) }}
+{{- include "rbac.binding" ( list $ $data.kind $crd ($crd.spec.accessLevel | kebabcase) (printf "d8:user-authz:%s" ($crd.spec.accessLevel | kebabcase)) ) }}
       {{- range $customClusterRole := (pluck ($crd.spec.accessLevel | untitle) $.Values.userAuthz.internal.customClusterRoles | first) }}
 {{- include "rbac.binding" ( list $ $data.kind $crd (printf "%s:custom-cluster-role:%s" ($crd.spec.accessLevel | kebabcase) $customClusterRole) $customClusterRole ) }}
       {{- end }}
@@ -60,12 +60,12 @@ subjects:
 
     {{- if hasKey $crd.spec "portForwarding" }}
       {{- if ($crd.spec.portForwarding | default false) }}
-{{- include "rbac.binding" ( list $ $data.kind $crd "port-forward" "user-authz:port-forward" ) }}
+{{- include "rbac.binding" ( list $ $data.kind $crd "port-forward" "d8:user-authz:port-forward" ) }}
       {{- end }}
     {{- end }}
 
     {{- if $crd.spec.allowScale }}
-{{- include "rbac.binding" ( list $ $data.kind $crd "scale" "user-authz:scale" ) }}
+{{- include "rbac.binding" ( list $ $data.kind $crd "scale" "d8:user-authz:scale" ) }}
     {{- end }}
 
   {{- end }}

--- a/modules/140-user-authz/templates/cluster-role-bindings.yaml
+++ b/modules/140-user-authz/templates/cluster-role-bindings.yaml
@@ -27,7 +27,7 @@ namespace: {{ index . 1 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $kind }}
 metadata:
-  name: {{ printf "user-authz:%s:%s" $crd.name $namePostfix }}
+  name: {{ printf "d8:user-authz:%s:%s" $crd.name $namePostfix }}
   {{- include "rbac.namespace" (list $kind $crd.namespace) | nindent 2 }}
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
 roleRef:

--- a/modules/140-user-authz/templates/cluster-role-bindings.yaml
+++ b/modules/140-user-authz/templates/cluster-role-bindings.yaml
@@ -23,11 +23,16 @@ namespace: {{ index . 1 }}
   {{- $crd := index . 2 }}
   {{- $namePostfix := index . 3 }}
   {{- $roleName := index . 4 }}
+  {{- $namePrefix := "" }}
+
+  {{- if eq $kind "ClusterRoleBinding" }}
+    {{- $namePrefix = "d8:" }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $kind }}
 metadata:
-  name: {{ printf "d8:user-authz:%s:%s" $crd.name $namePostfix }}
+  name: {{ printf "%s:user-authz:%s:%s" $namePrefix $crd.name $namePostfix }}
   {{- include "rbac.namespace" (list $kind $crd.namespace) | nindent 2 }}
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
 roleRef:

--- a/modules/140-user-authz/templates/cluster-roles.yaml
+++ b/modules/140-user-authz/templates/cluster-roles.yaml
@@ -318,7 +318,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:user
+  name: d8:user-authz:user
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_common_rules" "User" }}
@@ -327,7 +327,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:privileged-user
+  name: d8:user-authz:privileged-user
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_common_rules" "PrivilegedUser" }}
@@ -337,7 +337,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:editor
+  name: d8:user-authz:editor
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_common_rules" "Editor" }}
@@ -348,7 +348,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:admin
+  name: d8:user-authz:admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_common_rules" "Admin" }}
@@ -360,7 +360,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:cluster-editor
+  name: d8:user-authz:cluster-editor
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_common_rules" "ClusterAdmin" }}
@@ -372,7 +372,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:cluster-admin
+  name: d8:user-authz:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_common_rules" "ClusterAdmin" }}
@@ -386,7 +386,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: user-authz:super-admin
+  name: d8:user-authz:super-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_super_admin_rules" . }}

--- a/tools/helm_generate/runners/authz_generate_rules_for_roles/authz-generate.go
+++ b/tools/helm_generate/runners/authz_generate_rules_for_roles/authz-generate.go
@@ -427,7 +427,7 @@ func replacePlaceholder(text, replaceContent []byte, startPlaceholder, endPlaceh
 
 // newRoleFromClusterRoleName generates user-authz role name from ClusterRole name
 func newRoleFromClusterRoleName(name string) string {
-	return strcase.ToCamel(strings.TrimPrefix(name, "user-authz:"))
+	return strcase.ToCamel(strings.TrimPrefix(name, "d8:user-authz:"))
 }
 
 // sliceToString sorts slice of strings and return joined by comma string


### PR DESCRIPTION
## Description
ClusterRoleBindings created by module are prefixed with 'd8:'.

## Why do we need it, and what problem does it solve?
It is our standard to name cluster-wide resources created by Deckhouse with prefix 'd8:'.

## What is the expected result?
All ClusterRoleBindings generated by user-authz module are prefixed.
```
kubectl get clusterrolebindings  | grep user-authz
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: ClusterRoleBindings created by module are prefixed with 'd8:'.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
