### PR TITLE
Fixed copyright date in footer

### DIFF
--- a/docs/site/_includes/copyright.html
+++ b/docs/site/_includes/copyright.html
@@ -9,8 +9,8 @@
     {%- endfor %}
   </ul>
   {% if page.lang == "ru" %}
-    <span>© 2023 Флант. Все права защищены.</span>
+    <span>© {{ "now" | date: "%Y" }} Флант. Все права защищены.</span>
   {% else %}
-    <span>© 2023 Flant JSC. All rights reserved.</span>
+    <span>© {{ "now" | date: "%Y" }} Flant JSC. All rights reserved.</span>
   {% endif %}
 </div>


### PR DESCRIPTION
## Description

Set the date in the documentation footer automatically.

## Changelog entries
```changes
section: docs
type: chore
summary: Set the date in the documentation footer automatically.
impact_level: low
```