### PR TITLE
[dhctl] fix(dhctl-for-commander): create all terraform runners using TerraformContext

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -35,7 +36,9 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	app.DefinePreflight(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.Bootstrap()
 	})
 

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -31,7 +32,9 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 	app.DefineDeckhouseInstallFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.InstallDeckhouse()
 	})
 
@@ -46,7 +49,9 @@ func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause) *kingpin.C
 	app.DefineBashibleBundleFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.ExecuteBashible()
 	})
 
@@ -61,7 +66,9 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineKubeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.CreateResources()
 	})
 
@@ -78,7 +85,9 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineAbortFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.Abort(app.ForceAbortFromCache)
 	})
 
@@ -92,7 +101,9 @@ func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause) *kingpin.CmdClau
 	app.DefineDropCacheFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.BaseInfrastructure()
 	})
 
@@ -106,7 +117,9 @@ func DefineExecPostBootstrapScript(parent *kingpin.CmdClause) *kingpin.CmdClause
 	app.DefinePostBootstrapScriptFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{})
+		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			TerraformContext: terraform.NewTerraformContext(),
+		})
 		return bootstraper.ExecPostBootstrap()
 	})
 

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -65,9 +66,10 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 		}
 
 		destroyer, err := destroy.NewClusterDestroyer(&destroy.Params{
-			SSHClient:     sshClient,
-			StateCache:    cache.Global(),
-			SkipResources: app.SkipResources,
+			SSHClient:        sshClient,
+			StateCache:       cache.Global(),
+			SkipResources:    app.SkipResources,
+			TerraformContext: terraform.NewTerraformContext(),
 		})
 		if err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -127,9 +127,12 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 			log.DebugF(fmt.Sprintf("Abort from cache. tf-state-and-manifests-in-cluster=%v; Force abort %v\n", ok, forceAbortFromCache))
 			if metaConfig.ClusterType == config.CloudClusterType {
 				terraStateLoader := terrastate.NewFileTerraStateLoader(stateCache, metaConfig)
-				destroyer = infrastructure.NewClusterInfraWithOptions(terraStateLoader, stateCache, infrastructure.ClusterInfraOptions{
-					PhasedExecutionContext: b.PhasedExecutionContext,
-				})
+				destroyer = infrastructure.NewClusterInfraWithOptions(
+					terraStateLoader, stateCache, b.TerraformContext,
+					infrastructure.ClusterInfraOptions{
+						PhasedExecutionContext: b.PhasedExecutionContext,
+					},
+				)
 			} else {
 				sshClient, err := getSSHClient(b.initializeNewAgent)
 				if err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -23,7 +23,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
 func (b *ClusterBootstrapper) BaseInfrastructure() error {
@@ -62,10 +61,7 @@ func (b *ClusterBootstrapper) BaseInfrastructure() error {
 	metaConfig.UUID = clusterUUID
 
 	return log.Process("bootstrap", "Cloud infrastructure", func() error {
-		baseRunner := terraform.NewRunnerFromConfig(metaConfig, "base-infrastructure", stateCache).
-			WithVariables(metaConfig.MarshalConfig()).
-			WithAutoApprove(true)
-		tomb.RegisterOnShutdown("base-infrastructure", baseRunner.Stop)
+		baseRunner := b.Params.TerraformContext.GetBootstrapBaseInfraRunner(metaConfig, stateCache)
 
 		_, err := terraform.ApplyPipeline(baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
 		return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -37,7 +37,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
 const (
@@ -77,6 +76,7 @@ type Params struct {
 	DisableBootstrapClearCache bool
 	OnPhaseFunc                phases.OnPhaseFunc
 	CommanderMode              bool
+	TerraformContext           *terraform.TerraformContext
 
 	ConfigPath              string
 	ResourcesPath           string
@@ -283,10 +283,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			return err
 		}
 		err = log.Process("bootstrap", "Cloud infrastructure", func() error {
-			baseRunner := terraform.NewRunnerFromConfig(metaConfig, "base-infrastructure", stateCache).
-				WithVariables(metaConfig.MarshalConfig()).
-				WithAutoApprove(true)
-			tomb.RegisterOnShutdown("base-infrastructure", baseRunner.Stop)
+			baseRunner := b.TerraformContext.GetBootstrapBaseInfraRunner(metaConfig, stateCache)
 
 			baseOutputs, err := terraform.ApplyPipeline(baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
 			if err != nil {
@@ -304,11 +301,14 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			}
 
 			masterNodeName := fmt.Sprintf("%s-master-0", metaConfig.ClusterPrefix)
-			masterRunner := terraform.NewRunnerFromConfig(metaConfig, "master-node", stateCache).
-				WithVariables(metaConfig.NodeGroupConfig("master", 0, "")).
-				WithName(masterNodeName).
-				WithAutoApprove(true)
-			tomb.RegisterOnShutdown(masterNodeName, masterRunner.Stop)
+			masterRunner := b.Params.TerraformContext.GetBootstrapNodeRunner(metaConfig, stateCache, terraform.BootstrapNodeRunnerOptions{
+				AutoApprove:     true,
+				NodeName:        masterNodeName,
+				NodeGroupStep:   "master-node",
+				NodeGroupName:   "master",
+				NodeIndex:       0,
+				NodeCloudConfig: "",
+			})
 
 			masterOutputs, err := terraform.ApplyPipeline(masterRunner, masterNodeName, terraform.GetMasterNodeResult)
 			if err != nil {
@@ -407,7 +407,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		}
 
 		err := converge.NewInLockLocalRunner(kubeCl, "local-bootstraper").Run(func() error {
-			return bootstrapAdditionalNodesForCloudCluster(kubeCl, metaConfig, masterAddressesForSSH)
+			return bootstrapAdditionalNodesForCloudCluster(kubeCl, metaConfig, masterAddressesForSSH, b.TerraformContext)
 		})
 		if err != nil {
 			return err
@@ -526,13 +526,13 @@ func generateClusterUUID(stateCache state.Cache) (string, error) {
 	return clusterUUID, err
 }
 
-func bootstrapAdditionalNodesForCloudCluster(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, masterAddressesForSSH map[string]string) error {
-	if err := BootstrapAdditionalMasterNodes(kubeCl, metaConfig, masterAddressesForSSH); err != nil {
+func bootstrapAdditionalNodesForCloudCluster(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, masterAddressesForSSH map[string]string, terraformContext *terraform.TerraformContext) error {
+	if err := BootstrapAdditionalMasterNodes(kubeCl, metaConfig, masterAddressesForSSH, terraformContext); err != nil {
 		return err
 	}
 
 	terraNodeGroups := metaConfig.GetTerraNodeGroups()
-	if err := BootstrapTerraNodes(kubeCl, metaConfig, terraNodeGroups); err != nil {
+	if err := BootstrapTerraNodes(kubeCl, metaConfig, terraNodeGroups, terraformContext); err != nil {
 		return err
 	}
 

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/frontend"
+	tf "github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
@@ -47,6 +48,8 @@ type Params struct {
 
 	CommanderMode bool
 	*commander.CommanderModeParams
+
+	TerraformContext *tf.TerraformContext
 }
 
 type ClusterDestroyer struct {
@@ -87,7 +90,7 @@ func NewClusterDestroyer(params *Params) (*ClusterDestroyer, error) {
 		terraStateLoader = terraform.NewLazyTerraStateLoader(terraform.NewCachedTerraStateLoader(d8Destroyer, state.cache))
 	}
 
-	clusterInfra := infra.NewClusterInfraWithOptions(terraStateLoader, state.cache, infra.ClusterInfraOptions{PhasedExecutionContext: pec})
+	clusterInfra := infra.NewClusterInfraWithOptions(terraStateLoader, state.cache, params.TerraformContext, infra.ClusterInfraOptions{PhasedExecutionContext: pec})
 
 	staticDestroyer := NewStaticMastersDestroyer(params.SSHClient)
 

--- a/dhctl/pkg/terraform/pipeline.go
+++ b/dhctl/pkg/terraform/pipeline.go
@@ -101,7 +101,7 @@ func CheckPipeline(r RunnerInterface, name string) (int, *PlanDestructiveChanges
 
 type BaseInfrastructureDestructiveChanges struct {
 	PlanDestructiveChanges
-	OutputBrokenReason string      `json:"output_broken_reason"`
+	OutputBrokenReason string      `json:"output_broken_reason,omitempty"`
 	OutputZonesChanged ValueChange `json:"output_zones_changed,omitempty"`
 }
 


### PR DESCRIPTION
## Description

Prepare terraform runner creation code to reuse terraform runners between check and actual converge inside check+converge operation. This is part 1/2 PR to achieve this task.

## Why do we need it, and what problem does it solve?

Plan should be generated only once, because we approve first plan generated by the terraform check. It should not be changed after this approval. Otherwise we will converge unapproved changes.

