### PR TITLE
[documentation]  Use werf artifact for the `docs-builder-artifact` image

### DIFF
--- a/docs/site/werf-docs-builder.inc.yaml
+++ b/docs/site/werf-docs-builder.inc.yaml
@@ -1,5 +1,5 @@
 ---
-image: docs-builder-artifact
+artifact: docs-builder-artifact
 from: {{ .ctx.Images.BASE_GOLANG_20_ALPINE }}
 ansible:
   install:
@@ -28,7 +28,7 @@ from: {{ .ctx.Images.BASE_ALPINE }}
 docker:
   WORKDIR: /app
 import:
-  - image: docs-builder-artifact
+  - artifact: docs-builder-artifact
     add: /go/src/app/server
     to: /app/server
     before: setup

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -185,9 +185,6 @@ var DefaultImagesDigests = map[string]interface{}{
 	"docsBuilder": map[string]interface{}{
 		"docsBuilder": "imageHash-docsBuilder-docsBuilder",
 	},
-	"docsBuilderArtifact": map[string]interface{}{
-		"docsBuilderArtifact": "imageHash-docsBuilderArtifact-docsBuilderArtifact",
-	},
 	"documentation": map[string]interface{}{
 		"web": "imageHash-documentation-web",
 	},


### PR DESCRIPTION
## Description
Use werf artifact for the `docs-builder-artifact` image.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: documentation
type: chore
summary: Use werf artifact for the `docs-builder-artifact` image.
impact_level: low
```
