### PR TITLE
[metallb] Add MetalLB grafana dashboard

### DIFF
--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -25,7 +25,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 42,
-  "iteration": 1708010318522,
+  "iteration": 1708331262271,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -195,7 +195,7 @@
           "refId": "A"
         }
       ],
-      "title": "Addresses Usage",
+      "title": "Pool Usage",
       "type": "gauge"
     }
   ],
@@ -228,7 +228,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "frontend-pool"
           ],

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -291,7 +291,7 @@
     ]
   },
   "timezone": "",
-  "title": "Metallb / pools",
+  "title": "Metallb / Pools",
   "uid": "sZzUB4ymk3",
   "version": 1,
   "weekStart": ""

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -1,0 +1,233 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 53,
+  "iteration": 1707814462935,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
+          "expr": "metallb_allocator_addresses_total{pool=\"$pool\"}",
+          "interval": "",
+          "legendFormat": "Total in {{pool}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
+          "expr": "metallb_allocator_addresses_in_use_total{pool=\"$pool\"}",
+          "hide": false,
+          "legendFormat": "Used in {{pool}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Addresses",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "main"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "main",
+          "value": "main"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "my-pool-l2"
+          ],
+          "value": [
+            "my-pool-l2"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds_prometheus}"
+        },
+        "definition": "label_values(metallb_allocator_addresses_in_use_total,pool)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pool",
+        "multi": true,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "label_values(metallb_allocator_addresses_in_use_total,pool)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Metallb / pools",
+  "uid": "sZzUB4ymk3",
+  "version": 3,
+  "weekStart": ""
+}

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -32,7 +32,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -106,7 +106,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
           "expr": "metallb_allocator_addresses_total{pool=\"$pool\"}",
@@ -118,7 +118,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
           "expr": "metallb_allocator_addresses_in_use_total{pool=\"$pool\"}",

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -142,6 +142,8 @@
             "mode": "thresholds"
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -134,7 +134,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -187,7 +187,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "expr": "metallb_allocator_addresses_in_use_total{pool=\"$pool\"} / metallb_allocator_addresses_total{pool=\"$pool\"} * 100",
           "refId": "A"

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-pool.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 53,
-  "iteration": 1707814462935,
+  "id": 42,
+  "iteration": 1708010318522,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -85,8 +85,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
-        "w": 24,
+        "h": 10,
+        "w": 17,
         "x": 0,
         "y": 0
       },
@@ -130,6 +130,71 @@
       ],
       "title": "Addresses",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 96
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 7,
+        "x": 17,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "expr": "metallb_allocator_addresses_in_use_total{pool=\"$pool\"} / metallb_allocator_addresses_total{pool=\"$pool\"} * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Addresses Usage",
+      "type": "gauge"
     }
   ],
   "refresh": "",
@@ -161,12 +226,12 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
-            "my-pool-l2"
+            "frontend-pool"
           ],
           "value": [
-            "my-pool-l2"
+            "frontend-pool"
           ]
         },
         "datasource": {
@@ -228,6 +293,6 @@
   "timezone": "",
   "title": "Metallb / pools",
   "uid": "sZzUB4ymk3",
-  "version": 3,
+  "version": 1,
   "weekStart": ""
 }

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -501,7 +501,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "GARP Announces",
+      "title": "ARP packets",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -1,0 +1,293 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 78,
+  "iteration": 1707727525056,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 796,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(pod, ip, node) (metallb_speaker_announced)",
+          "format": "table",
+          "instant": false,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Announced by speakers",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": []
+              },
+              "ip": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "node": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "pod": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {},
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.5.13",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "expr": "metallb_allocator_addresses_total",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "expr": "metallb_allocator_addresses_in_use_total",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Address utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "main"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "main",
+          "value": "main"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Metallb",
+  "uid": "sZzUB4ymk2",
+  "version": 7,
+  "weekStart": ""
+}

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -128,7 +128,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
           "expr": "metallb_allocator_addresses_total",
