### PR TITLE
[candi] remove `yum versionlock` and `apt-mark hold`

### DIFF
--- a/candi/bashible/bashbooster/50_apt.sh
+++ b/candi/bashible/bashbooster/50_apt.sh
@@ -102,7 +102,6 @@ bb-apt-install() {
         bb-apt-update
         bb-log-info "Installing packages '${PACKAGES_TO_INSTALL[@]}'"
         apt -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install --allow-change-held-packages --allow-downgrades -y ${PACKAGES_TO_INSTALL[@]}
-        bb-apt-hold ${PACKAGES_TO_INSTALL[@]}
         bb-exit-on-error "Failed to install packages '${PACKAGES_TO_INSTALL[@]}'"
         printf '%s\n' "${PACKAGES_TO_INSTALL[@]}" >> "$BB_APT_UNHANDLED_PACKAGES_STORE"
         NEED_FIRE=true
@@ -138,24 +137,6 @@ bb-apt-autoremove() {
     export DEBIAN_FRONTEND=noninteractive
     bb-log-info 'Autoremoving unused packages'
     apt -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --purge -y autoremove
-}
-
-bb-apt-hold?() {
-    dpkg -s "$1" 2> /dev/null | grep -q '^Status:.\+installed'
-}
-
-bb-apt-hold() {
-    for PACKAGE in "$@"
-    do
-        apt-mark hold "$PACKAGE"
-    done
-}
-
-bb-apt-unhold() {
-    for PACKAGE in "$@"
-    do
-        apt-mark unhold "$PACKAGE"
-    done
 }
 
 bb-apt-package-upgrade?() {

--- a/candi/bashible/bashbooster/50_yum.sh
+++ b/candi/bashible/bashbooster/50_yum.sh
@@ -62,15 +62,7 @@ bb-yum-install() {
         bb-yum-update
         bb-log-info "Installing packages '${PACKAGES_TO_INSTALL[@]}'"
 
-        for PACKAGE in ${PACKAGES_TO_INSTALL[@]}; do
-            # nfs-utils-1.3.0-0.68.el7.x86_64 -> nfs-utils
-            # nfs-utils -> nfs-utils
-            PACKAGE_NAME="${PACKAGE%-*-*}"
-            bb-yum-versionlock-delete $PACKAGE_NAME
-        done
-
         yum install $BB_YUM_INSTALL_EXTRA_ARGS -y ${PACKAGES_TO_INSTALL[@]}
-        bb-yum-versionlock-add ${PACKAGES_TO_INSTALL[@]}
         bb-exit-on-error "Failed to install packages '${PACKAGES_TO_INSTALL[@]}'"
         printf '%s\n' "${PACKAGES_TO_INSTALL[@]}" >> "$BB_YUM_UNHANDLED_PACKAGES_STORE"
         NEED_FIRE=true
@@ -88,24 +80,6 @@ bb-yum-remove() {
             bb-log-info "Removing package '$PACKAGE'"
             yum remove -y "$PACKAGE"
             bb-exit-on-error "Failed to remove package '$PACKAGE'"
-        fi
-    done
-}
-
-bb-yum-versionlock-add() {
-    for PACKAGE in "$@"; do
-        bb-log-info "Locking package version of '$PACKAGE'"
-        yum versionlock add "$PACKAGE"
-        bb-exit-on-error "Failed to lock package version of '$PACKAGE'"
-    done
-}
-
-bb-yum-versionlock-delete() {
-    for PACKAGE in "$@"; do
-        if yum versionlock list | grep -q "$PACKAGE"; then
-            bb-log-info "Unlocking package version of '$PACKAGE'"
-            yum versionlock delete "$PACKAGE"
-            bb-exit-on-error "Failed to unlock package version of '$PACKAGE'"
         fi
     done
 }

--- a/candi/bashible/bundles/centos/all/003_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/bundles/centos/all/003_install_mandatory_packages.sh.tpl
@@ -23,12 +23,6 @@ fi
 if bb-is-centos-version? 9; then
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} policycoreutils-python-utils"
 fi
-# yum-plugin-versionlock is needed for bb-yum-install
-if yum --version | grep -q dnf; then
-  bb-yum-install python3-dnf-plugin-versionlock
-else
-  bb-yum-install yum-plugin-versionlock
-fi
 
 bb-yum-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}
 

--- a/ee/be/candi/bashible/bundles/redos/all/003_install_mandatory_packages.sh.tpl
+++ b/ee/be/candi/bashible/bundles/redos/all/003_install_mandatory_packages.sh.tpl
@@ -7,8 +7,6 @@ if bb-is-redos-version? 7.3; then
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} policycoreutils-python"
 fi
 
-bb-yum-install python3-dnf-plugin-versionlock
-
 bb-yum-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}
 
 bb-rp-install "jq:{{ .images.registrypackages.jq16 }}" "curl:{{ .images.registrypackages.d8Curl821 }}"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove `yum versionlock` and `apt-mark hold`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close #6242.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Remove 'yum versionlock' and 'apt-mark hold'.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
