### PR TITLE
[docs] Mark K8s 1.24 as EOL on the site

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -19,7 +19,7 @@ bashible: &bashible
     '10.2':
 k8s:
   '1.24':
-    status: available
+    status: end-of-life
     patch: 17
     bashible: *bashible
     clusterAutoscalerPatch: 3


### PR DESCRIPTION
## Description

Mark K8s 1.24 as EOL on the site.

Ref: https://github.com/deckhouse/deckhouse/pull/7268

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Mark K8s 1.24 as EOL on the site.
impact_level: low
```
