### PR TITLE
[dhctl] feat(dhctl-for-commander) Add strict unmarshal mode

### DIFF
--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -174,7 +174,7 @@ func parseConfigFromCluster(kubeCl *client.KubernetesClient) (*MetaConfig, error
 	return metaConfig.Prepare()
 }
 
-func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore) error {
+func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore, opts ValidateOptions) error {
 	doc = strings.TrimSpace(doc)
 	if doc == "" {
 		return nil
@@ -195,7 +195,7 @@ func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore)
 			return err
 		}
 
-		_, err = schemaStore.Validate(&docData)
+		_, err = schemaStore.validate(&docData, opts)
 		if err != nil {
 			return fmt.Errorf("module config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
 		}
@@ -204,7 +204,7 @@ func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore)
 		return nil
 	}
 
-	_, err = schemaStore.Validate(&docData)
+	_, err = schemaStore.validate(&docData, opts)
 	if err != nil {
 		return fmt.Errorf("config validation: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
 	}
@@ -236,7 +236,7 @@ func ParseConfigFromData(configData string) (*MetaConfig, error) {
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {
-		if err := parseDocument(doc, &metaConfig, schemaStore); err != nil {
+		if err := parseDocument(doc, &metaConfig, schemaStore, ValidateOptions{}); err != nil {
 			return nil, err
 		}
 	}
@@ -248,7 +248,7 @@ apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse: {}
 `
-		if err := parseDocument(doc, &metaConfig, schemaStore); err != nil {
+		if err := parseDocument(doc, &metaConfig, schemaStore, ValidateOptions{}); err != nil {
 			return nil, err
 		}
 	}

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -57,6 +57,7 @@ type ConnectionConfig struct {
 func ParseConnectionConfig(
 	configData string,
 	schemaStore *SchemaStore,
+	opts ValidateOptions,
 ) (*ConnectionConfig, error) {
 	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(configData), -1)
 
@@ -71,7 +72,7 @@ func ParseConnectionConfig(
 			return nil, err
 		}
 
-		err = schemaStore.ValidateWithIndex(&index, &docData)
+		err = schemaStore.ValidateWithIndexOpts(&index, &docData, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -153,5 +154,5 @@ func parseConnectionConfigFromFile(path string) (*ConnectionConfig, error) {
 		return nil, fmt.Errorf("loading connection config file: %v", err)
 	}
 
-	return ParseConnectionConfig(string(configData), NewSchemaStore())
+	return ParseConnectionConfig(string(configData), NewSchemaStore(), ValidateOptions{})
 }

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -43,6 +43,7 @@ func TestParseConnectionConfig(t *testing.T) {
 	tests := map[string]struct {
 		config   string
 		expected *ConnectionConfig
+		opts     ValidateOptions
 		wantErr  bool
 	}{
 		"valid config": {
@@ -86,12 +87,17 @@ func TestParseConnectionConfig(t *testing.T) {
 			config:  invalidSSHConfigNoHosts,
 			wantErr: true,
 		},
+		"invalid config: duplicated field": {
+			config:  validSSHConfig,
+			opts:    ValidateOptions{StrictUnmarshal: true},
+			wantErr: true,
+		},
 	}
 
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			config, err := ParseConnectionConfig(tt.config, newStore)
+			config, err := ParseConnectionConfig(tt.config, newStore, tt.opts)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, config)
@@ -107,6 +113,7 @@ var validSSHConfig = `
 apiVersion: dhctl.deckhouse.io/v1
 kind: SSHConfig
 sshUser: ubuntu
+sshPort: 21 # without strict unmarshalling will be overwritten with value below
 sshPort: 22
 sshExtraArgs: -vvv
 sshAgentPrivateKeys:

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -44,7 +44,7 @@ func TestValidateClusterSettingsFormat(t *testing.T) {
 
 	t.Run("not ok", func(t *testing.T) {
 		t.Run("unexpected field", func(t *testing.T) {
-			err := ValidateClusterSettingsFormat(unknownFieldFormat, validateOpts)
+			err := ValidateClusterSettingsFormat(unknownFieldFormat, ValidateOptions{CommanderMode: true})
 			require.Error(t, err)
 		})
 	})


### PR DESCRIPTION
## Description
Add new validate functions which support `Strict` unmarshal.

## Why do we need it, and what problem does it solve?
To return an error in Commander to the user as quickly as possible and prevent errors with fields being overwritten
