### PR TITLE
[external-module-manager] prevent releases with versions less than a …

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/predictor.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/predictor.go
@@ -51,8 +51,7 @@ func (rp *releasePredictor) calculateRelease() {
 	}
 
 	for index, rl := range rp.releases {
-		switch rl.Status.Phase {
-		case v1alpha1.PhasePending:
+		if rl.Status.Phase == v1alpha1.PhasePending {
 			if rp.desiredReleaseIndex >= 0 {
 				previousPredictedRelease := rp.releases[rp.desiredReleaseIndex]
 				if previousPredictedRelease.Spec.Version.Major() != rl.Spec.Version.Major() {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/predictor.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/predictor.go
@@ -44,10 +44,14 @@ func newReleasePredictor(releases []*v1alpha1.ModuleRelease) *releasePredictor {
 
 func (rp *releasePredictor) calculateRelease() {
 	for index, rl := range rp.releases {
-		switch rl.Status.Phase {
-		case v1alpha1.PhaseDeployed:
+		if rl.Status.Phase == v1alpha1.PhaseDeployed {
 			rp.currentReleaseIndex = index
+			break
+		}
+	}
 
+	for index, rl := range rp.releases {
+		switch rl.Status.Phase {
 		case v1alpha1.PhasePending:
 			if rp.desiredReleaseIndex >= 0 {
 				previousPredictedRelease := rp.releases[rp.desiredReleaseIndex]
@@ -62,7 +66,15 @@ func (rp *releasePredictor) calculateRelease() {
 				rp.skippedPatchesIndexes = append(rp.skippedPatchesIndexes, rp.desiredReleaseIndex)
 			}
 
-			// release is predicted to be Deployed
+			// if we have a deployed a release
+			if rp.currentReleaseIndex >= 0 {
+				// if deployed version is greater than the pending one, this pending release should be superseded
+				if rp.releases[rp.currentReleaseIndex].Spec.Version.GreaterThan(rl.Spec.Version) {
+					rp.skippedPatchesIndexes = append(rp.skippedPatchesIndexes, index)
+					continue
+				}
+			}
+			// in other cases we have a new desired version of a module
 			rp.desiredReleaseIndex = index
 		}
 	}


### PR DESCRIPTION
…deployed one from deploying

## Description
This PR provides additional conditionals in the release predictor to prevent it from designating a release with a version less than the current deployed release version as a next desired release.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
As of now, it a new release emerges with a version less than the current deployed release version, it is regarded as next possible release and can be deployed instead of marking as superseded.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

## What is the expected result?
Only releases with versions greater than the current deploy version should be eligible for deploying.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: external-module-manager
type: chore
summary: Prevent releases with versions less than current deployed version from deploying.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
