### PR TITLE
[metallb] Change updateMode to Initial

### DIFF
--- a/ee/modules/380-metallb/templates/speaker/daemonset.yaml
+++ b/ee/modules/380-metallb/templates/speaker/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     kind: DaemonSet
     name: speaker
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Initial"
   resourcePolicy:
     containerPolicies:
     - containerName: speaker


### PR DESCRIPTION
## Description

To prevent frequent restarts of the speaker pods (in some cases), it was decided to switch the VPA to its original mode.

## Why do we need it, and what problem does it solve?

Due to high ARP and NDP packets activity on the network, speaker pods may consume more memory.
Additionally, changes in event intensity can also affect pod memory consumption.
In addition, when the intensity of events in the network changes, the memory consumption of the pod changes accordingly.

Frequent changes in network event intensity cause the VPA operating in Auto mode to periodically restart the pods.

## Why do we need it in the patch release (if we do)?

This patch will significantly improve stability of metallb in certain prod-clusters.

## What is the expected result?

The VPA will stop constantly rebooting pods. 
Resource changes will only be applied when the pods are reloaded organically

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Changing updateMode to Initial in VPA
impact_level: default
```
