### PR TITLE
[node-manager] Forbid to change NodeGroup if it contains unknown zone

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -16,6 +16,7 @@
 
 source /shell_lib.sh
 
+# "e30=" is base64-encoded empty JSON ("{}"). It is used as default so that `fromjson` does not return an error.
 function __config__(){
   cat <<EOF
 configVersion: v1
@@ -52,6 +53,23 @@ kubernetes:
         "defaultCRI": (.data."cluster-configuration.yaml" // "" | @base64d | match("[ ]*defaultCRI:[ ]+(.*)\n").captures[0].string),
         "clusterPrefixLen": (.data."cluster-configuration.yaml" // "" | @base64d | match("[ ]*prefix:[ ]+(.*)\n").captures[0].string | length),
         "clusterType": (.data."cluster-configuration.yaml" // "" | @base64d | match("clusterType:[ ]+(.*)\n").captures[0].string)
+      }
+  - name: provider_cluster_config
+    apiVersion: v1
+    kind: Secret
+    group: main
+    executeHookOnEvent: []
+    executeHookOnSynchronization: false
+    keepFullObjectsInMemory: false
+    namespace:
+      nameSelector:
+        matchNames: ["kube-system"]
+    nameSelector:
+      matchNames:
+        - d8-provider-cluster-configuration
+    jqFilter: |
+      {
+        "zones": (.data."cloud-provider-discovery-data.json" // "e30=" | @base64d | fromjson | .zones // [])
       }
   - name: deckhouse_config
     apiVersion: deckhouse.io/v1alpha1
@@ -102,6 +120,21 @@ EOF
 {"allowed":false, "message":"it is forbidden to set maxPerZone lower than minPerZone for NodeGroup"}
 EOF
     return 0
+  fi
+
+  # Check zones existence for CloudEphemeral nodes
+  allowedZones=$(context::jq -e -r 'if (.snapshots.provider_cluster_config | length) > 0 then .snapshots.provider_cluster_config[0].filterResult.zones else [] end | if . == [] then [] else .[] end')
+  ngZones=$(context::jq -r '.review.request.object.spec.cloudInstances.zones // []')
+
+  if [[ "$allowedZones" != "[]" ]]; then
+    for zone in $(jq -e -r '.[]' <<< "$ngZones"); do
+      if ! printf '%s\n' "${allowedZones[@]}" | grep -qE "^$zone\$"; then
+        cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"unknown zone \"${zone}\"}
+EOF
+        return 0
+      fi
+    done
   fi
 
   criType="$(context::jq -r '.review.request.object.spec.cri.type')"

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -130,7 +130,7 @@ EOF
     for zone in $(jq -e -r '.[]' <<< "$ngZones"); do
       if ! printf '%s\n' "${allowedZones[@]}" | grep -qE "^$zone\$"; then
         cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"unknown zone \"${zone}\"}
+{"allowed":false, "message":"unknown zone \"${zone}\""}
 EOF
         return 0
       fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Forbid to change NodeGroup if it contains unknown zone.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now, if a NodeGroup contains an unknown zone (e.g. a typo), node-manager will remove it from internal values and all nodes in that NodeGroup will be removed.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We added new zone support to YandexCloud in release 1.56 (https://github.com/deckhouse/deckhouse/pull/6652) and users can start actively changing zones in NodeGroup manifests and can break their cluster through configuration errors or typos.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Forbid to change NodeGroup if it contains unknown zone.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
