### PR TITLE
[dhctl] feat(dhctl-for-commander): support multiple ssh keys and passphrase

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -37,7 +38,13 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	app.DefinePreflight(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.Bootstrap()

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -33,7 +34,13 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 	app.DefineDeckhouseInstallFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.InstallDeckhouse()
@@ -50,7 +57,13 @@ func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause) *kingpin.C
 	app.DefineBashibleBundleFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.ExecuteBashible()
@@ -67,7 +80,13 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineKubeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.CreateResources()
@@ -86,7 +105,13 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineAbortFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.Abort(app.ForceAbortFromCache)
@@ -102,7 +127,13 @@ func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause) *kingpin.CmdClau
 	app.DefineDropCacheFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.BaseInfrastructure()
@@ -118,7 +149,13 @@ func DefineExecPostBootstrapScript(parent *kingpin.CmdClause) *kingpin.CmdClause
 	app.DefinePostBootstrapScriptFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
+			SSHClient:        sshClient,
 			TerraformContext: terraform.NewTerraformContext(),
 		})
 		return bootstraper.ExecPostBootstrap()

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -89,7 +89,6 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 			log.ErrorF("Can not load available ssh hosts: %v\n", err)
 			return err
 		}
-		app.SSHHosts = mastersIPs
 		b.SSHClient.Settings.SetAvailableHosts(mastersIPs)
 	}
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -26,7 +26,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	terrastate "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -42,34 +41,6 @@ func (b *ClusterBootstrapper) Abort(forceAbortFromCache bool) error {
 	}
 
 	return log.Process("bootstrap", "Abort", func() error { return b.doRunBootstrapAbort(forceAbortFromCache) })
-}
-
-func getSSHClient(initializeNewAgent bool) (*ssh.Client, error) {
-	if len(app.SSHHosts) == 0 {
-		mastersIPs, err := GetMasterHostsIPs()
-		if err != nil {
-			return nil, err
-		}
-		app.SSHHosts = mastersIPs
-	}
-
-	bastionHost, err := GetBastionHostFromCache()
-	if err != nil {
-		log.ErrorF("Can not load bastion host: %v\n", err)
-		return nil, err
-	}
-
-	if bastionHost != "" {
-		setBastionHost(bastionHost, nil)
-	}
-
-	sshClient := ssh.NewClientFromFlags()
-	sshClient.InitializeNewAgent = initializeNewAgent
-	if _, err := sshClient.Start(); err != nil {
-		return nil, fmt.Errorf("unable to start ssh client: %w", err)
-	}
-
-	return sshClient, nil
 }
 
 func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) error {
@@ -112,13 +83,24 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 
 	var destroyer destroy.Destroyer
 
-	var sshClient *ssh.Client
-	if b.initializeNewAgent {
-		defer func() {
-			if sshClient != nil {
-				sshClient.Stop()
-			}
-		}()
+	if len(b.SSHClient.Settings.AvailableHosts()) == 0 {
+		mastersIPs, err := GetMasterHostsIPs()
+		if err != nil {
+			log.ErrorF("Can not load available ssh hosts: %v\n", err)
+			return err
+		}
+		app.SSHHosts = mastersIPs
+		b.SSHClient.Settings.SetAvailableHosts(mastersIPs)
+	}
+
+	bastionHost, err := GetBastionHostFromCache()
+	if err != nil {
+		log.ErrorF("Can not load bastion host: %v\n", err)
+		return err
+	}
+
+	if bastionHost != "" {
+		b.SSHClient.Settings.BastionHost = bastionHost
 	}
 
 	err = log.Process("common", "Choice abort type", func() error {
@@ -137,11 +119,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 					},
 				)
 			} else {
-				sshClient, err := getSSHClient(b.initializeNewAgent)
-				if err != nil {
-					return err
-				}
-				destroyer = destroy.NewStaticMastersDestroyer(sshClient)
+				destroyer = destroy.NewStaticMastersDestroyer(b.SSHClient)
 			}
 
 			logMsg := "Deckhouse installation was not started before. Abort from cache"
@@ -154,23 +132,18 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 			return nil
 		}
 
