### PR TITLE
[monitoring] Fix UnsupportedContainerRuntimeVersion alert (add containerd 1.7.*)

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/cri-version.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/cri-version.tpl
@@ -3,7 +3,7 @@
   - alert: UnsupportedContainerRuntimeVersion
     expr: |
       sum by (container_runtime_version, job, kernel_version, kubelet_version, kubeproxy_version, node, os_image) (
-        kube_node_info{kubelet_version=~"v1.(1[6-9]|2[0-9]).+", container_runtime_version!~"docker://1\\.13\\..*|docker://1[7-9]\\..*|docker://20\\..*|docker://3\\..*|containerd://1\\.[4-6]\\..*"}
+        kube_node_info{kubelet_version=~"v1.(1[6-9]|2[0-9]).+", container_runtime_version!~"docker://1\\.13\\..*|docker://1[7-9]\\..*|docker://20\\..*|docker://3\\..*|containerd://1\\.[4-7]\\..*"}
         * on (node) group_left(label_node_deckhouse_io_group) kube_node_labels
         * on (label_node_deckhouse_io_group) group_left(cri_type)
         label_replace(
@@ -31,6 +31,7 @@
         * Containerd 1.4.*
         * Containerd 1.5.*
         * Containerd 1.6.*
+        * Containerd 1.7.*
       summary: >
         Unsupported version of CRI {{`{{$labels.container_runtime_version}}`}} installed for Kubernetes version: {{`{{$labels.kubelet_version}}`}}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes alert UnsupportedContainerRuntimeVersion to support the newest versions of containerd - 1.7.*.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Fix `UnsupportedContainerRuntimeVersion` alert to support the newest containerd versions (`1.7.*`).
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
