### PR TITLE
[candi][cloud-provider-yandex] Allow to customize NAT instance resources

### DIFF
--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/base-infrastructure/main.tf
@@ -39,6 +39,8 @@ module "vpc_components" {
   nat_instance_internal_address = local.nat_instance_internal_address
   nat_instance_internal_subnet_id = local.nat_instance_internal_subnet_id
   nat_instance_external_subnet_id = local.nat_instance_external_subnet_id
+  nat_instance_cores = local.nat_instance_cores
+  nat_instance_memory = local.nat_instance_memory
   nat_instance_ssh_key = var.providerClusterConfiguration.sshPublicKey
 
   labels = local.labels

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
@@ -47,6 +47,8 @@ locals {
   nat_instance_external_subnet_id = lookup(var.providerClusterConfiguration.withNATInstance, "externalSubnetID", null)
   nat_instance_external_address = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceExternalAddress", null)
   nat_instance_internal_address = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceInternalAddress", null)
+  nat_instance_cores = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceCores", 2)
+  nat_instance_memory = floor(lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceMemory", 2048) / 1024)
   exporter_api_key = lookup(var.providerClusterConfiguration.withNATInstance, "exporterAPIKey", "")
 
   dhcp_options = lookup(var.providerClusterConfiguration, "dhcpOptions", null)

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
@@ -47,8 +47,8 @@ locals {
   nat_instance_external_subnet_id = lookup(var.providerClusterConfiguration.withNATInstance, "externalSubnetID", null)
   nat_instance_external_address = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceExternalAddress", null)
   nat_instance_internal_address = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceInternalAddress", null)
-  nat_instance_cores = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceCores", 2)
-  nat_instance_memory = floor(lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceMemory", 2048) / 1024)
+  nat_instance_cores = lookup(var.providerClusterConfiguration.withNATInstance.natInstanceResources, "cores", 2)
+  nat_instance_memory = floor(lookup(var.providerClusterConfiguration.withNATInstance.natInstanceResources, "memory", 2048) / 1024)
   exporter_api_key = lookup(var.providerClusterConfiguration.withNATInstance, "exporterAPIKey", "")
 
   dhcp_options = lookup(var.providerClusterConfiguration, "dhcpOptions", null)

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -377,6 +377,7 @@ apiVersions:
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
             type: object
             default: {"cores": 2, "memory": 2048}
+            x-doc-default: ""
             properties:
               cores:
                 description: |

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -372,18 +372,22 @@ apiVersions:
             description: |
               If specified, an additional network interface will be added to the node (the node will use it as a default route).
             type: string
-          natInstanceCores:
+          natInstanceResources:
             description: |
-              Amount of CPU cores to provision on the NAT instance.
-            type: integer
-            default: 2
-            x-doc-default: 2
-          natInstanceMemory:
-            description: |
-              Amount of primary memory in MB provision on the NAT instance.
-            type: integer
-            default: 2048
-            x-doc-default: 2048
+              Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
+            type: object
+            default: {}
+            properties:
+              cores:
+                description: |
+                  Amount of CPU cores to provision on the NAT instance.
+                type: integer
+                default: 2
+              memory:
+                description: |
+                  Amount of primary memory in MB provision on the NAT instance.
+                type: integer
+                default: 2048
       provider:
         type: object
         description: |

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -377,7 +377,7 @@ apiVersions:
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
             type: object
             default: {"cores": 2, "memory": 2048}
-            x-doc-default: ""
+            x-doc-default: {}
             properties:
               cores:
                 description: |

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -372,6 +372,18 @@ apiVersions:
             description: |
               If specified, an additional network interface will be added to the node (the node will use it as a default route).
             type: string
+          natInstanceCores:
+            description: |
+              Amount of CPU cores to provision on the NAT instance.
+            type: integer
+            default: 2
+            x-doc-default: 2
+          natInstanceMemory:
+            description: |
+              Amount of primary memory in MB provision on the NAT instance.
+            type: integer
+            default: 2048
+            x-doc-default: 2048
       provider:
         type: object
         description: |

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -376,7 +376,6 @@ apiVersions:
             description: |
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
             type: object
-            default: {}
             properties:
               cores:
                 description: |

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -376,6 +376,7 @@ apiVersions:
             description: |
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
             type: object
+            default: {"cores": 2, "memory": 2048}
             properties:
               cores:
                 description: |

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -174,6 +174,12 @@ apiVersions:
           externalSubnetID:
             description: |
               Подключаемый к узлу дополнительный сетевой интерфейс, в который будет идти маршрут по умолчанию.
+          natInstanceCores:
+            description: |
+              Количество ядер у создаваемого NAT-инстанса.
+          natInstanceMemory:
+            description: |
+              Количество оперативной памяти (в мегабайтах) у создаваемого NAT-инстанса.
       provider:
         description: |
           [Параметры подключения](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-yandex/environment.html) к API Yandex Cloud.

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -174,12 +174,17 @@ apiVersions:
           externalSubnetID:
             description: |
               Подключаемый к узлу дополнительный сетевой интерфейс, в который будет идти маршрут по умолчанию.
-          natInstanceCores:
+          natInstanceResources:
             description: |
-              Количество ядер у создаваемого NAT-инстанса.
-          natInstanceMemory:
-            description: |
-              Количество оперативной памяти (в мегабайтах) у создаваемого NAT-инстанса.
+              Вычислительные ресурсы, выделяемые для NAT-инстанса. Если параметр не указан, будут использоваться значения по умолчанию.
+            type: object
+            properties:
+              cores:
+                description: |
+                  Количество ядер у создаваемого NAT-инстанса.
+              memory:
+                description: |
+                  Количество оперативной памяти (в мегабайтах) у создаваемого NAT-инстанса.
       provider:
         description: |
           [Параметры подключения](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-yandex/environment.html) к API Yandex Cloud.

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -115,8 +115,8 @@ resource "yandex_compute_instance" "nat_instance" {
 
   platform_id = "standard-v2"
   resources {
-    cores  = 2
-    memory = 2
+    cores  = var.nat_instance_cores
+    memory = var.nat_instance_memory
   }
 
   boot_disk {

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -64,6 +64,14 @@ variable "nat_instance_external_subnet_id" {
   default = null
 }
 
+variable "nat_instance_cores" {
+  type = number
+}
+
+variable "nat_instance_memory" {
+  type = number
+}
+
 variable "nat_instance_ssh_key" {
   type = string
   default = ""

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -66,10 +66,12 @@ variable "nat_instance_external_subnet_id" {
 
 variable "nat_instance_cores" {
   type = number
+  default = null
 }
 
 variable "nat_instance_memory" {
   type = number
+  default = null
 }
 
 variable "nat_instance_ssh_key" {

--- a/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
@@ -98,6 +98,9 @@ withNATInstance:
   internalSubnetID: test
   natInstanceExternalAddress: 84.201.160.148
   exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
 nodeNetworkCIDR: 84.201.160.148/31
 sshPublicKey: ssh-rsa AAAAAbbbb
 `

--- a/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
@@ -98,6 +98,8 @@ withNATInstance:
   internalSubnetID: test
   natInstanceExternalAddress: 84.201.160.148
   exporterAPIKey: ""
+  natInstanceCores: 2
+  natInstanceMemory: 2048
 nodeNetworkCIDR: 84.201.160.148/31
 sshPublicKey: ssh-rsa AAAAAbbbb
 `

--- a/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
@@ -98,8 +98,6 @@ withNATInstance:
   internalSubnetID: test
   natInstanceExternalAddress: 84.201.160.148
   exporterAPIKey: ""
-  natInstanceCores: 2
-  natInstanceMemory: 2048
 nodeNetworkCIDR: 84.201.160.148/31
 sshPublicKey: ssh-rsa AAAAAbbbb
 `


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Allow to customize NAT instance resources, instead of hardcoded values (2 CPUs/2048MiB).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In highly loaded environments, the resources provided by default are not enough.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We don't.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Allow to customize Yandex Cloud NAT instance resources.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
