### PR TITLE
[docs][openapi] Update nodeGroup examples to fix markup

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -1318,9 +1318,7 @@ spec:
                 nodeTemplate:
                   labels:
                     tier: test
-              ```
-          - |
-              ```yaml
+              ---
               # NodeGroup for static nodes on bare metal servers (or VMs).
               apiVersion: deckhouse.io/v1
               kind: NodeGroup


### PR DESCRIPTION
## Description
Temporary fix.
Markup breaks if there is more than one example on the root level of the CRD spec.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix nodeGroup examples.
impact_level: low
```
