### PR TITLE
[docs][multitenancy-manager] Mark the ProjectType resource fields as deprecated

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -56,6 +56,9 @@ common:
   deprecated_parameter:
     en: Deprecated
     ru: Параметр устарел
+  deprecated_resource:
+    en: Deprecated resource. Support for the resource might be removed in a later release.
+    ru: Устаревший ресурс. Поддержка ресурса может быть исключена в следующих версиях.
   deprecated_parameter_hint:
     en: Support for the parameter might be removed in a later release.
     ru: Поддержка параметра может быть исключена в следующих версиях.

--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -638,6 +638,10 @@ module Jekyll
                         activeStatus = ""
                     end
 
+                     if get_hash_value(item,'deprecated') then
+                         result.push(sprintf('<p><strong>%s</strong></p>',get_i18n_term('deprecated_resource')))
+                     end
+
                     description = ''
                     if get_hash_value(item,'schema','openAPIV3Schema','description') then
                        if    input['i18n'][@context.registers[:page]["lang"]] and

--- a/ee/modules/160-multitenancy-manager/crds/projecttypes.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/projecttypes.yaml
@@ -30,6 +30,7 @@ spec:
             spec:
               properties:
                 namespaceMetadata:
+                  x-doc-deprecated: true
                   description:
                     Labels and annotations that apply to created
                     namespaces when setting up the environment.
@@ -38,10 +39,12 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                      x-doc-deprecated: true
                     labels:
                       additionalProperties:
                         type: string
                       type: object
+                      x-doc-deprecated: true
                   type: object
                 openAPI:
                   additionalProperties:
@@ -49,6 +52,7 @@ spec:
                   description:
                     OpenAPI specification for template values (the [resourcesTemplate](#projecttype-v1alpha1-spec-resourcestemplate) parameter).
                   type: object
+                  x-doc-deprecated: true
                 resourcesTemplate:
                   description: |
                     Resource templates in `helm` format to be created when setting up a new environment.
@@ -63,10 +67,12 @@ spec:
                     > **Note!** Specifying `.metadata.namespace` fields for objects is optional,
                     > as they are automatically set with the name of the created environment (CR `Project`).
                   type: string
+                  x-doc-deprecated: true
                 subjects:
                   description:
                     List of ServiceAccounts, Groups and Users to provide
                     access to the created environment (project).
+                  x-doc-deprecated: true
                   items:
                     oneOf:
                       - properties:
@@ -102,12 +108,14 @@ spec:
                           - User
                           - Group
                         type: string
+                        x-doc-deprecated: true
                       name:
                         description:
                           The name of the target resource to apply access
                           to the environment.
                         minLength: 1
                         type: string
+                        x-doc-deprecated: true
                       namespace:
                         description:
                           The namespace of the target resource to apply environment access to.
@@ -115,6 +123,7 @@ spec:
                           Required only when using `ServiceAccount` from another namespace.
                         pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
                         type: string
+                        x-doc-deprecated: true
                       role:
                         description: Role name from [user-authz module](../140-user-authz/cr.html#clusterauthorizationrule-v1-spec-accesslevel)
                         enum:
@@ -123,6 +132,7 @@ spec:
                           - Editor
                           - Admin
                         type: string
+                        x-doc-deprecated: true
                     type: object
                   type: array
               type: object


### PR DESCRIPTION
## Description
- Mark the `ProjectType` resource fields as deprecated.
- Fix the OpenAPI generator to show the deprecation status of a resource if `spec.versions[].deprecated` resource field is set to `true`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: multitenancy-maanger
type: chore
summary: Mark the `ProjectType` resource as deprecated.
impact_level: low
```
