### PR TITLE
[cni-cilium] migrate cilium-operator image to distroless

### DIFF
--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -4,16 +4,24 @@ artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: quay.io/cilium/operator:v{{- $ciliumVersion }}@sha256:56cc1822109c4b34d192784a3106150cfb645252ce0b34aab67e9c820ac41bab
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_SCRATCH }}
+fromImage: common/distroless
 import:
 - artifact: {{ $.ModuleName }}/builder-cert-artifact
   add: /etc/ssl/certs/ca-certificates.crt
   to: /etc/ssl/certs/ca-certificates.crt
   before: install
+- artifact: {{ $.ModuleName }}/builder-gops-artifact
+  add: /out/linux/amd64/bin/gops
+  to: /bin/gops
+  before: install
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /usr/bin/cilium-operator
   to: /usr/bin/cilium-operator
   before: install
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /LICENSE.all
+  to: /LICENSE.all
+  before: install
 docker:
-  USER: nobody
+  USER: 64535
   ENTRYPOINT: ["/usr/bin/cilium-operator"]

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -1,7 +1,19 @@
 {{- $ciliumVersion := "1.14.5" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-base-artifact
 from: quay.io/cilium/operator:v{{- $ciliumVersion }}@sha256:56cc1822109c4b34d192784a3106150cfb645252ce0b34aab67e9c820ac41bab
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+from: {{ $.Images.BASE_ALPINE }}
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-base-artifact
+  add: /usr/bin/cilium-operator
+  to: /usr/bin/cilium-operator
+  before: install
+shell:
+  install:
+  - chown 64535:64535 /usr/bin/cilium-operator
+  - chmod 0700 /usr/local/bin/hubble-relay
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
@@ -10,17 +22,9 @@ import:
   add: /etc/ssl/certs/ca-certificates.crt
   to: /etc/ssl/certs/ca-certificates.crt
   before: install
-- artifact: {{ $.ModuleName }}/builder-gops-artifact
-  add: /out/linux/amd64/bin/gops
-  to: /bin/gops
-  before: install
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /usr/bin/cilium-operator
   to: /usr/bin/cilium-operator
-  before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /LICENSE.all
-  to: /LICENSE.all
   before: install
 docker:
   USER: 64535

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -6,34 +6,25 @@ from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
-# import:
-# - artifact: {{ $.ModuleName }}/builder-src
-#   add: /go/src/github.com/cilium/cilium
-#   to: /go/src/github.com/cilium/cilium
-#   before: install
 shell:
   beforeInstall:
   - apk add --no-cache make git bash
   install:
   - export GO_VERSION=${GOLANG_VERSION}
   - export GOPROXY={{ $.GOPROXY }}
+  - export GOOS=linux GOARCH=amd64
   - mkdir -p /go/src/github.com/cilium/cilium
   - git clone --depth 1 --branch v{{ $ciliumVersion }} {{ $.SOURCE_REPO }}/cilium/cilium.git /go/src/github.com/cilium/cilium
   - cd /go/src/github.com/cilium/cilium
   - make DESTDIR=/out/linux/amd64 build-container-operator install-container-binary-operator
-  - make licenses-all && mv LICENSE.all /out/linux/amd64
   - mkdir -p /tmp/install
-  - cp -t /tmp/install/ /out/linux/amd64/usr/bin/cilium-operator /out/linux/amd64/LICENSE.all
+  - cp -t /tmp/install/ /out/linux/amd64/usr/bin/cilium-operator
   - chown 64535:64535 /tmp/install/cilium-operator
   - chmod 0700 /tmp/install/cilium-operator
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/builder-cert-artifact
-  add: /etc/ssl/certs/ca-certificates.crt
-  to: /etc/ssl/certs/ca-certificates.crt
-  before: install
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /tmp/install/cilium-operator
   to: /usr/bin/cilium-operator

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -1,6 +1,4 @@
 {{- $ciliumVersion := "1.14.5" }}
-# Source repo  settings. Delete after clone repo to fox
-{{- $_ := set . "SOURCE_REPO" "https://github.com" }}
 ---
 # Based on https://github.com/cilium/cilium/blob/v1.14.5/images/operator/Dockerfile
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -13,7 +13,7 @@ import:
 shell:
   install:
   - chown 64535:64535 /usr/bin/cilium-operator
-  - chmod 0700 /usr/local/bin/hubble-relay
+  - chmod 0700 /usr/bin/cilium-operator
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -24,8 +24,10 @@ shell:
   - cd /go/src/github.com/cilium/cilium
   - make DESTDIR=/out/linux/amd64 build-container-operator install-container-binary-operator
   - make licenses-all && mv LICENSE.all /out/linux/amd64
-  - chown 64535:64535 /usr/bin/cilium-operator
-  - chmod 0700 /usr/bin/cilium-operator
+  - mkdir -p /tmp/install
+  - cp -t /tmp/install/ /out/linux/amd64/usr/bin/cilium-operator /out/linux/amd64/LICENSE.all
+  - chown 64535:64535 /tmp/install/cilium-operator
+  - chmod 0700 /tmp/install/cilium-operator
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
@@ -35,7 +37,7 @@ import:
   to: /etc/ssl/certs/ca-certificates.crt
   before: install
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
-  add: /usr/bin/cilium-operator
+  add: /tmp/install/cilium-operator
   to: /usr/bin/cilium-operator
   before: install
 docker:

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -17,16 +17,14 @@ shell:
   - git clone --depth 1 --branch v{{ $ciliumVersion }} {{ $.SOURCE_REPO }}/cilium/cilium.git /go/src/github.com/cilium/cilium
   - cd /go/src/github.com/cilium/cilium
   - make DESTDIR=/out/linux/amd64 build-container-operator install-container-binary-operator
-  - mkdir -p /tmp/install
-  - cp -t /tmp/install/ /out/linux/amd64/usr/bin/cilium-operator
-  - chown 64535:64535 /tmp/install/cilium-operator
-  - chmod 0700 /tmp/install/cilium-operator
+  - chown 64535:64535 /out/linux/amd64/usr/bin/cilium-operator
+  - chmod 0700 /out/linux/amd64/usr/bin/cilium-operator
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
-  add: /tmp/install/cilium-operator
+  add: /out/linux/amd64/usr/bin/cilium-operator
   to: /usr/bin/cilium-operator
   before: install
 docker:

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -15,7 +15,7 @@ mount:
 #   before: install
 shell:
   beforeInstall:
-  - apk add --no-cache make git
+  - apk add --no-cache make git bash
   install:
   - export GO_VERSION=${GOLANG_VERSION}
   - export GOPROXY={{ $.GOPROXY }}

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -1,17 +1,29 @@
 {{- $ciliumVersion := "1.14.5" }}
+# Source repo  settings. Delete after clone repo to fox
+{{- $_ := set . "SOURCE_REPO" "https://github.com" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-base-artifact
-from: quay.io/cilium/operator:v{{- $ciliumVersion }}@sha256:56cc1822109c4b34d192784a3106150cfb645252ce0b34aab67e9c820ac41bab
----
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_ALPINE }}
-import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-base-artifact
-  add: /usr/bin/cilium-operator
-  to: /usr/bin/cilium-operator
-  before: install
+# Based on https://github.com/cilium/cilium/blob/v1.14.5/images/operator/Dockerfile
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+# import:
+# - artifact: {{ $.ModuleName }}/builder-src
+#   add: /go/src/github.com/cilium/cilium
+#   to: /go/src/github.com/cilium/cilium
+#   before: install
 shell:
+  beforeInstall:
+  - apk add --no-cache make git
   install:
+  - export GO_VERSION=${GOLANG_VERSION}
+  - export GOPROXY={{ $.GOPROXY }}
+  - mkdir -p /go/src/github.com/cilium/cilium
+  - git clone --depth 1 --branch v{{ $ciliumVersion }} {{ $.SOURCE_REPO }}/cilium/cilium.git /go/src/github.com/cilium/cilium
+  - cd /go/src/github.com/cilium/cilium
+  - make DESTDIR=/out/linux/amd64 build-container-operator install-container-binary-operator
+  - make licenses-all && mv LICENSE.all /out/linux/amd64
   - chown 64535:64535 /usr/bin/cilium-operator
   - chmod 0700 /usr/bin/cilium-operator
 ---
@@ -22,7 +34,7 @@ import:
   add: /etc/ssl/certs/ca-certificates.crt
   to: /etc/ssl/certs/ca-certificates.crt
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /usr/bin/cilium-operator
   to: /usr/bin/cilium-operator
   before: install

--- a/modules/021-cni-cilium/templates/operator/deployment.yaml
+++ b/modules/021-cni-cilium/templates/operator/deployment.yaml
@@ -52,7 +52,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "operator")) | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       containers:


### PR DESCRIPTION
## Description

cilium-operator is based on a distroless images.

## Why do we need it, and what problem does it solve?

We'd like to base our images on a distroless image.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: cilium-operator is now based on a distroless images
impact: cilium-operator pods will restart.
impact_level: default
```
