### PR TITLE
[dhctl](install) fix skipping preflight check about registry-through-proxy

### DIFF
--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/strings/slices"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -56,7 +54,8 @@ func (pc *Checker) CheckRegistryAccessThroughProxy() error {
 		log.DebugLn("No proxy is configured, skipping check")
 		return nil
 	}
-	if slices.Contains(noProxyAddresses, pc.metaConfig.Registry.Address) {
+
+	if tryToSkippingCheck(pc.metaConfig.Registry.Address, noProxyAddresses) {
 		log.DebugLn("Registry address found in proxy.noProxy list, skipping check")
 		return nil
 	}
@@ -88,6 +87,35 @@ Please check connectivity from the control-plane node to the proxy and from the 
 	}
 
 	return nil
+}
+
+func tryToSkippingCheck(registryAddress string, noProxyAddresses []string) bool {
+	for _, noProxyAddress := range noProxyAddresses {
+		if registryAddress == noProxyAddress {
+			return true
+		}
+
+		registryIPAddr, _ := net.ResolveIPAddr("ip", registryAddress)
+		if registryIPAddr == nil {
+			continue
+		}
+
+		noProxyAddressIPAddr, _ := net.ResolveIPAddr("ip", noProxyAddress)
+		if noProxyAddressIPAddr != nil {
+			if noProxyAddressIPAddr.IP.Equal(registryIPAddr.IP) {
+				return true
+			}
+
+			continue
+		}
+
+		_, noProxyIPNet, _ := net.ParseCIDR(noProxyAddress)
+		if noProxyIPNet != nil && noProxyIPNet.Contains(registryIPAddr.IP) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix skipping preflight check about registry-through-proxy.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close #7045

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: fix skipping preflight check about registry-through-proxy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
