### PR TITLE
[candi] Improve strict for validation pattern of proxy

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -137,7 +137,7 @@ apiVersions:
           httpProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTP requests.
 
@@ -148,7 +148,7 @@ apiVersions:
           httpsProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTPS requests.
 

--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -137,7 +137,7 @@ apiVersions:
           httpProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTP requests.
 
@@ -148,7 +148,7 @@ apiVersions:
           httpsProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://[0-9a-zA-Z\.\-:@_]+$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTPS requests.
 


### PR DESCRIPTION
## Description
Improve strict for validation pattern of proxy.

## Why do we need it, and what problem does it solve?
A more strict pattern is better than unexpected behavior during the installation process.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Improve strict for validation pattern of proxy.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
