### PR TITLE
[multitenancy-manager] resource validation

### DIFF
--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -271,6 +271,9 @@ featureGates:
 {{- if semverCompare "<1.27" .kubernetesVersion }}
   ExpandCSIVolumes: true
 {{- end }}
+{{- if semverCompare ">=1.26" .kubernetesVersion }}
+  ValidatingAdmissionPolicy: true
+{{- end }}
   RotateKubeletServerCertificate: true
 fileCheckFrequency: 20s
 imageMinimumGCAge: 2m0s

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -3,6 +3,9 @@ RotateKubeletServerCertificate default is true, but CIS becnhmark wants it to be
 https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 */}}
 {{- $featureGates := list "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" | join "," }}
+{{- if semverCompare ">= 1.26" .clusterConfiguration.kubernetesVersion }}
+    {{- $featureGates = list $featureGates "ValidatingAdmissionPolicy=true" | join "," }}
+{{- end }}
 {{- if semverCompare "< 1.27" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "DaemonSetUpdateSurge=true" | join "," }}
 {{- end }}
@@ -54,6 +57,7 @@ apiServer:
     {{- end }}
     enable-admission-plugins: "{{ $admissionPlugins | sortAlpha | join "," }}"
     admission-control-config-file: "/etc/kubernetes/deckhouse/extra-files/admission-control-config.yaml"
+    runtime-config: "admissionregistration.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true"
 # kubelet-certificate-authority flag should be set after bootstrap of first master.
 # This flag affects logs from kubelets, for period of time between kubelet start and certificate request approve by Deckhouse hook.
     kubelet-certificate-authority: "/etc/kubernetes/pki/ca.crt"

--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -13,14 +13,12 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/fatih/structs"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"helm.sh/helm/v3/pkg/releaseutil"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog"
 	"sigs.k8s.io/yaml"
 