@@ -139,7 +139,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
           "expr": "metallb_allocator_addresses_in_use_total",
@@ -263,7 +263,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -320,7 +320,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -371,7 +371,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "builder",
           "exemplar": false,
@@ -467,7 +467,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "expr": "rate(metallb_layer2_gratuitous_sent{instance=~\"$layer2instance\"}[5m])",
           "hide": false,
@@ -479,7 +479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "expr": "rate(metallb_layer2_requests_received{instance=~\"$layer2instance\"}[5m])",
           "hide": false,
@@ -490,7 +490,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "expr": "rate(metallb_layer2_responses_sent{instance=~\"$layer2instance\"}[5m])",
           "hide": false,
@@ -574,7 +574,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
           "expr": "metallb_allocator_addresses_total",
@@ -586,7 +586,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "editorMode": "code",
           "expr": "metallb_allocator_addresses_in_use_total",

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 41,
-  "iteration": 1708010008984,
+  "id": 53,
+  "iteration": 1708330138680,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -349,8 +349,108 @@
           "refId": "A"
         }
       ],
-      "title": "Addresses Usage",
+      "title": "Pools usage (Total)",
       "type": "gauge"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.5.13",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "metallb_allocator_addresses_total",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Total addresses in pool: {{pool}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "metallb_allocator_addresses_in_use_total",
+          "interval": "",
+          "legendFormat": "Used addresses in pool: {{pool}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Pools usage (Total)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
     },
     {
       "datasource": {
@@ -388,7 +488,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 15
       },
       "id": 796,
       "options": {
@@ -456,213 +556,235 @@
       "type": "table"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${ds_prometheus}"
-      },
-      "fill": 1,
-      "fillGradient": 0,
+      "collapsed": true,
       "gridPos": {
-        "h": 9,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 23
       },
-      "hiddenSeries": false,
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.13",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "id": 804,
+      "panels": [
         {
+          "cards": {
+            "cardHSpacing": 2,
+            "cardMinWidth": 5,
+            "cardVSpacing": 2
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateGnYlRd",
+            "defaultColor": "#757575",
+            "exponent": 0.5,
+            "mode": "discrete",
+            "thresholds": [
+              {
+                "$$hashKey": "object:96",
+                "color": "#E02F44",
+                "tooltip": "Session is not established",
+                "value": "0"
+              },
+              {
+                "$$hashKey": "object:100",
+                "color": "#56A64B",
+                "tooltip": "Session is established",
+                "value": "1"
+              }
+            ]
+          },
           "datasource": {
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(metallb_layer2_gratuitous_sent{instance=~\"$layer2instance\"}[5m])",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "gratuitous_sent instance={{instance}} ip={{ip}} ",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 24
           },
-          "expr": "rate(metallb_layer2_requests_received{instance=~\"$layer2instance\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "requests_received instance={{instance}} ip={{ip}} ",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
+          "hideBranding": false,
+          "highlightCards": true,
+          "id": 806,
+          "legend": {
+            "show": true
           },
-          "expr": "rate(metallb_layer2_responses_sent{instance=~\"$layer2instance\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "responses_sent instance={{instance}} ip={{ip}} ",
-          "refId": "C"
+          "nullPointMode": "as empty",
+          "pageSize": 15,
+          "seriesFilterIndex": -1,
+          "statusmap": {
+            "ConfigVersion": "v1"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${ds_prometheus}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "metallb_bgp_session_up",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{pod}}->{{peer}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sessions",
+          "tooltip": {
+            "extraInfo": "",
+            "freezeOnClick": true,
+            "items": [],
+            "show": true,
+            "showExtraInfo": false,
+            "showItems": false
+          },
+          "transformations": [],
+          "type": "flant-statusmap-panel",
+          "useMax": true,
+          "usingPagination": false,
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "maxWidth": -1,
+            "minWidth": -1,
+            "show": true
+          },
+          "yAxisSort": "metrics",
+          "yLabel": {
+            "delimiter": "",
+            "labelTemplate": "",
+            "usingSplitLabel": false
+          }
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "ARP packets",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "BGP",
+      "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${ds_prometheus}"
-      },
-      "description": "",
-      "fill": 1,
-      "fillGradient": 0,
+      "collapsed": true,
       "gridPos": {
-        "h": 7,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 24
       },
-      "hiddenSeries": false,
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.13",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "id": 802,
+      "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "editorMode": "code",
-          "expr": "metallb_allocator_addresses_total",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Total addresses in pool: {{pool}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 25
           },
-          "editorMode": "code",
-          "expr": "metallb_allocator_addresses_in_use_total",
-          "interval": "",
-          "legendFormat": "Used addresses in pool: {{pool}}",
-          "range": true,
-          "refId": "B"
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.5.13",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${ds_prometheus}"
+              },
+              "expr": "rate(metallb_layer2_gratuitous_sent{instance=~\"$layer2instance\"}[5m])",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "gratuitous_sent instance={{instance}} ip={{ip}} ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${ds_prometheus}"
+              },
+              "expr": "rate(metallb_layer2_requests_received{instance=~\"$layer2instance\"}[5m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "requests_received instance={{instance}} ip={{ip}} ",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${ds_prometheus}"
+              },
+              "expr": "rate(metallb_layer2_responses_sent{instance=~\"$layer2instance\"}[5m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "responses_sent instance={{instance}} ip={{ip}} ",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "ARP packets",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Address utilization (Total)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "L2",
+      "type": "row"
     }
   ],
   "refresh": "",
