### PR TITLE
Fix false test triggering when cluster configuration secret is unavailable

### DIFF
--- a/modules/340-monitoring-kubernetes/hooks/auto_k8s_version_test.go
+++ b/modules/340-monitoring-kubernetes/hooks/auto_k8s_version_test.go
@@ -74,26 +74,20 @@ data:
 
 	f := HookExecutionConfigInit("{\"global\": {\"discovery\": {}}}", "{}")
 	Context("helm3 release with deprecated versions", func() {
-		BeforeEach(func() {
-			f.KubeStateSet("")
-			var sec corev1.Secret
-			_ = yaml.Unmarshal([]byte(helm3ReleaseWithDeprecated), &sec)
-
-			_, err := dependency.TestDC.MustGetK8sClient().
-				CoreV1().
-				Secrets("appns").
-				Create(context.TODO(), &sec, metav1.CreateOptions{})
-			Expect(err).To(BeNil())
-
-			f.BindingContexts.Set(f.GenerateScheduleContext("0 * * * *"))
-
-		})
-
 		Context("check for kubernetesVersion: \"Automatic\"", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.KubeStateSet(stateAutomatic))
-				f.RunGoHook()
 
+				var sec corev1.Secret
+				_ = yaml.Unmarshal([]byte(helm3ReleaseWithDeprecated), &sec)
+
+				_, err := dependency.TestDC.MustGetK8sClient().
+					CoreV1().
+					Secrets("appns").
+					Create(context.TODO(), &sec, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
+
+				f.RunGoHook()
 			})
 
 			It("must have autoK8sVersion", func() {
@@ -121,6 +115,14 @@ data:
 		Context("check for kubernetesVersion: \"1.25\"", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.KubeStateSet(stateConcreteVersion))
+				var sec corev1.Secret
+				_ = yaml.Unmarshal([]byte(helm3ReleaseWithDeprecated), &sec)
+
+				_, err := dependency.TestDC.MustGetK8sClient().
+					CoreV1().
+					Secrets("appns").
+					Create(context.TODO(), &sec, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
 				f.RunGoHook()
 			})
 
@@ -142,6 +144,15 @@ data:
 
 		Context("check for empty \"ClusterConfiguration\"", func() {
 			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(""))
+				var sec corev1.Secret
+				_ = yaml.Unmarshal([]byte(helm3ReleaseWithDeprecated), &sec)
+
+				_, err := dependency.TestDC.MustGetK8sClient().
+					CoreV1().
+					Secrets("appns").
+					Create(context.TODO(), &sec, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
 				f.RunGoHook()
 			})
 
@@ -163,25 +174,20 @@ data:
 	})
 
 	Context("helm3 release without deprecated apis", func() {
-		BeforeEach(func() {
-			f.KubeStateSet("")
-			var sec corev1.Secret
-			_ = yaml.Unmarshal([]byte(helm3ReleaseWithoutDeprecated), &sec)
-
-			_, err := dependency.TestDC.MustGetK8sClient().
-				CoreV1().
-				Secrets("default").
-				Create(context.TODO(), &sec, metav1.CreateOptions{})
-			Expect(err).To(BeNil())
-			f.BindingContexts.Set(f.GenerateScheduleContext("0 * * * *"))
-			f.RunGoHook()
-		})
-
 		Context("check for kubernetesVersion: \"Automatic\"", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.KubeStateSet(stateAutomatic))
-				f.RunGoHook()
 
+				var sec corev1.Secret
+				_ = yaml.Unmarshal([]byte(helm3ReleaseWithoutDeprecated), &sec)
+
+				_, err := dependency.TestDC.MustGetK8sClient().
+					CoreV1().
+					Secrets("default").
+					Create(context.TODO(), &sec, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
+
+				f.RunGoHook()
 			})
 
 			It("autoK8sVersion must be empty", func() {
@@ -199,28 +205,22 @@ data:
 				Expect(reasons).To(BeEmpty())
 			})
 		})
-
 	})
 
 	Context("helm2 release with deprecated versions", func() {
-		BeforeEach(func() {
-			f.KubeStateSet("")
-			var cm corev1.ConfigMap
-			_ = yaml.Unmarshal([]byte(helm2ReleaseWithDeprecated), &cm)
-
-			_, err := dependency.TestDC.MustGetK8sClient().
-				CoreV1().
-				ConfigMaps("default").
-				Create(context.TODO(), &cm, metav1.CreateOptions{})
-			Expect(err).To(BeNil())
-			f.BindingContexts.Set(f.GenerateScheduleContext("0 * * * *"))
-			f.RunGoHook()
-
-		})
-
 		Context("check for kubernetesVersion: \"Automatic\"", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.KubeStateSet(stateAutomatic))
+
+				var cm corev1.ConfigMap
+				_ = yaml.Unmarshal([]byte(helm2ReleaseWithDeprecated), &cm)
+
+				_, err := dependency.TestDC.MustGetK8sClient().
+					CoreV1().
+					ConfigMaps("default").
+					Create(context.TODO(), &cm, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
+
 				f.RunGoHook()
 
 			})
@@ -247,7 +247,8 @@ data:
 
 	Context("release with doubled fields", func() {
 		BeforeEach(func() {
-			f.KubeStateSet("")
+			f.BindingContexts.Set(f.KubeStateSet(stateAutomatic))
+
 			var sec corev1.Secret
 			_ = yaml.Unmarshal([]byte(releaseWithDoubleFields), &sec)
 
@@ -256,8 +257,7 @@ data:
 				Secrets("default").
 				Create(context.TODO(), &sec, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
-			f.BindingContexts.Set(f.GenerateScheduleContext("0 * * * *"))
-			f.BindingContexts.Set(f.KubeStateSet(stateAutomatic))
+
 			f.RunGoHook()
 
 		})


### PR DESCRIPTION
## Description

Autotest has a high probability of false positives when running in the test pipeline because the cluster configuration is not set in time.

![screen](https://github.com/deckhouse/deckhouse/assets/52157046/e868fc99-7f18-4e5f-a68a-be999c528c9d)

## Why do we need it, and what problem does it solve?

Eliminates the need to repeatedly restart the testing pipeline.

## What is the expected result?

Significantly reduces the chances of false positive tests.
In testing, 3 out of 3 launches were successful.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Reduces the chances of false positive tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
