### PR TITLE
[operator-trivy] Update base image

### DIFF
--- a/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/node-collector/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_ALT_P101
+ARG BASE_ALT
 ARG BASE_GOLANG_20_ALPINE
 
 FROM $BASE_GOLANG_20_ALPINE AS build
@@ -19,6 +19,6 @@ RUN patch -p1 < 001-change-node-collector-config.patch
 
 RUN go build -ldflags '-s -w -extldflags "-static"' -o node-collector ./cmd/node-collector/main.go
 
-FROM $BASE_ALT_P101
+FROM $BASE_ALT
 COPY --from=build /src/node-collector /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/node-collector" ]

--- a/werf.yaml
+++ b/werf.yaml
@@ -711,6 +711,7 @@ dockerfile: Dockerfile
 args:
   BASE_ALPINE: {{ .Images.BASE_ALPINE }}
   BASE_ALT_P101: {{ .Images.BASE_ALT_P101 }}
+  BASE_ALT: {{ .Images.BASE_ALT }}
   BASE_RUST: {{ .Images.BASE_RUST }}
   BASE_GOLANG_ALPINE: {{ .Images.BASE_GOLANG_ALPINE }}
   BASE_GOLANG_16_ALPINE: {{ .Images.BASE_GOLANG_16_ALPINE }}


### PR DESCRIPTION
## Description

Update the base image for the operator-trivy module.

Ref: https://github.com/deckhouse/deckhouse/pull/7329

## Why do we need it in the patch release (if we do)?

The build of the 1.57 release fails.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: chore
summary: Update the base image for the operator-trivy module.
impact_level: low
```
