### PR TITLE
[prometheus] fix alerts-receiver lock issue

### DIFF
--- a/modules/300-prometheus/images/alerts-receiver/src/main.go
+++ b/modules/300-prometheus/images/alerts-receiver/src/main.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/prometheus/common/model"
 )
 
 func main() {
@@ -93,10 +95,11 @@ func reconcile(ctx context.Context, s *storeStruct) {
 
 	// Add or update CRs
 	alertSet := make(map[string]struct{}, len(s.memStore.alerts))
+	alertsToRemove := make([]model.Fingerprint, 0, len(s.memStore.alerts))
 	s.memStore.RLock()
 	for fingerprint, alert := range s.memStore.alerts {
 		if alert.Resolved() {
-			defer s.memStore.removeAlert(fingerprint)
+			alertsToRemove = append(alertsToRemove, fingerprint)
 			continue
 		}
 
@@ -117,6 +120,8 @@ func reconcile(ctx context.Context, s *storeStruct) {
 		}
 	}
 	s.memStore.RUnlock()
+
+	s.memStore.removeAlerts(alertsToRemove)
 
 	// Remove CRs which do not have corresponding alerts
 	for k := range crSet {

--- a/modules/300-prometheus/images/alerts-receiver/src/main.go
+++ b/modules/300-prometheus/images/alerts-receiver/src/main.go
@@ -96,7 +96,7 @@ func reconcile(ctx context.Context, s *storeStruct) {
 	s.memStore.RLock()
 	for fingerprint, alert := range s.memStore.alerts {
 		if alert.Resolved() {
-			s.memStore.removeAlert(fingerprint)
+			defer s.memStore.removeAlert(fingerprint)
 			continue
 		}
 

--- a/modules/300-prometheus/images/alerts-receiver/src/memstore.go
+++ b/modules/300-prometheus/images/alerts-receiver/src/memstore.go
@@ -85,6 +85,16 @@ func (a *memStore) removeAlert(fingerprint model.Fingerprint) {
 	delete(a.alerts, fingerprint)
 }
 
+// Remove a bunch of alerts from internal store
+func (a *memStore) removeAlerts(fingerprints []model.Fingerprint) {
+	a.Lock()
+	defer a.Unlock()
+	for _, fingerprint := range fingerprints {
+		log.Infof("alert with fingerprint %s removed from queue", fingerprint)
+		delete(a.alerts, fingerprint)
+	}
+}
+
 // Get alert from internal store
 func (a *memStore) getAlert(fingerprint model.Fingerprint) (*types.Alert, bool) {
 	a.Lock()


### PR DESCRIPTION
## Description
Instead of deleting resolved alerts one by one, we accumulate them in a list, take a Lock over memStore and delete all of them at once.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
There is a bug in the code: It takes RLock for the whole loop over memstore map while inside the loop there is another Lock to delete some elemets from the map. It prevents alerts-receiver from deleting stale alerts from memStore.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It fixes a bug introduced by another fix.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Clusteralerts are get deleted properly.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus-operator
type: fix
summary: Fix alerts-receiver reconcile loop issue.
impact: Alerts-receiver pod will be recreated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