@@ -761,6 +883,6 @@
   "timezone": "",
   "title": "Metallb",
   "uid": "sZzUB4ymk2",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -24,7 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1707810347466,
+  "id": 32,
+  "iteration": 1707906593583,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -103,12 +104,36 @@
                 ]
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
           }
         ]
       },
       "gridPos": {
         "h": 8,
-        "w": 20,
+        "w": 24,
         "x": 0,
         "y": 0
       },
@@ -259,63 +284,6 @@
         }
       ],
       "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${ds_prometheus}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 8,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "8.5.13",
-      "targets": [
-        {
-          "expr": "sum(metallb_k8s_client_config_stale_bool)",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "client_config_stale",
-          "refId": "A"
-        }
-      ],
-      "title": "Stale config",
-      "type": "gauge"
     },
     {
       "datasource": {
@@ -534,7 +502,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
       "description": "",
       "fill": 1,
       "fillGradient": 0,
@@ -598,7 +569,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Address utilization",
+      "title": "Address utilization (Total)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -637,7 +608,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "main",
           "value": "main"
         },
@@ -656,9 +627,13 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "type": "prometheus",
@@ -719,6 +694,6 @@
   "timezone": "",
   "title": "Metallb",
   "uid": "sZzUB4ymk2",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -296,6 +296,8 @@
             "mode": "thresholds"
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 32,
-  "iteration": 1707906593583,
+  "id": 41,
+  "iteration": 1708010008984,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -133,7 +133,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 18,
         "x": 0,
         "y": 0
       },
@@ -284,6 +284,71 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 76
+              },
+              {
+                "color": "red",
+                "value": 96
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 800,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "expr": "metallb_allocator_addresses_in_use_total / metallb_allocator_addresses_total * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Addresses Usage",
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -608,7 +673,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "main",
           "value": "main"
         },

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -24,8 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 52,
-  "iteration": 1707745212996,
+  "iteration": 1707810347466,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -56,11 +55,11 @@
               },
               {
                 "color": "#EAB839",
-                "value": 0.75
+                "value": 75
               },
               {
                 "color": "red",
-                "value": 0.96
+                "value": 96
               }
             ]
           },
