### PR TITLE
[docs][multitenancy-manager] Don't render the ProjectType resource in the documentation.

### DIFF
--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -79,7 +79,7 @@
   stageDependencies:
     setup: ['**/*']
   includePaths: ['*/docs/','*/openapi/','*/crds/', '*/oss.yaml']
-  excludePaths: ['*/openapi/values.yaml', '*/openapi/*-tests.yaml', '*/docs/internal/']
+  excludePaths: ['*/openapi/values.yaml', '*/openapi/*-tests.yaml', '*/docs/internal/', '160-multitenancy-manager/crds/projecttypes.yaml', '160-multitenancy-manager/crds/doc-ru-projecttypes.yaml']
 - add: /ee/candi/cloud-providers/openstack/openapi
   to: /src/ee/modules/030-cloud-provider-openstack/crds
   owner: jekyll


### PR DESCRIPTION
## Description
Don't render the ProjectType resource in the documentation as it has been deprecated.

## Changelog entries
```changes
section: multitenancy-manager
type: chore
summary: Don't render the ProjectType resource in the documentation as it has been deprecated.
```