-		sshClient, err := getSSHClient(b.initializeNewAgent)
-		if err != nil {
-			return err
-		}
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
 
 		if !b.CommanderMode {
-			if err = cache.InitWithOptions(sshClient.Check().String(), cache.CacheOptions{}); err != nil {
-				return fmt.Errorf(bootstrapAbortInvalidCacheMessage, sshClient.Check().String(), err)
+			if err = cache.InitWithOptions(b.SSHClient.Check().String(), cache.CacheOptions{}); err != nil {
+				return fmt.Errorf(bootstrapAbortInvalidCacheMessage, b.SSHClient.Check().String(), err)
 			}
 		}
 
 		destroyParams := &destroy.Params{
-			SSHClient:              sshClient,
+			SSHClient:              b.SSHClient,
 			StateCache:             cache.Global(),
 			PhasedExecutionContext: b.PhasedExecutionContext,
 			SkipResources:          app.SkipResources,

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -289,8 +289,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 				SaveBastionHostToCache(baseOutputs.BastionHost)
 			}
 
-			app.SSHHosts = []string{masterOutputs.MasterIPForSSH}
-			b.SSHClient.Settings.SetAvailableHosts(app.SSHHosts)
+			b.SSHClient.Settings.SetAvailableHosts([]string{masterOutputs.MasterIPForSSH})
 
 			nodeIP = masterOutputs.NodeInternalIP
 			devicePath = masterOutputs.KubeDataDevicePath
@@ -520,24 +519,6 @@ func bootstrapAdditionalNodesForCloudCluster(kubeCl *client.KubernetesClient, me
 		}
 		return nil
 	})
-}
-
-func setBastionHost(host string, sshClient *ssh.Client) {
-	app.SSHBastionHost = host
-
-	if app.SSHBastionUser == "" {
-		app.SSHBastionUser = app.SSHUser
-	}
-
-	if app.SSHBastionPort == "" {
-		app.SSHBastionPort = app.SSHPort
-	}
-
-	if sshClient != nil {
-		sshClient.Settings.BastionHost = app.SSHBastionHost
-		sshClient.Settings.BastionUser = app.SSHBastionUser
-		sshClient.Settings.BastionPort = app.SSHBastionPort
-	}
 }
 
 func createResources(kubeCl *client.KubernetesClient, resourcesToCreate template.Resources, metaConfig *config.MetaConfig) error {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -285,8 +285,12 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			deckhouseInstallConfig.TerraformState = baseOutputs.TerraformState
 
 			if baseOutputs.BastionHost != "" {
+				b.SSHClient.Settings.BastionHost = baseOutputs.BastionHost
 				SaveBastionHostToCache(baseOutputs.BastionHost)
 			}
+
+			app.SSHHosts = []string{masterOutputs.MasterIPForSSH}
+			b.SSHClient.Settings.SetAvailableHosts(app.SSHHosts)
 
 			nodeIP = masterOutputs.NodeInternalIP
 			devicePath = masterOutputs.KubeDataDevicePath

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -71,6 +71,7 @@ If you are confident in your actions, you can use the flag "--yes-i-am-sane-and-
 
 // TODO(remove-global-app): Support all needed parameters in Params, remove usage of app.*
 type Params struct {
+	SSHClient                  *ssh.Client
 	InitialState               phases.DhctlState
 	ResetInitialState          bool
 	DisableBootstrapClearCache bool
@@ -82,10 +83,6 @@ type Params struct {
 	ResourcesPath           string
 	ResourcesTimeout        time.Duration
 	DeckhouseTimeout        time.Duration
-	SSHUser                 string
-	SSHBastionUser          string
-	SSHAgentPrivateKeys     []string
-	SSHHosts                []string
 	PostBootstrapScriptPath string
 	UseTfCache              *bool
 	AutoApprove             *bool
@@ -134,27 +131,6 @@ func (b *ClusterBootstrapper) applyParams() (func(), error) {
 	}
 	if b.DeckhouseTimeout != 0 {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.DeckhouseTimeout, b.DeckhouseTimeout))
-	}
-	if b.SSHUser != "" {
-		restoreFuncs = append(restoreFuncs, setWithRestore(&app.SSHUser, b.SSHUser))
-	}
-	if b.SSHBastionUser != "" {
-		restoreFuncs = append(restoreFuncs, setWithRestore(&app.SSHBastionUser, b.SSHBastionUser))
-	}
-	if b.SSHAgentPrivateKeys != nil {
-		restoreFuncs = append(restoreFuncs, setWithRestore(&app.SSHAgentPrivateKeys, b.SSHAgentPrivateKeys))
-
-		privKeys, err := app.ParseSSHPrivateKeyPaths(b.SSHAgentPrivateKeys)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing ssh agent private keys %v: %w", b.SSHAgentPrivateKeys, err)
-		}
-		restoreFuncs = append(restoreFuncs, setWithRestore(&app.SSHPrivateKeys, privKeys))
-
-		// NOTICE: disable "ssh-agent is singleton" logic
-		b.initializeNewAgent = true
-	}
-	if b.SSHHosts != nil {
-		restoreFuncs = append(restoreFuncs, setWithRestore(&app.SSHHosts, b.SSHHosts))
 	}
 	if b.PostBootstrapScriptPath != "" {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.PostBootstrapScriptPath, b.PostBootstrapScriptPath))