@@ -76,6 +75,32 @@
               {
                 "id": "custom.displayMode",
                 "value": "color-background-solid"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pool"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Pool detail",
+                    "url": "/d/sZzUB4ymk3/?var-ds_prometheus=${ds_prometheus}&var-pool=${__value.raw}&${__url_time_range}"
+                  }
+                ]
               }
             ]
           }
@@ -153,11 +178,31 @@
               "tier 1": true,
               "tier 2": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "Time 1": 1,
+              "Time 2": 9,
+              "Value #A": 18,
+              "Value #B": 17,
+              "__name__ 1": 2,
+              "__name__ 2": 10,
+              "container 1": 3,
+              "container 2": 11,
+              "instance 1": 4,
+              "instance 2": 12,
+              "job 1": 5,
+              "job 2": 13,
+              "namespace 1": 6,
+              "namespace 2": 14,
+              "pod 1": 7,
+              "pod 2": 15,
+              "pool": 0,
+              "tier 1": 8,
+              "tier 2": 16
+            },
             "renameByName": {
               "Time 1": "",
-              "Value #A": "Total addresses",
-              "Value #B": "Used addresses",
+              "Value #A": "Total",
+              "Value #B": "Used",
               "instance 2": "",
               "job 2": "",
               "pool": "Pool",
@@ -169,12 +214,12 @@
         {
           "id": "calculateField",
           "options": {
-            "alias": "Usage",
+            "alias": "UsageAbs",
             "binary": {
-              "left": "Used addresses",
+              "left": "Used",
               "operator": "/",
               "reducer": "sum",
-              "right": "Total addresses"
+              "right": "Total"
             },
             "mode": "binary",
             "reduce": {
@@ -183,9 +228,33 @@
           }
         },
         {
-          "id": "merge",
+          "id": "calculateField",
           "options": {
-            "reducers": []
+            "alias": "Usage",
+            "binary": {
+              "left": "UsageAbs",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "100"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Pool",
+                "Used",
+                "Total",
+                "Usage"
+              ]
+            }
           }
         }
       ],
@@ -356,7 +425,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${ds_prometheus}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -393,6 +465,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
           "expr": "rate(metallb_layer2_gratuitous_sent{instance=~\"$layer2instance\"}[5m])",
           "hide": false,
           "instant": false,
@@ -401,6 +477,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
           "expr": "rate(metallb_layer2_requests_received{instance=~\"$layer2instance\"}[5m])",
           "hide": false,
           "interval": "",
