### PR TITLE
[candi] Add the tzdata package to the bootstrap script on AltLinux

### DIFF
--- a/ee/be/candi/bashible/bundles/altlinux/all/003_install_mandatory_packages.sh.tpl
+++ b/ee/be/candi/bashible/bundles/altlinux/all/003_install_mandatory_packages.sh.tpl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO/RESOLVEME : apt-transport-https
-SYSTEM_PACKAGES="curl wget virt-what bash-completion lvm2 parted  sudo nfs-clients nfs-utils nfs-stats"
+SYSTEM_PACKAGES="curl wget virt-what bash-completion lvm2 parted sudo nfs-clients nfs-utils nfs-stats tzdata"
 KUBERNETES_DEPENDENCIES="iptables iproute2 socat util-linux mount ebtables ethtool conntrack-tools vim-console"
 
 bb-apt-rpm-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}


### PR DESCRIPTION
## Description

Add the `tzdata` package to the bootstrap script on AltLinux `10.0`.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Add the `tzdata` package to the bootstrap script on AltLinux `10.0`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
