### PR TITLE
[kube-dns] fixed sts-pods-hosts-appender-webhook wait timeout

### DIFF
--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/webhook-configuration.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/webhook-configuration.yaml
@@ -10,7 +10,7 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   sideEffects: None
-  timeoutSeconds: 3
+  timeoutSeconds: 30
   admissionReviewVersions:
   - v1
   clientConfig:


### PR DESCRIPTION
## Description
increased the waiting timeout for the sts-pods-hosts-appender-webhook so that there would be no waiting errors for StatefulSets with large manifests.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
If the StatefulSet manifest is large, the webhook takes a long time to work out.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: fix 
summary: Increased sts-pods-hosts-appender-webhook wait timeout
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