@@ -408,6 +488,10 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
           "expr": "rate(metallb_layer2_responses_sent{instance=~\"$layer2instance\"}[5m])",
           "hide": false,
           "interval": "",

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -24,11 +24,230 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 78,
-  "iteration": 1707727525056,
+  "id": 52,
+  "iteration": 1707745212996,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "right",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "decimals": 2,
+          "displayName": "",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.96
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Usage"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 20,
+        "x": 0,
+        "y": 0
+      },
+      "id": 798,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
+          "expr": "metallb_allocator_addresses_total",
+          "format": "table",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P0D6E4079E36703EB"
+          },
+          "editorMode": "code",
+          "expr": "metallb_allocator_addresses_in_use_total",
+          "format": "table",
+          "hide": false,
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pools",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "pool"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "container 1": true,
+              "container 2": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job 1": true,
+              "job 2": true,
+              "namespace 1": true,
+              "namespace 2": true,
+              "pod 1": true,
+              "pod 2": true,
+              "tier 1": true,
+              "tier 2": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Time 1": "",
+              "Value #A": "Total addresses",
+              "Value #B": "Used addresses",
+              "instance 2": "",
+              "job 2": "",
+              "pool": "Pool",
+              "tier 1": "",
+              "tier 2": ""
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Usage",
+            "binary": {
+              "left": "Used addresses",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Total addresses"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "merge",
+          "options": {
+            "reducers": []
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P0D6E4079E36703EB"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "expr": "sum(metallb_k8s_client_config_stale_bool)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "client_config_stale",
+          "refId": "A"
+        }
+      ],
+      "title": "Stale config",
+      "type": "gauge"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -65,7 +284,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 796,
       "options": {
@@ -137,6 +356,100 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${ds_prometheus}",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.5.13",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(metallb_layer2_gratuitous_sent{instance=~\"$layer2instance\"}[5m])",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "gratuitous_sent instance={{instance}} ip={{ip}} ",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(metallb_layer2_requests_received{instance=~\"$layer2instance\"}[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "requests_received instance={{instance}} ip={{ip}} ",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(metallb_layer2_responses_sent{instance=~\"$layer2instance\"}[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "responses_sent instance={{instance}} ip={{ip}} ",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "GARP Announces",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": {},
       "description": "",
       "fill": 1,
@@ -145,7 +458,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 2,
@@ -179,10 +492,11 @@
             "type": "prometheus",
             "uid": "P0D6E4079E36703EB"
           },
+          "editorMode": "code",
           "expr": "metallb_allocator_addresses_total",
           "instant": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "Total addresses in pool: {{pool}}",
           "refId": "A"
         },
         {
@@ -190,9 +504,11 @@
             "type": "prometheus",
             "uid": "P0D6E4079E36703EB"
           },
+          "editorMode": "code",
           "expr": "metallb_allocator_addresses_in_use_total",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "Used addresses in pool: {{pool}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -253,6 +569,37 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds_prometheus}"
+        },
+        "definition": "label_values(metallb_layer2_gratuitous_sent,instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Layer 2 instance",
+        "multi": true,
+        "name": "layer2instance",
+        "options": [],
+        "query": {
+          "query": "label_values(metallb_layer2_gratuitous_sent,instance)",
+          "refId": "main-layer2instance-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -288,6 +635,6 @@
   "timezone": "",
   "title": "Metallb",
   "uid": "sZzUB4ymk2",
-  "version": 7,
+  "version": 2,
   "weekStart": ""
 }

--- a/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
+++ b/ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb.json
@@ -288,7 +288,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "fieldConfig": {
         "defaults": {
@@ -341,7 +341,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "${ds_prometheus}"
           },
           "expr": "metallb_allocator_addresses_in_use_total / metallb_allocator_addresses_total * 100",
           "refId": "A"
@@ -569,7 +569,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "${ds_prometheus}"
       },
       "description": "",
       "fill": 1,

--- a/ee/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -19,6 +19,25 @@
         ```
       summary: MetalLB config not loaded.
 
+  - alert: D8MetalLBConfigStale
+    expr: metallb_k8s_client_config_stale_bool == 1
+    for: 5m
+    labels:
+      severity_level: "4"
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__d8_metallb_failed: D8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_metallb_failed: D8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      description: |
+        {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has run on a stale configuration, because the latest config failed to load.
+        To figure out the problem, check controller logs:
+        ```
+        kubectl -n d8-metallb logs deploy/controller -c controller
+        ```
+      summary: MetalLB running on a stale configuration, because the latest config failed to load.
+
   - alert: D8MetalLBBGPSessionDown
     expr: metallb_bgp_session_up == 0
     for: 5m

--- a/ee/modules/380-metallb/templates/monitoring.yaml
+++ b/ee/modules/380-metallb/templates/monitoring.yaml
@@ -1,1 +1,2 @@
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
 {{- include "helm_lib_prometheus_rules" (list . "d8-metallb") }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add MetalLB and MetalLB/pools dashboards to Grafana: 
* The table to discover from which node the virtual ip is being announced. 
* Pools usage.
* L2 & BGP -specific metrics.

Also, added an alert D8MetalLBConfigStale which is firing if MetalLB running on a stale configuration, because the latest config failed to load.

The screenshots [are bellow](https://github.com/deckhouse/deckhouse/pull/7459#issuecomment-1951945806).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We had no ability to discover which speaker announces the ip. At the same time we developed the dashboard with other metrics. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
The MetalLB dashboard exists in Grafana.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: metallb
type: feature
summary: MetalLB dashboard for Grafana
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
