### PR TITLE
[dhctl] feat(dhctl-for-commander) Add more ClusterConfiguration validations

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -45,6 +45,7 @@ apiVersions:
           region: eu-central-1
         tags:
           team: rangers
+    x-unsafe-rules: [deleteZones]
     additionalProperties: false
     required: [apiVersion, kind, layout, provider, masterNodeGroup, sshPublicKey]
     properties:
@@ -77,6 +78,7 @@ apiVersions:
               The number of master nodes to create.
 
               It is important to have an odd number of masters to ensure a quorum.
+            x-unsafe-rules: [updateReplicas]
           instanceClass:
             type: object
             required: [instanceType, ami]
@@ -358,6 +360,7 @@ apiVersions:
           A subnet to use in the VPC being created.
 
           **A mandatory parameter** if the `existingVPCID` parameter is omitted.
+        x-unsafe: true
       nodeNetworkCIDR:
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
@@ -370,6 +373,7 @@ apiVersions:
           If a new VPC is created along with a new cluster and no `vpcNetworkCIDR` is provided, then the range from  `nodeNetworkCIDR` is used for the VPC. Thus, the entire VPC is allocated for the cluster networks, and you will not be able to add other resources to this VPC.
 
           The `nodeNetworkCIDR` range is distributed between subnets depending on the number of availability zones in the selected region. For example, if `nodeNetworkCIDR: "10.241.1.0/20"` and there are three availability zones in the region, subnets will be created with the `/22` mask.
+        x-unsafe: true
       existingVPCID:
         type: string
         description: |
@@ -417,6 +421,7 @@ apiVersions:
             type: string
             description: |
               The name of the AWS region where instances will be provisioned.
+            x-unsafe: true
       zones:
         type: array
         items:

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -15,6 +15,7 @@ apiVersions:
       ```
     x-doc-search: |
       ProviderClusterConfiguration
+    x-unsafe-rules: [deleteZones]
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: AzureClusterConfiguration
@@ -50,6 +51,7 @@ apiVersions:
           Read [more](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/layouts.html) about possible provider layouts.
         type: string
         enum: [Standard]
+        x-unsafe: true
       standard:
         description: |
           Settings for the [`Standard`](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/layouts.html#standard) layout.
@@ -83,6 +85,7 @@ apiVersions:
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.0.0.0/16
+        x-unsafe: true
       subnetCIDR:
         description: |
           A [subnet](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-vnet-plan-design-arm#subnets) from the `vNetCIDR` address space for cluster nodes.
@@ -91,6 +94,7 @@ apiVersions:
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         example: 10.1.2.0/24
+        x-unsafe: true
       peeredVNets:
         description: |
           An array of `VNets` to merge with the cluster network.
@@ -132,6 +136,7 @@ apiVersions:
               It is important to have an odd number of masters to ensure a quorum.
             type: integer
             minimum: 1
+            x-unsafe-rules: [updateReplicas]
           zones:
             description: |
               A list of zones where master nodes can be created.
@@ -348,10 +353,12 @@ apiVersions:
               az account list-locations -o table
               ```
             type: string
+            x-unsafe: true
           subscriptionId:
             description: |
               The ID of the subscription.
             type: string
+            x-unsafe: true
           clientId:
             description: |
               The client ID.
@@ -364,6 +371,7 @@ apiVersions:
             description: |
               The ID of the tenant.
             type: string
+            x-unsafe: true
       zones:
         description: |
           The globally restricted set of zones that this Cloud Provider works with.