@@ -228,16 +204,6 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	b.lastState = nil
 	defer b.PhasedExecutionContext.Finalize(stateCache)
 
-	sshClient := ssh.NewClientFromFlags()
-	sshClient.InitializeNewAgent = b.initializeNewAgent
-	// after verifying configs and cache ask password
-	if _, err := sshClient.Start(); err != nil {
-		return fmt.Errorf("unable to start ssh client: %w", err)
-	}
-	if b.initializeNewAgent {
-		defer sshClient.Stop()
-	}
-
 	err = terminal.AskBecomePassword()
 	if err != nil {
 		return err
@@ -260,7 +226,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	deckhouseInstallConfig.KubeadmBootstrap = true
 	deckhouseInstallConfig.MasterNodeSelector = true
 
-	preflightChecker := preflight.NewChecker(sshClient, deckhouseInstallConfig, metaConfig)
+	preflightChecker := preflight.NewChecker(b.SSHClient, deckhouseInstallConfig, metaConfig)
 	if err := preflightChecker.Global(); err != nil {
 		return err
 	}
@@ -319,12 +285,8 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			deckhouseInstallConfig.TerraformState = baseOutputs.TerraformState
 
 			if baseOutputs.BastionHost != "" {
-				setBastionHost(baseOutputs.BastionHost, sshClient)
 				SaveBastionHostToCache(baseOutputs.BastionHost)
 			}
-
-			app.SSHHosts = []string{masterOutputs.MasterIPForSSH}
-			sshClient.Settings.SetAvailableHosts(app.SSHHosts)
 
 			nodeIP = masterOutputs.NodeInternalIP
 			devicePath = masterOutputs.KubeDataDevicePath
@@ -350,12 +312,12 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		_ = json.Unmarshal(metaConfig.ClusterConfig["static"], &static)
 		nodeIP = static.NodeIP
 
-		if sshClient.Settings.BastionHost != "" {
-			SaveBastionHostToCache(sshClient.Settings.BastionHost)
+		if b.SSHClient.Settings.BastionHost != "" {
+			SaveBastionHostToCache(b.SSHClient.Settings.BastionHost)
 		}
 
 		SaveMasterHostsToCache(map[string]string{
-			"first-master": sshClient.Settings.Host(),
+			"first-master": b.SSHClient.Settings.Host(),
 		})
 	}
 
@@ -378,10 +340,10 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		return nil
 	}
 
