### PR TITLE
[docs] Fix storageClass in bare metal GS

### DIFF
--- a/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
@@ -84,9 +84,6 @@ spec:
           # [<en>] Use self-signed certificates for Deckhouse modules.
           # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
           clusterIssuerName: selfsigned
-    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-    storageClass: localpath-deckhouse-system
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -84,9 +84,6 @@ spec:
           # [<en>] Use self-signed certificates for Deckhouse modules.
           # [<ru>] Использовать самоподписанные сертификаты для модулей Deckhouse.
           clusterIssuerName: selfsigned
-    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-    storageClass: localpath-deckhouse-system
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -28,31 +28,33 @@ Add a new node to the cluster:
   </li>
   <li>
   Configure the StorageClass for the <a href="/documentation/v1/modules/031-local-path-provisioner/cr.html#localpathprovisioner">local storage</a> by running the following command on the <strong>master node</strong>:
-  {% snippetcut %}
-  ```shell
-  sudo /opt/deckhouse/bin/kubectl create -f - << EOF
-  apiVersion: deckhouse.io/v1alpha1
-  kind: LocalPathProvisioner
-  metadata:
-    name: localpath-deckhouse
-  spec:
-    nodeGroups:
-    - worker
-    path: "/opt/local-path-provisioner"
-  EOF
-  ```
-  {% endsnippetcut %}
+{% snippetcut %}
+```shell
+sudo /opt/deckhouse/bin/kubectl create -f - << EOF
+apiVersion: deckhouse.io/v1alpha1
+kind: LocalPathProvisioner
+metadata:
+  name: localpath-deckhouse
+spec:
+  nodeGroups:
+  - worker
+  path: "/opt/local-path-provisioner"
+EOF
+```
+{% endsnippetcut %}
   </li>
   <li>
-  Make created StorageClass default by adding the annotation:
-  {% snippetcut %}
-  sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'
-  {% endsnippetcut %}
+  Make the created StorageClass as the default one by adding the `storageclass.kubernetes.io/is-default-class='true'` annotation:
+{% snippetcut %}
+```shell
+sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'
+```
+{% endsnippetcut %}
   </li>
   <li>
     Create a <a href="/documentation/v1/modules/040-node-manager/cr.html#nodegroup">NodeGroup</a> <code>worker</code>. To do so, run the following command on the <strong>master node</strong>:
-    {% snippetcut %}
-  ```bash
+{% snippetcut %}
+```bash
 sudo /opt/deckhouse/bin/kubectl create -f - << EOF
 apiVersion: deckhouse.io/v1
 kind: NodeGroup
@@ -61,24 +63,24 @@ metadata:
 spec:
   nodeType: Static
 EOF
-  ```
-    {% endsnippetcut %}
+```
+{% endsnippetcut %}
   </li>
   <li>
     Deckhouse will generate the script needed to configure the prospective node and include it in the cluster. Print its contents in Base64 format (you will need them at the next step):
-    {% snippetcut %}
-  ```bash
+{% snippetcut %}
+```bash
 sudo /opt/deckhouse/bin/kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
-  ```
-  {% endsnippetcut %}
+```
+{% endsnippetcut %}
   </li>
   <li>
     On the <strong>virtual machine you have started</strong>, run the following command by pasting the script code from the previous step:    
-  {% snippetcut %}
-  ```bash
+{% snippetcut %}
+```bash
 echo <Base64-SCRIPT-CODE> | base64 -d | sudo bash
-  ```
-  {% endsnippetcut %}
+```
+{% endsnippetcut %}
   </li>
 </ul>
 

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -44,7 +44,7 @@ EOF
 {% endsnippetcut %}
   </li>
   <li>
-  Make the created StorageClass as the default one by adding the `storageclass.kubernetes.io/is-default-class='true'` annotation:
+  Make the created StorageClass as the default one by adding the <code>storageclass.kubernetes.io/is-default-class='true'</code> annotation:
 {% snippetcut %}
 ```shell
 sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -34,13 +34,19 @@ Add a new node to the cluster:
   apiVersion: deckhouse.io/v1alpha1
   kind: LocalPathProvisioner
   metadata:
-    name: localpath-deckhouse-system
+    name: localpath-deckhouse
   spec:
     nodeGroups:
     - worker
     path: "/opt/local-path-provisioner"
   EOF
   ```
