### PR TITLE
[dhctl] feat(dhctl-for-commander) Add ssh -connection-config flag

### DIFF
--- a/candi/openapi/dhctl/ssh_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_configuration.yaml
@@ -12,6 +12,7 @@ apiVersions:
         kind: SSHConfig
         sshUser: user
         sshPort: 22
+        sshExtraArgs: -vvv
         sshAgentPrivateKeys:
           - key: <ssh-private-key>
     properties:
@@ -26,6 +27,8 @@ apiVersions:
         type: string
       sshPort:
         type: integer
+      sshExtraArgs:
+        type: string
       sshAgentPrivateKeys:
         type: array
         minItems: 1

--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -24,7 +25,7 @@ import (
 
 func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	cmd := kpApp.Command("bootstrap", "Bootstrap cluster.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
 	app.DefineCacheFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -24,7 +25,7 @@ import (
 
 func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("install-deckhouse", "Install deckhouse and wait for its readiness.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -43,7 +44,7 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 
 func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("execute-bashible-bundle", "Prepare Master node and install Kubernetes.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
 	app.DefineBashibleBundleFlags(cmd)
@@ -60,7 +61,7 @@ func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause) *kingpin.C
 
 func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("create-resources", "Create resources in Kubernetes cluster.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineResourcesFlags(cmd, true)
 	app.DefineKubeFlags(cmd)
@@ -77,7 +78,7 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 
 func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("abort", "Delete every node, which was created during bootstrap process.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)
 	app.DefineCacheFlags(cmd)
@@ -112,7 +113,7 @@ func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause) *kingpin.CmdClau
 
 func DefineExecPostBootstrapScript(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("exec-post-bootstrap", "Test scp upload and ssh run uploaded script.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefinePostBootstrapScriptFlags(cmd)
 

--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -28,7 +29,7 @@ import (
 
 func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("manager", "Test control plane manager is ready.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 	app.DefineControlPlaneFlags(cmd, false)
@@ -65,7 +66,7 @@ func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause) *kingp
 
 func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("node", "Test control plane node is ready.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 	app.DefineControlPlaneFlags(cmd, true)

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -16,6 +16,8 @@ package commands
 
 import (
 	"context"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -26,7 +28,7 @@ import (
 
 func DefineConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	cmd := kpApp.Command("converge", "Converge kubernetes cluster.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
@@ -50,7 +52,7 @@ func DefineConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 func DefineAutoConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	cmd := kpApp.Command("converge-periodical", "Start service for periodical run converge.")
 	app.DefineAutoConvergeFlags(cmd)
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -30,7 +30,7 @@ import (
 
 func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("remove-deployment", "Delete deckhouse deployment.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
@@ -63,7 +63,7 @@ func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause) *kingpin.CmdClau
 
 func DefineDeckhouseCreateDeployment(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("create-deployment", "Install deckhouse after terraform is applied successful.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -16,6 +16,8 @@ package commands
 
 import (
 	"fmt"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -42,7 +44,7 @@ If you understand what you are doing, you can use flag "--yes-i-am-sane-and-i-un
 
 func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	cmd := parent.Command("destroy", "Destroy Kubernetes cluster.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineCacheFlags(cmd)
 	app.DefineSanityFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"gopkg.in/alecthomas/kingpin.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ const allowUnsafeAnnotation = "deckhouse.io/allow-unsafe"
 
 func connectionFlags(parent *kingpin.CmdClause) {
 	app.DefineKubeFlags(parent)
-	app.DefineSSHFlags(parent)
+	app.DefineSSHFlags(parent, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(parent)
 }
 

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -32,7 +33,7 @@ import (
 
 func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("kubernetes-api-connection", "Test connection to kubernetes api via ssh or directly.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
@@ -75,7 +76,7 @@ func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause) *kingpi
 
 func DefineWaitDeploymentReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("deployment-ready", "Wait while deployment is ready.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"gopkg.in/alecthomas/kingpin.v2"
 	v1 "k8s.io/api/coordination/v1"
 
@@ -38,7 +39,7 @@ Lock info:
 func DefineReleaseConvergeLockCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("release", "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful")
 	app.DefineSanityFlags(cmd)
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -29,7 +30,7 @@ import (
 
 func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("ssh-connection", "Test connection via ssh.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -62,7 +63,7 @@ func DefineTestSCPCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	var Direction string
 
 	cmd := parent.Command("scp", "Test scp file operations.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
 	cmd.Flag("src", "source path").Short('s').StringVar(&SrcPath)
@@ -128,7 +129,7 @@ func DefineTestUploadExecCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	var ScriptPath string
 	var Sudo bool
 	cmd := parent.Command("upload-exec", "Test scp upload and ssh run uploaded script.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("script", "source path").
 		StringVar(&ScriptPath)
@@ -166,7 +167,7 @@ func DefineTestBundle(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	var BundleDir string
 
 	cmd := parent.Command("bashible-bundle", "Test upload and execute a bundle.")
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("bundle-dir", "path of a bundle root directory").
 		Short('d').

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -34,7 +35,7 @@ func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause) *kingpin.
 	cmd := parent.Command("converge-exporter", "Run terraform converge exporter.")
 	app.DefineKubeFlags(cmd)
 	app.DefineConvergeExporterFlags(cmd)
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -49,7 +50,7 @@ func DefineTerraformCheckCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd := parent.Command("check", "Check differences between state of Kubernetes cluster and Terraform state.")
 	app.DefineKubeFlags(cmd)
 	app.DefineOutputFlag(cmd)
-	app.DefineSSHFlags(cmd)
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -17,7 +17,6 @@ package config
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -255,31 +254,4 @@ deckhouse: {}
 	}
 
 	return metaConfig.Prepare()
-}
-
-// ValidateClusterSettings parses and validates cluster configuration and resources.
-// It checks the cluster configuration yamls for compliance with the yaml format and schema.
-// Non-config resources are checked only for compliance with the yaml format and the validity of apiVersion and kind fields.
-// It can be used as an imported functionality in external modules.
-func ValidateClusterSettings(configData string) error {
-	schemaStore := NewSchemaStore()
-
-	bigFileTmp := strings.TrimSpace(configData)
-	docs := input.YAMLSplitRegexp.Split(bigFileTmp, -1)
-
-	metaConfig := MetaConfig{}
-	for _, doc := range docs {
-		err := parseDocument(doc, &metaConfig, schemaStore)
-		// Cluster resources are not stored in the dhctl cache, there is no need to check them for compliance with the schema: just check the index and yaml format.
-		if err != nil && !errors.Is(err, ErrSchemaNotFound) {
-			return err
-		}
-	}
-
-	_, err := metaConfig.Prepare()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -174,7 +174,7 @@ func parseConfigFromCluster(kubeCl *client.KubernetesClient) (*MetaConfig, error
 	return metaConfig.Prepare()
 }
 
-func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore) error {
+func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore, opts ValidateOptions) error {
 	doc = strings.TrimSpace(doc)
 	if doc == "" {
 		return nil
@@ -195,7 +195,7 @@ func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore)
 			return err
 		}
 
-		_, err = schemaStore.Validate(&docData)
+		_, err = schemaStore.validate(&docData, opts)
 		if err != nil {
 			return fmt.Errorf("module config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
 		}
@@ -204,7 +204,7 @@ func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore)
 		return nil
 	}
 
-	_, err = schemaStore.Validate(&docData)
+	_, err = schemaStore.validate(&docData, opts)
 	if err != nil {
 		return fmt.Errorf("config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
 	}
@@ -236,7 +236,7 @@ func ParseConfigFromData(configData string) (*MetaConfig, error) {
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {
-		if err := parseDocument(doc, &metaConfig, schemaStore); err != nil {
+		if err := parseDocument(doc, &metaConfig, schemaStore, ValidateOptions{}); err != nil {
 			return nil, err
 		}
 	}
@@ -248,7 +248,7 @@ apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse: {}
 `
-		if err := parseDocument(doc, &metaConfig, schemaStore); err != nil {
+		if err := parseDocument(doc, &metaConfig, schemaStore, ValidateOptions{}); err != nil {
 			return nil, err
 		}
 	}

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -16,8 +16,11 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"sigs.k8s.io/yaml"
 )
@@ -31,6 +34,7 @@ type SSHConfig struct {
 	SSHUser             string               `json:"sshUser"`
 	SSHPort             *int32               `json:"sshPort,omitempty"`
 	SSHAgentPrivateKeys []SSHAgentPrivateKey `json:"sshAgentPrivateKeys"`
+	SSHExtraArgs        string               `json:"sshExtraArgs,omitempty"`
 	SSHBastionHost      string               `json:"sshBastionHost,omitempty"`
 	SSHBastionPort      *int32               `json:"sshBastionPort,omitempty"`
 	SSHBastionUser      string               `json:"sshBastionUser,omitempty"`
@@ -45,23 +49,18 @@ type SSHHost struct {
 	Host string `json:"host"`
 }
 
-type DHCTLConfig struct {
+type ConnectionConfig struct {
 	SSHConfig *SSHConfig
 	SSHHosts  []SSHHost
 }
 
-type DHCTLConfigOptions struct {
-	CommanderMode bool
-}
-
-func ParseDHCTLConfig(configData string, schemaStore *SchemaStore, opts DHCTLConfigOptions) (*DHCTLConfig, error) {
-	if !opts.CommanderMode {
-		panic("ParseSSHConfigFromData operation currently supported only in commander mode")
-	}
-
+func ParseConnectionConfig(
+	configData string,
+	schemaStore *SchemaStore,
+) (*ConnectionConfig, error) {
 	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(configData), -1)
 
-	config := &DHCTLConfig{}
+	config := &ConnectionConfig{}
 
 	for _, doc := range docs {
 		docData := []byte(doc)
@@ -104,4 +103,55 @@ func ParseDHCTLConfig(configData string, schemaStore *SchemaStore, opts DHCTLCon
 	}
 
 	return config, nil
+}
+
+type ConnectionConfigParser struct{}
+
+// ParseConnectionConfigFromFile parses SSH connection config from file (app.ConnectionConfigPath)
+// and fills app.SSH* variables with corresponding data.
+func (ConnectionConfigParser) ParseConnectionConfigFromFile() error {
+	cfg, err := parseConnectionConfigFromFile(app.ConnectionConfigPath)
+	if err != nil {
+		return fmt.Errorf("parsing ssh config from file: %w", err)
+	}
+
+	keys := make([]string, 0, len(cfg.SSHConfig.SSHAgentPrivateKeys))
+	for _, key := range cfg.SSHConfig.SSHAgentPrivateKeys {
+		keys = append(keys, key.Key)
+	}
+
+	hosts := make([]string, 0, len(cfg.SSHHosts))
+	for _, host := range cfg.SSHHosts {
+		hosts = append(hosts, host.Host)
+	}
+
+	bastionPort := ""
+	if cfg.SSHConfig.SSHBastionPort != nil {
+		bastionPort = strconv.Itoa(int(*cfg.SSHConfig.SSHBastionPort))
+	}
+
+	port := ""
+	if cfg.SSHConfig.SSHPort != nil {
+		port = strconv.Itoa(int(*cfg.SSHConfig.SSHPort))
+	}
+
+	app.SSHPrivateKeys = keys
+	app.SSHBastionHost = cfg.SSHConfig.SSHBastionHost
+	app.SSHBastionPort = bastionPort
+	app.SSHBastionUser = cfg.SSHConfig.SSHBastionUser
+	app.SSHUser = cfg.SSHConfig.SSHUser
+	app.SSHHosts = hosts
+	app.SSHPort = port
+	app.SSHExtraArgs = cfg.SSHConfig.SSHExtraArgs
+
+	return nil
+}
+
+func parseConnectionConfigFromFile(path string) (*ConnectionConfig, error) {
+	configData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading connection config file: %v", err)
+	}
+
+	return ParseConnectionConfig(string(configData), NewSchemaStore())
 }

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -57,6 +57,7 @@ type ConnectionConfig struct {
 func ParseConnectionConfig(
 	configData string,
 	schemaStore *SchemaStore,
+	opts ValidateOptions,
 ) (*ConnectionConfig, error) {
 	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(configData), -1)
 
@@ -71,7 +72,7 @@ func ParseConnectionConfig(
 			return nil, err
 		}
 
-		err = schemaStore.ValidateWithIndex(&index, &docData)
+		err = schemaStore.ValidateWithIndexOpts(&index, &docData, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -153,5 +154,5 @@ func parseConnectionConfigFromFile(path string) (*ConnectionConfig, error) {
 		return nil, fmt.Errorf("loading connection config file: %v", err)
 	}
 
-	return ParseConnectionConfig(string(configData), NewSchemaStore())
+	return ParseConnectionConfig(string(configData), NewSchemaStore(), ValidateOptions{})
 }

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -24,49 +24,34 @@ import (
 func TestLoadDHCTLConfigSchema(t *testing.T) {
 	const schemasDir = "./../../../candi/openapi/dhctl"
 
-	t.Run("commander mode: false", func(t *testing.T) {
-		newStore := newSchemaStore([]string{schemasDir}, LoadOptions{CommanderMode: false})
+	newStore := newSchemaStore([]string{schemasDir})
 
-		require.Nil(t, newStore.Get(&SchemaIndex{
-			Kind:    "SSHConfig",
-			Version: "dhctl.deckhouse.io/v1",
-		}))
-		require.Nil(t, newStore.Get(&SchemaIndex{
-			Kind:    "SSHHost",
-			Version: "dhctl.deckhouse.io/v1",
-		}))
-	})
-
-	t.Run("commander mode: true", func(t *testing.T) {
-		newStore := newSchemaStore([]string{schemasDir}, LoadOptions{CommanderMode: true})
-
-		require.NotEmpty(t, newStore.Get(&SchemaIndex{
-			Kind:    "SSHConfig",
-			Version: "dhctl.deckhouse.io/v1",
-		}))
-		require.NotEmpty(t, newStore.Get(&SchemaIndex{
-			Kind:    "SSHHost",
-			Version: "dhctl.deckhouse.io/v1",
-		}))
-	})
-
+	require.NotEmpty(t, newStore.Get(&SchemaIndex{
+		Kind:    "SSHConfig",
+		Version: "dhctl.deckhouse.io/v1",
+	}))
+	require.NotEmpty(t, newStore.Get(&SchemaIndex{
+		Kind:    "SSHHost",
+		Version: "dhctl.deckhouse.io/v1",
+	}))
 }
 
-func TestParseSSHConfig(t *testing.T) {
+func TestParseConnectionConfig(t *testing.T) {
 	const schemasDir = "./../../../candi/openapi/dhctl"
-	newStore := newSchemaStore([]string{schemasDir}, LoadOptions{CommanderMode: true})
+	newStore := newSchemaStore([]string{schemasDir})
 
 	tests := map[string]struct {
 		config   string
-		expected *DHCTLConfig
+		expected *ConnectionConfig
 		wantErr  bool
 	}{
 		"valid config": {
 			config: validSSHConfig,
-			expected: &DHCTLConfig{
+			expected: &ConnectionConfig{
 				SSHConfig: &SSHConfig{
-					SSHUser: "ubuntu",
-					SSHPort: pointer.Int32(22),
+					SSHUser:      "ubuntu",
+					SSHPort:      pointer.Int32(22),
+					SSHExtraArgs: "-vvv",
 					SSHAgentPrivateKeys: []SSHAgentPrivateKey{
 						{
 							Key:        "-----BEGIN RSA PRIVATE KEY-----\nsome-key\n-----END RSA PRIVATE KEY-----\n",
@@ -106,7 +91,7 @@ func TestParseSSHConfig(t *testing.T) {
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			config, err := ParseDHCTLConfig(tt.config, newStore, DHCTLConfigOptions{CommanderMode: true})
+			config, err := ParseConnectionConfig(tt.config, newStore)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, config)
@@ -123,6 +108,7 @@ apiVersion: dhctl.deckhouse.io/v1
 kind: SSHConfig
 sshUser: ubuntu
 sshPort: 22
+sshExtraArgs: -vvv
 sshAgentPrivateKeys:
 - key: |
     -----BEGIN RSA PRIVATE KEY-----

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -43,6 +43,7 @@ func TestParseConnectionConfig(t *testing.T) {
 	tests := map[string]struct {
 		config   string
 		expected *ConnectionConfig
+		opts     ValidateOptions
 		wantErr  bool
 	}{
 		"valid config": {
@@ -86,12 +87,17 @@ func TestParseConnectionConfig(t *testing.T) {
 			config:  invalidSSHConfigNoHosts,
 			wantErr: true,
 		},
+		"invalid config: duplicated field": {
+			config:  validSSHConfig,
+			opts:    ValidateOptions{StrictUnmarshal: true},
+			wantErr: true,
+		},
 	}
 
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			config, err := ParseConnectionConfig(tt.config, newStore)
+			config, err := ParseConnectionConfig(tt.config, newStore, tt.opts)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, config)
@@ -107,6 +113,7 @@ var validSSHConfig = `
 apiVersion: dhctl.deckhouse.io/v1
 kind: SSHConfig
 sshUser: ubuntu
+sshPort: 21 # without strict unmarshalling will be overwritten with value below
 sshPort: 22
 sshExtraArgs: -vvv
 sshAgentPrivateKeys:

--- a/dhctl/pkg/config/load_test.go
+++ b/dhctl/pkg/config/load_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestVersionBackwardCompatibility(t *testing.T) {
-	newStore := newSchemaStore([]string{"/tmp"}, LoadOptions{})
+	newStore := newSchemaStore([]string{"/tmp"})
 
 	schema := []byte(`
 kind: ClusterConfiguration
@@ -64,7 +64,7 @@ clusterType: Cloud
 }
 
 func TestSchemaPattern(t *testing.T) {
-	newStore := newSchemaStore([]string{"/tmp"}, LoadOptions{})
+	newStore := newSchemaStore([]string{"/tmp"})
 
 	schema := []byte(`
 kind: ClusterConfiguration
@@ -118,7 +118,7 @@ jsonObject: " {}"
 }
 
 func TestSchemaStore(t *testing.T) {
-	newStore := newSchemaStore([]string{"/tmp"}, LoadOptions{})
+	newStore := newSchemaStore([]string{"/tmp"})
 
 	err := newStore.upload([]byte(`
 kind: TestKind

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestValidateClusterSettingsFormat(t *testing.T) {
 	once.Do(func() {
-		store = newSchemaStore([]string{"./../../../candi/openapi"}, LoadOptions{})
+		store = newSchemaStore([]string{"./../../../candi/openapi"})
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -252,7 +252,7 @@ masterNodeGroup:
 
 func loadTestSchemaStore() error {
 	once.Do(func() {
-		store = newSchemaStore([]string{"/tmp"}, LoadOptions{})
+		store = newSchemaStore([]string{"/tmp"})
 	})
 
 	schema := []byte(`
@@ -290,7 +290,7 @@ apiVersions:
 
 func loadTestRulesSchemaStore() error {
 	once.Do(func() {
-		store = newSchemaStore([]string{"/tmp"}, LoadOptions{})
+		store = newSchemaStore([]string{"/tmp"})
 	})
 
 	schema := []byte(`

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -44,7 +44,7 @@ func TestValidateClusterSettingsFormat(t *testing.T) {
 
 	t.Run("not ok", func(t *testing.T) {
 		t.Run("unexpected field", func(t *testing.T) {
-			err := ValidateClusterSettingsFormat(unknownFieldFormat, validateOpts)
+			err := ValidateClusterSettingsFormat(unknownFieldFormat, ValidateOptions{CommanderMode: true})
 			require.Error(t, err)
 		})
 	})

--- a/dhctl/pkg/terraform/pipeline_test.go
+++ b/dhctl/pkg/terraform/pipeline_test.go
@@ -145,7 +145,7 @@ func TestCheckBaseInfrastructurePipeline(t *testing.T) {
 				WithStatePath("./mocks/pipeline/empty_state.json").
 				withTerraformExecutor(executor)
 
-			res, err := CheckBaseInfrastructurePipeline(runner, "test")
+			res, _, err := CheckBaseInfrastructurePipeline(runner, "test")
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
 			} else {

--- a/dhctl/pkg/terraform/runner_test.go
+++ b/dhctl/pkg/terraform/runner_test.go
@@ -34,22 +34,21 @@ func newTestRunner() *Runner {
 
 func TestCheckPlanDestructiveChanges(t *testing.T) {
 	tests := []struct {
-		name        string
-		plan        string
-		destructive bool
-		err         error
+		name    string
+		plan    string
+		changes *PlanDestructiveChanges
+		err     error
 	}{
 		{
-			name:        "Empty Changes",
-			plan:        "./mocks/checkplan/empty.json",
-			destructive: false,
-			err:         nil,
+			name:    "Empty Changes",
+			plan:    "./mocks/checkplan/empty.json",
+			changes: nil,
+			err:     nil,
 		},
 		{
-			name:        "Has destructive changes",
-			plan:        "./mocks/checkplan/destructively_changed.json",
-			destructive: true,
-			err:         nil,
+			name:    "Has destructive changes",
+			plan:    "./mocks/checkplan/destructively_changed.json",
+			changes: destructivelyChanged,
 		},
 	}
 
@@ -64,14 +63,14 @@ func TestCheckPlanDestructiveChanges(t *testing.T) {
 
 			runner := newTestRunner().withTerraformExecutor(executor)
 
-			code, err := runner.getPlanDestructiveChanges("")
+			changes, err := runner.getPlanDestructiveChanges("")
 			if tc.err != nil {
 				require.EqualError(t, err, tc.err.Error())
 			} else {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, tc.destructive, code)
+			require.Equal(t, tc.changes, changes)
 		})
 	}
 }
@@ -209,4 +208,60 @@ func TestConcurrentExec(t *testing.T) {
 	_, err := runner.execTerraform()
 
 	require.Equal(t, "Terraform have been already executed.", err.Error())
+}
+
+var destructivelyChanged = &PlanDestructiveChanges{
+	ResourcesDeleted: nil,
+	ResourcesRecreated: []ValueChange{
+		{
+			CurrentValue: map[string]any{
+				"allow_stopping_for_update": true,
+				"boot_disk": []any{map[string]any{
+					"auto_delete":       true,
+					"device_name":       "test",
+					"disk_id":           "test",
+					"initialize_params": []any{map[string]any{"description": "", "image_id": "tests", "name": "kubernetes-data-root", "size": float64(35), "snapshot_id": "", "type": "network-ssd"}},
+					"mode":              "READ_WRITE"},
+				},
+				"created_at":                "2021-02-26T09:41:42Z",
+				"description":               "",
+				"folder_id":                 "test",
+				"fqdn":                      "kube-master",
+				"hostname":                  "kube-master",
+				"id":                        "test",
+				"labels":                    map[string]any{},
+				"metadata":                  map[string]any{"ssh-keys": "", "user-data": ""},
+				"name":                      "kube-master",
+				"network_acceleration_type": "standard",
+				"network_interface":         []any{map[string]any{"index": float64(0), "ip_address": "10.233.2.21", "ipv4": true, "ipv6": false, "ipv6_address": "", "mac_address": "test", "nat": false, "nat_ip_address": "", "nat_ip_version": "", "security_group_ids": []any{}, "subnet_id": "test"}},
+				"platform_id":               "standard-v2",
+				"resources":                 []any{map[string]any{"core_fraction": float64(100), "cores": float64(4), "gpus": float64(0), "memory": float64(8)}},
+				"scheduling_policy":         []any{map[string]any{"preemptible": false}},
+				"secondary_disk":            []any{map[string]any{"auto_delete": false, "device_name": "kubernetes-data", "disk_id": "test", "mode": "READ_WRITE"}},
+				"service_account_id":        "",
+				"status":                    "running",
+				"timeouts":                  nil,
+				"zone":                      "ru-central1-c",
+			},
+			NextValue: map[string]any{
+				"allow_stopping_for_update": true,
+				"boot_disk": []any{map[string]any{
+					"auto_delete":       true,
+					"initialize_params": []any{map[string]any{"image_id": "test", "size": float64(45), "type": "network-ssd"}},
+				}},
+				"description":               nil,
+				"hostname":                  "kube-master",
+				"labels":                    nil,
+				"metadata":                  map[string]any{"node-network-cidr": "10.233.0.0/22", "ssh-keys": "test", "user-data": ""},
+				"name":                      "kube-master",
+				"network_acceleration_type": "standard",
+				"network_interface":         []any{map[string]any{"ipv4": true, "nat": false, "subnet_id": "test"}},
+				"platform_id":               "standard-v2",
+				"resources":                 []any{map[string]any{"core_fraction": float64(100), "cores": float64(4), "gpus": nil, "memory": float64(8)}},
+				"secondary_disk":            []any{map[string]any{"auto_delete": false, "device_name": "kubernetes-data", "disk_id": "test", "mode": "READ_WRITE"}},
+				"timeouts":                  nil,
+				"zone":                      "ru-central1-c",
+			},
+		},
+	},
 }


### PR DESCRIPTION
## Description
Added the ability to specify ssh settings using a configuration file. Thus, the same code will be used in the cli and in the commander for parsing and validating connection configuration.

## Why do we need it, and what problem does it solve?
A uniform approach to obtaining configuration for connecting via ssh.

The main problem was that the `app` package with global variables was imported everywhere in the project. Importing the `config` package from the `app` package resulted in cyclic imports. Because of this, I was not able to parse the ssh configuration file in the `DefineSSHFlags` function.

I had to slightly change the calls to the `app.DefineSSHFlags` function and add another parameter with the config parser.
