### PR TITLE
[cni-flannel][docs] Update documentation

### DIFF
--- a/modules/035-cni-flannel/docs/CONFIGURATION.md
+++ b/modules/035-cni-flannel/docs/CONFIGURATION.md
@@ -2,8 +2,4 @@
 title: "The cni-flannel module: configuration"
 ---
 
-The module is **automatically** enabled for the following cloud providers:
-- [OpenStack](../../modules/030-cloud-provider-openstack/);
-- [VMware vSphere](../../modules/030-cloud-provider-vsphere/).
-
 <!-- SCHEMA -->

--- a/modules/035-cni-flannel/docs/CONFIGURATION_RU.md
+++ b/modules/035-cni-flannel/docs/CONFIGURATION_RU.md
@@ -2,8 +2,4 @@
 title: "Модуль cni-flannel: настройки"
 ---
 
-Модуль включается **автоматически** для следующих облачных провайдеров:
-- [OpenStack](../../modules/030-cloud-provider-openstack/);
-- [VMware vSphere](../../modules/030-cloud-provider-vsphere/).
-
 <!-- SCHEMA -->


### PR DESCRIPTION
## Description

Fix documentation of the cni-flannel module. cni-flannel is NOT enabled automatically in OpenStack and Vsphere.

```changes
section: cni-flannel
type: chore
summary: Update documentation.
impact_level: low
```
