### PR TITLE
[flant-integration] Correct metrics_path for flant-pricing container

### DIFF
--- a/ee/modules/600-flant-integration/templates/pricing/config.yaml
+++ b/ee/modules/600-flant-integration/templates/pricing/config.yaml
@@ -31,6 +31,7 @@ prometheus:
     - job_name: 'flant-pricing'
       params:
         module: [http_2xx]  # Look for a HTTP 200 response.
+      metrics_path: /metrics/hooks
       static_configs:
       - targets:
         - 127.0.0.1:9115


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Shell operator hooks metrics path was changed from `metrics` to `metrics/hooks`. This PR sets correct path.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
No metrics from flant pricing

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: flant-integration
type: fix
summary: Correct `metrics_path`.
```
