### PR TITLE
[shell_lib] Fix an error with password generation in shell hooks

### DIFF
--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -26,6 +26,9 @@ import:
     add: /usr/lib64/python3.9
     before: install
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib/python3/site-packages
+    before: install
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/local/lib/python3/site-packages
     before: install
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact

--- a/shell_lib/hook.sh
+++ b/shell_lib/hook.sh
@@ -25,8 +25,6 @@ function hook::run() {
   for i in `seq 0 $((CONTEXT_LENGTH - 1))`; do
     export BINDING_CONTEXT_CURRENT_INDEX="${i}"
     export BINDING_CONTEXT_CURRENT_BINDING=$(context::jq -r '.binding // "unknown"')
-    echo $BINDING_CONTEXT_CURRENT_BINDING
-    context::jq -r '.'
     case "${BINDING_CONTEXT_CURRENT_BINDING}" in
     "beforeAll")
       HANDLERS="__on_before_all"

--- a/shell_lib/hook.sh
+++ b/shell_lib/hook.sh
@@ -25,7 +25,8 @@ function hook::run() {
   for i in `seq 0 $((CONTEXT_LENGTH - 1))`; do
     export BINDING_CONTEXT_CURRENT_INDEX="${i}"
     export BINDING_CONTEXT_CURRENT_BINDING=$(context::jq -r '.binding // "unknown"')
-
+    echo $BINDING_CONTEXT_CURRENT_BINDING
+    context::jq -r '.'
     case "${BINDING_CONTEXT_CURRENT_BINDING}" in
     "beforeAll")
       HANDLERS="__on_before_all"
@@ -43,7 +44,7 @@ function hook::run() {
       HANDLERS="__on_after_delete_helm"
     ;;
     *)
-      HANDLERS=$(hook::_determine_kubernetes_and_scheduler_handlers)
+      HANDLERS=$(hook::_get_possible_handler_names)
     esac
     HANDLERS="${HANDLERS} __main__"
 

--- a/shell_lib/tools.sh
+++ b/shell_lib/tools.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 function tools::generate_password() {
-  pwgen -s 20 1
+  python3 -c 'import secrets,sys; sys.stdout.write(secrets.token_urlsafe(20))'
 }
 
 function tools::to_slug() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix an error with password generation in shell hooks.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously shell lib uses pwgen to generate passwords. Now we use python to do it.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: Fix an error with password generation in shell hooks
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
