### PR TITLE
[dhctl] Mirror Trivy vulnerability database image

### DIFF
--- a/dhctl/pkg/app/mirror.go
+++ b/dhctl/pkg/app/mirror.go
@@ -40,28 +40,28 @@ const (
 )
 
 var (
-	MirrorRegistry         = ""
-	MirrorRegistryHost     = ""
-	MirrorRegistryPath     = ""
-	MirrorRegistryUsername = ""
-	MirrorRegistryPassword = ""
+	MirrorRegistry         string
+	MirrorRegistryHost     string
+	MirrorRegistryPath     string
+	MirrorRegistryUsername string
+	MirrorRegistryPassword string
 
-	MirrorInsecure       = false
-	MirrorTLSSkipVerify  = false
-	MirrorDHLicenseToken = ""
-	MirrorTarBundlePath  = ""
+	MirrorInsecure       bool
+	MirrorTLSSkipVerify  bool
+	MirrorDHLicenseToken string
+	MirrorTarBundlePath  string
 
-	mirrorMinVersionString                 = ""
-	MirrorMinVersion       *semver.Version = nil
+	mirrorMinVersionString string
+	MirrorMinVersion       *semver.Version
 
-	MirrorSourceRegistryRepo     = enterpriseEditionRepo
-	MirrorSourceRegistryLogin    = ""
-	MirrorSourceRegistryPassword = ""
+	MirrorSourceRegistryRepo     = enterpriseEditionRepo // Fallback to EE just in case.
+	MirrorSourceRegistryLogin    string
+	MirrorSourceRegistryPassword string
 
-	MirrorValidationMode = ""
+	MirrorValidationMode string
 
-	MirrorDoGOSTDigest            = false
-	MirrorDontContinuePartialPull = false
+	MirrorDoGOSTDigest            bool
+	MirrorDontContinuePartialPull bool
 )
 
 func DefineMirrorFlags(cmd *kingpin.CmdClause) {
@@ -106,12 +106,11 @@ func DefineMirrorFlags(cmd *kingpin.CmdClause) {
 		Short('v').
 		Envar(configEnvName("MIRROR_MIN_VERSION")).
 		StringVar(&mirrorMinVersionString)
-	cmd.Flag("validation", "Validation of mirrored indexes and images. "+
-		`Defaults to "fast" validation, which only checks if manifests and indexes are compliant with OCI specs, `+
-		`"full" validation also checks images contents for corruption`).
+	cmd.Flag("validation", "Validate mirrored indexes and images after pull is complete. "+
+		`Defaults to "fast" validation, which only checks if manifests, configs and indexes are compliant with OCI specs, `+
+		`"full" validation also checks images contents for corruption.`).
 		Hidden().
 		Default(mirrorFastValidation).
-		Envar(configEnvName("MIRROR_VALIDATION")).
 		EnumVar(&MirrorValidationMode, mirrorNoValidation, mirrorFastValidation, mirrorFullValidation)
 	cmd.Flag("gost-digest", "Calculate GOST R 34.11-2012 STREEBOG digest for downloaded bundle").
 		Envar(configEnvName("MIRROR_DO_GOST_DIGESTS")).

--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -40,6 +40,9 @@ type ImageLayouts struct {
 	ReleaseChannel       layout.Path
 	ReleaseChannelImages map[string]struct{}
 
+	Security       layout.Path
+	SecurityImages map[string]struct{}
+
 	Modules map[string]ModuleImageLayout
 }
 
@@ -62,6 +65,7 @@ func CreateOCIImageLayoutsForDeckhouse(
 		&layouts.Deckhouse:      rootFolder,
 		&layouts.Install:        filepath.Join(rootFolder, "install"),
 		&layouts.ReleaseChannel: filepath.Join(rootFolder, "release-channel"),
+		&layouts.Security:       filepath.Join(rootFolder, "security", "trivy-db"),
 	}
 	for layoutPtr, fsPath := range fsPaths {
 		*layoutPtr, err = CreateEmptyImageLayoutAtPath(fsPath)
@@ -165,6 +169,10 @@ func FillLayoutsImages(mirrorCtx *Context, layouts *ImageLayouts, deckhouseVersi
 		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:early-access": {},
 		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:stable":       {},
 		mirrorCtx.DeckhouseRegistryRepo + "/release-channel:rock-solid":   {},
+	}
+
+	layouts.SecurityImages = map[string]struct{}{
+		mirrorCtx.DeckhouseRegistryRepo + "/security/trivy-db:2": {},
 	}
 
 	for _, version := range deckhouseVersions {

--- a/dhctl/pkg/operations/mirror/layouts_test.go
+++ b/dhctl/pkg/operations/mirror/layouts_test.go
@@ -14,31 +14,24 @@
 
 package mirror
 
-import "strings"
+import (
+	"os"
+	"path/filepath"
+	"testing"
 
-func isImageNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
+	"github.com/stretchr/testify/require"
+)
 
-	errMsg := err.Error()
-	return strings.Contains(errMsg, "MANIFEST_UNKNOWN") || strings.Contains(errMsg, "404 Not Found")
-}
+func TestCreateEmptyImageLayoutAtPath(t *testing.T) {
+	p, err := os.MkdirTemp(os.TempDir(), "create_layout_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(p)
+	})
 
-func isRepoNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errMsg := err.Error()
-	return strings.Contains(errMsg, "NAME_UNKNOWN")
-}
-
-func IsTrivyMediaTypeNotAllowedError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errMsg := err.Error()
-	return strings.Contains(errMsg, "MANIFEST_INVALID") && strings.Contains(errMsg, "vnd.aquasec.trivy")
+	_, err = CreateEmptyImageLayoutAtPath(p)
+	require.NoError(t, err)
+	require.DirExists(t, p)
+	require.FileExists(t, filepath.Join(p, "oci-layout"))
+	require.FileExists(t, filepath.Join(p, "index.json"))
 }

--- a/dhctl/pkg/operations/mirror/trivy-db.go
+++ b/dhctl/pkg/operations/mirror/trivy-db.go
@@ -1,0 +1,46 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+)
+
+func PullTrivyVulnerabilityDatabaseImageToLayout(
+	sourceRepo string,
+	authProvider authn.Authenticator,
+	targetLayout layout.Path,
+	insecure, skipVerifyTLS bool,
+) error {
+	nameOpts, _ := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
+
+	trivyDBPath := path.Join(sourceRepo, "security", "trivy-db:2")
+	ref, err := name.ParseReference(trivyDBPath, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parse trivy-db reference: %w", err)
+	}
+
+	images := map[string]struct{}{ref.String(): {}}
+	if err = PullImageSet(authProvider, targetLayout, images, insecure, skipVerifyTLS, false); err != nil {
+		return fmt.Errorf("pull vulnerability database: %w", err)
+	}
+
+	return nil
+}

