### PR TITLE
[external-module-manager] add deckhouse-service init heck for release/override controllers

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -217,6 +217,16 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
+	// Check if controller's dependencies have been initialized
+	_ = wait.PollUntilContextCancel(ctx, utils.SyncedPollPeriod, false,
+		func(context.Context) (bool, error) {
+			// TODO: add modulemanager initialization check c.modulesValidator.AreModulesInited() (required for reloading modules without restarting deckhouse)
+			if deckhouseconfig.IsServiceInited() {
+				return true, nil
+			}
+			return false, nil
+		})
+
 	// Start the informer factories to begin populating the informer caches
 	c.logger.Info("Starting ModuleRelease controller")
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -221,10 +221,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	_ = wait.PollUntilContextCancel(ctx, utils.SyncedPollPeriod, false,
 		func(context.Context) (bool, error) {
 			// TODO: add modulemanager initialization check c.modulesValidator.AreModulesInited() (required for reloading modules without restarting deckhouse)
-			if deckhouseconfig.IsServiceInited() {
-				return true, nil
-			}
-			return false, nil
+			return deckhouseconfig.IsServiceInited(), nil
 		})
 
 	// Start the informer factories to begin populating the informer caches

--- a/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
@@ -134,10 +134,7 @@ func (c *ModulePullOverrideController) Run(ctx context.Context, workers int) {
 	_ = wait.PollUntilContextCancel(ctx, utils.SyncedPollPeriod, false,
 		func(context.Context) (bool, error) {
 			// TODO: add modulemanager initialization check c.modulesValidator.AreModulesInited() (required for reloading modules without restarting deckhouse)
-			if deckhouseconfig.IsServiceInited() {
-				return true, nil
-			}
-			return false, nil
+			return deckhouseconfig.IsServiceInited(), nil
 		})
 
 	// Start the informer factories to begin populating the informer caches

--- a/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
@@ -15,8 +15,14 @@
 package utils
 
 import (
+	"time"
+
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
+)
+
+const (
+	SyncedPollPeriod = 100 * time.Millisecond
 )
 
 // GenerateRegistryOptions feteches settings from ModuleSource and generate registry options from them

--- a/go_lib/deckhouse-config/service.go
+++ b/go_lib/deckhouse-config/service.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	serviceInstance     *ConfigService
-	serviceInstanceLock sync.RWMutex
+	serviceInstanceLock sync.Mutex
 )
 
 func InitService(mm ModuleManager) {
@@ -50,9 +50,7 @@ func InitService(mm ModuleManager) {
 }
 
 func IsServiceInited() bool {
-	serviceInstanceLock.RLock()
-	defer serviceInstanceLock.RUnlock()
-	return serviceInstance.possibleNames != nil && serviceInstance.moduleNamesToSources != nil
+	return serviceInstance != nil
 }
 
 func Service() *ConfigService {

--- a/go_lib/deckhouse-config/service.go
+++ b/go_lib/deckhouse-config/service.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	serviceInstance     *ConfigService
-	serviceInstanceLock sync.Mutex
+	serviceInstanceLock sync.RWMutex
 )
 
 func InitService(mm ModuleManager) {
@@ -47,6 +47,12 @@ func InitService(mm ModuleManager) {
 		statusReporter:       NewModuleInfo(mm, possibleNames),
 		moduleNamesToSources: make(map[string]string),
 	}
+}
+
+func IsServiceInited() bool {
+	serviceInstanceLock.RLock()
+	defer serviceInstanceLock.RUnlock()
+	return serviceInstance.possibleNames != nil && serviceInstance.moduleNamesToSources != nil
 }
 
 func Service() *ConfigService {


### PR DESCRIPTION
## Description
Adds checks to module release/override controllers to check if deckhouse-config service was initialized before creating controllers' workers.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
As of now, Deckhouse panics on restart if there are Pending module releases or module pull overrides in the cluster because deckhouse-config service gets initialized a bit after module release/override controllers. It should be checked before starting module controllers if deckhouse-config service was initialized.
Closes #7139
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Deckhouse doesn't panic on restart if there are Pending module releases or module pull overrides in the cluster.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-module-controller
type: chore
summary: Add deckhouse-service initialization check.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
