### PR TITLE
[docs][module documentation] Update renderer config

### DIFF
--- a/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
+++ b/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
@@ -36,10 +36,8 @@ markup:
       wrapStandAloneImageWithinParagraph: true
     renderer:
       hardWraps: false
-      unsafe: false
+      unsafe: true
       xhtml: false
-
-markup:
   highlight:
     anchorLineNos: false
     codeFences: true
@@ -54,7 +52,6 @@ markup:
     noHl: false
     style: native
     tabWidth: 4
-
 
 # "404" "home" "page" "robotsTXT" "RSS" "section" "sitemap" "taxonomy" "term"
 disableKinds:


### PR DESCRIPTION
## Description
Update Hugo config. Allow inline HTML rendering.

## Why do we need it, and what problem does it solve?
Want to render inline HTML like complicated tables e. g., that can't be properly rendered using markdown 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update Hugo config.
impact_level: low
```
