### PR TITLE
[docs][openapi] Render general CRD examples

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -674,6 +674,14 @@ module Jekyll
                                           item['name'],
                                           searchKeywords)
 
+                    if item["schema"]["openAPIV3Schema"].has_key?('x-doc-examples') or item["schema"]["openAPIV3Schema"].has_key?('x-doc-example') or
+                       item["schema"]["openAPIV3Schema"].has_key?('example') or item["schema"]["openAPIV3Schema"].has_key?('x-examples')
+                    then
+                        result.push('<div markdown="0">')
+                        result.push(format_examples(nil, item["schema"]["openAPIV3Schema"]))
+                        result.push('</div>')
+                    end
+
                     if get_hash_value(item,'schema','openAPIV3Schema','properties')
                         header = '<ul class="resources">'
                         item['schema']['openAPIV3Schema']['properties'].each do |key, value|
@@ -755,12 +763,17 @@ module Jekyll
             result.push('</font></p>')
         end
 
-        result.push('<div markdown="0">')
-        result.push(format_examples(nil, input))
-        result.push('</div>')
+        if input.has_key?('x-doc-examples') or input.has_key?('x-doc-example') or
+           input.has_key?('example') or input.has_key?('x-examples')
+        then
+            result.push('<div markdown="0">')
+            result.push(format_examples(nil, input))
+            result.push('</div>')
+        end
+
 
         if ( get_hash_value(input, "properties") )
-           then
+        then
             result.push('<ul class="resources">')
             input['properties'].sort.to_h.each do |key, value|
                 _primaryLanguage = nil


### PR DESCRIPTION
## Description
Render examples from the .spec.[]versrions.schema.openAPIV3Schema.[x-doc-examples|x-doc-example|x-examples|example] field. It is a good place for examples of the whole CRD.

## Why do we need it, and what problem does it solve?
At now, the site generator renders only examples from the field of an OpenAPI spec.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Render examples of the whole CRD from the spec.
impact_level: low
```