--- a/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
@@ -15,6 +15,7 @@ apiVersions:
       ```
     x-doc-search: |
       ProviderClusterConfiguration
+    x-unsafe-rules: [deleteZones]
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: GCPClusterConfiguration
@@ -58,6 +59,7 @@ apiVersions:
         type: string
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
         description: A subnet to use for cluster nodes.
+        x-unsafe: true
       sshKey:
         type: string
         description: A public key to access nodes as `user`.
@@ -104,6 +106,7 @@ apiVersions:
               The number of master nodes to create.
 
               It is important to have an odd number of masters to ensure a quorum.
+            x-unsafe-rules: [updateReplicas]
           additionalNetworkTags:
             description: |
               The list of additional tags.
@@ -250,6 +253,7 @@ apiVersions:
           `Standard` - set [Cloud NAT](https://cloud.google.com/nat/docs/overview#benefits) mode. [More info...](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-gcp/layouts.html#standard)
 
           `WithoutNAT` - a dedicated VPC is created for the cluster. All cluster nodes have public IP addresses. [More info...](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-gcp/layouts.html#withoutnat)
+        x-unsafe: true
       standard:
         type: object
         description: Settings for the `Standard` layout.
@@ -276,6 +280,7 @@ apiVersions:
           region:
             type: string
             description: The name of the region where instances will be provisioned.
+          x-unsafe: true
           serviceAccountJSON:
             type: string
             description: |

--- a/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
@@ -280,7 +280,7 @@ apiVersions:
           region:
             type: string
             description: The name of the region where instances will be provisioned.
-          x-unsafe: true
+            x-unsafe: true
           serviceAccountJSON:
             type: string
             description: |

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -15,6 +15,7 @@ apiVersions:
       ```
     x-doc-search: |
       ProviderClusterConfiguration
+    x-unsafe-rules: [deleteZones]
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: YandexClusterConfiguration
@@ -79,6 +80,7 @@ apiVersions:
               The number of master nodes to create. It is important to have an odd number of masters to ensure a quorum.
             type: integer
             minimum: 1
+            x-unsafe-rules: [updateReplicas]
           zones:
             description: |
               A limited set of zones in which nodes can be created.
@@ -286,11 +288,11 @@ apiVersions:
           The ID of the existing VPC Network.
       nodeNetworkCIDR:
         type: string
-        x-unsafe: true
         description: |
           This subnet will be split into **three** equal parts.
 
           They will serve as a basis for subnets in three Yandex Cloud zones.
+        x-unsafe: true
       existingZoneToSubnetIDMap:
         type: object
         description: |

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -121,7 +121,6 @@ apiVersions:
         description: |
           ID существующей VPC Network.
       nodeNetworkCIDR:
-        x-unsafe: true
         description: |
           Данная подсеть будет разделена на **три** равные части и использована для создания подсетей в трех зонах Yandex Cloud.
       existingZoneToSubnetIDMap:
@@ -182,11 +181,9 @@ apiVersions:
           cloudID:
             description: |
               Идентификатор облака.
-            x-unsafe: true
           folderID:
             description: |
               Идентификатор директории.
