### PR TITLE
[user-authn] Bring dex-auth manifest to complience with restricted admission-control policy

### DIFF
--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -115,10 +115,10 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
       containers:
       - name: dex-authenticator
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list $context "dexAuthenticator") }}
         args:
         - --provider=oidc
@@ -195,7 +195,7 @@ spec:
         - containerPort: 8443
           protocol: TCP
       - name: redis
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list $context "redisStatic") }}
         args:
           - "--save"


### PR DESCRIPTION
## Description
[user-authn] Bring dex-auth to complience with restricted admission-control policy

## Why do we need it, and what problem does it solve?
When `restricted` policy of admission-control module is active for namespace, dex-authentificator pods cannot to start in it.
To comply the requirements of admission-control module, some "capabilities drop" must be injected to deployment manifest
## Why do we need it in the patch release (if we do)?
Some clients encountered with this issue, and asked for solution.
## What is the expected result?
When this patch applied, during enabled admission-policy module is enabled, dex-authentificator pods is able to start and work as expected in namespaces with label `security.deckhouse.io/pod-policy: restricted`.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: user-authn
type: fix
summary: dex-authentificator is able to run in namespaces with restricted admission-policy
impact_level: default
```