### PR TITLE
[node-manager](caps) Fix public key authentication

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/ssh.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/ssh.go
@@ -55,14 +55,6 @@ func ExecSSHCommand(instanceScope *scope.InstanceScope, command string, stdout i
 		fmt.Sprintf("-p %d", instanceScope.Credentials.Spec.SSHPort),
 	}
 
-	for _, arg := range strings.Split(instanceScope.Credentials.Spec.SSHExtraArgs, " ") {
-		if arg == "" {
-			continue
-		}
-
-		args = append(args, arg)
-	}
-
 	var stdin io.Reader
 
 	// If the sudo password is set, we need to pipe it to the ssh command.
@@ -71,7 +63,17 @@ func ExecSSHCommand(instanceScope *scope.InstanceScope, command string, stdout i
 
 		command = fmt.Sprintf(`sudo -S sh -c "%s"`, command)
 	} else {
+		args = append(args, "-o", "PasswordAuthentication=no")
+
 		command = fmt.Sprintf(`sudo sh -c "%s"`, command)
+	}
+
+	for _, arg := range strings.Split(instanceScope.Credentials.Spec.SSHExtraArgs, " ") {
+		if arg == "" {
+			continue
+		}
+
+		args = append(args, arg)
 	}
 
 	args = append(args, []string{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add the `PasswordAuthentication=no` option to the OpenSSH client if public key authentication is used.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If we specify an incorrect private key in `SSHCredentials`, the server may prompt for a password and the SSH session will freeze.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Add the `PasswordAuthentication=no` option to the OpenSSH client if public key authentication is used.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
