### PR TITLE
[metallb] Add livenessProbe and readinessProbe to speaker

### DIFF
--- a/ee/modules/380-metallb/templates/speaker/daemonset.yaml
+++ b/ee/modules/380-metallb/templates/speaker/daemonset.yaml
@@ -89,6 +89,26 @@ spec:
             - containerPort: 7946
               name: memberlist-udp
               protocol: UDP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              host: 127.0.0.1
+              port: 7472
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              host: 127.0.0.1
+              port: 7472
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}


### PR DESCRIPTION
## Description

Adding livenessProbe and readinessProbe in metallb speaker spec.

## Why do we need it, and what problem does it solve?

Goals:
Reducing the number of errors when launching the pod.
Making updating smoother and seamless.

## Why do we need it in the patch release (if we do)?

This patch will significantly improve stability of metallb in certain prod-clusters.

## What is the expected result?

If the Metallb speaker pods are not working properly, they will be restarted.
The update process will be smoother and more seamless.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Adding livenessProbe and readinessProbe in metallb speaker spec.
impact: The metallb-speaker pods will be restarted.
impact_level: default
```