-            x-unsafe: true
           serviceAccountJSON:
             description: |
               Ключ к service account'у в JSON-формате.

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -20,10 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -233,7 +233,7 @@ func ParseConfigFromData(configData string) (*MetaConfig, error) {
 	schemaStore := NewSchemaStore()
 
 	bigFileTmp := strings.TrimSpace(configData)
-	docs := regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(bigFileTmp, -1)
+	docs := input.YAMLSplitRegexp.Split(bigFileTmp, -1)
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {
@@ -265,7 +265,7 @@ func ValidateClusterSettings(configData string) error {
 	schemaStore := NewSchemaStore()
 
 	bigFileTmp := strings.TrimSpace(configData)
-	docs := regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(bigFileTmp, -1)
+	docs := input.YAMLSplitRegexp.Split(bigFileTmp, -1)
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -19,26 +19,37 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"github.com/go-openapi/spec"
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 )
 
-const xUnsafeExtension = "x-unsafe"
+const (
+	xUnsafeExtension      = "x-unsafe"
+	xUnsafeRulesExtension = "x-unsafe-rules"
+)
+
+type ValidateOptions struct {
+	CommanderMode bool
+}
 
 // ValidateClusterSettingsFormat parses and validates cluster configuration and resources.
 // It checks the cluster configuration yamls for compliance with the yaml format and schema.
 // Non-config resources are checked only for compliance with the yaml format and the validity of apiVersion and kind fields.
 // It can be used as an imported functionality in external modules.
-func ValidateClusterSettingsFormat(settings string) error {
+func ValidateClusterSettingsFormat(settings string, opts ValidateOptions) error {
+	if !opts.CommanderMode {
+		panic("ValidateClusterSettingsFormat operation currently supported only in commander mode")
+	}
+
 	schemaStore := NewSchemaStore()
 
 	bigFileTmp := strings.TrimSpace(settings)
-	docs := regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(bigFileTmp, -1)
+	docs := input.YAMLSplitRegexp.Split(bigFileTmp, -1)
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {
@@ -57,32 +68,30 @@ func ValidateClusterSettingsFormat(settings string) error {
 	return nil
 }
 
-type RuleValidationOption struct {
-	path string
-	rule ValidationRule
-}
-
-func NewRuleValidationOption(path string, rule ValidationRule) RuleValidationOption {
-	return RuleValidationOption{
-		path: path,
-		rule: rule,
-	}
-}
-
 // ValidateClusterSettingsChanges validates changes of current cluster configuration with the previous one.
 // It checks the configuration changes for compliance with the current phase and schema extension rule (x-unsafe).
-// It denies any changes for fields with `x-unsafe: true` for non-BaseInfra phases. On the BaseInfra phase changes are allowed.
+// It denies any changes for fields with `x-unsafe: true`.
+// It applies all validation rules to fields with not empty `x-unsafe-rules` extension.
+// On the BaseInfra phase changes are allowed.
 // Non-config resources are checked only for compliance with the yaml format and the validity of apiVersion and kind fields: no changes validation for them.
 // It can be used as an imported functionality in external modules.
-func ValidateClusterSettingsChanges(phase phases.OperationPhase, oldSettings, newSettings string, options ...RuleValidationOption) error {
+func ValidateClusterSettingsChanges(
+	phase phases.OperationPhase,
+	oldSettings, newSettings string,
+	opts ValidateOptions,
+) error {
+	if !opts.CommanderMode {
+		panic("ValidateClusterSettingsChanges operation currently supported only in commander mode")
+	}
+
 	if phase == phases.BaseInfraPhase {
 		return nil
 	}
 
 	schemaStore := NewSchemaStore()
 
-	oldRawDocs := regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(strings.TrimSpace(oldSettings), -1)
-	newRawDocs := regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(strings.TrimSpace(newSettings), -1)
+	oldRawDocs := input.YAMLSplitRegexp.Split(strings.TrimSpace(oldSettings), -1)
+	newRawDocs := input.YAMLSplitRegexp.Split(strings.TrimSpace(newSettings), -1)
 
 	oldDocs := map[SchemaIndex]string{}
 	newDocs := map[SchemaIndex]string{}
@@ -105,8 +114,6 @@ func ValidateClusterSettingsChanges(phase phases.OperationPhase, oldSettings, ne
 		return ErrConfigAmountChanged
 	}
 
-	ruleValidators := NewDefaultRuleValidators()
-
 	for index, newDoc := range newDocs {
 		oldDoc, ok := oldDocs[index]
 		if !ok {
@@ -118,12 +125,7 @@ func ValidateClusterSettingsChanges(phase phases.OperationPhase, oldSettings, ne
 			return errors.New("unknown yaml configuration index")
 		}
 
-		ruleValidator := ruleValidators[index]
-		for _, option := range options {
-			ruleValidator.CreateRule(option.path, option.rule)
-		}
-
-		err := compareWith([]byte(oldDoc), []byte(newDoc), *schema, &ruleValidator)
+		err := compareWith([]byte(oldDoc), []byte(newDoc), *schema)
 		if err != nil {
 			return err
 		}
@@ -163,7 +165,7 @@ func setConfigs(schemaStore *SchemaStore, configs map[SchemaIndex]string, doc st
 	return nil
 }
 
-func compareWith(oldDoc, newDoc json.RawMessage, schema spec.Schema, ruleValidator *RuleValidator) error {
+func compareWith(oldDoc, newDoc json.RawMessage, schema spec.Schema) error {
 	if schema.Properties == nil {
 		return nil
 	}
@@ -181,33 +183,47 @@ func compareWith(oldDoc, newDoc json.RawMessage, schema spec.Schema, ruleValidat
 		return err
 	}
 
+	err = validateXUnsafeExtensions(oldDoc, newDoc, schema)
+	if err != nil {
+		return err
+	}
+
 	for field, fieldSchema := range schema.Properties {
-		isUnsafe, _ := fieldSchema.Extensions.GetBool(xUnsafeExtension)
-		if isUnsafe {
-			if bytes.Equal(oldProperties[field], newProperties[field]) {
-				continue
-			}
-
-			return fmt.Errorf("%s: %w", field, ErrUnsafeFieldChanged)
+		err = validateXUnsafeExtensions(oldProperties[field], newProperties[field], fieldSchema)
+		if err != nil {
+			return fmt.Errorf("%s: %w", field, err)
 		}
 
-		if ruleValidator != nil && ruleValidator.rules != nil && ruleValidator.rules[field] != nil {
-			err = ruleValidator.rules[field](oldProperties[field], newProperties[field])
-			if err != nil {
-				return fmt.Errorf("%s: %w", field, err)
-			}
-		}
-
-		var fieldValidator *RuleValidator
-		if ruleValidator != nil && ruleValidator.validators != nil {
-			fieldValidator = ruleValidator.validators[field]
-		}
-
-		err = compareWith(oldProperties[field], newProperties[field], fieldSchema, fieldValidator)
+		err = compareWith(oldProperties[field], newProperties[field], fieldSchema)
 		if err != nil {
 			return fmt.Errorf("%s: %w", field, err)
 		}
 	}
 
+	return nil
+}
+
+func validateXUnsafeExtensions(
+	oldDoc, newDoc json.RawMessage,
+	schema spec.Schema,
+) error {
+	isUnsafe, _ := schema.Extensions.GetBool(xUnsafeExtension)
+	if isUnsafe && !bytes.Equal(oldDoc, newDoc) {
+		return ErrUnsafeFieldChanged
+	}
+
+	if xRules, ok := schema.Extensions.GetStringSlice(xUnsafeRulesExtension); ok {
+		for _, rule := range xRules {
+			validator, ok := validators[rule]
+			if !ok {
+				continue
+			}
+
+			err := validator(oldDoc, newDoc)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/dhctl/pkg/config/validation_rules.go
+++ b/dhctl/pkg/config/validation_rules.go
@@ -17,53 +17,23 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	xUnsafeRuleUpdateReplicas = "updateReplicas"
+	xUnsafeRuleDeleteZones    = "deleteZones"
+)
+
 type ValidationRule func(oldValue, newValue json.RawMessage) error
 
-type RuleValidator struct {
-	rules      map[string]ValidationRule
-	validators map[string]*RuleValidator
+var validators = map[string]ValidationRule{
+	xUnsafeRuleUpdateReplicas: UpdateReplicasRule,
+	xUnsafeRuleDeleteZones:    DeleteZonesRule,
 }
 
-func (v *RuleValidator) CreateRule(path string, rule ValidationRule) {
-	separatorIndex := strings.IndexByte(path, '.')
-	if separatorIndex == -1 {
-		if v.rules == nil {
-			v.rules = make(map[string]ValidationRule)
-		}
-		v.rules[path] = rule
-		return
-	}
-
-	if v.validators == nil {
-		v.validators = make(map[string]*RuleValidator)
-	}
-
-	if v.validators[path[:separatorIndex]] == nil {
-		v.validators[path[:separatorIndex]] = &RuleValidator{}
-	}
-
-	v.validators[path[:separatorIndex]].CreateRule(path[separatorIndex+1:], rule)
-}
-
-func NewDefaultRuleValidators() map[SchemaIndex]RuleValidator {
-	var v RuleValidator
-	v.CreateRule("masterNodeGroup.replicas", NotLessRule)
-	v.CreateRule("nodeGroups.replicas", NotLessRule)
-
-	return map[SchemaIndex]RuleValidator{
-		SchemaIndex{
-			Kind:    "YandexClusterConfiguration",
-			Version: "deckhouse.io/v1",
-		}: v,
-	}
-}
-
-func NotLessRule(oldRaw, newRaw json.RawMessage) error {
+func UpdateReplicasRule(oldRaw, newRaw json.RawMessage) error {
 	var oldValue int
 	var newValue int
 
@@ -77,13 +47,49 @@ func NotLessRule(oldRaw, newRaw json.RawMessage) error {
 		return err
 	}
 
-	if newValue < oldValue {
-		return fmt.Errorf("%w: the new value (%d) cannot be less that than previous one (%d)", ErrValidationRuleFailed, newValue, oldValue)
+	if newValue == 0 {
+		return fmt.Errorf("%w: got unacceptable replicas zero value", ErrValidationRuleFailed)
 	}
 
-	if newValue == 0 {
-		return fmt.Errorf("%w: got unacceptable zero value", ErrValidationRuleFailed)
+	if newValue < oldValue && newValue < 2 {
+		return fmt.Errorf("%w: the new replicas value (%d) cannot be less that than 2 (%d)", ErrValidationRuleFailed, newValue, oldValue)
 	}
 
 	return nil
+}
+
+func DeleteZonesRule(oldRaw, newRaw json.RawMessage) error {
+	type clusterConfig struct {
+		Zones           []string `yaml:"zones"`
+		MasterNodeGroup struct {
+			Replicas int `yaml:"replicas"`
+		} `yaml:"masterNodeGroup"`
+	}
+
+	var oldClusterConfig clusterConfig
+	var newClusterConfig clusterConfig
+
+	err := yaml.Unmarshal(oldRaw, &oldClusterConfig)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(newRaw, &newClusterConfig)
+	if err != nil {
+		return err
+	}
+
+	if len(newClusterConfig.Zones) >= len(oldClusterConfig.Zones) {
+		return nil
+	}
+
+	if newClusterConfig.MasterNodeGroup.Replicas >= 3 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: can't delete zone if masterNodeGroup.Replicas < 3 (%d)",
+		ErrValidationRuleFailed,
+		newClusterConfig.MasterNodeGroup.Replicas,
+	)
 }

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Flant JSC
+// Copyright 2024 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,19 +29,22 @@ func TestValidateClusterSettingsFormat(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		t.Run("cluster configuration", func(t *testing.T) {
-			err := ValidateClusterSettingsFormat(clusterConfigFormat)
+			err := ValidateClusterSettingsFormat(clusterConfigFormat, validateOpts)
 			require.NoError(t, err)
 		})
 		t.Run("resource", func(t *testing.T) {
-			err := ValidateClusterSettingsFormat(resourceFormat)
+			err := ValidateClusterSettingsFormat(resourceFormat, validateOpts)
 			require.NoError(t, err)
 		})
 		t.Run("cluster configuration with resource", func(t *testing.T) {
-			err := ValidateClusterSettingsFormat(clusterConfigWithResourcesFormat)
+			err := ValidateClusterSettingsFormat(clusterConfigWithResourcesFormat, validateOpts)
 			require.NoError(t, err)
 		})
+	})
+
+	t.Run("not ok", func(t *testing.T) {
 		t.Run("unexpected field", func(t *testing.T) {
-			err := ValidateClusterSettingsFormat(unknownFieldFormat)
+			err := ValidateClusterSettingsFormat(unknownFieldFormat, validateOpts)
 			require.Error(t, err)
 		})
 	})
@@ -52,49 +55,95 @@ func TestValidateClusterSettingsChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ok", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, newSettings)
-		require.NoError(t, err)
+		t.Run("cluster configuration", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, newSettings, validateOpts)
+			require.NoError(t, err)
+		})
+
+		t.Run("base infra phase", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.BaseInfraPhase, oldSettings, unsafeNewSettings, validateOpts)
+			require.NoError(t, err)
+		})
+
+		t.Run("non-config resources without changes", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldResourceSettings, oldResourceSettings, validateOpts)
+			require.NoError(t, err)
+		})
+
+		t.Run("non-config resources with changes", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldResourceSettings, newResourceSettings, validateOpts)
+			require.NoError(t, err)
+		})
 	})
 
-	t.Run("ok: base infra phase", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.BaseInfraPhase, oldSettings, unsafeNewSettings)
-		require.NoError(t, err)
-	})
+	t.Run("not ok", func(t *testing.T) {
+		t.Run("unsafe field changed", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, unsafeNewSettings, validateOpts)
+			require.ErrorIs(t, err, ErrUnsafeFieldChanged)
+		})
 
