### PR TITLE
[ingress-nginx] fix hostwithfailover proxy filter

### DIFF
--- a/modules/402-ingress-nginx/templates/failover/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/failover/configmap.yaml
@@ -10,9 +10,11 @@ metadata:
   {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name)) | nindent 2 }}
 data:
   accept-requests-from.conf: |
+  {{- if $crd.spec.acceptRequestsFrom }}
     {{- range $cidr := $crd.spec.acceptRequestsFrom }}
     allow {{ $cidr }};
     {{- end }}
     deny all;
+  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Updates `proxy-failover` configmap template so that if `.spec.acceptRequestsFrom` isn't set, no filters are applied by `proxy-failover` nginx.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Pr fixes a nasty bug in `HostWithFailover` ingress-nginx inlet when there is no `.spec.acceptRequestFrom` setting in an ingress-nginx and `proxy-failover` just denies all requests, resulting in an outage when upgrading `ingress-nginx`.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It's a bug in ingress-nginx module and it's better to fix it in the current release.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
if `.spec.acceptRequestsFrom` isn't set, `proxy-failover` configmap should be empty and has no filters set.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix HostWithFailover inlet proxy filter.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
