### PR TITLE
[descheduler] fix removeDuplicates

### DIFF
--- a/modules/400-descheduler/templates/configmap.yaml
+++ b/modules/400-descheduler/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
         params:
           nodeAffinityType:
             - "requiredDuringSchedulingIgnoredDuringExecution"
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.removePodsViolatingNodeAffinity | nindent 10 }}
   {{- else }}
       "RemovePodsViolatingNodeAffinity":
         enabled: false
@@ -65,7 +65,7 @@ data:
       "RemovePodsViolatingInterPodAntiAffinity":
         enabled: true
         params:
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.removePodsViolatingInterPodAntiAffinity | nindent 10 }}
   {{- else }}
       "RemovePodsViolatingInterPodAntiAffinity":
         enabled: false
@@ -85,7 +85,7 @@ data:
               "cpu": 80
               "memory": 90
               "pods": 80
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.lowNodeUtilization | nindent 10 }}
   {{- else }}
       "LowNodeUtilization":
         enabled: false
@@ -99,7 +99,7 @@ data:
             thresholds:
               "cpu": 50
               "memory": 50
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.highNodeUtilization | nindent 10 }}
   {{- else }}
       "HighNodeUtilization":
         enabled: false
@@ -109,7 +109,7 @@ data:
       "RemovePodsViolatingNodeTaints":
         enabled: true
         params:
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.removePodsViolatingNodeTaints | nindent 10 }}
   {{- else }}
       "RemovePodsViolatingNodeTaints":
         enabled: false
@@ -119,7 +119,7 @@ data:
       "RemovePodsViolatingTopologySpreadConstraint":
         enabled: true
         params:
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.removePodsViolatingTopologySpreadConstraint | nindent 10 }}
   {{- else }}
       "RemovePodsViolatingTopologySpreadConstraint":
         enabled: false
@@ -132,7 +132,7 @@ data:
           podsHavingTooManyRestarts:
             podRestartThreshold: 100
             includingInitContainers: true
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
+    {{- include "additional_parameters" $strategies.removePodsHavingTooManyRestarts | nindent 10 }}
   {{- else }}
       "RemovePodsHavingTooManyRestarts":
         enabled: false
@@ -146,7 +146,6 @@ data:
             maxPodLifeTimeSeconds: 86400
             podStatusPhases:
               - "Pending"
-    {{- include "additional_parameters" $strategies.removeDuplicates | nindent 10 }}
   {{- else }}
       "PodLifeTime":
         enabled: false


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove incorrect inclusions of the `removeDuplicates` field in the descheduler policy ConfigMap.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close #5844

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: fix
summary: Remove incorrect inclusions of the 'removeDuplicates' field.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
