### PR TITLE
[extended-monitoring] migrate exporter image to distroless

### DIFF
--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/Dockerfile
@@ -1,8 +1,0 @@
-ARG BASE_PYTHON_ALPINE
-FROM $BASE_PYTHON_ALPINE
-WORKDIR /app
-ADD src /app
-RUN apk add --no-cache --virtual .build-deps build-base libffi-dev openssl-dev && \
-    pip3 install -r /app/requirements.txt && \
-    apk del .build-deps
-ENTRYPOINT ["python3"]

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -1,1 +1,1 @@
-kubernetes==22.6.0
+git+${SOURCE_REPO}/python-modules/kubernetes.git@v22.6.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -1,0 +1,42 @@
+{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so*" }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+fromImage: common/alt
+git:
+  - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
+    to: /tmp/requirements.txt
+    stageDependencies:
+      install:
+        - '**/*'
+shell:
+  install:
+    - apt-get update
+    - apt-get install -y python3 pip git
+    - export SOURCE_REPO={{ .SOURCE_REPO }}
+    - pip3 install -r /tmp/requirements.txt
+    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+git:
+  - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/extended-monitoring.py
+    to: /app/extended-monitoring.py
+import:
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /relocate
+    to: /
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3.9
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/local/lib/python3
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/local/lib64/python3
+    before: install
+docker:
+  ENTRYPOINT: ["python3"]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`extended-monitoring-exporter` image is based on a distroless image.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We'd like to base our images on a distroless image.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: feature
summary: |
  `extended-monitoring-exporter` image is based on a distroless image.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
