### PR TITLE
[upmeter] database retention

### DIFF
--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -46,10 +46,10 @@ func parseServerArgs(cmd *kingpin.CmdClause, config *server.Config) {
 		StringVar(&config.DatabasePath)
 
 	// Database retention
-	cmd.Flag("db-retention", "Database episodes 5m retention").
-		Envar("UPMETER_RETENTION").
+	cmd.Flag("db-retention", "Database episodes 5m retention days").
+		Envar("UPMETER_RETENTION_DAYS").
 		Default("548").
-		IntVar(&config.DatabaseRetention)
+		IntVar(&config.DatabaseRetentionDays)
 
 	// Origins count
 	cmd.Flag("origins", "The expected number of origins, used for exporting episodes as metrics when they are fulfilled by this number of agents.").

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -45,6 +45,12 @@ func parseServerArgs(cmd *kingpin.CmdClause, config *server.Config) {
 		Default("upmeter.db").
 		StringVar(&config.DatabasePath)
 
+	// Database retention
+	cmd.Flag("db-retention", "Database episodes 5m retention").
+		Envar("UPMETER_RETENTION").
+		Default("548").
+		IntVar(&config.DatabaseRetention)
+
 	// Origins count
 	cmd.Flag("origins", "The expected number of origins, used for exporting episodes as metrics when they are fulfilled by this number of agents.").
 		Required().

--- a/modules/500-upmeter/images/upmeter/pkg/db/dao/episode5m.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/dao/episode5m.go
@@ -243,3 +243,12 @@ func (d *EpisodeDao5m) ListEpisodeSumsForRanges(rng ranges.StepRange, ref check.
 
 	return res, nil
 }
+
+func (d *EpisodeDao5m) DeleteUpTo(slot time.Time) error {
+	const query = `
+	DELETE FROM episodes_5m
+	WHERE timeslot <= ?
+	`
+	_, err := d.DbCtx.StmtRunner().Exec(query, slot.Unix())
+	return err
+}

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -64,8 +64,8 @@ type Config struct {
 	ListenPort string
 	UserAgent  string
 
-	DatabasePath      string
-	DatabaseRetention int
+	DatabasePath          string
+	DatabaseRetentionDays int
 
 	OriginsCount int
 
@@ -120,7 +120,7 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	go cleanOld30sEpisodes(ctx, dbctx)
-	go cleanOld5mEpisodes(ctx, dbctx, s.config.DatabaseRetention)
+	go cleanOld5mEpisodes(ctx, dbctx, s.config.DatabaseRetentionDays)
 
 	// Probe lister that can only list groups and probes
 	probeLister := newProbeLister(s.config.DisabledProbes, s.config.DynamicProbes)
@@ -178,14 +178,14 @@ func cleanOld30sEpisodes(ctx context.Context, dbCtx *dbcontext.DbContext) {
 func cleanOld5mEpisodes(ctx context.Context, dbCtx *dbcontext.DbContext, retDays int) {
 	dayBack := -24 * time.Hour * time.Duration(retDays)
 	period := 300 * time.Second
-	tickerPeriod := 24 * time.Hour
 
 	conn := dbCtx.Start()
 	defer conn.Stop()
 
 	storage := dao.NewEpisodeDao5m(conn)
 
-	ticker := time.NewTicker(tickerPeriod)
+	interval := 24 * time.Hour
+	ticker := time.NewTicker(interval)
 
 	for {
 		select {

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -64,7 +64,7 @@ type Config struct {
 	ListenPort string
 	UserAgent  string
 
-	DatabasePath string
+	DatabasePath      string
 	DatabaseRetention int
 
 	OriginsCount int
@@ -120,7 +120,7 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	go cleanOld30sEpisodes(ctx, dbctx)
-	go cleanOld5mEpisodes(ctx, dbctx)
+	go cleanOld5mEpisodes(ctx, dbctx, s.config.DatabaseRetention)
 
 	// Probe lister that can only list groups and probes
 	probeLister := newProbeLister(s.config.DisabledProbes, s.config.DynamicProbes)
@@ -175,10 +175,10 @@ func cleanOld30sEpisodes(ctx context.Context, dbCtx *dbcontext.DbContext) {
 	}
 }
 
-func cleanOld5mEpisodes(ctx context.Context, dbCtx *dbcontext.DbContext) {
-	dayBack := -24 * time.Hour * ctx.config.DatabaseRetention
+func cleanOld5mEpisodes(ctx context.Context, dbCtx *dbcontext.DbContext, retDays int) {
+	dayBack := -24 * time.Hour * time.Duration(retDays)
 	period := 300 * time.Second
-	tickerPeriod := 24 * 60 * 60 * time.Second
+	tickerPeriod := 24 * time.Hour
 
 	conn := dbCtx.Start()
 	defer conn.Stop()

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -120,6 +120,8 @@ spec:
         env:
           - name: UPMETER_DB_PATH
             value: "/db/downtime.db.sqlite"
+          - name: UPMETER_RETENTION
+            value: "548"
           - name: UPMETER_LISTEN_HOST
             value: 127.0.0.1
           - name: UPMETER_LISTEN_PORT

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -120,7 +120,7 @@ spec:
         env:
           - name: UPMETER_DB_PATH
             value: "/db/downtime.db.sqlite"
-          - name: UPMETER_RETENTION
+          - name: UPMETER_RETENTION_DAYS
             value: "548"
           - name: UPMETER_LISTEN_HOST
             value: 127.0.0.1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add retention ability for upmeter database. 
It is not configurable and equal 548 days.
Retention started once per day.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Close https://github.com/deckhouse/deckhouse/issues/6285


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: feature 
summary:  database retention
impact: The upmeter database will only store data for the last 548 days
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