@@ -220,7 +218,7 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 	for _, manifest := range manifests {
 		var un unstructured.Unstructured
 
-		//var ns v1.Namespace
+		// var ns v1.Namespace
 		err = yaml.Unmarshal([]byte(manifest), &un)
 		if err != nil {
 			return renderedManifests, err

--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -217,8 +217,6 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 
 	for _, manifest := range manifests {
 		var un unstructured.Unstructured
-
-		// var ns v1.Namespace
 		err = yaml.Unmarshal([]byte(manifest), &un)
 		if err != nil {
 			return renderedManifests, err

--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/fatih/structs"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -213,26 +215,37 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 
 	manifests := releaseutil.SplitManifests(renderedManifests.String())
 
-	namespaces := make([]v1.Namespace, 0)
+	namespaces := make([]*unstructured.Unstructured, 0)
 
 	for _, manifest := range manifests {
-		var ns v1.Namespace
-		err = yaml.Unmarshal([]byte(manifest), &ns)
+		var un unstructured.Unstructured
+
+		//var ns v1.Namespace
+		err = yaml.Unmarshal([]byte(manifest), &un)
 		if err != nil {
 			return renderedManifests, err
 		}
 
-		if ns.APIVersion != "v1" || ns.Kind != "Namespace" {
-			builder.WriteString("\n---\n" + manifest)
+		// inject multitenancy-manager labels
+		labels := un.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string, 1)
+		}
+		labels["heritage"] = "multitenancy-manager"
+		un.SetLabels(labels)
+
+		if un.GetAPIVersion() != "v1" || un.GetKind() != "Namespace" {
+			data, _ := yaml.Marshal(un.Object)
+			builder.WriteString("\n---\n" + string(data))
 			continue
 		}
 
-		if ns.Name != ptr.projectName {
+		if un.GetName() != ptr.projectName {
 			// drop Namespace from manifests if it's not a project namespace
 			continue
 		}
 
-		namespaces = append(namespaces, ns)
+		namespaces = append(namespaces, &un)
 	}
 
 	result := bytes.NewBuffer(nil)
@@ -241,11 +254,8 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 		if _, ok := ns.GetAnnotations()["multitenancy-boilerplate"]; ok && len(namespaces) > 1 {
 			continue
 		}
-		if ns.Labels == nil {
-			ns.Labels = make(map[string]string, 1)
-		}
-		ns.Labels["heritage"] = "multitenancy-manager"
-		data, _ := yaml.Marshal(ns)
+
+		data, _ := yaml.Marshal(ns.Object)
 		result.WriteString("---\n")
 		result.Write(data)
 		break

--- a/ee/modules/160-multitenancy-manager/hooks/project_test.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project_test.go
@@ -495,14 +495,11 @@ data: {}
 apiVersion: v1
 kind: Namespace
 metadata:
-  creationTimestamp: null
   labels:
     heritage: multitenancy-manager
   annotations:
     multitenancy-boilerplate: "true"
   name: test-project-1
-spec: {}
-status: {}
 `, ns)
 	})
 
@@ -534,6 +531,8 @@ kind: ConfigMap
 metadata:
   namespace: test-project-1
   name: tututu
+  labels:
+    heritage: multitenancy-manager
 data: {}
 `
 
@@ -551,13 +550,10 @@ kind: Namespace
 metadata:
   annotations:
     foo: bar
-  creationTimestamp: null
   labels:
     heritage: multitenancy-manager
     twotwotwo: nanana
   name: test-project-1
-spec: {}
-status: {}
 `, ns)
 	})
 
@@ -593,6 +589,8 @@ kind: ConfigMap
 metadata:
   namespace: test-project-1
   name: tututu
+  labels:
+    heritage: multitenancy-manager
 data: {}
 `
 
@@ -608,13 +606,10 @@ data: {}
 apiVersion: v1
 kind: Namespace
 metadata:
-  creationTimestamp: null
   labels:
     heritage: multitenancy-manager
     twotwotwo: lalala
   name: test-project-1
-spec: {}
-status: {}
 `, ns)
 	})
 }

--- a/ee/modules/160-multitenancy-manager/templates/validating.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/validating.yaml
@@ -1,0 +1,45 @@
+{{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+{{- $policyName := "d8-multitenancy-manager" }}
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-manager") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["*"]
+        apiVersions: ["*"]
+        operations:  ["UPDATE", "DELETE"]
+        resources:   ["*"]
+        scope: "*"
+  validations:
+    - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"'
+      messageExpression: "'This resource is managed by ' + string(object.metadata.namespace) + ' Project. Manual modification is forbidden.'"
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-manager") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions: [Deny, Audit]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        heritage: multitenancy-manager
+    objectSelector:
+      matchLabels:
+        heritage: multitenancy-manager
+{{- end }}


### PR DESCRIPTION
## Description
Reject manual change for resources inside the namespace which are managed by Projects

## Why do we need it, and what problem does it solve?
Prevent manual modifications of resources. Manage them only via the ProjectTemplate

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
```yaml
# kubectl -n test-project-1 get cm tututu -o yaml
apiVersion: v1
data:
  a: b
  fhff: gg
  z: x
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: test-project-1
    meta.helm.sh/release-namespace: test-project-1
  creationTimestamp: "2024-02-13T21:18:14Z"
  labels:
    app.kubernetes.io/managed-by: Helm
  name: tututu
  namespace: test-project-1
  resourceVersion: "76800907"
  uid: 46fb7f19-b5c1-41fc-842f-699c1632f9fa
```

tries to patch:
```yaml
# kubectl -n test-project-1 patch cm tututu --type merge -p '{"data": {"foo": "bar"}}'
The configmaps "tututu" is invalid: : ValidatingAdmissionPolicy 'multitenancy-manager' with binding 'multitenancy-manager-binding' denied request: This resource is managed by test-project-1 Project. Manual modification is forbidden.
```

modify and apply the template:
```yaml
# kubectl apply -f template-with-ns.yaml
projecttemplate.deckhouse.io/test-with-ns configured

# kubectl -n test-project-1 get cm tututu -o yaml
apiVersion: v1
data:
  a: b
  z: x
  zxc: dfg
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: test-project-1
    meta.helm.sh/release-namespace: test-project-1
  creationTimestamp: "2024-02-13T21:18:14Z"
  labels:
    app.kubernetes.io/managed-by: Helm
  name: tututu
  namespace: test-project-1
  resourceVersion: "76805127"
  uid: 46fb7f19-b5c1-41fc-842f-699c1632f9fa
```

create and patch user resource:
```yaml
# kubectl -n test-project-1 create secret generic lalala
secret/lalala created

# kubectl -n test-project-1 patch secret lalala --type merge -p '{"data": {"foo": "YWRzCg=="}}'
secret/lalala patched
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: feature
summary: Prevent manual modification of Project resources.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
