### PR TITLE
[dhctl] feat(dhctl-for-commander) Add ssh openapi specs

### DIFF
--- a/candi/openapi/dhctl/ssh_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_configuration.yaml
@@ -1,0 +1,46 @@
+kind: SSHConfig
+apiVersions:
+- apiVersion: dhctl.deckhouse.io/v1
+  openAPISpec:
+    type: object
+    description: |
+      General dhctl SSH config.
+    additionalProperties: false
+    required: [apiVersion, kind, sshUser, sshAgentPrivateKeys]
+    x-examples:
+      - apiVersion: dhctl.deckhouse.io/v1
+        kind: SSHConfig
+        sshUser: user
+        sshPort: 22
+        sshAgentPrivateKeys:
+          - key: <ssh-private-key>
+    properties:
+      apiVersion:
+        type: string
+        description: Version of the Deckhouse API.
+        enum: [dhctl.deckhouse.io/v1]
+      kind:
+        type: string
+        enum: [SSHConfig]
+      sshUser:
+        type: string
+      sshPort:
+        type: integer
+      sshAgentPrivateKeys:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          additionalProperties: false
+          required: [key]
+          properties:
+            key:
+              type: string
+            passphrase:
+              type: string
+      sshBastionHost:
+        type: string
+      sshBastionPort:
+        type: int
+      sshBastionUser:
+        type: string

--- a/candi/openapi/dhctl/ssh_host_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_host_configuration.yaml
@@ -1,0 +1,23 @@
+kind: SSHHost
+apiVersions:
+- apiVersion: dhctl.deckhouse.io/v1
+  openAPISpec:
+    type: object
+    description: |
+      General dhctl SSH host config.
+    additionalProperties: false
+    required: [apiVersion,kind,host]
+    x-examples:
+      - apiVersion: dhctl.deckhouse.io/v1
+        kind: SSHHost
+        host: 172.16.0.0
+    properties:
+      apiVersion:
+        type: string
+        description: Version of the Deckhouse API.
+        enum: [dhctl.deckhouse.io/v1]
+      kind:
+        type: string
+        enum: [SSHHost]
+      host:
+        type: string

--- a/dhctl/pkg/config/dhctl.go
+++ b/dhctl/pkg/config/dhctl.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	SSHConfigKind     = "SSHConfig"
+	SSHConfigHostKind = "SSHHost"
+)
+
+type SSHConfig struct {
+	SSHUser             string               `json:"sshUser"`
+	SSHPort             *int32               `json:"sshPort,omitempty"`
+	SSHAgentPrivateKeys []SSHAgentPrivateKey `json:"sshAgentPrivateKeys"`
+	SSHBastionHost      string               `json:"sshBastionHost,omitempty"`
+	SSHBastionPort      *int32               `json:"sshBastionPort,omitempty"`
+	SSHBastionUser      string               `json:"sshBastionUser,omitempty"`
+}
+
+type SSHAgentPrivateKey struct {
+	Key        string `json:"key"`
+	Passphrase string `json:"passphrase,omitempty"`
+}
+
+type SSHHost struct {
+	Host string `json:"host"`
+}
+
+type DHCTLConfig struct {
+	SSHConfig *SSHConfig
+	SSHHosts  []SSHHost
+}
+
+type DHCTLConfigOptions struct {
+	CommanderMode bool
+}
+
+func ParseDHCTLConfig(configData string, schemaStore *SchemaStore, opts DHCTLConfigOptions) (*DHCTLConfig, error) {
+	if !opts.CommanderMode {
+		panic("ParseSSHConfigFromData operation currently supported only in commander mode")
+	}
+
+	// todo: reuse global regexp
+	docs := regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(strings.TrimSpace(configData), -1)
+
+	config := &DHCTLConfig{}
+
+	for _, doc := range docs {
+		docData := []byte(doc)
+
+		var index SchemaIndex
+		err := yaml.Unmarshal(docData, &index)
+		if err != nil {
+			return nil, err
+		}
+
+		err = schemaStore.ValidateWithIndex(&index, &docData)
+		if err != nil {
+			return nil, err
+		}
+
+		switch index.Kind {
+		case SSHConfigKind:
+			if config.SSHConfig != nil {
+				return nil, fmt.Errorf("only one SSHConfig expected")
+			}
+
+			var sshConfig *SSHConfig
+			if err = yaml.Unmarshal([]byte(doc), &sshConfig); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal SSHConfig: %w\n---\n%s\n", err, doc)
+			}
+			config.SSHConfig = sshConfig
+		case SSHConfigHostKind:
+			var sshHost SSHHost
+			if err = yaml.Unmarshal([]byte(doc), &sshHost); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal SSHHost: %w\n---\n%s\n", err, doc)
+			}
+			config.SSHHosts = append(config.SSHHosts, sshHost)
+		default:
+			return nil, fmt.Errorf("unknown kind %q, expected SSHConfig or SSHHost", index.Kind)
+		}
+	}
+
+	if config.SSHConfig == nil {
+		return nil, fmt.Errorf("SSHConfig required")
+	}
+
+	if len(config.SSHHosts) == 0 {
+		return nil, fmt.Errorf("SSHHosts required")
+	}
+
+	return config, nil
+}

