### PR TITLE
[istio] Fix depricated instructions for  Reproducing request in alerts

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
@@ -19,8 +19,8 @@
           ```
           Reproducing request to private endpoints (run from deckhouse pod):
           ```
-          KEY="$(deckhouse-controller module values istio -o json | jq -r .istio.internal.remoteAuthnKeypair.priv)"
-          LOCAL_CLUSTER_UUID="$(deckhouse-controller module values istio -o json | jq -r .global.discovery.clusterUUID)"
+          KEY="$(deckhouse-controller module values istio -o json | jq -r .internal.remoteAuthnKeypair.priv)"
+          LOCAL_CLUSTER_UUID="$(deckhouse-controller module values -g istio -o json | jq -r .global.discovery.clusterUUID)"
           REMOTE_CLUSTER_UUID="$(kubectl get istiofederation {{$labels.federation_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
           TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-federation --ttl 1h)"
           curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}

--- a/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
@@ -39,8 +39,8 @@
           ```
           Reproducing request to private endpoints (run from deckhouse pod):
           ```
-          KEY="$(deckhouse-controller module values istio -o json | jq -r .istio.internal.remoteAuthnKeypair.priv)"
-          LOCAL_CLUSTER_UUID="$(deckhouse-controller module values istio -o json | jq -r .global.discovery.clusterUUID)"
+          KEY="$(deckhouse-controller module values istio -o json | jq -r .internal.remoteAuthnKeypair.priv)"
+          LOCAL_CLUSTER_UUID="$(deckhouse-controller module values -g istio -o json | jq -r .global.discovery.clusterUUID)"
           REMOTE_CLUSTER_UUID="$(kubectl get istiomulticluster {{$labels.multicluster_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
           TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-multicluster --ttl 1h)"
           curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}


### PR DESCRIPTION
## Description
Fix diagnostic instructions in istio federation/multicluster alerts.

## Why do we need it, and what problem does it solve?
deckhouse-commander args have been changed, but the alert's wern't actualized.

## Why do we need it in the patch release (if we do)?

There are alerts with wrong instructions.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fix diagnostic instructions in istio federation/multicluster alerts.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