+  {% endsnippetcut %}
+  </li>
+  <li>
+  Make created StorageClass default by adding the annotation:
+  {% snippetcut %}
+  sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'
   {% endsnippetcut %}
   </li>
   <li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -27,6 +27,23 @@ Add a new node to the cluster:
     Start a <strong>new virtual machine</strong> that will become the cluster node.
   </li>
   <li>
+  Configure the StorageClass for the <a href="/documentation/v1/modules/031-local-path-provisioner/cr.html#localpathprovisioner">local storage</a> by running the following command on the <strong>master node</strong>:
+  {% snippetcut %}
+  ```shell
+  sudo /opt/deckhouse/bin/kubectl create -f - << EOF
+  apiVersion: deckhouse.io/v1alpha1
+  kind: LocalPathProvisioner
+  metadata:
+    name: localpath-deckhouse-system
+  spec:
+    nodeGroups:
+    - worker
+    path: "/opt/local-path-provisioner"
+  EOF
+  ```
+  {% endsnippetcut %}
+  </li>
+  <li>
     Create a <a href="/documentation/v1/modules/040-node-manager/cr.html#nodegroup">NodeGroup</a> <code>worker</code>. To do so, run the following command on the <strong>master node</strong>:
     {% snippetcut %}
   ```bash
@@ -128,23 +145,6 @@ NAME                                       READY   STATUS    RESTARTS   AGE
 controller-nginx-r6hxc                     3/3     Running   0          5m
 ```
 {%- endofftopic %}
-</li>
-<li><p><strong>Creating a StorageClass</strong></p>
-<p>Configure the StorageClass for the <a href="/documentation/v1/modules/031-local-path-provisioner/cr.html#localpathprovisioner">local storage</a> by running the following command on the <strong>master node</strong>:</p>
-{% snippetcut %}
-```shell
-sudo /opt/deckhouse/bin/kubectl create -f - << EOF
-apiVersion: deckhouse.io/v1alpha1
-kind: LocalPathProvisioner
-metadata:
-  name: localpath-deckhouse-system
-spec:
-  nodeGroups:
-  - worker
-  path: "/opt/local-path-provisioner"
-EOF
-```
-{% endsnippetcut %}
 </li>
 <li><p><strong>Create a user</strong> to access the cluster web interfaces</p>
 <p>Create on the <strong>master node</strong> the <code>user.yml</code> file containing the user account data and access rights:</p>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -28,31 +28,33 @@ sudo /opt/deckhouse/bin/kubectl patch nodegroup master --type json -p '[{"op": "
   </li>
   <li>
   Настройте StorageClass <a href="/documentation/v1/modules/031-local-path-provisioner/cr.html#localpathprovisioner">локального хранилища</a>, выполнив на <strong>master-узле</strong> следующую команду:
-  {% snippetcut %}
-  ```shell
-  sudo /opt/deckhouse/bin/kubectl create -f - << EOF
-  apiVersion: deckhouse.io/v1alpha1
-  kind: LocalPathProvisioner
-  metadata:
-    name: localpath-deckhouse
-  spec:
-    nodeGroups:
-    - worker
-    path: "/opt/local-path-provisioner"
-  EOF
-  ```
+{% snippetcut %}
+```shell
+sudo /opt/deckhouse/bin/kubectl create -f - << EOF
+apiVersion: deckhouse.io/v1alpha1
+kind: LocalPathProvisioner
+metadata:
+  name: localpath-deckhouse
+spec:
+  nodeGroups:
+  - worker
+  path: "/opt/local-path-provisioner"
+EOF
+```
+{% endsnippetcut %}
   </li>
   <li>
