### PR TITLE
Added sds-replicated-volume support in volume snapshot controller, and removed linstor support

### DIFF
--- a/modules/045-snapshot-controller/docs/README.md
+++ b/modules/045-snapshot-controller/docs/README.md
@@ -11,4 +11,4 @@ Deckhouse CSI-drivers that support snapshots:
 - [cloud-provider-aws](../030-cloud-provider-aws/)
 - [cloud-provider-azure](../030-cloud-provider-azure/)
 - [cloud-provider-gcp](../030-cloud-provider-gcp/)
-- [sds-replicated-volume](/modules/sds-replicated-volume/stable/)
+- [sds-replicated-volume](https://deckhouse.io/modules/sds-replicated-volume/stable/).

--- a/modules/045-snapshot-controller/docs/README_RU.md
+++ b/modules/045-snapshot-controller/docs/README_RU.md
@@ -11,4 +11,4 @@ CSI-драйверы в Deckhouse, которые поддерживают сн�
 - [cloud-provider-aws](../030-cloud-provider-aws/);
 - [cloud-provider-azure](../030-cloud-provider-azure/);
 - [cloud-provider-gcp](../030-cloud-provider-gcp/);
-- [sds-replicated-volume](/modules/sds-replicated-volume/stable/).
+- [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).

--- a/modules/045-snapshot-controller/docs/USAGE.md
+++ b/modules/045-snapshot-controller/docs/USAGE.md
@@ -19,7 +19,7 @@ kind: VolumeSnapshot
 metadata:
   name: my-first-snapshot
 spec:
-  volumeSnapshotClassName: drbd
+  volumeSnapshotClassName: sds-replicated-volume
   source:
     persistentVolumeClaimName: my-first-volume
 ```
@@ -32,7 +32,7 @@ $ kubectl describe volumesnapshots.snapshot.storage.k8s.io my-first-snapshot
 Spec:
   Source:
     Persistent Volume Claim Name:  my-first-snapshot
-  Volume Snapshot Class Name:      drbd
+  Volume Snapshot Class Name:      sds-replicated-volume
 Status:
   Bound Volume Snapshot Content Name:  snapcontent-b6072ab7-6ddf-482b-a4e3-693088136d2c
   Creation Time:                       2020-06-04T13:02:28Z
@@ -48,7 +48,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: my-first-volume-from-snapshot
 spec:
-  storageClassName: drbd-data-r2
+  storageClassName: sds-replicated-volume-data-r2
   dataSource:
     name: my-first-snapshot
     kind: VolumeSnapshot
@@ -74,7 +74,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: my-cloned-pvc
 spec:
-  storageClassName: drbd-data-r2
+  storageClassName: sds-replicated-volume-data-r2
   dataSource:
     name: my-origin-pvc
     kind: PersistentVolumeClaim

--- a/modules/045-snapshot-controller/docs/USAGE_RU.md
+++ b/modules/045-snapshot-controller/docs/USAGE_RU.md
@@ -19,7 +19,7 @@ kind: VolumeSnapshot
 metadata:
   name: my-first-snapshot
 spec:
-  volumeSnapshotClassName: drbd
+  volumeSnapshotClassName: sds-replicated-volume
   source:
     persistentVolumeClaimName: my-first-volume
 ```
@@ -32,7 +32,7 @@ $ kubectl describe volumesnapshots.snapshot.storage.k8s.io my-first-snapshot
 Spec:
   Source:
     Persistent Volume Claim Name:  my-first-snapshot
-  Volume Snapshot Class Name:      drbd
+  Volume Snapshot Class Name:      sds-replicated-volume
 Status:
   Bound Volume Snapshot Content Name:  snapcontent-b6072ab7-6ddf-482b-a4e3-693088136d2c
   Creation Time:                       2020-06-04T13:02:28Z
@@ -48,7 +48,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: my-first-volume-from-snapshot
 spec:
-  storageClassName: drbd-data-r2
+  storageClassName: sds-replicated-volume-data-r2
   dataSource:
     name: my-first-snapshot
     kind: VolumeSnapshot
@@ -74,7 +74,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: my-cloned-pvc
 spec:
-  storageClassName: drbd-data-r2
+  storageClassName: sds-replicated-volume-data-r2
   dataSource:
     name: my-origin-pvc
     kind: PersistentVolumeClaim

--- a/modules/045-snapshot-controller/enabled
+++ b/modules/045-snapshot-controller/enabled
@@ -26,7 +26,7 @@ function __main__() {
       cloud-provider-gcp \
       cloud-provider-openstack \
       cloud-provider-vsphere \
-      linstor \
+      sds-replicated-volume \
     ; do
     if values::array_has global.enabledModules "$module"; then
       enabled=true

--- a/modules/045-snapshot-controller/template_tests/module_test.go
+++ b/modules/045-snapshot-controller/template_tests/module_test.go
@@ -32,7 +32,7 @@ func Test(t *testing.T) {
 
 const (
 	globalValues = `
-  enabledModules: ["vertical-pod-autoscaler-crd", "linstor"]
+  enabledModules: ["vertical-pod-autoscaler-crd", "sds-replicated-volume"]
   highAvailability: true
   modules:
     placement: {}


### PR DESCRIPTION
## Description

This PR fixes the documentation and scripts in the snapshot-controller module by adding support for `sds-replicated-volume` and removing support for linstor.

## Why do we need it, and what problem does it solve?
Now snapshot controller have no support for `sds-replicated-volume` module.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Snapshot controller module supports for sds-replicated-volume module

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: snapshot-controller
type: chore
summary: Fix the documentation. Fix the enabled script to add support for `sds-replicated-volume` module instead of the deprecated `linstor` module.
impact_level: low
```
