### PR TITLE
[dhctl] mirror tests

### DIFF
--- a/dhctl/pkg/operations/mirror/auth_test.go
+++ b/dhctl/pkg/operations/mirror/auth_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeRemoteRegistryRequestOptionsAnonymous(t *testing.T) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(nil, false, false)
+	require.Len(t, remoteOpts, 0)
+	require.Len(t, nameOpts, 0)
+}
+
+func TestMakeRemoteRegistryRequestOptionsAnonymousInsecure(t *testing.T) {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(nil, true, false)
+	require.Len(t, remoteOpts, 0)
+	require.Len(t, nameOpts, 1)
+
+	expectedOptionFnPtr := reflect.PointerTo(reflect.TypeOf(name.Option(name.Insecure)))
+	gotOptionFnPtr := reflect.PointerTo(reflect.TypeOf(nameOpts[0]))
+	require.Equal(t, expectedOptionFnPtr, gotOptionFnPtr)
+}
+
+func TestInsecureReadAccessValidation(t *testing.T) {
+	blobHandler := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(blobHandler))
+	server := httptest.NewServer(registryHandler)
+	imageTag := strings.TrimPrefix(server.URL, "http://") + "/test:latest"
+
+	img, err := random.Image(256, 1)
+	require.NoError(t, err)
+
+	ref, err := name.ParseReference(imageTag, name.Insecure)
+	require.NoError(t, err)
+
+	err = remote.Write(ref, img, remote.WithPlatform(v1.Platform{Architecture: "amd64", OS: "linux"}))
+	require.NoError(t, err)
+
+	err = ValidateReadAccessForImage(imageTag, authn.Anonymous, true, false)
+	require.NoError(t, err, "Should validate successfully")
+}
+
+func TestReadAccessValidationWithSkipTLSVerify(t *testing.T) {
+	blobHandler := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(blobHandler))
+	server := httptest.NewTLSServer(registryHandler)
+	imageTag := strings.TrimPrefix(server.URL, "https://") + "/test:latest"
+
+	img, err := random.Image(256, 1)
+	require.NoError(t, err)
+
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(nil, false, true)
+	ref, err := name.ParseReference(imageTag, nameOpts...)
+	require.NoError(t, err)
+	remoteOpts = append(remoteOpts, remote.WithPlatform(v1.Platform{Architecture: "amd64", OS: "linux"}))
+
+	err = remote.Write(ref, img, remoteOpts...)
+	require.NoError(t, err)
+
+	err = ValidateReadAccessForImage(imageTag, authn.Anonymous, false, true)
+	require.NoError(t, err, "Should validate successfully")
+}
+
+func TestWriteAccessValidationWithSkipTLSVerify(t *testing.T) {
+	blobHandler := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(blobHandler))
+	server := httptest.NewTLSServer(registryHandler)
+	repo := strings.TrimPrefix(server.URL, "https://") + "/test"
+
+	err := ValidateWriteAccessForRepo(repo, authn.Anonymous, false, true)
+	require.NoError(t, err, "Should validate successfully")
+}
+
+func TestWriteAccessValidationInsecure(t *testing.T) {
+	blobHandler := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(blobHandler))
+	server := httptest.NewServer(registryHandler)
+	repo := strings.TrimPrefix(server.URL, "http://") + "/test"
+
+	err := ValidateWriteAccessForRepo(repo, authn.Anonymous, true, false)
+	require.NoError(t, err, "Should validate successfully")
+}