--- a/dhctl/pkg/operations/mirror/trivy-db_test.go
+++ b/dhctl/pkg/operations/mirror/trivy-db_test.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullTrivyVulnerabilityDatabaseImageSuccessSkipTLS(t *testing.T) {
+	blobHandler := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(blobHandler))
+	server := httptest.NewTLSServer(registryHandler)
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authn.Anonymous, false, true)
+	testLayout := prepareEmptyOCILayout(t)
+
+	deckhouseRepo := strings.TrimPrefix(server.URL, "https://") + "/deckhouse/ee"
+	trivyDBImageTag := deckhouseRepo + "/security/trivy-db:2"
+
+	ref, err := name.ParseReference(trivyDBImageTag, nameOpts...)
+	require.NoError(t, err)
+	wantImage, err := random.Image(256, 1)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ref, wantImage, remoteOpts...))
+
+	err = PullTrivyVulnerabilityDatabaseImageToLayout(deckhouseRepo, authn.Anonymous, testLayout, false, true)
+	require.NoError(t, err)
+
+	wantDigest, err := wantImage.Digest()
+	require.NoError(t, err)
+
+	gotImage, err := testLayout.Image(wantDigest)
+	require.NoError(t, err)
+
+	gotDigest, err := gotImage.Digest()
+	require.NoError(t, err)
+	require.Equal(t, wantDigest, gotDigest)
+}
+
+func TestPullTrivyVulnerabilityDatabaseImageSuccessInsecure(t *testing.T) {
+	blobHandler := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(blobHandler))
+	server := httptest.NewServer(registryHandler)
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authn.Anonymous, true, false)
+	testLayout := prepareEmptyOCILayout(t)
+
+	deckhouseRepo := strings.TrimPrefix(server.URL, "http://") + "/deckhouse/ee"
+	trivyDBImageTag := deckhouseRepo + "/security/trivy-db:2"
+
+	ref, err := name.ParseReference(trivyDBImageTag, nameOpts...)
+	require.NoError(t, err)
+	wantImage, err := random.Image(256, 1)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ref, wantImage, remoteOpts...))
+
+	err = PullTrivyVulnerabilityDatabaseImageToLayout(deckhouseRepo, authn.Anonymous, testLayout, true, false)
+	require.NoError(t, err)
+
+	wantDigest, err := wantImage.Digest()
+	require.NoError(t, err)
+
+	gotImage, err := testLayout.Image(wantDigest)
+	require.NoError(t, err)
+
+	gotDigest, err := gotImage.Digest()
+	require.NoError(t, err)
+	require.Equal(t, wantDigest, gotDigest)
+}
+
+func prepareEmptyOCILayout(t *testing.T) layout.Path {
+	t.Helper()
+	p, err := os.MkdirTemp(os.TempDir(), "trivy_pull_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(p)
+	})
+
+	l, err := CreateEmptyImageLayoutAtPath(p)
+	require.NoError(t, err)
+	return l
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added Trivy vulnerability database image to mirror dumps.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes `operator-trivy` scanning in isolated environments.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

It's a bugfix.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Mirroring will now include Trivy vulnerability database image.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