--- a/dhctl/pkg/config/dhctl_test.go
+++ b/dhctl/pkg/config/dhctl_test.go
@@ -1,0 +1,192 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+)
+
+func TestLoadDHCTLConfigSchema(t *testing.T) {
+	const schemasDir = "./../../../candi/openapi/dhctl"
+
+	t.Run("commander mode: false", func(t *testing.T) {
+		newStore := newSchemaStore([]string{schemasDir}, LoadOptions{CommanderMode: false})
+
+		require.Nil(t, newStore.Get(&SchemaIndex{
+			Kind:    "SSHConfig",
+			Version: "dhctl.deckhouse.io/v1",
+		}))
+		require.Nil(t, newStore.Get(&SchemaIndex{
+			Kind:    "SSHHost",
+			Version: "dhctl.deckhouse.io/v1",
+		}))
+	})
+
+	t.Run("commander mode: true", func(t *testing.T) {
+		newStore := newSchemaStore([]string{schemasDir}, LoadOptions{CommanderMode: true})
+
+		require.NotEmpty(t, newStore.Get(&SchemaIndex{
+			Kind:    "SSHConfig",
+			Version: "dhctl.deckhouse.io/v1",
+		}))
+		require.NotEmpty(t, newStore.Get(&SchemaIndex{
+			Kind:    "SSHHost",
+			Version: "dhctl.deckhouse.io/v1",
+		}))
+	})
+
+}
+
+func TestParseSSHConfig(t *testing.T) {
+	const schemasDir = "./../../../candi/openapi/dhctl"
+	newStore := newSchemaStore([]string{schemasDir}, LoadOptions{CommanderMode: true})
+
+	tests := map[string]struct {
+		config   string
+		expected *DHCTLConfig
+		wantErr  bool
+	}{
+		"valid config": {
+			config: validSSHConfig,
+			expected: &DHCTLConfig{
+				SSHConfig: &SSHConfig{
+					SSHUser: "ubuntu",
+					SSHPort: pointer.Int32(22),
+					SSHAgentPrivateKeys: []SSHAgentPrivateKey{
+						{
+							Key:        "-----BEGIN RSA PRIVATE KEY-----\nsome-key\n-----END RSA PRIVATE KEY-----\n",
+							Passphrase: "",
+						},
+						{
+							Key:        "-----BEGIN RSA PRIVATE KEY-----\nsome-key\n-----END RSA PRIVATE KEY-----\n",
+							Passphrase: "spicyburrito",
+						},
+					},
+				},
+				SSHHosts: []SSHHost{
+					{
+						Host: "158.160.112.65",
+					},
+					{
+						Host: "static.host.test",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		"invalid config: no user": {
+			config:  invalidSSHConfigNoUser,
+			wantErr: true,
+		},
+		"invalid config: no agent private keys": {
+			config:  invalidSSHConfigNoKeys,
+			wantErr: true,
+		},
+		"invalid config: no hosts": {
+			config:  invalidSSHConfigNoHosts,
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			config, err := ParseDHCTLConfig(tt.config, newStore, DHCTLConfigOptions{CommanderMode: true})
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, config)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, config)
+			}
+		})
+	}
+}
+
+var validSSHConfig = `
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHConfig
+sshUser: ubuntu
+sshPort: 22
+sshAgentPrivateKeys:
+- key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    some-key
+    -----END RSA PRIVATE KEY-----
+- key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    some-key
+    -----END RSA PRIVATE KEY-----
+  passphrase: spicyburrito
+---
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHHost
+host: 158.160.112.65
+---
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHHost
+host: static.host.test
+`
+
+var invalidSSHConfigNoUser = `
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHConfig
+sshPort: 22
+sshAgentPrivateKeys:
+- key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    some-key
+    -----END RSA PRIVATE KEY-----
+- key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    some-key
+    -----END RSA PRIVATE KEY-----
+  passphrase: spicyburrito
+---
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHHost
+host: 158.160.112.65
+`
+
+var invalidSSHConfigNoKeys = `
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHConfig
+sshUser: ubuntu
+sshPort: 22
+---
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHHost
+host: 158.160.112.65
+`
+
+var invalidSSHConfigNoHosts = `
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHConfig
+sshUser: ubuntu
+sshPort: 22
+sshAgentPrivateKeys:
+- key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    some-key
+    -----END RSA PRIVATE KEY-----
+- key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    some-key
+    -----END RSA PRIVATE KEY-----
+  passphrase: spicyburrito
+`

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -39,11 +39,19 @@ type SchemaStore struct {
 	moduleConfigsCache map[string]*spec.Schema
 }
 