-	if err := WaitForSSHConnectionOnMaster(sshClient); err != nil {
+	if err := WaitForSSHConnectionOnMaster(b.SSHClient); err != nil {
 		return err
 	}
-	if err := RunBashiblePipeline(sshClient, metaConfig, nodeIP, devicePath); err != nil {
+	if err := RunBashiblePipeline(b.SSHClient, metaConfig, nodeIP, devicePath); err != nil {
 		return err
 	}
 
@@ -391,7 +353,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		return nil
 	}
 
-	kubeCl, err := operations.ConnectToKubernetesAPI(sshClient)
+	kubeCl, err := operations.ConnectToKubernetesAPI(b.SSHClient)
 	if err != nil {
 		return err
 	}
@@ -439,7 +401,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	}
 
 	if app.PostBootstrapScriptPath != "" {
-		postScriptExecutor := NewPostBootstrapScriptExecutor(sshClient, app.PostBootstrapScriptPath, bootstrapState).
+		postScriptExecutor := NewPostBootstrapScriptExecutor(b.SSHClient, app.PostBootstrapScriptPath, bootstrapState).
 			WithTimeout(app.PostBootstrapScriptTimeout)
 
 		if err := postScriptExecutor.Execute(); err != nil {
@@ -475,7 +437,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	if metaConfig.ClusterType == config.CloudClusterType {
 		_ = log.Process("common", "Kubernetes Master Node addresses for SSH", func() error {
 			for nodeName, address := range masterAddressesForSSH {
-				fakeSession := sshClient.Settings.Copy()
+				fakeSession := b.SSHClient.Settings.Copy()
 				fakeSession.SetAvailableHosts([]string{address})
 				log.InfoF("%s | %s\n", nodeName, fakeSession.String())
 			}

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -170,9 +170,12 @@ func prepareSSHClient(connectionConfig *config.ConnectionConfig) (*ssh.Client, e
 		AvailableHosts: sshHosts,
 		User:           connectionConfig.SSHConfig.SSHUser,
 	})
-	privateKeys := make([]string, 0, len(connectionConfig.SSHConfig.SSHAgentPrivateKeys))
+	privateKeys := make([]session.AgentPrivateKey, 0, len(connectionConfig.SSHConfig.SSHAgentPrivateKeys))
 	for _, key := range connectionConfig.SSHConfig.SSHAgentPrivateKeys {
-		privateKeys = append(privateKeys, key.Key)
+		privateKeys = append(privateKeys, session.AgentPrivateKey{
+			Key:        key.Key,
+			Passphrase: key.Passphrase,
+		})
 	}
 	sshClient, err := ssh.NewClient(sess, privateKeys).Start()
 	if err != nil {

--- a/dhctl/pkg/system/ssh/client.go
+++ b/dhctl/pkg/system/ssh/client.go
@@ -29,7 +29,7 @@ var (
 )
 
 // initializeNewInstance disables singleton logic
-func initAgentInstance(privateKeys []string, initializeNewInstance bool) (*frontend.Agent, error) {
+func initAgentInstance(privateKeys []session.AgentPrivateKey, initializeNewInstance bool) (*frontend.Agent, error) {
 	var err error
 
 	if initializeNewInstance {
@@ -69,7 +69,7 @@ func initAgentInstance(privateKeys []string, initializeNewInstance bool) (*front
 	return agentInstance, err
 }
 
-func NewClient(session *session.Session, privKeys []string) *Client {
+func NewClient(session *session.Session, privKeys []session.AgentPrivateKey) *Client {
 	return &Client{
 		Settings:    session,
 		PrivateKeys: privKeys,
@@ -83,7 +83,7 @@ type Client struct {
 	Settings *session.Session
 	Agent    *frontend.Agent
 
-	PrivateKeys        []string
+	PrivateKeys        []session.AgentPrivateKey
 	InitializeNewAgent bool
 
 	kubeProxies []*frontend.KubeProxy

--- a/dhctl/pkg/system/ssh/default.go
+++ b/dhctl/pkg/system/ssh/default.go
@@ -33,9 +33,14 @@ func NewClientFromFlags() *Client {
 		ExtraArgs:      app.SSHExtraArgs,
 	})
 
+	keys := make([]session.AgentPrivateKey, 0, len(app.SSHPrivateKeys))
+	for _, key := range app.SSHPrivateKeys {
+		keys = append(keys, session.AgentPrivateKey{Key: key})
+	}
+
 	return &Client{
 		Settings:    settings,
-		PrivateKeys: app.SSHPrivateKeys,
+		PrivateKeys: keys,
 	}
 }
 

--- a/dhctl/pkg/system/ssh/frontend/agent.go
+++ b/dhctl/pkg/system/ssh/frontend/agent.go
@@ -15,13 +15,18 @@
 package frontend
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/cmd"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 type Agent struct {
@@ -64,22 +69,9 @@ func (a *Agent) Start() error {
 
 // TODO replace with x/crypto/ssh/agent ?
 func (a *Agent) AddKeys() error {
-	for _, k := range a.AgentSettings.PrivateKeys {
-		log.DebugF("add key %s\n", k)
-		sshAdd := cmd.NewSSHAdd(a.AgentSettings).KeyCmd(k)
-		output, err := sshAdd.CombinedOutput()
-		if err != nil {
-			werr := "signal: interrupt"
-			if err.Error() == werr {
-				return fmt.Errorf("process stopped")
-			}
-			return fmt.Errorf("ssh-add: %s %v", string(output), err)
-		}
-
-		str := string(output)
-		if str != "" && str != "\n" {
-			log.InfoF("ssh-add: %s\n", output)
-		}
+	err := addKeys(a.AgentSettings.AuthSock, a.AgentSettings.PrivateKeys)
+	if err != nil {
+		return fmt.Errorf("add keys: %w", err)
 	}
 
 	if app.IsDebug {
@@ -102,4 +94,62 @@ func (a *Agent) AddKeys() error {
 
 func (a *Agent) Stop() {
 	a.Agent.Stop()
+}
+
+func addKeys(authSock string, keys []session.AgentPrivateKey) error {
+	conn, err := net.Dial("unix", authSock)
+	if err != nil {
+		return fmt.Errorf("error dialing with ssh agent %s: %w", authSock, err)
+	}
+	defer conn.Close()
+
+	agentClient := agent.NewClient(conn)
+
+	for _, key := range keys {
+		privateKey, err := parsePrivateSSHKey(key.Key, []byte(key.Passphrase))
+		if err != nil {
+			return err
+		}
+
+		err = agentClient.Add(agent.AddedKey{PrivateKey: privateKey})
+		if err != nil {
+			return fmt.Errorf("adding ssh key with ssh agent %s: %w", authSock, err)
+		}
+	}
+
+	return nil
+}
+
+func parsePrivateSSHKey(keyPath string, passphrase []byte) (any, error) {
+	keyData, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading key file %q: %w", keyPath, err)
+	}
+
+	var privateKey interface{}
+
+	privateKey, err = ssh.ParseRawPrivateKey(keyData)
+	if err != nil {
+		var passphraseMissingError *ssh.PassphraseMissingError
+		switch {
+		case errors.As(err, &passphraseMissingError):
+			if len(passphrase) == 0 {
+				passphraseFromStdin, err := terminal.AskPassword(
+					fmt.Sprintf("Enter passphrase for ssh key %q: ", keyPath),
+				)
+				if err != nil {
+					return nil, fmt.Errorf("getting passphrase for ssh key %q: %w", keyPath, err)
+				}
+				passphrase = passphraseFromStdin
+			}
+			privateKey, err = ssh.ParseRawPrivateKeyWithPassphrase(keyData, passphrase)
+			if err != nil {
+				return nil, fmt.Errorf("parsing private key %q: %w", keyPath, err)
+			}
+		default:
+			return nil, fmt.Errorf("parsing private key %q: %w", keyPath, err)
+		}
+	}
+
+	return privateKey, nil
 }

--- a/dhctl/pkg/system/ssh/session/session.go
+++ b/dhctl/pkg/system/ssh/session/session.go
@@ -33,10 +33,15 @@ type Input struct {
 }
 
 type AgentSettings struct {
-	PrivateKeys []string
+	PrivateKeys []AgentPrivateKey
 
 	// runtime
 	AuthSock string
+}
+
+type AgentPrivateKey struct {
+	Key        string
+	Passphrase string
 }
 
 func (s *AgentSettings) AuthSockEnv() string {
@@ -49,7 +54,7 @@ func (s *AgentSettings) AuthSockEnv() string {
 func (s *AgentSettings) Clone() *AgentSettings {
 	return &AgentSettings{
 		AuthSock:    s.AuthSock,
-		PrivateKeys: append(make([]string, 0), s.PrivateKeys...),
+		PrivateKeys: append(make([]AgentPrivateKey, 0), s.PrivateKeys...),
 	}
 }
 

--- a/dhctl/pkg/terminal/ask-password.go
+++ b/dhctl/pkg/terminal/ask-password.go
@@ -48,3 +48,21 @@ func AskBecomePassword() (err error) {
 	app.BecomePass = string(data)
 	return nil
 }
+
+func AskPassword(prompt string) ([]byte, error) {
+	fd := int(os.Stdin.Fd())
+
+	if !terminal.IsTerminal(fd) {
+		return nil, fmt.Errorf("stdin is not a terminal, error reading password")
+	}
+
+	log.InfoF(prompt)
+	data, err := terminal.ReadPassword(fd)
+	log.InfoLn()
+
+	if err != nil {
+		return nil, fmt.Errorf("read secret: %w", err)
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
## Description
ClusterBootstrapper: eliminate usage of app.SSH* and add SSHClient to Params.
Add support for passphrase in Params.

## Why do we need it, and what problem does it solve?
Support of multiple ssh keys and passphrases in Commander.