### PR TITLE
Revert "[ingress-nginx] remove ingress-nginx version 1.1 (#6795)"

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -59,7 +59,7 @@ spec:
                     One of the supported NGINX Ingress controller versions.
 
                     **By default**: the version in the [module settings](configuration.html#parameters-defaultcontrollerversion) is used.
-                  enum: ['1.6','1.9']
+                  enum: ['1.1','1.6','1.9']
                 enableIstioSidecar:
                   type: boolean
                   description: |

--- a/modules/402-ingress-nginx/hooks/generate_admission_webhook_cert_test.go
+++ b/modules/402-ingress-nginx/hooks/generate_admission_webhook_cert_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("ingress-nginx :: hooks :: generate_admission_webhook_cert ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.6", "internal": {"admissionCertificate": {}}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {"admissionCertificate": {}}}}`, "")
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
 
 	Context("Fresh cluster", func() {

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("ingress-nginx :: hooks :: get_ingress_controllers ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.6", "internal": {}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`, "")
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
 
 	Context("Fresh cluster", func() {
@@ -48,7 +48,7 @@ metadata:
 spec:
   ingressClass: nginx
   inlet: LoadBalancer
-  controllerVersion: "1.6"
+  controllerVersion: "1.1"
   acceptRequestsFrom:
   - 127.0.0.1/32
   - 192.168.0.0/24
@@ -65,7 +65,7 @@ spec:
 "spec": {
   "config": {},
   "ingressClass": "nginx",
-  "controllerVersion": "1.6",
+  "controllerVersion": "1.1",
   "inlet": "LoadBalancer",
   "loadBalancer": {},
   "hstsOptions": {},

--- a/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
+++ b/modules/402-ingress-nginx/hooks/migrate_daemonset_and_pods_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = Describe("Global hooks :: discovery :: migrate_daemonset ", func() {
-	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.6", "internal": {}}}`
+	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`
 	globalValuesString := `{}`
 	f := HookExecutionConfigInit(initValuesString, globalValuesString)
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
@@ -36,7 +36,7 @@ kind: IngressNginxController
 metadata:
   name: test
 spec:
-  controllerVersion: "1.6"
+  controllerVersion: "1.1"
   ingressClass: "test"
   inlet: "HostWithFailover"
 ---

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version_test.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var _ = Describe("Global hooks :: discovery :: minimal_ingress_version ", func() {
-	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.6", "internal": {}}}`
+	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`
 	globalValuesString := `{}`
 	f := HookExecutionConfigInit(initValuesString, globalValuesString)
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
@@ -51,7 +51,7 @@ kind: IngressNginxController
 metadata:
   name: main
 spec:
-  controllerVersion: "1.6"
+  controllerVersion: "1.1"
   ingressClass: "nginx"
 `))
 			f.RunHook()
@@ -61,7 +61,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.6.0"))
+			Expect(value).To(BeEquivalentTo("1.1.0"))
 			v, _ := requirements.GetValue(incompatibleVersionsKey)
 			Expect(v).To(BeFalse())
 		})
@@ -84,7 +84,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.6.0"))
+			Expect(value).To(BeEquivalentTo("1.1.0"))
 			v, _ := requirements.GetValue(incompatibleVersionsKey)
 			Expect(v).To(BeFalse())
 		})
@@ -98,7 +98,7 @@ kind: IngressNginxController
 metadata:
   name: first
 spec:
-  controllerVersion: "1.6"
+  controllerVersion: "1.1"
   ingressClass: "test"
 ---
 apiVersion: deckhouse.io/v1
@@ -138,7 +138,7 @@ kind: IngressNginxController
 metadata:
   name: first
 spec:
