### PR TITLE
[ceph-csi] set livenessprobe address to host IP

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.16.0
-digest: sha256:bb336cf36e7921a9790ae25c89d5bc53f14c26336f1396f5248e2f899e68ed21
-generated: "2024-02-14T22:20:04.272056431+03:00"
+  version: 1.19.0
+digest: sha256:48ba1e18ae52b3d2b7374519d40213f308ac35bdf7da91ba5a0d7de39f428378
+generated: "2024-02-20T18:53:28.916883+08:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.16.0"
+    version: "1.19.0"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.16.0
+version: 1.19.0

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -306,10 +306,14 @@ spec:
         image: {{ $livenessprobeImage | quote }}
         args:
         - "--csi-address=$(ADDRESS)"
-        - "--health-port={{ $livenessProbePort }}"
+        - "--http-endpoint=$(HOST_IP):{{ $livenessProbePort }}"
         env:
         - name: ADDRESS
           value: /csi/csi.sock
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         volumeMounts:
         - name: socket-dir
           mountPath: /csi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Set `http-endpoint` address for `livenessprobe` to host IP address.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to avoid listening on all addresses.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ceph-csi
type: fix
summary: Avoid listening on all addresses and listen on the host IP address.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
