### PR TITLE
[candi] Add validation pattern for imagesRepo value

### DIFF
--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -40,7 +40,7 @@ apiVersions:
         properties:
           imagesRepo:
             type: string
-            pattern: '^[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?[0-9a-zA-Z\.\-\/]+$'
+            pattern: '^[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?(/[0-9a-zA-Z\.\-\_\/]+)+$'
             description: |
               Address of a container registry with Deckhouse images.
 

--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -40,7 +40,7 @@ apiVersions:
         properties:
           imagesRepo:
             type: string
-            pattern: '^[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?(/[0-9a-zA-Z\.\-\_\/]+)+$'
+            pattern: '^[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?(\/[0-9a-zA-Z\.\-\_\/]+)?$'
             description: |
               Address of a container registry with Deckhouse images.
 

--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -40,6 +40,7 @@ apiVersions:
         properties:
           imagesRepo:
             type: string
+            pattern: '^[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?[0-9a-zA-Z\.\-\/]+$'
             description: |
               Address of a container registry with Deckhouse images.
 


### PR DESCRIPTION
## Description
Add validation pattern for the `imagesRepo` parameter.

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/7046

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Add validation pattern for the `imagesRepo` parameter.
impact_level: default
```