-  {% endsnippetcut %}
-  Сделайте созданный StorageClass по-умолчанию, добавив аннотацию:
-  {% snippetcut %}
-  sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'
-  {% endsnippetcut %}
+  Укажите что созданный StorageClass должен использоваться как StorageClass по умолчанию, добавив аннотацию `storageclass.kubernetes.io/is-default-class='true'`:
+{% snippetcut %}
+```shell
+sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'
+```
+{% endsnippetcut %}
   </li>
   <li>
     Создайте <a href="/documentation/v1/modules/040-node-manager/cr.html#nodegroup">NodeGroup</a> <code>worker</code>. Для этого выполните на <strong>master-узле</strong> следующую команду:
-    {% snippetcut %}
-  ```bash
+{% snippetcut %}
+```bash
 sudo /opt/deckhouse/bin/kubectl create -f - << EOF
 apiVersion: deckhouse.io/v1
 kind: NodeGroup
@@ -61,24 +63,24 @@ metadata:
 spec:
   nodeType: Static
 EOF
-  ```
-    {% endsnippetcut %}
+```
+{% endsnippetcut %}
   </li>
   <li>
     Deckhouse подготовит скрипт, необходимый для настройки будущего узла и включения его в кластер. Выведите его содержимое в формате Base64 (оно понадобится на следующем шаге):
-    {% snippetcut %}
-  ```bash
+{% snippetcut %}
+```bash
 sudo /opt/deckhouse/bin/kubectl -n d8-cloud-instance-manager get secret manual-bootstrap-for-worker -o json | jq '.data."bootstrap.sh"' -r
-  ```
-  {% endsnippetcut %}
+```
+{% endsnippetcut %}
   </li>
   <li>
     <strong> На подготовленной виртуальной машине</strong> выполните следующую команду, вставив код скрипта, полученный на предыдущем шаге:
-  {% snippetcut %}
-  ```bash
+{% snippetcut %}
+```bash
 echo <Base64-КОД-СКРИПТА> | base64 -d | sudo bash
-  ```
-  {% endsnippetcut %}
+```
+{% endsnippetcut %}
   </li>
 </ul>
 

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -34,13 +34,17 @@ sudo /opt/deckhouse/bin/kubectl patch nodegroup master --type json -p '[{"op": "
   apiVersion: deckhouse.io/v1alpha1
   kind: LocalPathProvisioner
   metadata:
-    name: localpath-deckhouse-system
+    name: localpath-deckhouse
   spec:
     nodeGroups:
     - worker
     path: "/opt/local-path-provisioner"
   EOF
   ```
+  {% endsnippetcut %}
+  Сделайте созданный StorageClass по-умолчанию, добавив аннотацию:
+  {% snippetcut %}
+  sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'
   {% endsnippetcut %}
   </li>
   <li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -41,6 +41,8 @@ sudo /opt/deckhouse/bin/kubectl patch nodegroup master --type json -p '[{"op": "
     path: "/opt/local-path-provisioner"
   EOF
   ```
+  </li>
+  <li>
   {% endsnippetcut %}
   Сделайте созданный StorageClass по-умолчанию, добавив аннотацию:
   {% snippetcut %}

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -44,7 +44,7 @@ EOF
 {% endsnippetcut %}
   </li>
   <li>
-  Укажите что созданный StorageClass должен использоваться как StorageClass по умолчанию, добавив аннотацию `storageclass.kubernetes.io/is-default-class='true'`:
+  Укажите что созданный StorageClass должен использоваться как StorageClass по умолчанию, добавив аннотацию <code>storageclass.kubernetes.io/is-default-class='true'</code>:
 {% snippetcut %}
 ```shell
 sudo /opt/deckhouse/bin/kubectl annotate sc localpath-deckhouse storageclass.kubernetes.io/is-default-class='true'

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -27,6 +27,23 @@ sudo /opt/deckhouse/bin/kubectl patch nodegroup master --type json -p '[{"op": "
     Подготовьте <strong>чистую</strong> виртуальную машину, которая будет узлом кластера.
   </li>
   <li>
+  Настройте StorageClass <a href="/documentation/v1/modules/031-local-path-provisioner/cr.html#localpathprovisioner">локального хранилища</a>, выполнив на <strong>master-узле</strong> следующую команду:
+  {% snippetcut %}
+  ```shell
+  sudo /opt/deckhouse/bin/kubectl create -f - << EOF
+  apiVersion: deckhouse.io/v1alpha1
+  kind: LocalPathProvisioner
+  metadata:
+    name: localpath-deckhouse-system
+  spec:
+    nodeGroups:
+    - worker
+    path: "/opt/local-path-provisioner"
+  EOF
+  ```
+  {% endsnippetcut %}
+  </li>
+  <li>
     Создайте <a href="/documentation/v1/modules/040-node-manager/cr.html#nodegroup">NodeGroup</a> <code>worker</code>. Для этого выполните на <strong>master-узле</strong> следующую команду:
     {% snippetcut %}
   ```bash
