### PR TITLE
[candi] add support debian 12 and remove support debian 9

### DIFF
--- a/candi/bashible/bundles/debian/all/003_iptables_legacy.sh.tpl
+++ b/candi/bashible/bundles/debian/all/003_iptables_legacy.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if bb-is-debian-version? 10 || bb-is-debian-version? 11 ; then
+if bb-is-debian-version? 10 || bb-is-debian-version? 11 || bb-is-debian-version? 12 ; then
   if ls -l /etc/alternatives/iptables | grep -q iptables-nft; then
     update-alternatives --set iptables /usr/sbin/iptables-legacy
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -45,7 +45,7 @@ case "$ID" in
     name_is_not_supported
   ;;
   debian)
-    case "$VERSION_ID" in 9|10|11)
+    case "$VERSION_ID" in 10|11|12)
       echo "debian" && exit 0 ;;
     esac
     name_is_not_supported

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -4,9 +4,9 @@ bashible: &bashible
     '20.04':
     '22.04':
   debian:
-    '9':
     '10':
     '11':
+    '12':
   centos:
     '7':
     '8':

--- a/dhctl/README.md
+++ b/dhctl/README.md
@@ -27,7 +27,7 @@ Basic features:
 ### Preparations
 
 The first step is setting up a host.
-Only `Ubuntu 18.04`, `Ubuntu 20.04`, `Ubuntu 22.04`, `Centos 7`, `Centos 8`, `Centos 9`, `Debian 9`, `Debian 10`, `Debian 11` OS are supported.
+Only `Ubuntu 18.04`, `Ubuntu 20.04`, `Ubuntu 22.04`, `Centos 7`, `Centos 8`, `Centos 9`, `Debian 10`, `Debian 11`, `Debian 12` OS are supported.
 
 * **Bare metal** - provide SSH access to the host and sudo access.
 * **Cloud provider** - ensure that Deckhouse supports your cloud.

--- a/ee/be/candi/bashible/detect_bundle.sh
+++ b/ee/be/candi/bashible/detect_bundle.sh
@@ -40,7 +40,7 @@ case "$ID" in
     name_is_not_supported
   ;;
   debian)
-    case "$VERSION_ID" in 9|10|11)
+    case "$VERSION_ID" in 10|11|12)
       echo "debian" && exit 0 ;;
     esac
     name_is_not_supported

--- a/ee/be/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
+++ b/ee/be/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
@@ -324,7 +324,7 @@ function node_os_image_metrics() {
               [
                 "(?:(r)ed (h)at (e)nterprise (l)inux.*(7|8))",
                 "(?:(centos).*(7|8))",
-                "(?:(debian).*(9|10|11))",
+                "(?:(debian).*(10|11|12))",
                 "(?:(ubuntu).*(18.04|20.04|22.04))",
                 "(?:(rocky).*(8|9))",
                 "(?:(almalinux).*(7|8))",

--- a/modules/040-node-manager/hooks/minimal_node_os_version.go
+++ b/modules/040-node-manager/hooks/minimal_node_os_version.go
@@ -89,7 +89,7 @@ func discoverMinimalNodesOSVersion(input *go_hook.HookInput) error {
 			ctrlDebianVersion, err := semver.NewVersion(osImageDebianRegex.FindStringSubmatch(s.(string))[1])
 			if err != nil {
 				return err
-			} 
+			}
 			if minDebianVersion == nil || ctrlDebianVersion.LessThan(minUbuntuVersion) {
 				minDebianVersion = ctrlDebianVersion
 			}

--- a/modules/040-node-manager/hooks/minimal_node_os_version.go
+++ b/modules/040-node-manager/hooks/minimal_node_os_version.go
@@ -31,7 +31,8 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 )
 
-var osImageRegex = regexp.MustCompile(`^Ubuntu ([0-9.]+)( )?(LTS)?$`)
+var osImageUbuntuRegex = regexp.MustCompile(`^Ubuntu ([0-9.]+)( )?(LTS)?$`)
+var osImageDebianRegex = regexp.MustCompile(`^Debian GNU\/Linux ([0-9.]+)( )?(.*)?$`)
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager",
@@ -54,10 +55,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyNodesMinimalOSVersionFilter,
 		},
 	},
