### PR TITLE
[node-manager](caps) Check for `SSHCredentials` in the `StaticInstance` webhook

### DIFF
--- a/modules/040-node-manager/webhooks/validating/static_instance
+++ b/modules/040-node-manager/webhooks/validating/static_instance
@@ -33,6 +33,17 @@ kubernetes:
         "name": .metadata.name,
         "address": .spec.address,
       }
+  - name: sshCredentials
+    apiVersion: deckhouse.io/v1alpha1
+    kind: SSHCredentials
+    group: main
+    executeHookOnEvent: []
+    executeHookOnSynchronization: false
+    keepFullObjectsInMemory: false
+    jqFilter: |
+      {
+        "name": .metadata.name,
+      }
 kubernetesValidating:
 - name: staticinstances-unique.deckhouse.io
   group: main
@@ -48,10 +59,18 @@ EOF
 function __main__() {
   name=$(context::jq -r '.review.request.object.metadata.name')
   address=$(context::jq -r '.review.request.object.spec.address')
+  credentialsName=$(context::jq -r '.review.request.object.spec.credentialsRef.name')
 
   if instanceWithTheSameAddress="$(context::jq -er --arg name "$name" --arg address "$address" '.snapshots.instances[].filterResult | select(.name != $name) | select(.address == $address) | .name' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"staticinstances.deckhouse.io \"$name\", static instance \"$instanceWithTheSameAddress\" is already using the address \"$address\"" }
+EOF
+    return 0
+  fi
+
+  if ! context::jq -er --arg name "$credentialsName" '.snapshots.sshCredentials[].filterResult | select(.name == $name) | length == 1' >/dev/null 2>&1; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"staticinstances.deckhouse.io \"$name\", ssh credentials \"$credentialsName\" does not exist" }
 EOF
     return 0
   fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Check for `SSHCredentials` in the `StaticInstance` webhook.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to check if `SSHCredentials` exists before reconciling it in the `StaticInstance` controller.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Check for `SSHCredentials` in the `StaticInstance` webhook.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
