### PR TITLE
Revert "[external-module-manager] Fix module release cleanup"

### DIFF
--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -94,6 +94,7 @@ func cleanupReleases(input *go_hook.HookInput) error {
 		}
 
 		for _, release := range releases {
+			input.LogEntry.Infof("Cleanup release %q because module %q does not exist", release.Name, release.Module)
 			deleteModuleRelease(input, externalModulesDir, release)
 		}
 	}
@@ -104,6 +105,7 @@ func cleanupReleases(input *go_hook.HookInput) error {
 
 		if len(releases) > keepReleaseCount {
 			for i := keepReleaseCount; i < len(releases); i++ {
+				input.LogEntry.Infof("Cleanup release %q because it's outdated", releases[i].Name)
 				deleteModuleRelease(input, externalModulesDir, releases[i])
 			}
 		}

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hooks
 
 import (
+	"os"
+	"path"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
@@ -27,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -39,6 +42,14 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ExecuteHookOnEvents:          pointer.Bool(false),
 			ExecuteHookOnSynchronization: pointer.Bool(false),
 			FilterFunc:                   filterDeprecatedRelease,
+		},
+		{
+			Name:                         "modules",
+			ApiVersion:                   "deckhouse.io/v1alpha1",
+			Kind:                         "Module",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   filterModule,
 		},
 	},
 	Schedule: []go_hook.ScheduleConfig{
@@ -56,8 +67,14 @@ const (
 func cleanupReleases(input *go_hook.HookInput) error {
 	snap := input.Snapshots["releases"]
 
+	externalModulesDir := os.Getenv("EXTERNAL_MODULES_DIR")
+
 	moduleReleases := make(map[string][]deprecatedRelease, 0)
 	outdatedModuleReleases := make(map[string][]deprecatedRelease, 0)
+
+	// TODO(nabokihms): Instead of subscribing to Kubernetes objects,
+	//   make it available through global values like `enabledModules`
+	availableModules := set.NewFromSnapshot(input.Snapshots["modules"])
 
 	for _, sn := range snap {
 		if sn == nil {
@@ -70,19 +87,41 @@ func cleanupReleases(input *go_hook.HookInput) error {
 		}
 	}
 
+	// for absent modules - delete all ModuleRelease resources
+	for moduleName, releases := range moduleReleases {
+		if availableModules.Has(moduleName) {
+			continue
+		}
+
+		for _, release := range releases {
+			deleteModuleRelease(input, externalModulesDir, release)
+		}
+	}
+
 	// delete outdated release, keep only last 3
 	for _, releases := range outdatedModuleReleases {
 		sort.Sort(sort.Reverse(byVersion[deprecatedRelease](releases)))
 
 		if len(releases) > keepReleaseCount {
 			for i := keepReleaseCount; i < len(releases); i++ {
-				input.LogEntry.Infof("Cleanup release %q", releases[i].Name)
-				input.PatchCollector.Delete("deckhouse.io/v1alpha1", "ModuleRelease", "", releases[i].Name, object_patch.InBackground())
+				deleteModuleRelease(input, externalModulesDir, releases[i])
 			}
 		}
 	}
 
 	return nil
+}
+
+func deleteModuleRelease(input *go_hook.HookInput, externalModulesDir string, release deprecatedRelease) {
+	modulePath := path.Join(externalModulesDir, release.Module, "v"+release.Version.String())
+
+	err := os.RemoveAll(modulePath)
+	if err != nil {
+		input.LogEntry.Errorf("unable to remove module: %v", err)
+		return
+	}
+
+	input.PatchCollector.Delete("deckhouse.io/v1alpha1", "ModuleRelease", "", release.Name, object_patch.InBackground())
 }
 
 func filterDeprecatedRelease(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -99,6 +138,11 @@ func filterDeprecatedRelease(obj *unstructured.Unstructured) (go_hook.FilterResu
 		Version: release.Spec.Version,
 		Phase:   release.Status.Phase,
 	}, nil
+}
+
+// returns only Disabled modules
+func filterModule(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
 }
 
 type deprecatedRelease struct {

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -55,6 +55,16 @@ external-module-manager:
 			f.KubeStateSet(echoserverState + `
 ---
 apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: echoserver
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: hellow
+---
+apiVersion: deckhouse.io/v1alpha1
 kind: ModuleRelease
 metadata:
   name: echoserver-v0.0.6
@@ -92,6 +102,50 @@ status:
 
 			hel1 := f.KubernetesGlobalResource("ModuleRelease", "hellow-v0.0.1")
 			Expect(hel1.Exists()).To(BeTrue())
+		})
+	})
+
+	Context("Cluster has releases from absent module", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: testmodule
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  name: testmodule-v0.0.1
+spec:
+  moduleName: testmodule
+  version: 0.0.1
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  name: echoserver-v0.0.6
+spec:
+  moduleName: echoserver
+  version: 0.0.6
+status:
+  phase: Deployed
+`)
+
+			f.BindingContexts.Set(f.GenerateScheduleContext("13 3 * * *"))
+			f.RunHook()
+		})
+
+		It("Should delete echoserver and testmodule releases, should keep hellow releases", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			rele1 := f.KubernetesGlobalResource("ModuleRelease", "echoserver-v0.0.6")
+			Expect(rele1.Exists()).To(BeFalse())
+
+			test1 := f.KubernetesGlobalResource("ModuleRelease", "testmodule-v0.0.1")
+			Expect(test1.Exists()).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
## Description
Reverts deckhouse/deckhouse#7108

## Why do we need it, and what problem does it solve?
Wrong solution was made. Problem in Module resources not in the cleanup script.

## What is the expected result?
ModuleConfigs are get validated even if they don't have .spec.version/.spec.settings fields specified.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  external-module-manager
type: chore
summary: Revert module release cleanup.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
