### PR TITLE
[ingress-nginx] add missing tests for proxy-failover configmap

### DIFF
--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -161,6 +161,11 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
   spec:
     inlet: "HostPort"
     waitLoadBalancerOnTerminating: 0
+- name: filter
+  spec:
+    inlet: "HostWithFailover"
+    acceptRequestsFrom:
+    - 67.34.56.23/32
 `)
 			hec.HelmRender()
 		})
@@ -182,6 +187,7 @@ memory: 200Mi`))
 			Expect(cm.Exists()).To(BeTrue())
 			Expect(cm.Field("data.log-format-upstream").String()).To(ContainSubstring(`"my-cookie": "$cookie_MY_COOKIE"`))
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-custom-headers").Exists()).To(BeTrue())
+			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "proxy-test-failover-config").Exists()).To(BeFalse())
 			Expect(hec.KubernetesResource("Secret", "d8-ingress-nginx", "ingress-nginx-test-auth-tls").Exists()).To(BeTrue())
 
 			fakeIng := hec.KubernetesResource("Ingress", "d8-ingress-nginx", "test-custom-headers-reload")
@@ -217,6 +223,7 @@ memory: 200Mi`))
 			Expect(hec.KubernetesResource("PrometheusRule", "d8-monitoring", "prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-lbwpp-config").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-lbwpp-custom-headers").Exists()).To(BeTrue())
+			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "proxy-test-lbwpp-failover-config").Exists()).To(BeFalse())
 			Expect(hec.KubernetesResource("Secret", "d8-ingress-nginx", "ingress-nginx-test-lbwpp-auth-tls").Exists()).To(BeTrue())
 
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-lbwpp-load-balancer").Exists()).To(BeTrue())
@@ -250,6 +257,7 @@ memory: 200Mi`))
 
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-next-config").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-next-custom-headers").Exists()).To(BeTrue())
+			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "proxy-test-next-failover-config").Exists()).To(BeFalse())
 			Expect(hec.KubernetesResource("Secret", "d8-ingress-nginx", "ingress-nginx-test-next-auth-tls").Exists()).To(BeTrue())
 
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-next-load-balancer").Exists()).ToNot(BeTrue())
@@ -299,6 +307,10 @@ memory: 500Mi`))
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "solid-custom-headers").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Secret", "d8-ingress-nginx", "ingress-nginx-solid-auth-tls").Exists()).To(BeTrue())
 
+			proxyConfigMap := hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "proxy-solid-failover-config")
+			Expect(proxyConfigMap.Exists()).To(BeTrue())
+			Expect(proxyConfigMap.Field(`data.accept-requests-from\.conf`).String()).To(Equal(""))
+
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "controller-solid-failover").Exists()).To(BeTrue())
 
 			waitLbNonDefaultDs := hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-wait-lb-non-default")
@@ -308,6 +320,12 @@ memory: 500Mi`))
 			waitLbZeroDs := hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-wait-lb-zero")
 			Expect(waitLbZeroDs.Exists()).To(BeTrue())
 			Expect(waitLbZeroDs.Field("spec.template.spec.containers.0.args").Array()).To(ContainElement(ContainSubstring(`--shutdown-grace-period=0`)))
+
+			Expect(hec.KubernetesResource("DaemonSet", "d8-ingress-nginx", "controller-filter").Exists()).To(BeTrue())
+			proxyFilterConfigMap := hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "proxy-filter-failover-config")
+			Expect(proxyFilterConfigMap.Exists()).To(BeTrue())
+			Expect(proxyFilterConfigMap.Field(`data.accept-requests-from\.conf`).String()).To(Equal(`allow 67.34.56.23/32;
+deny all;`))
 		})
 
 		Context("Vertical pod autoscaler CRD is disabled", func() {


### PR DESCRIPTION
## Description
Adds missing tests for proxy-failover configmap of HostWithFailover inlet.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
New configmap template for proxy-failover was introduced but it wasn't covered with tests.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Related tests are in place and they pass.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: Ingress-nginx
type: chore
summary: Add missing tests.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