-	t.Run("unsafe field changed", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, unsafeNewSettings)
-		require.ErrorIs(t, err, ErrUnsafeFieldChanged)
-	})
+		t.Run("without expected config", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, oldResourceSettings, validateOpts)
+			require.ErrorIs(t, err, ErrConfigAmountChanged)
+		})
 
-	t.Run("without expected config", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, oldResourceSettings)
-		require.ErrorIs(t, err, ErrConfigAmountChanged)
-	})
-
-	t.Run("invalid document format", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, invalidSchemaSettings)
-		require.Error(t, err)
-	})
-
-	t.Run("non-config resources without changes", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldResourceSettings, oldResourceSettings)
-		require.NoError(t, err)
-	})
-
-	t.Run("non-config resources with changes", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldResourceSettings, newResourceSettings)
-		require.NoError(t, err)
-	})
-
-	t.Run("custom rule validation failed", func(t *testing.T) {
-		err = ValidateClusterSettingsChanges(phases.FinalizationPhase,
-			customValidationSettingsOld,
-			customValidationSettingsNew,
-			NewRuleValidationOption("testEmbeddedValidation.testValidation", NotLessRule),
-		)
-		require.ErrorIs(t, err, ErrValidationRuleFailed)
+		t.Run("invalid document format", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(phases.FinalizationPhase, oldSettings, invalidSchemaSettings, validateOpts)
+			require.Error(t, err)
+		})
 	})
 }
