### PR TITLE
[ingress-nginx] fix /tmp rights

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-6/Dockerfile
@@ -160,6 +160,7 @@ RUN apt-get update \
   done'
 
 RUN echo "/lib:/usr/lib:/usr/local/lib:/modules_mount/etc/nginx/modules/otel" > /etc/ld-musl-x86_64.path \
+  && chmod 1777 /tmp \
   && setcap    cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap -v cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap    cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added chmod 1777 /tmp to ingress-nginx controller-1.6 final image.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fix /tmp access rights in the controller image to avoid errors like
```
E0214 10:39:01.651045       7 queue.go:130] "requeuing" err="open /tmp/new-nginx-cfg1568789429: permission denied" key="d8-monitoring/prometheus-longterm-b89nt"
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress
type: fix
summary: Fix `/tmp` access rights for controller v1.6.
impact_level: default
```
