### PR TITLE
Add redirect for the virtualization module.

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -21,6 +21,7 @@ metadata:
       ssi on;
       ssi_silent_errors on;
       rewrite ^/source/modules/(.*)$ /modules/$1 permanent;
+      rewrite ^/documentation/v1/modules/490-virtualization/.*$ /modules/virtualization/stable/ permanent;
       rewrite ^/modules/([^./]+)/?$ /modules/$1/stable/ permanent;
       rewrite ^(/en|/ru)?/documentation/v1\.3[0-7](\.[0-9]+)?(/.*)$ /documentation/v1.38$3 permanent;
       rewrite ^(/en|/ru)?(/documentation/v1\.[0-9]+)\.[0-9]+(/.*)$ $2$3 permanent;


### PR DESCRIPTION
## Description
Add a redirect for the virtualization module, as the internal virtualization module was substituted by [the new module](https://deckhouse.io/modules/virtualization/stable/).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add a redirect for the virtualization module.
impact_level: low
```