-  controllerVersion: "1.6"
+  controllerVersion: "1.1"
   ingressClass: "test"
 ---
 apiVersion: deckhouse.io/v1

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("ingress-nginx :: hooks :: safe_daemonset_update ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.6", "internal": {}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`, "")
 	f.RegisterCRD("apps.kruise.io", "v1alpha1", "DaemonSet", true)
 
 	Context("Failover pods are ready, update postponed", func() {

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -4,7 +4,7 @@ properties:
     default: "1.6"
     oneOf:
       - type: string
-        enum: ["1.6", "1.9"]
+        enum: ["1.1", "1.6", "1.9"]
     description: |
       The version of the ingress-nginx controller that is used for all controllers by default if the `controllerVersion` parameter is omitted in the IngressNginxController CR.
   highAvailability:

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
 		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler-crd"})
 		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
 
-		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.6")
+		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.1")
 
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.ca", "test")
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.cert", "test")
@@ -76,7 +76,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
     additionalLogFields:
       my-cookie: "$cookie_MY_COOKIE"
     validationEnabled: true
-    controllerVersion: "1.6"
+    controllerVersion: "1.1"
     inlet: LoadBalancer
     hsts: true
     hstsOptions:
@@ -100,7 +100,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
     config:
       load-balance: ewma
     ingressClass: nginx
-    controllerVersion: "1.6"
+    controllerVersion: "1.1"
     inlet: LoadBalancerWithProxyProtocol
     resourcesRequests:
       mode: Static
@@ -119,13 +119,13 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
   spec:
     inlet: LoadBalancer
     ingressClass: nginx
-    controllerVersion: "1.6"
+    controllerVersion: "1.1"
     maxReplicas: 3
     minReplicas: 3
 - name: test-next
   spec:
     ingressClass: test
-    controllerVersion: "1.6"
+    controllerVersion: "1.1"
     inlet: "HostPortWithProxyProtocol"
     geoIP2:
       maxmindLicenseKey: abc12345
@@ -138,7 +138,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
 - name: solid
   spec:
     ingressClass: solid
-    controllerVersion: "1.6"
+    controllerVersion: "1.1"
     inlet: "HostWithFailover"
     resourcesRequests:
       mode: VPA
@@ -234,7 +234,7 @@ memory: 200Mi`))
 			testNextDaemonSet := hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-test-next")
 			Expect(testNextDaemonSet.Exists()).To(BeTrue())
 
-			Expect(testNextDaemonSet.Field(`metadata.annotations.ingress-nginx-controller\.deckhouse\.io/controller-version`).String()).To(Equal(`1.6`))
+			Expect(testNextDaemonSet.Field(`metadata.annotations.ingress-nginx-controller\.deckhouse\.io/controller-version`).String()).To(Equal(`1.1`))
 			Expect(testNextDaemonSet.Field(`metadata.annotations.ingress-nginx-controller\.deckhouse\.io/inlet`).String()).To(Equal(`HostPortWithProxyProtocol`))
 			Expect(testNextDaemonSet.Field("spec.template.spec.containers.0.args").Array()).To(ContainElement(ContainSubstring(`--shutdown-grace-period=60`)))
 			// should not have --publish-service, inlet: HostPort

--- a/release.yaml
+++ b/release.yaml
@@ -24,7 +24,7 @@
 # release requirements, don't forget to register check function in a file requirements.go
 requirements:
   "k8s": "1.24.0" # modules/040-control-plane-manager/requirements/check.go
-  "ingressNginx": "1.6" # modules/402-ingress-nginx/requirements/check.go
+  "ingressNginx": "1.1" # modules/402-ingress-nginx/requirements/check.go
   "nodesMinimalOSVersionUbuntu": "18.04" # modules/040-node-manager/requirements/check.go
   "containerdOnAllNodes": "true" # modules/040-node-manager/requirements/check.go
   "istioVer": "1.16" # modules/110-istio/requirements/check.go


### PR DESCRIPTION
## Description
This reverts  https://github.com/deckhouse/deckhouse/pull/6795 (commit ecbec6b4e560496826cf45f9f7452b19f36e017b). 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: chore
summary: Revert  https://github.com/deckhouse/deckhouse/pull/6795.
impact_level: low
```
