### PR TITLE
[docs][node-manager] Fix NodeUser uid example type (from string to number)

### DIFF
--- a/modules/040-node-manager/crds/nodeuser.yaml
+++ b/modules/040-node-manager/crds/nodeuser.yaml
@@ -47,7 +47,7 @@ spec:
                     We recommend using the values `>= 1100` to avoid conflicts with manually created users.
 
                     This parameter does not change during the entire resource life.
-                  x-doc-examples: ['1100']
+                  x-doc-examples: [1100]
                   minimum: 1001
                   x-doc-required: true
                 sshPublicKey:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
If we create a NodeUser following the examples from the instructions (uid: '1100'), we get an error 'apply resource "NodeUser/arch": failed to create typed patch object (/arch; deckhouse.io/v1, Kind=NodeUser): .spec.uid: expected numeric (int or float), got string'

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Change NodeUser uid example type (from string to number).
impact_level: low
```