--- a/dhctl/pkg/operations/mirror/bundle_test.go
+++ b/dhctl/pkg/operations/mirror/bundle_test.go
@@ -1,0 +1,102 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"crypto/rand"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundlePackingAndUnpacking(t *testing.T) {
+	tmpDir := os.TempDir()
+	tarBundlePath := filepath.Join(tmpDir, "pack_test.tar")
+
+	packFromDir, err := os.MkdirTemp(os.TempDir(), "pack_test")
+	require.NoError(t, err)
+	unpackToDir, err := os.MkdirTemp(os.TempDir(), "unpack_test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll(packFromDir)
+		_ = os.RemoveAll(packFromDir)
+		_ = os.Remove(tarBundlePath)
+	})
+
+	fillTestFileTree(t, packFromDir)
+	expectedFiles := findAllPaths(t, packFromDir)
+
+	err = PackBundle(&Context{
+		TarBundlePath:      tarBundlePath,
+		UnpackedImagesPath: packFromDir,
+	})
+	require.NoError(t, err, "Packing should finish without errors")
+	require.FileExists(t, tarBundlePath)
+
+	err = UnpackBundle(&Context{
+		TarBundlePath:      tarBundlePath,
+		UnpackedImagesPath: unpackToDir,
+	})
+	require.NoError(t, err, "Unpacking should finish without errors")
+
+	resultingFiles := findAllPaths(t, unpackToDir)
+	require.Equal(t, expectedFiles, resultingFiles, "Expected to find same file trees under source and target dirs")
+}
+
+func fillTestFileTree(t *testing.T, packFromDir string) {
+	t.Helper()
+
+	files := []string{
+		filepath.Join(packFromDir, "file"),
+		filepath.Join(packFromDir, "dir", "file1"),
+		filepath.Join(packFromDir, "dir", "dir2", "file3"),
+	}
+
+	require.NoError(t, os.MkdirAll(filepath.Join(packFromDir, "dir", "dir2"), 0777))
+
+	for _, filePath := range files {
+		file, err := os.Create(filePath)
+		require.NoError(t, err)
+
+		_, err = io.CopyN(file, rand.Reader, 256)
+		require.NoError(t, err)
+
+		require.NoError(t, file.Sync())
+		require.NoError(t, file.Close())
+	}
+}
+
+func findAllPaths(t *testing.T, dir string) []string {
+	t.Helper()
+
+	files := make([]string, 0)
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		files = append(files, strings.TrimPrefix(path, dir))
+		return nil
+	})
+	require.NoError(t, err, "Expected no errors during directory traversal")
+
+	return files
+}

--- a/dhctl/pkg/operations/mirror/digests_test.go
+++ b/dhctl/pkg/operations/mirror/digests_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/maputil"
+)
+
+func TestExtractImageDigestsFromDeckhouseInstaller(t *testing.T) {
+	expectedImages := []string{
+		"localhost:5001/deckhouse@sha256:72623af14db0cf2411cdf6364089b1954cbfd10e76e13ff08816a628b52a9712",
+		"localhost:5001/deckhouse@sha256:f58a7f8b3fbdc78a90578b45e8ddb1bf587102206d9320e9ce9f4fe9474f5650",
+	}
+	installerTag := "localhost:5001/deckhouse/install:stable"
+
+	installersLayout := createOCILayoytWithInstallerImage(t, "localhost:5001/deckhouse", installerTag, expectedImages)
+	images, err := ExtractImageDigestsFromDeckhouseInstaller(
+		&Context{DeckhouseRegistryRepo: "localhost:5001/deckhouse"},
+		installerTag,
+		installersLayout,
+	)
+	require.NoError(t, err)
+	require.True(t, len(images) == len(expectedImages))
+	require.ElementsMatch(t, maputil.Keys(images), expectedImages)
+}
+
+func createOCILayoytWithInstallerImage(t *testing.T, imagesReoo, installerTag string, images []string) layout.Path {
+	t.Helper()
+
+	// FROM scratch
+	base := empty.Image
+	layers := make([]v1.Layer, 0)
+
+	// COPY ./version /deckhouse/version
+	// COPY ./images_digests.json /deckhouse/candi/images_digests.json
+	imagesDigests, err := json.Marshal(
+		map[string]map[string]string{
+			"common": {
+				"alpine": strings.TrimPrefix(images[0], imagesReoo+"@"),
+			},
+			"nodeManager": {
+				"bashibleApiserver": strings.TrimPrefix(images[1], imagesReoo+"@"),
+			},
+		})
+	require.NoError(t, err)
+	l, err := crane.Layer(map[string][]byte{
+		"deckhouse/candi/images_digests.json": imagesDigests,
+	})
+	require.NoError(t, err)
+	layers = append(layers, l)
+
+	img, err := mutate.AppendLayers(base, layers...)
+	require.NoError(t, err)
+
+	tempDir, err := os.MkdirTemp(os.TempDir(), "digests_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tempDir)
+	})
+
+	installersLayout, err := CreateEmptyImageLayoutAtPath(tempDir)
+	require.NoError(t, err)
+
+	err = installersLayout.AppendImage(img, layout.WithAnnotations(map[string]string{
+		"org.opencontainers.image.ref.name": installerTag,
+	}))
+	require.NoError(t, err)
+
+	return installersLayout
+}

