### PR TITLE
[external-module-manager] fix restore absent module for multi master

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -877,7 +877,6 @@ func (c *Controller) restoreAbsentSourceModules() error {
 				if err := os.Remove(moduleDir); err != nil {
 					c.logger.Warnf("Couldn't delete stale symlink %s for module %s: err", moduleDir, moduleName, err)
 					continue
-
 				}
 				if err := c.createModuleSymlink(moduleName, moduleVersion, moduleSource, moduleWeight); err != nil {
 					c.logger.Warnf("Couldn't create module symlink: %s", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -844,39 +844,70 @@ func (c *Controller) restoreAbsentSourceModules() error {
 			continue
 		}
 
+		moduleWeight := item.Spec.Weight
+		moduleVersion := "v" + item.Spec.Version.String()
+		moduleName := item.Spec.ModuleName
+		moduleSource := item.GetModuleSource()
+
 		moduleDir := filepath.Join(c.symlinksDir, fmt.Sprintf("%d-%s", item.Spec.Weight, item.Spec.ModuleName))
 		_, err = os.Stat(moduleDir)
-		if err != nil && os.IsNotExist(err) {
-			log.Infof("Module %q is absent on file system. Restoring it from source %q", item.Spec.ModuleName, item.GetModuleSource())
-			moduleVersion := "v" + item.Spec.Version.String()
-			moduleName := item.Spec.ModuleName
-			moduleSource := item.GetModuleSource()
-
-			ms, err := c.moduleSourcesLister.Get(moduleSource)
+		if err != nil {
+			// module dir not found
+			if os.IsNotExist(err) {
+				err := c.createModuleSymlink(moduleName, moduleVersion, moduleSource, moduleWeight)
+				if err != nil {
+					c.logger.Warnf("Couldn't create module symlink: %s", err)
+					continue
+				}
+				// some other error
+			} else {
+				c.logger.Errorf("Module %s check error: %s", moduleName, err)
+				continue
+			}
+			// check if module versions is up to date
+		} else {
+			dstDir, err := filepath.EvalSymlinks(moduleDir)
 			if err != nil {
-				c.logger.Warnf("ModuleSource %q is absent. Skipping restoration of the module %q", moduleSource, moduleName)
+				c.logger.Errorf("Couldn't evaluate module %s symlink %s: %s", moduleName, moduleDir, err)
 				continue
 			}
 
-			md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
-			err = md.DownloadByModuleVersion(moduleName, moduleVersion)
-			if err != nil {
-				log.Warnf("Download module %q with version %s failed: %s. Skipping", moduleName, moduleVersion, err)
-				continue
+			// module version on file system doesn't equal to the deployed module release
+			if filepath.Base(dstDir) != moduleVersion {
+				err := c.createModuleSymlink(moduleName, moduleVersion, moduleSource, moduleWeight)
+				if err != nil {
+					c.logger.Warnf("Couldn't create module symlink: %s", err)
+					continue
+				}
 			}
-
-			// restore symlink
-			moduleRelativePath := filepath.Join("../", moduleName, moduleVersion)
-			symlinkPath := filepath.Join(c.symlinksDir, fmt.Sprintf("%d-%s", item.Spec.Weight, moduleName))
-			err = restoreModuleSymlink(c.externalModulesDir, symlinkPath, moduleRelativePath)
-			if err != nil {
-				log.Warnf("Create symlink for module %q failed: %s", moduleName, err)
-				continue
-			}
-
-			log.Infof("Module %s:%s restored", moduleName, moduleVersion)
 		}
 	}
+
+	return nil
+}
+
+func (c *Controller) createModuleSymlink(moduleName, moduleVersion, moduleSource string, moduleWeight uint32) error {
+	log.Infof("Module %q is absent on file system. Restoring it from source %q", moduleName, moduleSource)
+
+	ms, err := c.moduleSourcesLister.Get(moduleSource)
+	if err != nil {
+		return errors.Errorf("ModuleSource %q is absent. Skipping restoration of the module %q", moduleSource, moduleName)
+	}
+
+	md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
+	err = md.DownloadByModuleVersion(moduleName, moduleVersion)
+	if err != nil {
+		return errors.Errorf("Download module %q with version %s failed: %s. Skipping", moduleName, moduleVersion, err)
+	}
+
+	// restore symlink
+	moduleRelativePath := filepath.Join("../", moduleName, moduleVersion)
+	symlinkPath := filepath.Join(c.symlinksDir, fmt.Sprintf("%d-%s", moduleWeight, moduleName))
+	err = restoreModuleSymlink(c.externalModulesDir, symlinkPath, moduleRelativePath)
+	if err != nil {
+		return errors.Errorf("Create symlink for module %q failed: %s", moduleName, err)
+	}
+	log.Infof("Module %s:%s restored", moduleName, moduleVersion)
 
 	return nil
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -874,8 +874,12 @@ func (c *Controller) restoreAbsentSourceModules() error {
 
 			// module version on file system doesn't equal to the deployed module release
 			if filepath.Base(dstDir) != moduleVersion {
-				err := c.createModuleSymlink(moduleName, moduleVersion, moduleSource, moduleWeight)
-				if err != nil {
+				if err := os.Remove(moduleDir); err != nil {
+					c.logger.Warnf("Couldn't delete stale symlink %s for module %s: err", moduleDir, moduleName, err)
+					continue
+
+				}
+				if err := c.createModuleSymlink(moduleName, moduleVersion, moduleSource, moduleWeight); err != nil {
 					c.logger.Warnf("Couldn't create module symlink: %s", err)
 					continue
 				}


### PR DESCRIPTION
## Description
Update restoreAbsentSourceModules so that it also checks that there is up to date version of a module is used by deckhouse.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It should fix the problem with multi-master clusters when masters have different version of modules on their file systems. Only latest deployed version should be used by masters.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It fixes a bug.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
If there is a symlink leading to an old superseded version of a module, this symlink should be updated to the latest module version directory.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Fix outdated module versions in multi-master environment.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
