### PR TITLE
[docs][openapi][node-manager] Remove DeckhouseControlPlane CR from the documentation

### DIFF
--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -9,6 +9,7 @@
   - '*/openapi/*-tests.yaml'
   - '*/docs/internal/'
   - '005-external-module-manager/crds/external-module-*'
+  - '040-node-manager/crds/deckhousecontrolplane.yaml'
   - '040-node-manager/crds/mcm.yaml'
   - '040-node-manager/crds/cluster.yaml'
   - '040-node-manager/crds/extension-config.yaml'


### PR DESCRIPTION
## Description
Remove DeckhouseControlPlane CR from the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove DeckhouseControlPlane CR from the documentation.
impact_level: low
```