@@ -128,23 +145,6 @@ NAME                                       READY   STATUS    RESTARTS   AGE
 controller-nginx-r6hxc                     3/3     Running   0          5m
 ```
 {%- endofftopic %}
-</li>
-<li><p><strong>Создание StorageClass</strong></p>
-<p>Настройте StorageClass <a href="/documentation/v1/modules/031-local-path-provisioner/cr.html#localpathprovisioner">локального хранилища</a>, выполнив на <strong>master-узле</strong> следующую команду:</p>
-{% snippetcut %}
-```shell
-sudo /opt/deckhouse/bin/kubectl create -f - << EOF
-apiVersion: deckhouse.io/v1alpha1
-kind: LocalPathProvisioner
-metadata:
-  name: localpath-deckhouse-system
-spec:
-  nodeGroups:
-  - worker
-  path: "/opt/local-path-provisioner"
-EOF
-```
-{% endsnippetcut %}
 </li>
 <li><p><strong>Создание пользователя</strong> для доступа в веб-интерфейсы кластера</p>
 <p>Создайте на <strong>master-узле</strong> файл <code>user.yml</code> содержащий описание учетной записи пользователя и прав доступа:</p>

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
@@ -67,8 +67,6 @@ spec:
       # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
-    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
@@ -69,7 +69,6 @@ spec:
       publicDomainTemplate: "%s.example.com"
     # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-    storageClass: localpath-deckhouse-system
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
@@ -67,7 +67,6 @@ spec:
       publicDomainTemplate: "%s.example.com"
     # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-    storageClass: localpath-deckhouse-system
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
@@ -65,8 +65,6 @@ spec:
       # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
-    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
@@ -59,7 +59,6 @@ spec:
       publicDomainTemplate: "%s.example.com"
     # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-    storageClass: localpath-deckhouse-system
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
@@ -57,8 +57,6 @@ spec:
       # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
-    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
@@ -67,7 +67,6 @@ spec:
       publicDomainTemplate: "%s.example.com"
     # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
     # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
-    storageClass: localpath-deckhouse-system
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
@@ -65,8 +65,6 @@ spec:
       # [<ru>] Например, Grafana для %s.example.com будет доступна на домене 'grafana.example.com'.
       # [<ru>] Можете изменить на свой сразу, либо следовать шагам руководства и сменить его после установки.
       publicDomainTemplate: "%s.example.com"
-    # [<en>] The storage class to use with all Deckhouse components (Prometheus, Grafana, OpenVPN, etc.).
-    # [<ru>] Имя storage class, который будет использоваться для всех компонентов Deckhouse (Prometheus, Grafana, OpenVPN и т. д.).
 ---
 # [<en>] user-authn module settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html


### PR DESCRIPTION
## Description
- Remove `storageClass` from `global` `moduleConfig`
- Move creation of `LocalPathProvisioner` `StorageClass` step before bootstrapping a worker node. 

## Why do we need it, and what problem does it solve?
- Setting `storageClass` in `global` `moduleConfig` isn't needed, as this parameter [should only be used in exceptional circumstances.](https://deckhouse.io/documentation/v1/deckhouse-configure-global.html#parameters-storageclass)
- Creation of `StorageClass` before bootstrapping first worker node ensures that `d8` components won't get created using `emptyDir`
- The 'Use master without taints' variant will still use `EmptyDirs`. Before there was no way to start StatefulSets correctly.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Minor changes to getting started docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
