### PR TITLE
[node-manager] Don't allow more than one taint with the same key and effect

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -94,6 +94,8 @@ EOF
 }
 
 function __main__() {
+  echo "$(context::jq)"
+  
   operationType="$(context::jq -r '.review.request.operation')"
 
   clusterType="$(context::jq -r '.snapshots.cluster_config[0].filterResult.clusterType')"

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -220,7 +220,7 @@ EOF
   fi
 
   # Forbid more than one taint with the same key and effect
-  if context::jq -e -r '.review.request.oldObject.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)' >/dev/null 2>&1; then
+  if context::jq -e -r '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)' >/dev/null 2>&1; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":".spec.nodeTemplate.taints must contains only one object with the same key and effect"}
 EOF

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -94,8 +94,6 @@ EOF
 }
 
 function __main__() {
-  echo "$(context::jq)"
-
   operationType="$(context::jq -r '.review.request.operation')"
 
   clusterType="$(context::jq -r '.snapshots.cluster_config[0].filterResult.clusterType')"

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -221,7 +221,7 @@ EOF
 
   # Forbid more than one taint with the same key and effect
   if context::jq -e -r '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)' >/dev/null 2>&1; then
-    taints="$(context::jq -e -r -c '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[][]' 2>/dev/null)"
+    taints="$(context::jq -e -r -c '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)[] | "\(.effect):\(.key):\(.value)"' 2>/dev/null)"
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":".spec.nodeTemplate.taints must contains only one taint with the same key and effect\n$taints"}
 EOF

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -221,8 +221,9 @@ EOF
 
   # Forbid more than one taint with the same key and effect
   if context::jq -e -r '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)' >/dev/null 2>&1; then
+    taints="$(context::jq -e -r -c '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[][]' 2>/dev/null)"
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":".spec.nodeTemplate.taints must contains only one object with the same key and effect"}
+{"allowed":false, "message":".spec.nodeTemplate.taints must contains only one taint with the same key and effect\n$taints"}
 EOF
     return 0
   fi

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -221,9 +221,8 @@ EOF
 
   # Forbid more than one taint with the same key and effect
   if context::jq -e -r '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)' >/dev/null 2>&1; then
-    taints="$(context::jq -e -r -c '.review.request.object.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)[] | "\(.effect):\(.key):\(.value)"' 2>/dev/null)"
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":".spec.nodeTemplate.taints must contains only one taint with the same key and effect\n$taints"}
+{"allowed":false, "message":".spec.nodeTemplate.taints must contains only one taint with the same key and effect"}
 EOF
     return 0
   fi

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -95,7 +95,7 @@ EOF
 
 function __main__() {
   echo "$(context::jq)"
-  
+
   operationType="$(context::jq -r '.review.request.operation')"
 
   clusterType="$(context::jq -r '.snapshots.cluster_config[0].filterResult.clusterType')"
@@ -220,6 +220,15 @@ EOF
         return 0
     fi
   fi
+
+  # Forbid more than one taint with the same key and effect
+  if context::jq -e -r '.review.request.oldObject.spec.nodeTemplate.taints // [] | group_by(.key,.effect)[] | select(length > 1)' >/dev/null 2>&1; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":".spec.nodeTemplate.taints must contains only one object with the same key and effect"}
+EOF
+    return 0
+  fi
+
 
   cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added NodeGroup validation to prevent adding more than one taint with the same key and effect.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Tests

<details><summary>Details</summary>

```shell
root@dev2-master-0:~# kubectl edit ng redos 
error: nodegroups.deckhouse.io "redos" could not be patched: admission webhook "nodegroup-policy.deckhouse.io" denied the request: .spec.nodeTemplate.taints must contains only one taint with the same key and effect
You can run `kubectl replace -f /tmp/kubectl-edit-3126790586.yaml` to try this update again.
```

</details>


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Added NodeGroup validation to prevent adding more than one taint with the same key and effect.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
