### PR TITLE
[chrony] listen on host IP only

### DIFF
--- a/modules/470-chrony/images/chrony/main.go
+++ b/modules/470-chrony/images/chrony/main.go
@@ -41,6 +41,7 @@ type ChronyConfigTemplateData struct {
 	NTPRole              string
 	NTPServers           []string
 	ChronyMastersService string
+	HostIP               string
 }
 
 func main() {
@@ -70,6 +71,7 @@ func main() {
 		NTPRole:              os.Getenv("NTP_ROLE"),
 		NTPServers:           ntpServersList,
 		ChronyMastersService: os.Getenv("CHRONY_MASTERS_SERVICE"),
+		HostIP:               os.Getenv("HOST_IP"),
 	}
 
 	configBuffer := &bytes.Buffer{}
@@ -89,7 +91,7 @@ func main() {
 		log.Fatal(errors.Wrapf(err, "failed to remove %s file", chronydPidFilePath))
 	}
 
-	cmd := exec.Command(chronydPath, "-d", "-s", "-f", chronyConfPath)
+	cmd := exec.Command(chronydPath, "-4", "-d", "-s", "-f", chronyConfPath)
 	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/modules/470-chrony/template_tests/module_test.go
+++ b/modules/470-chrony/template_tests/module_test.go
@@ -96,6 +96,14 @@ var _ = Describe("Module :: chrony :: helm template ::", func() {
           {
             "name": "CHRONY_MASTERS_SERVICE",
             "value": "chrony-masters.d8-chrony.svc.cluster.local"
+          },
+          {
+            "name": "HOST_IP",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "status.hostIP"
+              }
+            }
           }
         ]
 `))
@@ -112,6 +120,14 @@ var _ = Describe("Module :: chrony :: helm template ::", func() {
           {
             "name": "NTP_SERVERS",
             "value": "pool.ntp.org. ntp.ubuntu.com."
+          },
+          {
+            "name": "HOST_IP",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "status.hostIP"
+              }
+            }
           }
         ]
 `))

--- a/modules/470-chrony/templates/configmap.yaml
+++ b/modules/470-chrony/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
     driftfile /var/run/chrony/chrony.drift
     makestep 1.0 -1
     rtcsync
-    bindaddress 0.0.0.0
+    bindaddress {{ .HostIP }}
     cmdallow 127/8
 
     {{ if (eq .NTPRole "source") }}

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -130,6 +130,10 @@ spec:
           value: {{ join " " $ntpServers | quote }}
         - name: CHRONY_MASTERS_SERVICE
           value: {{ printf "chrony-masters.d8-%s.svc.%s" .Chart.Name .Values.global.clusterConfiguration.clusterDomain | quote }}
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         ports:
         - name: ntp
           containerPort: 123
@@ -242,6 +246,10 @@ spec:
           value: source
         - name: NTP_SERVERS
           value: {{ join " " $ntpServers | quote }}
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         ports:
         - name: ntp
           containerPort: 123


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Set `bindaddress` to host IP.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to avoid listening on all addresses.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony
type: fix
summary: Avoid listening on all addresses and listen on the host IP address.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