--- a/dhctl/pkg/operations/mirror/versions.go
+++ b/dhctl/pkg/operations/mirror/versions.go
@@ -100,17 +100,15 @@ func filterOnlyLatestPatches(versions []*semver.Version) []*semver.Version {
 }
 
 func getReleaseChannelVersionFromRegistry(mirrorCtx *Context, releaseChannel string) (*semver.Version, error) {
-	refOpts := []name.Option{name.StrictValidation}
-	if mirrorCtx.Insecure {
-		refOpts = append(refOpts, name.Insecure)
-	}
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
+	nameOpts = append(nameOpts, name.StrictValidation)
 
-	ref, err := name.ParseReference(mirrorCtx.DeckhouseRegistryRepo+"/release-channel:"+releaseChannel, refOpts...)
+	ref, err := name.ParseReference(mirrorCtx.DeckhouseRegistryRepo+"/release-channel:"+releaseChannel, nameOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("parse rock solid release ref: %w", err)
 	}
 
-	rockSolidReleaseImage, err := remote.Image(ref, remote.WithAuth(mirrorCtx.RegistryAuth))
+	rockSolidReleaseImage, err := remote.Image(ref, remoteOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("get %s release channel data: %w", releaseChannel, err)
 	}

--- a/dhctl/pkg/operations/mirror_test.go
+++ b/dhctl/pkg/operations/mirror_test.go
@@ -1,0 +1,264 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/mirror"
+)
+
+func TestMirrorE2E_Insecure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "mirror_e2e")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+	workingDir := filepath.Join(tmpDir, "pull")
+
+	sourceHost, sourceRepoPath, sourceBlobHandler := setupEmptyRegistryRepo(false)
+	targetHost, targetRepoPath, targetBlobHandler := setupEmptyRegistryRepo(false)
+
+	createDeckhouseControllersAndInstallersInRegistry(t, sourceHost+sourceRepoPath)
+	createDeckhouseReleaseChannelsInRegistry(t, sourceHost+sourceRepoPath)
+
+	pullCtx := &mirror.Context{
+		Insecure:              true,
+		DeckhouseRegistryRepo: sourceHost + sourceRepoPath,
+		UnpackedImagesPath:    workingDir,
+		ValidationMode:        mirror.NoValidation,
+	}
+	pushCtx := &mirror.Context{
+		Insecure:              true,
+		DeckhouseRegistryRepo: sourceHost + sourceRepoPath,
+		RegistryHost:          targetHost,
+		RegistryPath:          targetRepoPath,
+		UnpackedImagesPath:    workingDir,
+		ValidationMode:        mirror.NoValidation,
+	}
+
+	err = MirrorDeckhouseToLocalFS(
+		pullCtx,
+		[]semver.Version{
+			*semver.MustParse("v1.56.5"),
+			*semver.MustParse("v1.55.7"),
+		},
+	)
+	require.NoError(t, err, "Pull should be completed without errors")
+	for _, layoutName := range []string{"", "install", "release-channel"} {
+		require.DirExists(t, filepath.Join(pullCtx.UnpackedImagesPath, layoutName), "Image layouts should exist after pull")
+		require.DirExists(t, filepath.Join(pullCtx.UnpackedImagesPath, layoutName, "blobs"), "Blobs should exist after pull")
+	}
+
+	err = PushDeckhouseToRegistry(pushCtx)
+	require.NoError(t, err, "Push should be completed without errors")
+
+	require.Subset(t, sourceBlobHandler.ListBlobs(), targetBlobHandler.ListBlobs())
+}
+
+func setupEmptyRegistryRepo(useTLS bool) (host, repoPath string, blobHandler *ListableBlobHandler) {
+	memBlobHandler := registry.NewInMemoryBlobHandler()
+	bh := &ListableBlobHandler{
+		BlobHandler:    memBlobHandler,
+		BlobPutHandler: memBlobHandler.(registry.BlobPutHandler),
+	}
+	registryHandler := registry.New(registry.WithBlobHandler(bh), registry.Logger(log.New(io.Discard, "", 0)))
+
+	server := httptest.NewUnstartedServer(registryHandler)
+	if useTLS {
+		server.StartTLS()
+	} else {
+		server.Start()
+	}
+
+	host = strings.TrimPrefix(server.URL, "http://")
+	repoPath = "/deckhouse/ee"
+	if useTLS {
+		host = strings.TrimPrefix(server.URL, "https://")
+	}
+
+	return host, repoPath, bh
+}
+
+func createDeckhouseReleaseChannelsInRegistry(t *testing.T, repo string) {
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "alpha", "v1.56.5")
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "beta", "v1.56.5")
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "early-access", "v1.55.7")
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "stable", "v1.55.7")
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "rock-solid", "v1.55.7")
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "v1.55.7", "v1.55.7")
+	createDeckhouseReleaseChannelImageInRegistry(t, repo+"/release-channel", "v1.56.5", "v1.56.5")
+}
+
+func createDeckhouseControllersAndInstallersInRegistry(t *testing.T, repo string) {
+	t.Helper()
+
+	nameOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(nil, true, false)
+
+	createRandomImageInRegistry(t, repo+":alpha")
+	createRandomImageInRegistry(t, repo+":beta")
+	createRandomImageInRegistry(t, repo+":early-access")
+	createRandomImageInRegistry(t, repo+":stable")
+	createRandomImageInRegistry(t, repo+":rock-solid")
+	createRandomImageInRegistry(t, repo+":v1.56.5")
+	createRandomImageInRegistry(t, repo+":v1.55.7")
+
+	installers := map[string]v1.Image{
+		"v1.56.5": createSyntheticInstallerImage(t, "v1.56.5", repo),
+		"v1.55.7": createSyntheticInstallerImage(t, "v1.55.7", repo),
+	}
+	installers["alpha"] = installers["v1.56.5"]
+	installers["beta"] = installers["v1.56.5"]
+	installers["early-access"] = installers["v1.55.7"]
+	installers["stable"] = installers["v1.55.7"]
+	installers["rock-solid"] = installers["v1.55.7"]
+
+	for shortTag, installer := range installers {
+		ref, err := name.ParseReference(repo+"/install:"+shortTag, nameOpts...)
+		require.NoError(t, err)
+
+		err = remote.Write(ref, installer, remoteOpts...)
+		require.NoError(t, err)
+	}
+}
+
+func createSyntheticInstallerImage(t *testing.T, version, repo string) v1.Image {
+	t.Helper()
+
+	// FROM scratch
+	base := empty.Image
+	layers := make([]v1.Layer, 0)
+
+	// COPY ./version /deckhouse/version
+	// COPY ./images_digests.json /deckhouse/candi/images_digests.json
+	imagesDigests, err := json.Marshal(
+		map[string]map[string]string{
+			"common": {
+				"alpine": createRandomImageInRegistry(t, repo+":alpine"+version),
+			},
+			"nodeManager": {
+				"bashibleApiserver": createRandomImageInRegistry(t, repo+":bashibleApiserver"+version),
+			},
+		})
+	require.NoError(t, err)
+	l, err := crane.Layer(map[string][]byte{
+		"deckhouse/version":                   []byte(version),
+		"deckhouse/candi/images_digests.json": imagesDigests,
+	})
+	require.NoError(t, err)
+	layers = append(layers, l)
+
+	img, err := mutate.AppendLayers(base, layers...)
+	require.NoError(t, err)
+
+	// ENTRYPOINT ["/bin/bash"]
+	img, err = mutate.Config(img, v1.Config{
+		Entrypoint: []string{"/bin/bash"},
+	})
+	require.NoError(t, err)
+
+	return img
+}
+
+func createRandomImageInRegistry(t *testing.T, tag string) (digest string) {
+	t.Helper()
+
+	img, err := random.Image(int64(rand.Intn(1024)+1), int64(rand.Intn(5)+1))
+	require.NoError(t, err)
+
+	nameOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(nil, true, false)
+	ref, err := name.ParseReference(tag, nameOpts...)
+	require.NoError(t, err)
+
+	err = remote.Write(ref, img, remoteOpts...)
+	require.NoError(t, err)
+
+	digestHash, err := img.Digest()
+	require.NoError(t, err)
+
+	return digestHash.String()
+}
+
+func createDeckhouseReleaseChannelImageInRegistry(t *testing.T, repo, tag, version string) (digest string) {
+	t.Helper()
+
+	// FROM scratch
+	base := empty.Image
+	layers := make([]v1.Layer, 0)
+
+	// COPY ./version.json /version.json
+	l, err := crane.Layer(map[string][]byte{
+		"version.json": []byte(fmt.Sprintf(`{"version": %q}`, version)),
+	})
+	require.NoError(t, err)
+	layers = append(layers, l)
+
+	img, err := mutate.AppendLayers(base, layers...)
+	require.NoError(t, err)
+
+	nameOpts, remoteOpts := mirror.MakeRemoteRegistryRequestOptions(nil, true, false)
+	ref, err := name.ParseReference(repo+":"+tag, nameOpts...)
+	require.NoError(t, err)
+
+	err = remote.Write(ref, img, remoteOpts...)
+	require.NoError(t, err)
+
+	digestHash, err := img.Digest()
+	require.NoError(t, err)
+
+	return digestHash.String()
+}
+
+type ListableBlobHandler struct {
+	registry.BlobHandler
+	registry.BlobPutHandler
+
+	mu            sync.Mutex
+	ingestedBlobs []string
+}
+
+func (h *ListableBlobHandler) Get(ctx context.Context, repo string, hash v1.Hash) (io.ReadCloser, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ingestedBlobs = append(h.ingestedBlobs, hash.String())
+
+	return h.BlobHandler.Get(ctx, repo, hash)
+}
+
+func (h *ListableBlobHandler) ListBlobs() []string {
+	return h.ingestedBlobs
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added some tests for mirroring.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Why not?

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Added tests for dhctl mirror.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
