### PR TITLE
[external-module-manager] delete old symlinks on restore

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -893,7 +893,10 @@ func (c *Controller) createModuleSymlink(moduleName, moduleVersion, moduleSource
 	log.Infof("Module %q is absent on file system. Restoring it from source %q", moduleName, moduleSource)
 
 	// check if there is a symlink for the module with different weight in the symlink folder
-	anotherModuleSymlink, _ := findExistingModuleSymlink(c.symlinksDir, moduleName)
+	anotherModuleSymlink, err := findExistingModuleSymlink(c.symlinksDir, moduleName)
+	if err != nil {
+		return errors.Errorf("Couldn't check if there are any other symlinks for module %s: err", moduleName, err)
+	}
 	if len(anotherModuleSymlink) > 0 {
 		if err := os.Remove(filepath.Join(c.symlinksDir, anotherModuleSymlink)); err != nil {
 			return errors.Errorf("Couldn't delete stale symlink %s for module %s: err", anotherModuleSymlink, moduleName, err)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -892,6 +892,14 @@ func (c *Controller) restoreAbsentSourceModules() error {
 func (c *Controller) createModuleSymlink(moduleName, moduleVersion, moduleSource string, moduleWeight uint32) error {
 	log.Infof("Module %q is absent on file system. Restoring it from source %q", moduleName, moduleSource)
 
+	// check if there is a symlink for the module with different weight in the symlink folder
+	anotherModuleSymlink, _ := findExistingModuleSymlink(c.symlinksDir, moduleName)
+	if len(anotherModuleSymlink) > 0 {
+		if err := os.Remove(filepath.Join(c.symlinksDir, anotherModuleSymlink)); err != nil {
+			return errors.Errorf("Couldn't delete stale symlink %s for module %s: err", anotherModuleSymlink, moduleName, err)
+		}
+	}
+
 	ms, err := c.moduleSourcesLister.Get(moduleSource)
 	if err != nil {
 		return errors.Errorf("ModuleSource %q is absent. Skipping restoration of the module %q", moduleSource, moduleName)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -895,23 +895,23 @@ func (c *Controller) createModuleSymlink(moduleName, moduleVersion, moduleSource
 	// check if there is a symlink for the module with different weight in the symlink folder
 	anotherModuleSymlink, err := findExistingModuleSymlink(c.symlinksDir, moduleName)
 	if err != nil {
-		return errors.Errorf("Couldn't check if there are any other symlinks for module %s: err", moduleName, err)
+		return fmt.Errorf("Couldn't check if there are any other symlinks for module %v: %w", moduleName, err)
 	}
 	if len(anotherModuleSymlink) > 0 {
-		if err := os.Remove(filepath.Join(c.symlinksDir, anotherModuleSymlink)); err != nil {
-			return errors.Errorf("Couldn't delete stale symlink %s for module %s: err", anotherModuleSymlink, moduleName, err)
+		if err := os.Remove(anotherModuleSymlink); err != nil {
+			return fmt.Errorf("Couldn't delete stale symlink %v for module %v: %w", anotherModuleSymlink, moduleName, err)
 		}
 	}
 
 	ms, err := c.moduleSourcesLister.Get(moduleSource)
 	if err != nil {
-		return errors.Errorf("ModuleSource %q is absent. Skipping restoration of the module %q", moduleSource, moduleName)
+		return fmt.Errorf("ModuleSource %v is absent. Skipping restoration of the module %v", moduleSource, moduleName)
 	}
 
 	md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
 	err = md.DownloadByModuleVersion(moduleName, moduleVersion)
 	if err != nil {
-		return errors.Errorf("Download module %q with version %s failed: %s. Skipping", moduleName, moduleVersion, err)
+		return fmt.Errorf("Download module %v with version %v failed: %w. Skipping", moduleName, moduleVersion, err)
 	}
 
 	// restore symlink
@@ -919,7 +919,7 @@ func (c *Controller) createModuleSymlink(moduleName, moduleVersion, moduleSource
 	symlinkPath := filepath.Join(c.symlinksDir, fmt.Sprintf("%d-%s", moduleWeight, moduleName))
 	err = restoreModuleSymlink(c.externalModulesDir, symlinkPath, moduleRelativePath)
 	if err != nil {
-		return errors.Errorf("Create symlink for module %q failed: %s", moduleName, err)
+		return fmt.Errorf("Create symlink for module %v failed: %w", moduleName, err)
 	}
 	log.Infof("Module %s:%s restored", moduleName, moduleVersion)
 


### PR DESCRIPTION
## Description
* Before restoring a module symlink we check if there is another symlink for the module in the folder and delete it if it's the case.
* fixes message formats
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixes a situation when module controller restores a missing symlink for current version of a module, ending up having several symlinks for the module if the module's weight was changed in the newer release.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It fixes current issue for sds-drbd module.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Module controller deletes old symlink if it exists before restoring a module from its source.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: fix
summary: Fix multiple symlinks for a single module in the symlink folder.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
