### PR TITLE
[testing] Ignore alerts generated by not init ebpf exporter only for older kernels in e2e tests

### DIFF
--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -24,8 +24,14 @@ allow_alerts=(
 "CertmanagerCertificateExpired" # On some system do not have DNS
 "CertmanagerCertificateExpiredSoon" # Same as above
 "DeckhouseModuleUseEmptyDir" # TODO Need made split storage class
-"KubernetesDaemonSetReplicasUnavailable" # TODO In e2e tests with OS on older cores (AWS, Azure), ebpf_exporter does not run
 )
+
+# In e2e tests with OS on older cores (AWS, Azure), ebpf_exporter does not initiliaze. Ignore this alerts
+kernelVersion=$(uname -r | cut -c 1)$(uname -r | cut -c 3,4)
+echo "${kernelVersion}"
+if [[ ${kernelVersion} < 515 ]]; then # Min kernel for ebpf exporter is 5.15
+  allow_alerts+=("D8NodeHasUnmetKernelRequirements" "KubernetesDaemonSetReplicasUnavailable")
+fi
 
 # With sleep timeout of 30s, we have 25 minutes period in total to catch the 100% availability from upmeter
 for i in $(seq $attempts); do

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -29,7 +29,7 @@ allow_alerts=(
 # In e2e tests with OS on older cores (AWS, Azure), ebpf_exporter does not initiliaze. Ignore this alerts
 kernelVersion=$(uname -r | cut -c 1)$(uname -r | cut -c 3,4)
 echo "${kernelVersion}"
-if [[ ${kernelVersion} < 515 ]]; then # Min kernel for ebpf exporter is 5.15
+if [[ ${kernelVersion} < 508 ]]; then # Min kernel for ebpf exporter is 5.08
   allow_alerts+=("D8NodeHasUnmetKernelRequirements" "KubernetesDaemonSetReplicasUnavailable")
 fi
 

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -16,7 +16,7 @@ export LANG=C
 set -Eeuo pipefail
 
 availability=""
-attempts=50
+attempts=20
 
 allow_alerts=(
 "D8DeckhouseIsNotOnReleaseChannel" # Tests may be made on dev branch

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -28,7 +28,6 @@ allow_alerts=(
 
 # In e2e tests with OS on older cores (AWS, Azure), ebpf_exporter does not initiliaze. Ignore this alerts
 kernelVersion=$(uname -r | cut -c 1)$(uname -r | cut -c 3,4)
-echo "${kernelVersion}"
 if [[ ${kernelVersion} < 508 ]]; then # Min kernel for ebpf exporter is 5.08
   allow_alerts+=("D8NodeHasUnmetKernelRequirements" "KubernetesDaemonSetReplicasUnavailable")
 fi

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -783,7 +783,6 @@ function wait_cluster_ready() {
 
   testAlerts=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh")
 
-  sleep 240
   test_failed="true"
   if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
     test_failed=""

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -783,6 +783,7 @@ function wait_cluster_ready() {
 
   testAlerts=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh")
 
+  sleep 240
   test_failed="true"
   if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
     test_failed=""

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -783,17 +783,14 @@ function wait_cluster_ready() {
 
   testAlerts=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh")
 
-  testRunAttempts=5
-  for ((i=1; i<=$testRunAttempts; i++)); do
-    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
-      test_failed=""
-      break
-    else
-      test_failed="true"
-      >&2 echo "Run test script via SSH: attempt $i/$testRunAttempts failed. Sleeping 30 seconds..."
-      sleep 30
-    fi
-  done
+  if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
+    test_failed=""
+    break
+  else
+    test_failed="true"
+    >&2 echo "Run test script via SSH: attempt $i/$testRunAttempts failed. Sleeping 30 seconds..."
+    sleep 30
+  fi
 
   if [[ $test_failed == "true" ]] ; then
       return 1

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -783,9 +783,9 @@ function wait_cluster_ready() {
 
   testAlerts=$(cat "$(pwd)/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh")
 
+  test_failed="true"
   if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testAlerts}"; then
     test_failed=""
-    break
   else
     test_failed="true"
     >&2 echo "Run test script via SSH: attempt $i/$testRunAttempts failed. Sleeping 30 seconds..."


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
On kernels <5.08, the ebpf exporter cannot start. Fix the validation warning in the e2e tests that are displayed on older kernels.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In some clouds, we run vm's with a kernel lower than 5.08. e2e tests with this vm's fail due to an incorrect kernel. We have to ignore it.

## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
The e2e test runs on virtual machines running on old kernels. On a newer kernel, we should not ignore the alerts "D8NodeHasUnmetKernelRequirements" and "KubernetesDaemonSetReplicasUnavailable".

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: Ignore alerts generated by not init ebpf exporter only for older kernels in e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
