### PR TITLE
[ingress-nginx] add .status.labelSelector to ADS and patch VPA

### DIFF
--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/openkruise-daemonset-apiversion.patch
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/openkruise-daemonset-apiversion.patch
@@ -1,0 +1,40 @@
+diff --git a/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher.go b/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher.go
+index dcbd11ee2..7f7ea6a39 100644
+--- a/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher.go
++++ b/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher.go
+@@ -203,7 +203,9 @@ func (f *controllerFetcher) getParentOfController(controllerKey ControllerKeyWit
+ 	kind := wellKnownController(controllerKey.Kind)
+ 	informer, exists := f.informersMap[kind]
+ 	if exists {
+-		return getParentOfWellKnownController(informer, controllerKey)
++		if kind != daemonSet || (kind == daemonSet && controllerKey.ApiVersion != "apps.kruise.io/v1alpha1") {
++			return getParentOfWellKnownController(informer, controllerKey)
++		}
+ 	}
+ 
+ 	groupKind, err := controllerKey.groupKind()
+@@ -240,6 +242,9 @@ func (c *ControllerKeyWithAPIVersion) groupKind() (schema.GroupKind, error) {
+ 
+ func (f *controllerFetcher) isWellKnown(key *ControllerKeyWithAPIVersion) bool {
+ 	kind := wellKnownController(key.ControllerKey.Kind)
++	if kind == daemonSet && key.ApiVersion == "apps.kruise.io/v1alpha1" {
++		return false
++	}
+ 	_, exists := f.informersMap[kind]
+ 	return exists
+ }
+diff --git a/vertical-pod-autoscaler/pkg/target/fetcher.go b/vertical-pod-autoscaler/pkg/target/fetcher.go
+index f7cb73bd0..7d96a62ec 100644
+--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
++++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
+@@ -123,7 +123,9 @@ func (f *vpaTargetSelectorFetcher) Fetch(vpa *vpa_types.VerticalPodAutoscaler) (
+ 	kind := wellKnownController(vpa.Spec.TargetRef.Kind)
+ 	informer, exists := f.informersMap[kind]
+ 	if exists {
+-		return getLabelSelector(informer, vpa.Spec.TargetRef.Kind, vpa.Namespace, vpa.Spec.TargetRef.Name)
++		if kind != daemonSet || (kind == daemonSet && vpa.Spec.TargetRef.APIVersion != "apps.kruise.io/v1alpha1") {
++			return getLabelSelector(informer, vpa.Spec.TargetRef.Kind, vpa.Namespace, vpa.Spec.TargetRef.Name)
++		}
+ 	}
+ 
+ 	// not on a list of known controllers, use scale sub-resource

--- a/modules/402-ingress-nginx/crds/kruise/crd_daemonsets.yaml
+++ b/modules/402-ingress-nginx/crds/kruise/crd_daemonsets.yaml
@@ -410,6 +410,9 @@ spec:
                     pod
                   format: int32
                   type: integer
+                labelSelector:
+                  description: A serialized label selector in string form
+                  type: string
               required:
                 - currentNumberScheduled
                 - daemonSetHash
@@ -426,6 +429,7 @@ spec:
         scale:
           specReplicasPath: .spec.replicas
           statusReplicasPath: .status.numberAvailable
+          labelSelectorPath: .status.labelSelector
 status:
   acceptedNames:
     kind: ""

--- a/modules/402-ingress-nginx/images/kruise/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise/patches/README.md
@@ -36,3 +36,7 @@ go get -u github.com/opencontainers/runc@v1.1.5
 go get -u gopkg.in/yaml.v3@v3.0.1
 git diff
 ```
+
+### Add label selector to scale
+Adds .status.labelSelector field to the daemonset crd and implements updating this status field with a serialized label selector in string form (required to implement VPA for advanced daemonsets).
+(this patch should go along wth Add pdb patch)

--- a/modules/402-ingress-nginx/images/kruise/patches/add-label-selector-to-scale.patch
+++ b/modules/402-ingress-nginx/images/kruise/patches/add-label-selector-to-scale.patch
@@ -1,0 +1,76 @@
+diff --git a/apis/apps/v1alpha1/daemonset_types.go b/apis/apps/v1alpha1/daemonset_types.go
+index cfbf05e2..3e7314db 100644
+--- a/apis/apps/v1alpha1/daemonset_types.go
++++ b/apis/apps/v1alpha1/daemonset_types.go
+@@ -224,6 +224,9 @@ type DaemonSetStatus struct {
+ 
+ 	// DaemonSetHash is the controller-revision-hash, which represents the latest version of the DaemonSet.
+ 	DaemonSetHash string `json:"daemonSetHash"`
++
++	// LabeSelector is serialized label selector in string form.
++	LabelSelector string `json:"labelSelector"`
+ }
+ 
+ // +genclient
+diff --git a/pkg/controller/daemonset/daemonset_controller.go b/pkg/controller/daemonset/daemonset_controller.go
+index f5e7bbc1..9f2ccbbb 100644
+--- a/pkg/controller/daemonset/daemonset_controller.go
++++ b/pkg/controller/daemonset/daemonset_controller.go
+@@ -512,6 +512,12 @@ func NewPod(ds *appsv1alpha1.DaemonSet, nodeName string) *corev1.Pod {
+ }
+ 
+ func (dsc *ReconcileDaemonSet) updateDaemonSetStatus(ds *appsv1alpha1.DaemonSet, nodeList []*corev1.Node, hash string, updateObservedGen bool) error {
++	labelSelector, err := metav1.LabelSelectorAsMap(ds.Spec.Selector)
++	if err != nil {
++		return fmt.Errorf("couldn't convert label selector to map for DaemonSet %q: %v", ds.Name, err)
++	}
++
++	labelSelectorString := labels.SelectorFromSet(labelSelector).String()
+ 	nodeToDaemonPods, err := dsc.getNodesToDaemonPods(ds)
+ 	if err != nil {
+ 		return fmt.Errorf("couldn't get node to daemon pod mapping for DaemonSet %q: %v", ds.Name, err)
+@@ -555,7 +561,7 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
+ 	}
+ 	numberUnavailable := desiredNumberScheduled - numberAvailable
+ 
+-	err = dsc.storeDaemonSetStatus(ds, desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady, updatedNumberScheduled, numberAvailable, numberUnavailable, updateObservedGen, hash)
++	err = dsc.storeDaemonSetStatus(ds, desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady, updatedNumberScheduled, numberAvailable, numberUnavailable, updateObservedGen, hash, labelSelectorString)
+ 	if err != nil {
+ 		return fmt.Errorf("error storing status for DaemonSet %v: %v", ds.Name, err)
+ 	}
+@@ -630,7 +636,7 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetReplicas(ds *appsv1alpha1.DaemonSe
+ 				klog.Infof("Updating relevant PodDisruptionBudget %s/%s", ds.Namespace, ds.Name)
+ 				toUpdate.Status.ExpectedPods = newScale.Spec.Replicas
+ 
+-				_, err = policyClient.UpdateStatus(context.TODO(), toUpdate, metav1.UpdateOptions{}) 
++				_, err = policyClient.UpdateStatus(context.TODO(), toUpdate, metav1.UpdateOptions{})
+ 				if err != nil {
+ 					klog.Errorf("Couldn't update relevant PodDisruptionBudget status for DaemonSet %s/%s: %v", ds.Namespace, ds.Name, err)
+ 					return err
+@@ -643,7 +649,7 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetReplicas(ds *appsv1alpha1.DaemonSe
+ 	})
+ }
+ 
+-func (dsc *ReconcileDaemonSet) storeDaemonSetStatus(ds *appsv1alpha1.DaemonSet, desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady, updatedNumberScheduled, numberAvailable, numberUnavailable int, updateObservedGen bool, hash string) error {
++func (dsc *ReconcileDaemonSet) storeDaemonSetStatus(ds *appsv1alpha1.DaemonSet, desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady, updatedNumberScheduled, numberAvailable, numberUnavailable int, updateObservedGen bool, hash, labelSelector string) error {
+ 	if int(ds.Status.DesiredNumberScheduled) == desiredNumberScheduled &&
+ 		int(ds.Status.CurrentNumberScheduled) == currentNumberScheduled &&
+ 		int(ds.Status.NumberMisscheduled) == numberMisscheduled &&
+@@ -652,7 +658,8 @@ func (dsc *ReconcileDaemonSet) storeDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
+ 		int(ds.Status.NumberAvailable) == numberAvailable &&
+ 		int(ds.Status.NumberUnavailable) == numberUnavailable &&
+ 		ds.Status.ObservedGeneration >= ds.Generation &&
+-		ds.Status.DaemonSetHash == hash {
++		ds.Status.DaemonSetHash == hash &&
++		ds.Status.LabelSelector == labelSelector {
+ 		return nil
+ 	}
+ 
+@@ -671,6 +678,7 @@ func (dsc *ReconcileDaemonSet) storeDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
+ 		toUpdate.Status.NumberAvailable = int32(numberAvailable)
+ 		toUpdate.Status.NumberUnavailable = int32(numberUnavailable)
+ 		toUpdate.Status.DaemonSetHash = hash
++		toUpdate.Status.LabelSelector = labelSelector
+ 
+ 		if _, updateErr = dsClient.UpdateStatus(context.TODO(), toUpdate, metav1.UpdateOptions{}); updateErr == nil {
+ 			klog.Infof("Updated DaemonSet %s/%s status to %v", ds.Namespace, ds.Name, kruiseutil.DumpJSON(toUpdate.Status))

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -33,7 +33,7 @@ metadata:
   {{ include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $name )) | nindent 2 }}
 spec:
   targetRef:
-    apiVersion: "apps/v1"
+    apiVersion: "apps.kruise.io/v1alpha1"
     kind: DaemonSet
     name: controller-{{ $name }}
     {{- if eq ($resourcesRequests.mode | default "") "VPA" }}

--- a/modules/402-ingress-nginx/templates/failover/daemonset.yaml
+++ b/modules/402-ingress-nginx/templates/failover/daemonset.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list $context (dict "app" "proxy-failover" "name" $crd.name)) | nindent 2 }}
 spec:
   targetRef:
-    apiVersion: "apps/v1"
+    apiVersion: "apps.kruise.io/v1alpha1"
     kind: DaemonSet
     name: proxy-{{ $crd.name }}-failover
   updatePolicy:


### PR DESCRIPTION
## Description
PR includes the following changes:
* `Vertical pod autoscaler` is patched so that it could tell the difference between original `apps/v1 daemonsets` and `openkruise apps.kruise.io/v1alpha1 advanved daemonsets`. With the proposed changes VPA is able to discover necessary pods of an advanced daemonetset via the daemonset's `scale subresource` (`labelSelectorPath` option);
* OpenKruise controller is patched to set a proper value to `.status.labelSelecor` field of an advanved daemonset. This values is used as `labelSelectorPath` option of a `scale subresource` and `labelSelectorPath` value is used by VPA to discover relevant pods of a controller;
* OpenKruise AdvancedDaemonetSet CR is updated with `.status.labelSelector` and `.subresources.scale.labelSelectorPath` fields so that advanced daemonset sets would be compatible with VPA;
* VPAs for ingress-controllers are updated to use correct `apps.kruise.io/v1alpha1` values in their TargetRefs;
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
As of now, VPA can't calculate recommendations for pods created by OpenKruise advanced daemonsets.
It happens because advanced daemonet sets also have Kind set to `daemonset` and VPA treats it as a well-known controller, trying to fetch required information via apps/v1 informer and  ending up with `daemonset not found`.
Closes #6746 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
VPA is able to provide recommendations for an advanced daemonset's pods.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx, vpa
type: feature
summary: Add VPA support to openkruise advance daemonsets.
impact: Vpa-admission-controller/recommender/updater pods will be recreated. OpenKruise controller manager pod will be recreated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