+type LoadOptions struct {
+	CommanderMode bool
+}
+
 var once sync.Once
 
 var store *SchemaStore
 
 func NewSchemaStore(paths ...string) *SchemaStore {
+	return NewSchemaStoreWithOpts(LoadOptions{}, paths...)
+}
+
+func NewSchemaStoreWithOpts(opts LoadOptions, paths ...string) *SchemaStore {
 	paths = append([]string{candiDir}, paths...)
 
 	pathsStr := strings.TrimSpace(os.Getenv("DHCTL_CLI_ADDITIONAL_SCHEMAS_PATHS"))
@@ -54,10 +62,10 @@ func NewSchemaStore(paths ...string) *SchemaStore {
 		}
 	}
 
-	return newOnceSchemaStore(paths)
+	return newOnceSchemaStore(paths, opts)
 }
 
-func newSchemaStore(schemasDir []string) *SchemaStore {
+func newSchemaStore(schemasDir []string, opts LoadOptions) *SchemaStore {
 	st := &SchemaStore{
 		cache:              make(map[SchemaIndex]*spec.Schema),
 		moduleConfigsCache: make(map[string]*spec.Schema),
@@ -70,6 +78,14 @@ func newSchemaStore(schemasDir []string) *SchemaStore {
 
 		switch info.Name() {
 		case "init_configuration.yaml", "cluster_configuration.yaml", "static_cluster_configuration.yaml", "cloud_discovery_data.yaml", "cloud_provider_discovery_data.yaml":
+			uploadError := st.UploadByPath(path)
+			if uploadError != nil {
+				return uploadError
+			}
+		case "ssh_configuration.yaml", "ssh_host_configuration.yaml":
+			if !opts.CommanderMode {
+				break
+			}
 			uploadError := st.UploadByPath(path)
 			if uploadError != nil {
 				return uploadError
@@ -89,7 +105,7 @@ func newSchemaStore(schemasDir []string) *SchemaStore {
 	entries, err := os.ReadDir(modulesDir)
 	if err != nil {
 		// autoconverger and state exporter do not contains module dir
-		log.WarnF("Modules dir not found")
+		log.WarnF("Modules dir not found\n")
 		return st
 	}
 
@@ -108,7 +124,7 @@ func newSchemaStore(schemasDir []string) *SchemaStore {
 			}
 			st.moduleConfigsCache[moduleName] = schema
 		} else if errors.Is(err, os.ErrNotExist) {
-			log.DebugF("openapi spec not found for module %s", moduleName)
+			log.DebugF("openapi spec not found for module %s\n", moduleName)
 		} else {
 			return err
 		}
@@ -138,9 +154,9 @@ func newSchemaStore(schemasDir []string) *SchemaStore {
 	return st
 }
 
-func newOnceSchemaStore(schemasDir []string) *SchemaStore {
+func newOnceSchemaStore(schemasDir []string, opts LoadOptions) *SchemaStore {
 	once.Do(func() {
-		store = newSchemaStore(schemasDir)
+		store = newSchemaStore(schemasDir, opts)
 	})
 	return store
 }

--- a/dhctl/pkg/config/load_test.go
+++ b/dhctl/pkg/config/load_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestVersionBackwardCompatibility(t *testing.T) {
-	newStore := newSchemaStore([]string{"/tmp"})
+	newStore := newSchemaStore([]string{"/tmp"}, LoadOptions{})
 
 	schema := []byte(`
 kind: ClusterConfiguration
@@ -64,7 +64,7 @@ clusterType: Cloud
 }
 
 func TestSchemaPattern(t *testing.T) {
-	newStore := newSchemaStore([]string{"/tmp"})
+	newStore := newSchemaStore([]string{"/tmp"}, LoadOptions{})
 
 	schema := []byte(`
 kind: ClusterConfiguration
@@ -118,7 +118,7 @@ jsonObject: " {}"
 }
 
 func TestSchemaStore(t *testing.T) {
-	newStore := newSchemaStore([]string{"/tmp"})
+	newStore := newSchemaStore([]string{"/tmp"}, LoadOptions{})
 
 	err := newStore.upload([]byte(`
 kind: TestKind

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestValidateClusterSettingsFormat(t *testing.T) {
 	once.Do(func() {
-		store = newSchemaStore([]string{"./../../../candi/openapi"})
+		store = newSchemaStore([]string{"./../../../candi/openapi"}, LoadOptions{})
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -187,7 +187,7 @@ testEmbeddedValidation:
 
 func loadTestSchemaStore() error {
 	once.Do(func() {
-		store = newSchemaStore([]string{"/tmp"})
+		store = newSchemaStore([]string{"/tmp"}, LoadOptions{})
 	})
 
 	schema := []byte(`


### PR DESCRIPTION
## Description

Add ssh connection config parsing/validating with openapi specs.

## Why do we need it, and what problem does it solve?

In commander we use dhctl as a library. Therefore, obtaining configuration for ssh connection from cli arguments is not suitable for us. Added the ability to parse the configuration from a string and openapi spec