-}, discoverMinimalNodesOSVersiopon)
+}, discoverMinimalNodesOSVersion)
 
 const (
-	minVersionValuesKey = "nodeManager:nodesMinimalOSVersionUbuntu"
+	minVersionUbuntuValuesKey = "nodeManager:nodesMinimalOSVersionUbuntu"
+	minVersionDebianValuesKey = "nodeManager:nodesMinimalOSVersionDebian"
 )
 
 func applyNodesMinimalOSVersionFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -65,32 +67,47 @@ func applyNodesMinimalOSVersionFilter(obj *unstructured.Unstructured) (go_hook.F
 	return version, err
 }
 
-func discoverMinimalNodesOSVersiopon(input *go_hook.HookInput) error {
+func discoverMinimalNodesOSVersion(input *go_hook.HookInput) error {
 	snap := input.Snapshots["nodes_os_version"]
 	if len(snap) == 0 {
 		return nil
 	}
 
-	var minVersion *semver.Version
+	var minUbuntuVersion, minDebianVersion *semver.Version
 
 	for _, s := range snap {
-		if !osImageRegex.MatchString(s.(string)) {
+		switch {
+		case osImageUbuntuRegex.MatchString(s.(string)):
+			ctrlUbuntuVersion, err := semver.NewVersion(osImageUbuntuRegex.FindStringSubmatch(s.(string))[1])
+			if err != nil {
+				return err
+			}
+			if minUbuntuVersion == nil || ctrlUbuntuVersion.LessThan(minUbuntuVersion) {
+				minUbuntuVersion = ctrlUbuntuVersion
+			}
+		case osImageDebianRegex.MatchString(s.(string)):
+			ctrlDebianVersion, err := semver.NewVersion(osImageDebianRegex.FindStringSubmatch(s.(string))[1])
+			if err != nil {
+				return err
+			} 
+			if minDebianVersion == nil || ctrlDebianVersion.LessThan(minUbuntuVersion) {
+				minDebianVersion = ctrlDebianVersion
+			}
+		default:
 			continue
 		}
-		ctrlVersion, err := semver.NewVersion(osImageRegex.FindStringSubmatch(s.(string))[1])
-		if err != nil {
-			return err
-		}
-		if minVersion == nil || ctrlVersion.LessThan(minVersion) {
-			minVersion = ctrlVersion
-		}
 	}
 
-	if minVersion == nil {
-		requirements.RemoveValue(minVersionValuesKey)
-		return nil
+	if minUbuntuVersion == nil {
+		requirements.RemoveValue(minVersionUbuntuValuesKey)
+	} else {
+		requirements.SaveValue(minVersionUbuntuValuesKey, minUbuntuVersion.String())
+	}
+	if minDebianVersion == nil {
+		requirements.RemoveValue(minVersionDebianValuesKey)
+	} else {
+		requirements.SaveValue(minVersionDebianValuesKey, minDebianVersion.String())
 	}
 
-	requirements.SaveValue(minVersionValuesKey, minVersion.String())
 	return nil
 }

--- a/modules/040-node-manager/hooks/minimal_node_os_version_test.go
+++ b/modules/040-node-manager/hooks/minimal_node_os_version_test.go
@@ -82,7 +82,7 @@ var _ = Describe("node-manager :: minimal_node_os_version ", func() {
 
 		It("Should have no minimal version", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			_, exists := requirements.GetValue(minVersionValuesKey)
+			_, exists := requirements.GetValue(minVersionUbuntuValuesKey)
 			Expect(exists).To(BeFalse())
 		})
 	})
@@ -95,7 +95,7 @@ var _ = Describe("node-manager :: minimal_node_os_version ", func() {
 
 		It("Should have no minimal version", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			_, exists := requirements.GetValue(minVersionValuesKey)
+			_, exists := requirements.GetValue(minVersionUbuntuValuesKey)
 			Expect(exists).To(BeFalse())
 		})
 	})
@@ -108,7 +108,7 @@ var _ = Describe("node-manager :: minimal_node_os_version ", func() {
 
 		It("Should have minimal version", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			value, exists := requirements.GetValue(minVersionValuesKey)
+			value, exists := requirements.GetValue(minVersionUbuntuValuesKey)
 			Expect(exists).To(BeTrue())
 			Expect(value).To(BeEquivalentTo("20.4.3"))
 		})
@@ -116,14 +116,14 @@ var _ = Describe("node-manager :: minimal_node_os_version ", func() {
 
 	Context("One node with Centos OS and requirements set", func() {
 		BeforeEach(func() {
-			requirements.SaveValue(minVersionValuesKey, "1.2.3")
+			requirements.SaveValue(minVersionUbuntuValuesKey, "1.2.3")
 			f.BindingContexts.Set(f.KubeStateSet(nodeCentos7))
 			f.RunHook()
 		})
 
 		It("Should remove minimal version", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			_, exists := requirements.GetValue(minVersionValuesKey)
+			_, exists := requirements.GetValue(minVersionUbuntuValuesKey)
 			Expect(exists).To(BeFalse())
 		})
 	})
@@ -136,7 +136,7 @@ var _ = Describe("node-manager :: minimal_node_os_version ", func() {
 
 		It("Should have minimal version", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			value, exists := requirements.GetValue(minVersionValuesKey)
+			value, exists := requirements.GetValue(minVersionUbuntuValuesKey)
 			Expect(exists).To(BeTrue())
 			Expect(value).To(BeEquivalentTo("18.4.5"))
 		})
@@ -150,7 +150,7 @@ var _ = Describe("node-manager :: minimal_node_os_version ", func() {
 
 		It("Should have minimal version", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			value, exists := requirements.GetValue(minVersionValuesKey)
+			value, exists := requirements.GetValue(minVersionUbuntuValuesKey)
 			Expect(exists).To(BeTrue())
 			Expect(value).To(BeEquivalentTo("18.4.5"))
 		})

--- a/modules/040-node-manager/requirements/check.go
+++ b/modules/040-node-manager/requirements/check.go
@@ -18,6 +18,7 @@ package requirements
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -27,31 +28,20 @@ import (
 
 const (
 	minUbuntuVersionValuesKey = "nodeManager:nodesMinimalOSVersionUbuntu"
-	requirementsKey           = "nodesMinimalOSVersionUbuntu"
+	minDebianVersionValuesKey = "nodeManager:nodesMinimalOSVersionDebian"
+	requirementsUbuntuKey     = "nodesMinimalOSVersionUbuntu"
+	requirementsDebianKey     = "nodesMinimalOSVersionDebian"
 	containerdRequirementsKey = "containerdOnAllNodes"
 	hasNodesWithDocker        = "nodeManager:hasNodesWithDocker"
 )
 
 func init() {
-	checkRequirementFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
-		desiredVersion, err := semver.NewVersion(requirementValue)
-		if err != nil {
-			return false, err
-		}
-		currentVersionRaw, exists := getter.Get(minUbuntuVersionValuesKey)
-		if !exists {
-			return true, nil
-		}
-		currentVersion, err := semver.NewVersion(currentVersionRaw.(string))
-		if err != nil {
-			return false, err
-		}
+	checkRequirementUbuntuFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		return baseFuncMinVerOS(requirementValue, getter, "Ubuntu")
+	}
 
-		if currentVersion.LessThan(desiredVersion) {
-			return false, errors.New("minimal node Ubuntu OS version is lower then required")
-		}
-
-		return true, nil
+	checkRequirementDebianFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		return baseFuncMinVerOS(requirementValue, getter, "Debian")
 	}
 
 	checkContainerdRequirementFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
@@ -71,6 +61,36 @@ func init() {
 
 		return true, nil
 	}
-	requirements.RegisterCheck(requirementsKey, checkRequirementFunc)
+	requirements.RegisterCheck(requirementsUbuntuKey, checkRequirementUbuntuFunc)
+	requirements.RegisterCheck(requirementsDebianKey, checkRequirementDebianFunc)
 	requirements.RegisterCheck(containerdRequirementsKey, checkContainerdRequirementFunc)
+}
+
+func baseFuncMinVerOS(requirementValue string, getter requirements.ValueGetter, osImage string) (bool, error) {
+	var minVersionValuesKey string
+	desiredVersion, err := semver.NewVersion(requirementValue)
+	if err != nil {
+		return false, err
+	}
+	switch osImage {
+	case "Ubuntu":
+		minVersionValuesKey = minUbuntuVersionValuesKey
+	case "Debian":
+		minVersionValuesKey = minDebianVersionValuesKey
+	}
+
+	currentVersionRaw, exists := getter.Get(minVersionValuesKey)
+	if !exists {
+		return true, nil
+	}
+	currentVersion, err := semver.NewVersion(currentVersionRaw.(string))
+	if err != nil {
+		return false, err
+	}
+
+	if currentVersion.LessThan(desiredVersion) {
+		return false, fmt.Errorf("minimal node %v OS version is lower then required", osImage)
+	}
+
+	return true, nil
 }

--- a/modules/040-node-manager/requirements/check_test.go
+++ b/modules/040-node-manager/requirements/check_test.go
@@ -27,16 +27,30 @@ import (
 
 func TestNodeOSVersionRequirement(t *testing.T) {
 	requirements.RemoveValue(minUbuntuVersionValuesKey)
+	requirements.RemoveValue(minDebianVersionValuesKey)
 	t.Run("requirement met", func(t *testing.T) {
 		requirements.SaveValue(minUbuntuVersionValuesKey, "18.4.5")
-		ok, err := requirements.CheckRequirement(requirementsKey, "18.04")
+		ok, err := requirements.CheckRequirement(requirementsUbuntuKey, "18.04")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+	t.Run("requirement met", func(t *testing.T) {
+		requirements.SaveValue(minDebianVersionValuesKey, "11")
+		ok, err := requirements.CheckRequirement(requirementsDebianKey, "10")
 		assert.True(t, ok)
 		require.NoError(t, err)
 	})
 
 	t.Run("requirement failed", func(t *testing.T) {
 		requirements.SaveValue(minUbuntuVersionValuesKey, "16.4.5")
-		ok, err := requirements.CheckRequirement(requirementsKey, "18.04")
+		ok, err := requirements.CheckRequirement(requirementsUbuntuKey, "18.04")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+
+	t.Run("requirement failed", func(t *testing.T) {
+		requirements.SaveValue(minDebianVersionValuesKey, "9")
+		ok, err := requirements.CheckRequirement(requirementsDebianKey, "10")
 		assert.False(t, ok)
 		require.Error(t, err)
 	})

--- a/release.yaml
+++ b/release.yaml
@@ -26,6 +26,7 @@ requirements:
   "k8s": "1.25.0" # modules/040-control-plane-manager/requirements/check.go
   "ingressNginx": "1.1" # modules/402-ingress-nginx/requirements/check.go
   "nodesMinimalOSVersionUbuntu": "18.04" # modules/040-node-manager/requirements/check.go
+#  "nodesMinimalOSVersionDebian": "10" # modules/040-node-manager/requirements/check.go
   "containerdOnAllNodes": "true" # modules/040-node-manager/requirements/check.go
   "istioVer": "1.16" # modules/110-istio/requirements/check.go
 

--- a/testing/cloud_layouts/OpenStack/Standard/resources.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/resources.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   rootDiskSize: 20
   flavorName: m1.large
-  imageName: "debian-11-genericcloud-amd64-20220911-1135"
+  imageName: "debian-12-genericcloud-amd64"
 ---
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController


### PR DESCRIPTION
## Description
add support debian 12 and remove debian 9

Closes #5446 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
<img width="1777" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/34042989-6a11-4b27-97f7-0c90bd71e2e3">


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature 
summary: Add support for Debian 12, remove support for Debian 9.
impact_level: default
---
section: node-manager
type: feature
summary: Add check for minimal Debian version.
impact_level: default
---
section: testing
type: chore
summary: Change the default image for OpenStack `cloud_layouts` on Debian 12.
impact_level: default
```
