### PR TITLE
[prometheus] alerts-receiver: fix concurrent map access

### DIFF
--- a/modules/300-prometheus/images/alerts-receiver/src/main.go
+++ b/modules/300-prometheus/images/alerts-receiver/src/main.go
@@ -93,6 +93,7 @@ func reconcile(ctx context.Context, s *storeStruct) {
 
 	// Add or update CRs
 	alertSet := make(map[string]struct{}, len(s.memStore.alerts))
+	s.memStore.RLock()
 	for fingerprint, alert := range s.memStore.alerts {
 		if alert.Resolved() {
 			s.memStore.removeAlert(fingerprint)
@@ -115,6 +116,7 @@ func reconcile(ctx context.Context, s *storeStruct) {
 			log.Error(err)
 		}
 	}
+	s.memStore.RUnlock()
 
 	// Remove CRs which do not have corresponding alerts
 	for k := range crSet {


### PR DESCRIPTION
## Description
Add RLock/RUnlock while reading memStore alert map on periodic reconcile.
This map is also accessed by the webserver handler (evokes insertAlert() which uses Lock/Unlick).
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Alerts-receiver periodically throws `fatal error: concurrent map iteration and map write` errors.
```
goroutine 35 [running]:
main.reconcile({0xc7ce58, 0xc000223480}, 0xc00021fdd0)
	/app/main.go:96 +0x1e6
main.reconcileLoop({0xc7ce58, 0xc000223480}, 0x0?)
	/app/main.go:80 +0x59
created by main.main
	/app/main.go:63 +0x31f

goroutine 1 [chan receive, 301 minutes]:
main.main()
	/app/main.go:65 +0x339

goroutine 8 [syscall, 301 minutes]:
os/signal.signal_recv()
	/usr/local/go/src/runtime/sigqueue.go:152 +0x2f
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:23 +0x19
created by os/signal.Notify.func1.1
	/usr/local/go/src/os/signal/signal.go:151 +0x2a

goroutine 33 [chan receive, 301 minutes]:
main.main.func1()
	/app/main.go:44 +0x35
created by main.main
	/app/main.go:43 +0x22d

goroutine 34 [IO wait]:
internal/poll.runtime_pollWait(0x7f70e0088ef8, 0x72)
	/usr/local/go/src/runtime/netpoll.go:305 +0x89
internal/poll.(*pollDesc).wait(0xc00012a080?, 0x6?, 0x0)
...
```
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
There is no `fatal error: concurrent map iteration and map write` errors there.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus-operator
type: chore
summary: Fix concurrent map access error.
impact: Internal alerts-receiver will be restarted.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
