### PR TITLE
[helm_lib] Running check-linux-kernel init-container as deckhouse user

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
@@ -46,7 +46,7 @@
   {{- $semver_constraint := index . 1  -}} {{- /* Semver constraint */ -}}
 - name: check-linux-kernel
   image: {{ include "helm_lib_module_common_image" (list $context "checkKernelVersion") }}
-  {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 2 }}
+  {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
   env:
   - name: KERNEL_CONSTRAINT
     value: {{ $semver_constraint | quote }}


### PR DESCRIPTION
## Description

Running check-kernel-version init-container as deckhouse user

## Why do we need it, and what problem does it solve?

During migration to distroless we missed it. Now pods with the init-container can't pass admission-policy-engine check:
```
Error: container has runAsNonRoot and image will run as root (pod: "xxxxxx(8be44c16-456e-4a1f-9042-e00d4301b2f1)", container: check-linux-kernel).
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: helm_lib
type: fix
summary: Running check-kernel-version init-container as deckhouse user
impact: All related Pods will be restarted — cilium-agent, node-local-dns, openvpn.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
