### PR TITLE
[cilium] Remove deprecated annotation from safe-agent-updater

### DIFF
--- a/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
@@ -33,7 +33,6 @@ spec:
     metadata:
       annotations:
         configmap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         app: safe-agent-updater
     spec:


### PR DESCRIPTION
## Description

Removing deprecated annotation from safe-agent-updater.

## Why do we need it, and what problem does it solve?

The `scheduler.alpha.kubernetes.io/critical-pod` annotation has been non-functional since Kubernetes version 1.16. Its use may cause confusion.

## What is the expected result?

We don't use deprecated annotations in manifests and don't see warnings that they are in the cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cilium
type: chore
summary: Removing deprecated annotation from safe-agent-updater.
impact: The `safe-agent-updater` pods will be restarted
impact_level: low
```
