### PR TITLE
[monitoring-kubernetes] Correct LoadBalancerServiceWithoutExternalIP alert

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -8,13 +8,13 @@
         tier: cluster
       annotations:
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__cluster_has_node_alerts: "LoadBalancerServiceWithoutExternalIP,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__cluster_has_node_alerts: "LoadBalancerServiceCluster,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__cluster_has_node_alerts: "LoadBalancerServiceCluster,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         description: |-
           One or more services with the LoadBalancer type cannot get an external address.
 
           The list of services can be obtained with the following command:
-          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.allocateLoadBalancerNodePorts == true) | "name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
+          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.allocateLoadBalancerNodePorts == true) | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
 
           Check the cloud-controller-manager logs in the 'd8-cloud-provider-*' namespace
           If you are using a bare-metal cluster with the metallb module enabled, check that the address space of the pool has not been exhausted.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -14,8 +14,7 @@
           One or more services with the LoadBalancer type cannot get an external address.
 
           The list of services can be obtained with the following command:
-          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.allocateLoadBalancerNodePorts == true) | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
-
+          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
           Check the cloud-controller-manager logs in the 'd8-cloud-provider-*' namespace
           If you are using a bare-metal cluster with the metallb module enabled, check that the address space of the pool has not been exhausted.
         summary: A load balancer has not been created.


### PR DESCRIPTION
## Description
When the alert is active, it makes an error, because of `incorrect plk_group param`.

## Why do we need it, and what problem does it solve?
Alert appears with error.

## Why do we need it in the patch release (if we do)?
Not necessary but has a medium impact.

## What is the expected result?
Alert appears correctly.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: chore
summary: Correct the `LoadBalancerServiceWithoutExternalIP` alert.
impact_level: low
```