+
+func TestValidateRulesClusterSettingsChanges(t *testing.T) {
+	err := loadTestRulesSchemaStore()
+	require.NoError(t, err)
+
+	t.Run("ok", func(t *testing.T) {
+		t.Run("x-unsafe-rules validation", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(
+				phases.FinalizationPhase,
+				validateRuleSettingsOK,
+				validateRuleSettingsOK1,
+				validateOpts,
+			)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("not ok", func(t *testing.T) {
+		t.Run("x-unsafe-rules updateReplicas validation failed, 0 replicas", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(
+				phases.FinalizationPhase,
+				validateRuleSettingsOK1,
+				validateRuleSettingsUpdateReplicasInvalid1,
+				validateOpts,
+			)
+			require.ErrorIs(t, err, ErrValidationRuleFailed)
+		})
+
+		t.Run("x-unsafe-rules updateReplicas validation failed, less than 2 replicas", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(
+				phases.FinalizationPhase,
+				validateRuleSettingsOK1,
+				validateRuleSettingsUpdateReplicasInvalid2,
+				validateOpts,
+			)
+			require.ErrorIs(t, err, ErrValidationRuleFailed)
+		})
+
+		t.Run("x-unsafe-rules deleteZones validation failed", func(t *testing.T) {
+			err = ValidateClusterSettingsChanges(
+				phases.FinalizationPhase,
+				validateRuleSettingsOK,
+				validateRuleSettingsDeleteZonesInvalid,
+				validateOpts,
+			)
+			require.ErrorIs(t, err, ErrValidationRuleFailed)
+		})
+	})
+}
+
+var validateOpts = ValidateOptions{CommanderMode: true}
 
 var (
 	clusterConfigFormat = `---
@@ -169,20 +218,36 @@ metadata:
   name: bar
 spec:
   enabled: true`
-	customValidationSettingsOld = `---
+	validateRuleSettingsOK = `---
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
-clusterType: Static
-clusterDomain: old-domain
-testEmbeddedValidation:
-  testValidation: 222`
-	customValidationSettingsNew = `---
+zones: [ru-central1, ru-central2]
+masterNodeGroup:
+  replicas: 1`
+	validateRuleSettingsOK1 = `---
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
-clusterType: Static
-clusterDomain: new-domain
-testEmbeddedValidation:
-  testValidation: 111`
+zones: [ru-central1, ru-central2, ru-central3]
+masterNodeGroup:
+  replicas: 3`
+	validateRuleSettingsUpdateReplicasInvalid1 = `---
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+zones: [ru-central1, ru-central2]
+masterNodeGroup:
+  replicas: 0`
+	validateRuleSettingsUpdateReplicasInvalid2 = `---
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+zones: [ru-central1, ru-central2]
+masterNodeGroup:
+  replicas: 1`
+	validateRuleSettingsDeleteZonesInvalid = `---
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+zones: [ru-central2]
+masterNodeGroup:
+  replicas: 1`
 )
 
 func loadTestSchemaStore() error {
@@ -218,12 +283,44 @@ apiVersions:
           prefix:
             type: string
             pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-      testEmbeddedValidation:
+`)
+
+	return store.upload(schema)
+}
+
+func loadTestRulesSchemaStore() error {
+	once.Do(func() {
+		store = newSchemaStore([]string{"/tmp"})
+	})
+
+	schema := []byte(`
+kind: ClusterConfiguration
+apiVersions:
+- apiVersion: deckhouse.io/v1
+  openAPISpec:
+    type: object
+    additionalProperties: false
+    x-unsafe-rules: [deleteZones]
+    properties:
+      apiVersion:
+        type: string
+        enum: [deckhouse.io/v1, deckhouse.io/v1alpha1]
+      kind:
+        type: string
+        enum: [ClusterConfiguration]
+      zones:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        uniqueItems: true
+      masterNodeGroup:
         type: object
         additionalProperties: false
         properties:
-          testValidation:
-            type: number
+          replicas:
+            type: integer
+            x-unsafe-rules: [updateReplicas]
 `)
 
 	return store.upload(schema)

--- a/dhctl/pkg/template/resources.go
+++ b/dhctl/pkg/template/resources.go
@@ -18,12 +18,12 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 	"text/template"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -212,5 +212,5 @@ func ParseResources(path string, data map[string]interface{}) (Resources, error)
 
 func BigFileSplit(content string) []string {
 	bigFileTmp := strings.TrimSpace(content)
-	return regexp.MustCompile(`(?:^|\s*\n)---\s*`).Split(bigFileTmp, -1)
+	return input.YAMLSplitRegexp.Split(bigFileTmp, -1)
 }

--- a/dhctl/pkg/util/input/yaml.go
+++ b/dhctl/pkg/util/input/yaml.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import "regexp"
+
+var YAMLSplitRegexp = regexp.MustCompile(`(?:^|\s*\n)---\s*`)

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -15,6 +15,7 @@ apiVersions:
       ```
     x-doc-search: |
       ProviderClusterConfiguration
+    x-unsafe-rules: [deleteZones]
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: OpenStackClusterConfiguration
@@ -113,6 +114,7 @@ apiVersions:
             minimum: 1
             description: |
               The number of master nodes to create. It is important to have an odd number of masters to ensure a quorum.
+            x-unsafe-rules: [updateReplicas]
           instanceClass:
             description: |
               Partial contents of the fields of the [OpenStackInstanceClass](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cr.html#openstackinstanceclass).
@@ -353,6 +355,7 @@ apiVersions:
 
           Read [more](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/layouts.html) about possible provider layouts.
         type: string
+        x-unsafe: true
       standard:
         description: |
           Settings for the [`Standard`](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/layouts.html#standard) layout.
@@ -414,6 +417,7 @@ apiVersions:
               Routing for the internal cluster network.
             type: string
             pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
+            x-unsafe: true
           internalNetworkDNSServers:
             description: |
               A list of addresses of the recursive DNSs of the internal cluster network.
@@ -431,6 +435,7 @@ apiVersions:
               The name of the network for external connections.
               Get a list of all available networks: `openstack network list`.
             type: string
+            x-unsafe: true
       standardWithNoRouter:
         description: |
           Settings for the [`StandardWithNoRouter`](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/layouts.html#standardwithnorouter) layout.
@@ -547,6 +552,7 @@ apiVersions:
               The project id.
 
               Cannot be used together with `tenantName`.
+            x-unsafe: true
           username:
             type: string
             description: |
@@ -559,6 +565,7 @@ apiVersions:
             type: string
             description: |
               The OpenStack region where the cluster will be deployed.
+            x-unsafe: true
         oneOf:
         - required: [authURL, domainName, tenantName, username, password, region]
         - required: [authURL, domainName, tenantID, username, password, region]

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -16,6 +16,7 @@ apiVersions:
       ```
     x-doc-search: |
       ProviderClusterConfiguration
+    x-unsafe-rules: [deleteZones]
     x-examples:
       - apiVersion: deckhouse.io/v1
         kind: VsphereClusterConfiguration
@@ -84,6 +85,7 @@ apiVersions:
             minimum: 1
             description: |
               The number of master nodes to create. It is important to have an odd number of masters to ensure a quorum.
+            x-unsafe-rules: [updateReplicas]
           zones:
             type: array
             items:
@@ -307,11 +309,13 @@ apiVersions:
         description: |
           The name of the tag category used to identify the region (vSphere Datacenter).
         default: "k8s-region"
+        x-unsafe: true
       zoneTagCategory:
         type: string
         description: |
           The name of the tag category used to identify the zone (vSphere Cluster).
         default: "k8s-zone"
+        x-unsafe: true
       disableTimesync:
         x-doc-default: true
         type: boolean
@@ -328,6 +332,7 @@ apiVersions:
         x-examples:
         - - MAIN-1
           - public
+        x-unsafe: true
       internalNetworkNames:
         type: array
         items:
@@ -337,6 +342,7 @@ apiVersions:
         x-examples:
         - - KUBE-3
           - devops-internal
+        x-unsafe: true
       internalNetworkCIDR:
         type: string
         description: |
@@ -346,16 +352,19 @@ apiVersions:
 
           The `internalNetworkCIDR` is used if `additionalNetworks` are defined in `masterInstanceClass`.
         pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
+        x-unsafe: true
       vmFolderPath:
         type: string
         description: |
           The path to the VirtualMachine Folder where the cloned VMs will be created.
         x-examples:
           - "dev/test"
+        x-unsafe: true
       region:
         type: string
         description: |
           Is a tag added to the vSphere Datacenter where all actions will occur: provisioning VirtualMachines, storing virtual disks on datastores, connecting to the network.
+        x-unsafe: true
       zones:
         type: array
         description: |
@@ -368,6 +377,7 @@ apiVersions:
         type: string
         description: |
           A path (relative to vSphere Cluster) to the existing parent `resourcePool` for all `resourcePool` created in each zone.
+        x-unsafe: true
       useNestedResourcePool:
         type: boolean
         description: |
@@ -379,6 +389,7 @@ apiVersions:
           The way resources are located in the cloud.
 
           Read [more](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-vsphere/layouts.html) about possible provider layouts.
+        x-unsafe: true
       provider:
         type: object
         additionalProperties: false


### PR DESCRIPTION
## Description

Add ClusterConfiguration openapi extensions. Support new extensions in ValidateClusterSettingsChanges function. 

## Why do we need it, and what problem does it solve?

Better ClusterConfiguration validation in Commander. Prevent potentially dangerous field changes when updating configuration.
