### PR TITLE
[docs] Show BE modules on the site

### DIFF
--- a/docs/documentation/modules_list.sh
+++ b/docs/documentation/modules_list.sh
@@ -23,9 +23,9 @@ if [ -f modules_menu_skip ]; then
   modules_skip_list=$(cat modules_menu_skip)
 fi
 
-for module_revision_path in $(find ${MODULES_DIR} -regex '.*/docs/README.md' -print | sed -E "s#^${MODULES_DIR}/modules/#${MODULES_DIR}/ce/modules/#" | sed -E "s#^${MODULES_DIR}/(ce/|ee/|fe/)?modules/([^/]+)/.*\$#\1\2#" | sort -t/ -k 2.4 ); do
+for module_revision_path in $(find ${MODULES_DIR} -regex '.*/docs/README.md' -print | sed -E "s#^${MODULES_DIR}/modules/#${MODULES_DIR}/ce/modules/#" | sed -E "s#^${MODULES_DIR}/(ce/|be/|se/|ee/|fe/)?modules/([^/]+)/.*\$#\1\2#" | sort -t/ -k 2.4 ); do
   skip=false
-  module_path=$(echo $module_revision_path | sed -E 's#ce/|ee/|fe/##')
+  module_path=$(echo $module_revision_path | sed -E 's#ce/|be/|se/|ee/|fe/##')
   # Skip unnecessary modules
   for skip_item in $modules_skip_list ; do
     if [[ $skip_item == $module_path ]] ; then skip=true; break; fi

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -47,6 +47,23 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
+{{- if or (eq .Env "BE") (eq .Env "SE") (eq .Env "EE") (eq .Env "FE") (eq .Env "development") }}
+- add: /ee/be/modules
+  to: /srv/jekyll-data/documentation/_data/bundles/raw/be
+  owner: jekyll
+  group: jekyll
+  stageDependencies:
+    setup: ['**/*']
+  includePaths: ['values-*.yaml']
+- add: /ee/be/modules
+  to: /src/be/modules
+  owner: jekyll
+  group: jekyll
+  stageDependencies:
+    setup: ['**/*']
+  includePaths: ['*/docs/','*/openapi/','*/crds/', '*/oss.yaml']
+  excludePaths: ['*/openapi/values.yaml', '*/openapi/*-tests.yaml', '*/docs/internal/']
+{{- end }}
 {{- if or (eq .Env "EE") (eq .Env "FE") (eq .Env "development") }}
 - add: /ee/modules
   to: /srv/jekyll-data/documentation/_data/bundles/raw/ee

--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -60,6 +60,8 @@ ansible:
         chdir: /srv/jekyll-data/documentation/
     - name: "{{ .Env }} version. Merging modules of different releases"
       shell: |
+        cp -rf /src/be/modules /src >& /dev/null
+        cp -rf /src/se/modules /src >& /dev/null
         cp -rf /src/ee/modules /src >& /dev/null
         cp -rf /src/fe/modules /src >& /dev/null
         cp /src/modules/010-prometheus-crd/crds/*.yaml /src/modules/300-prometheus/crds

--- a/modules/810-documentation/images/web/werf.inc.yaml
+++ b/modules/810-documentation/images/web/werf.inc.yaml
@@ -40,6 +40,8 @@ ansible:
         chdir: /srv/jekyll-data/documentation/
     - name: "{{ .Env }} version. Merging modules of different releases..."
       shell: |
+        cp -rf /src/be/modules /src >& /dev/null
+        cp -rf /src/se/modules /src >& /dev/null
         cp -rf /src/ee/modules /src >& /dev/null
         cp -rf /src/fe/modules /src >& /dev/null
         cp /src/modules/010-prometheus-crd/crds/*.yaml /src/modules/300-prometheus/crds


### PR DESCRIPTION
## Description
Show documentation for the `node-local-dns` and `flant-integration` modules.

## Why do we need it, and what problem does it solve?
`node-local-dns` and `flant-integration` modules were moved to the BE and disappeared from the site.

## Why do we need it in the patch release (if we do)?

We have to return the module documentation to the site.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Show documentation for the node-local-dns and flant-integration modules.
impact_level: low
```
