### PR TITLE
[deckhouse-controller] Fix modules registration

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -179,6 +179,7 @@ func (dml *DeckhouseController) handleModulePurge(m *models.DeckhouseModule) err
 
 func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModule) error {
 	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+		fmt.Println("11111 REGISTER MODULE", m.GetBasicModule().GetName())
 		src := dml.sourceModules[m.GetBasicModule().GetName()]
 		newModule := m.AsKubeObject(src)
 		newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
@@ -193,6 +194,8 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 			return err
 		}
 
+		fmt.Println("11111 MODULE EXISTS", len(existModule.Labels), existModule.Labels)
+
 		existModule.Properties = newModule.Properties
 		if len(existModule.Labels) == 0 {
 			newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
@@ -200,7 +203,11 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 			existModule.Labels[epochLabelKey] = epochLabelValue
 		}
 
+		fmt.Println("11111 MODULE AFTER", len(existModule.Labels), existModule.Labels)
+
 		_, err = dml.kubeClient.DeckhouseV1alpha1().Modules().Update(dml.ctx, existModule, v1.UpdateOptions{})
+
+		fmt.Println("11111 MODULE ERR", err)
 
 		return err
 	})

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -179,7 +179,6 @@ func (dml *DeckhouseController) handleModulePurge(m *models.DeckhouseModule) err
 
 func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModule) error {
 	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
-		fmt.Println("11111 REGISTER MODULE", m.GetBasicModule().GetName())
 		src := dml.sourceModules[m.GetBasicModule().GetName()]
 		newModule := m.AsKubeObject(src)
 		newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
@@ -194,8 +193,6 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 			return err
 		}
 
-		fmt.Println("11111 MODULE EXISTS", len(existModule.Labels), existModule.Labels)
-
 		existModule.Properties = newModule.Properties
 		if len(existModule.Labels) == 0 {
 			existModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
@@ -203,11 +200,7 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 			existModule.Labels[epochLabelKey] = epochLabelValue
 		}
 
-		fmt.Println("11111 MODULE AFTER", len(existModule.Labels), existModule.Labels)
-
 		_, err = dml.kubeClient.DeckhouseV1alpha1().Modules().Update(dml.ctx, existModule, v1.UpdateOptions{})
-
-		fmt.Println("11111 MODULE ERR", err)
 
 		return err
 	})

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -198,7 +198,7 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 
 		existModule.Properties = newModule.Properties
 		if len(existModule.Labels) == 0 {
-			newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
+			existModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
 		} else {
 			existModule.Labels[epochLabelKey] = epochLabelValue
 		}


### PR DESCRIPTION
## Description
Fix modules registration

## Why do we need it, and what problem does it solve?
Modules are not created if they don't have any labels

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix | feature | chore
summary: Fix modules registration on startup.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
