### PR TITLE
[kube-rbac-proxy] listen on pod IP

### DIFF
--- a/ee/be/modules/600-flant-integration/templates/pricing/daemonset.yaml
+++ b/ee/be/modules/600-flant-integration/templates/pricing/daemonset.yaml
@@ -175,7 +175,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/ee/modules/380-metallb/templates/controller/deployment.yaml
+++ b/ee/modules/380-metallb/templates/controller/deployment.yaml
@@ -83,7 +83,9 @@ spec:
               name: https-metrics
           env:
             - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-              value: "0.0.0.0"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: KUBE_RBAC_PROXY_CONFIG
               value: |
                 upstreams:

--- a/ee/modules/380-metallb/templates/speaker/daemonset.yaml
+++ b/ee/modules/380-metallb/templates/speaker/daemonset.yaml
@@ -128,7 +128,9 @@ spec:
               name: https-metrics
           env:
             - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-              value: "0.0.0.0"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: KUBE_RBAC_PROXY_CONFIG
               value: |
                 upstreams:

--- a/ee/modules/500-operator-trivy/templates/deployment.yaml
+++ b/ee/modules/500-operator-trivy/templates/deployment.yaml
@@ -171,7 +171,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -226,7 +226,9 @@ spec:
           - "--livez-path=/livez"
           env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-            value: "0.0.0.0"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: KUBE_RBAC_PROXY_CONFIG
             value: |
               upstreams:

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -108,7 +108,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -103,7 +103,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -129,7 +129,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -115,7 +115,9 @@ spec:
           - "--stale-cache-interval=1h30m"
           env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-            value: "0.0.0.0"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KUBE_RBAC_PROXY_CONFIG
             value: |
               upstreams:

--- a/modules/200-operator-prometheus/templates/operator.yaml
+++ b/modules/200-operator-prometheus/templates/operator.yaml
@@ -88,7 +88,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:

--- a/modules/300-prometheus/templates/grafana/deployment.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment.yaml
@@ -220,7 +220,9 @@ spec:
         - "--livez-path=/livez"
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/300-prometheus/templates/trickster/deployment.yaml
+++ b/modules/300-prometheus/templates/trickster/deployment.yaml
@@ -102,7 +102,9 @@ spec:
           name: https
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/340-extended-monitoring/templates/extended-monitoring-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/extended-monitoring-exporter/deployment.yaml
@@ -103,7 +103,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
@@ -71,7 +71,9 @@ spec:
             scheme: HTTPS
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
@@ -96,7 +96,9 @@ spec:
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/500-dashboard/templates/dashboard/deployment-dashboard.yaml
+++ b/modules/500-dashboard/templates/dashboard/deployment-dashboard.yaml
@@ -102,7 +102,9 @@ spec:
         - "--livez-path=/livez"
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -329,7 +329,9 @@ spec:
           name: https
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -180,7 +180,9 @@ spec:
           name: https
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-          value: "0.0.0.0"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             excludePaths:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Set `KUBE_RBAC_PROXY_LISTEN_ADDRESS` environment variable to pod IP.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to avoid listening on all addresses.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-rbac-proxy
type: fix
summary: kube-rbac-proxy sidecar listening on the pod IP address.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
