### PR TITLE
[node-manager](caps) Add the ability to disable StaticInstance bootstrapping

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -129,7 +129,11 @@ bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-w
 
 A `StaticInstance` that is in the `Pending` state can be deleted with no adverse effects.
 
-To delete a `StaticInstance` in any state other than `Pending` (`Runnig`, `Cleaning`, `Bootstraping`), you need to delete the corresponding  [Instance](cr.html#instance) resource, and then the `StaticInstance` will be deleted automatically.
+To delete a `StaticInstance` in any state other than `Pending` (`Runnig`, `Cleaning`, `Bootstraping`), you need to:
+1. Add the label `"node.deckhouse.io/allow-bootstrap": "false"` to the `StaticInstance`.
+1. Wait until the `StaticInstance` status becomes `Pending`.
+1. Delete the `StaticInstance`.
+1. Decrease the `NodeGroup.spec.staticInstances.count` field by 1.
 
 ### How do I change the IP address of a StaticInstance?
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -132,7 +132,7 @@ bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-w
 
 `StaticInstance`, находящийся в состоянии `Pending` можно удалять без каких-либо проблем.
 
-Чтобы удалить `StaticInstance` находящийся в любом состоянии отличном от `Pending` (`Runnig`, `Cleaning`, `Bootstraping`):
+Чтобы удалить `StaticInstance` находящийся в любом состоянии, отличном от `Pending` (`Running`, `Cleaning`, `Bootstraping`):
 1. Добавьте лейбл `"node.deckhouse.io/allow-bootstrap": "false"` в `StaticInstance`.
 1. Дождитесь, пока `StaticInstance` перейдет в статус `Pending`.
 1. Удалите `StaticInstance`.

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -132,7 +132,11 @@ bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-w
 
 `StaticInstance`, находящийся в состоянии `Pending` можно удалять без каких-либо проблем.
 
-Чтобы удалить `StaticInstance` находящийся в любом состоянии отличном от `Pending` (`Runnig`, `Cleaning`, `Bootstraping`), нужно удалить соответствующий ресурс [Instance](cr.html#instance), после чего `StaticInstance` удалится автоматически.
+Чтобы удалить `StaticInstance` находящийся в любом состоянии отличном от `Pending` (`Runnig`, `Cleaning`, `Bootstraping`):
+1. Добавьте лейбл `"node.deckhouse.io/allow-bootstrap": "false"` в `StaticInstance`.
+1. Дождитесь, пока `StaticInstance` перейдет в статус `Pending`.
+1. Удалите `StaticInstance`.
+1. Уменьшите значение параметра `NodeGroup.spec.staticInstances.count` на 1.
 
 ### Как изменить IP-адрес StaticInstance?
 

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
@@ -81,7 +81,7 @@ func (r *StaticInstance) ValidateDelete() (admission.Warnings, error) {
 		return nil, apierrors.NewForbidden(schema.GroupResource{
 			Group:    r.GroupVersionKind().Group,
 			Resource: "staticinstances",
-		}, r.Name, errors.New("if you need to delete a StaticInstance that is not pending, you can find the associated Instance and delete it manually, after which the StaticInstance will be deleted automatically"))
+		}, r.Name, errors.New(`if you need to delete a StaticInstance that is not pending, you need to add the label '"node.deckhouse.io/allow-bootstrap": "false"' to the StaticInstance, after which you need to wait until the StaticInstance status becomes 'Pending'. Do not forget to decrease the 'NodeGroup.spec.staticInstances.count' field by 1, if needed`))
 	}
 
 	return nil, nil

--- a/modules/040-node-manager/images/caps-controller-manager/src/go.mod
+++ b/modules/040-node-manager/images/caps-controller-manager/src/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.2
 	golang.org/x/crypto v0.14.0
 	k8s.io/api v0.28.1
 	k8s.io/apimachinery v0.28.1
@@ -49,6 +50,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/modules/040-node-manager/images/caps-controller-manager/src/go.sum
+++ b/modules/040-node-manager/images/caps-controller-manager/src/go.sum
@@ -140,6 +140,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/machine_scope_test.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/machine_scope_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	infrav1 "caps-controller-manager/api/infrastructure/v1alpha1"
+)
+
+func TestMachineScopeLabelSelector(t *testing.T) {
+	tests := []struct {
+		machineScope MachineScope
+		err          bool
+	}{
+		{
+			machineScope: MachineScope{
+				StaticMachine: &infrav1.StaticMachine{},
+			},
+		},
+		{
+			machineScope: MachineScope{
+				StaticMachine: &infrav1.StaticMachine{
+					Spec: infrav1.StaticMachineSpec{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"node-group": "worker",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			machineScope: MachineScope{
+				StaticMachine: &infrav1.StaticMachine{
+					Spec: infrav1.StaticMachineSpec{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"node.deckhouse.io/allow-bootstrap": "true",
+							},
+						},
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			machineScope: MachineScope{
+				StaticMachine: &infrav1.StaticMachine{
+					Spec: infrav1.StaticMachineSpec{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "node.deckhouse.io/allow-bootstrap",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"false"},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: true,
+		},
+	}
+
+	allowBootstrapRequirement, err := labels.NewRequirement("node.deckhouse.io/allow-bootstrap", selection.NotIn, []string{"false"})
+	require.NoError(t, err)
+
+	for _, test := range tests {
+		labelSelector, err := test.machineScope.LabelSelector()
+		if test.err {
+			require.Error(t, err)
+			continue
+		}
+
+		require.NoError(t, err)
+
+		requirements, _ := labelSelector.Requirements()
+
+		require.Equal(t, *allowBootstrapRequirement, requirements[len(requirements)-1])
+	}
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add the `"node.deckhouse.io/allow-bootstrap": "false"` label requirement to the `StaticInstance` label selector. Add a detailed description of `StaticInstance` deletion to the documentation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close #7370.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Add the ability to disable StaticInstance bootstrapping by adding the '"node.deckhouse.io/allow-bootstrap": "false"' label.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
