### PR TITLE
[docs][modules-docs] Show that a parameter is required according to the OpenAPI spec.

### DIFF
--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -42,3 +42,5 @@ boolean: boolean
 of_boolean: of booleans
 version: version
 version_of_schema: Schema version
+required_value_sentence: Required value
+

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -42,3 +42,4 @@ boolean: булевый
 of_boolean: булевых значений
 version: версия
 version_of_schema: Версия схемы
+required_value_sentence: Обязательный параметр

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
@@ -7,6 +7,7 @@
 {{ $ancestors := .ancestors }} {{/* A map, containing the parameter ancestors */}}
 {{ $apiVersion := .apiVersion }} {{/* A string. APIVersion of the resource of the parameter, to build the parameter HTML id (for links). Optional. */}}
 {{ $resourceName := .resourceName }} {{/* A string. The name of the resource of the parameter, to build the parameter HTML id (for links). Required. */}}
+{{ $required  := .required }} {{/* Array of the required parameters. */}}
 
 {{ $description :=  "" }}
 
@@ -60,18 +61,21 @@
     {{ end }}
   {{ end }}
 {{ end }}
-
+{{- if or (in $required $name) ( index $data "x-doc-required" ) }}
+<p class="resources__attrs required"><span class="resources__attrs_name required">{{ T "required_value_sentence" }}</span></p>
+{{- end }}
 
 {{ if reflect.IsMap $data }}
   {{ partial "openapi/format-attributes" ( dict "name" $name "attributes" $data "parent" $parent "langData" $langData "linkAnchor" $linkAnchor) }}
 {{ end }}
 
 {{ if and (reflect.IsMap $data) $data.properties }}
+  {{- $requiredParameters := $data.required }}
   <ul>
   {{ range $subParameterName, $subParameterAttributes := $data.properties }}
     {{ $subParameterLangData := index $langData.properties $subParameterName }}
 
-    {{ partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName) }}
+    {{ partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "required" $requiredParameters ) }}
   {{ end }}
   </ul>
 {{ else if and (reflect.IsMap $data) $data.items }}


### PR DESCRIPTION
## Description
Show that a parameter is required according to the OpenAPI spec in the modules documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Show that a parameter is required according to the OpenAPI spec in the modules documentation.
impact_level: low
```
