### PR TITLE
[prometheus] fix build errors

### DIFF
--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "webhook-handler")) | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: webhook-handler
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
+++ b/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
@@ -1,8 +1,14 @@
+Subject: [PATCH] +
+---
+Index: discovery/kubernetes/pod.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
 diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
-index 396720c22..faf28654a 100644
---- a/discovery/kubernetes/pod.go
-+++ b/discovery/kubernetes/pod.go
-@@ -299,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+--- a/discovery/kubernetes/pod.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
++++ b/discovery/kubernetes/pod.go	(date 1708969586167)
+@@ -299,6 +299,7 @@
  			// The user has to add a port manually.
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:     lv(pod.Status.PodIP),
@@ -10,7 +16,7 @@ index 396720c22..faf28654a 100644
  				podContainerNameLabel:  lv(c.Name),
  				podContainerIDLabel:    lv(cID),
  				podContainerImageLabel: lv(c.Image),
-@@ -313,6 +314,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+@@ -313,6 +314,7 @@
 
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:            lv(addr),
@@ -18,48 +24,15 @@ index 396720c22..faf28654a 100644
  				podContainerNameLabel:         lv(c.Name),
  				podContainerIDLabel:           lv(cID),
  				podContainerImageLabel:        lv(c.Image),
-diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
-index a19f06e7d..f19f6e3bb 100644
---- a/discovery/kubernetes/service.go
-+++ b/discovery/kubernetes/service.go
-@@ -193,6 +193,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
-
- 		labelSet := model.LabelSet{
- 			model.AddressLabel:       lv(addr),
-+			"__sample_limit__":       lv(""),
- 			servicePortNameLabel:     lv(port.Name),
- 			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
- 			servicePortProtocolLabel: lv(string(port.Protocol)),
-diff --git a/scrape/scrape.go b/scrape/scrape.go
-index f38527ff3..e8a14a2a0 100644
---- a/scrape/scrape.go
-+++ b/scrape/scrape.go
-@@ -305,6 +305,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
- 		}
- 		opts.target.SetMetadataStore(cache)
-
-+		limit := opts.target.SampleLimit()
-+		if limit == 0 {
-+			limit = opts.sampleLimit
-+		}
-+
- 		return newScrapeLoop(
- 			ctx,
- 			opts.scraper,
-@@ -318,7 +323,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
- 			cache,
- 			jitterSeed,
- 			opts.honorTimestamps,
--			opts.sampleLimit,
-+			limit,
- 			opts.labelLimits,
- 			opts.interval,
- 			opts.timeout,
+Index: scrape/target.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
 diff --git a/scrape/target.go b/scrape/target.go
-index f250910c1..1c505d0a4 100644
---- a/scrape/target.go
-+++ b/scrape/target.go
-@@ -18,6 +18,7 @@ import (
+--- a/scrape/target.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
++++ b/scrape/target.go	(date 1708969158549)
+@@ -18,6 +18,7 @@
  	"hash/fnv"
  	"net"
  	"net/url"
@@ -67,7 +40,7 @@ index f250910c1..1c505d0a4 100644
  	"strings"
  	"sync"
  	"time"
-@@ -517,3 +518,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
+@@ -546,3 +547,15 @@
  	}
  	return targets, failures
  }
@@ -83,3 +56,48 @@ index f250910c1..1c505d0a4 100644
 +	}
 +	return convertedLimit
 +}
+Index: discovery/kubernetes/service.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
+--- a/discovery/kubernetes/service.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
++++ b/discovery/kubernetes/service.go	(date 1708969340212)
+@@ -193,6 +193,7 @@
+
+ 		labelSet := model.LabelSet{
+ 			model.AddressLabel:       lv(addr),
++			"__sample_limit__":       lv(""),
+ 			servicePortNameLabel:     lv(port.Name),
+ 			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
+ 			servicePortProtocolLabel: lv(string(port.Protocol)),
+Index: scrape/scrape.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/scrape/scrape.go b/scrape/scrape.go
+--- a/scrape/scrape.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
++++ b/scrape/scrape.go	(date 1708969586163)
+@@ -314,6 +314,11 @@
+ 		}
+ 		opts.target.SetMetadataStore(cache)
+
++		limit := opts.target.SampleLimit()
++		if limit == 0 {
++			limit = opts.sampleLimit
++		}
++
+ 		return newScrapeLoop(
+ 			ctx,
+ 			opts.scraper,
+@@ -327,7 +332,7 @@
+ 			cache,
+ 			offsetSeed,
+ 			opts.honorTimestamps,
+-			opts.sampleLimit,
++			limit,
+ 			opts.bucketLimit,
+ 			opts.labelLimits,
+ 			opts.interval,

--- a/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
+++ b/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
@@ -1,14 +1,8 @@
-Subject: [PATCH] +
----
-Index: discovery/kubernetes/pod.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
---- a/discovery/kubernetes/pod.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
-+++ b/discovery/kubernetes/pod.go	(date 1708969586167)
-@@ -299,6 +299,7 @@
+index 732cf52ad..3080f013b 100644
+--- a/discovery/kubernetes/pod.go
++++ b/discovery/kubernetes/pod.go
+@@ -299,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
  			// The user has to add a port manually.
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:     lv(pod.Status.PodIP),
@@ -16,7 +10,7 @@ diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
  				podContainerNameLabel:  lv(c.Name),
  				podContainerIDLabel:    lv(cID),
  				podContainerImageLabel: lv(c.Image),
-@@ -313,6 +314,7 @@
+@@ -313,6 +314,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:            lv(addr),
@@ -24,15 +18,48 @@ diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
  				podContainerNameLabel:         lv(c.Name),
  				podContainerIDLabel:           lv(cID),
  				podContainerImageLabel:        lv(c.Image),
-Index: scrape/target.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
+index 40e17679e..32e3ea46c 100644
+--- a/discovery/kubernetes/service.go
++++ b/discovery/kubernetes/service.go
+@@ -193,6 +193,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
+
+ 		labelSet := model.LabelSet{
+ 			model.AddressLabel:       lv(addr),
++			"__sample_limit__":       lv(""),
+ 			servicePortNameLabel:     lv(port.Name),
+ 			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
+ 			servicePortProtocolLabel: lv(string(port.Protocol)),
+diff --git a/scrape/scrape.go b/scrape/scrape.go
+index 8c4cc51e7..e7bff4dcb 100644
+--- a/scrape/scrape.go
++++ b/scrape/scrape.go
+@@ -314,6 +314,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
+ 		}
+ 		opts.target.SetMetadataStore(cache)
+
++		limit := opts.target.SampleLimit()
++		if limit == 0 {
++			limit = opts.sampleLimit
++		}
++
+ 		return newScrapeLoop(
+ 			ctx,
+ 			opts.scraper,
+@@ -327,7 +332,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
+ 			cache,
+ 			offsetSeed,
+ 			opts.honorTimestamps,
+-			opts.sampleLimit,
++			limit,
+ 			opts.bucketLimit,
+ 			opts.labelLimits,
+ 			opts.interval,
 diff --git a/scrape/target.go b/scrape/target.go
---- a/scrape/target.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
-+++ b/scrape/target.go	(date 1708969158549)
-@@ -18,6 +18,7 @@
+index a655e8541..fbd437e01 100644
+--- a/scrape/target.go
++++ b/scrape/target.go
+@@ -18,6 +18,7 @@ import (
  	"hash/fnv"
  	"net"
  	"net/url"
@@ -40,7 +67,7 @@ diff --git a/scrape/target.go b/scrape/target.go
  	"strings"
  	"sync"
  	"time"
-@@ -546,3 +547,15 @@
+@@ -546,3 +547,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
  	}
  	return targets, failures
  }
@@ -56,48 +83,3 @@ diff --git a/scrape/target.go b/scrape/target.go
 +	}
 +	return convertedLimit
 +}
-Index: discovery/kubernetes/service.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
---- a/discovery/kubernetes/service.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
-+++ b/discovery/kubernetes/service.go	(date 1708969340212)
-@@ -193,6 +193,7 @@
-
- 		labelSet := model.LabelSet{
- 			model.AddressLabel:       lv(addr),
-+			"__sample_limit__":       lv(""),
- 			servicePortNameLabel:     lv(port.Name),
- 			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
- 			servicePortProtocolLabel: lv(string(port.Protocol)),
-Index: scrape/scrape.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/scrape/scrape.go b/scrape/scrape.go
---- a/scrape/scrape.go	(revision 3d6b7e665928a78c4a18675802436fe92f3f4e04)
-+++ b/scrape/scrape.go	(date 1708969586163)
-@@ -314,6 +314,11 @@
- 		}
- 		opts.target.SetMetadataStore(cache)
-
-+		limit := opts.target.SampleLimit()
-+		if limit == 0 {
-+			limit = opts.sampleLimit
-+		}
-+
- 		return newScrapeLoop(
- 			ctx,
- 			opts.scraper,
-@@ -327,7 +332,7 @@
- 			cache,
- 			offsetSeed,
- 			opts.honorTimestamps,
--			opts.sampleLimit,
-+			limit,
- 			opts.bucketLimit,
- 			opts.labelLimits,
- 			opts.interval,

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -42,7 +42,7 @@ shell:
   - cd /prometheus/prometheus
   - scripts/compress_assets.sh
   - go mod tidy
-  - find /patches -name '*.patch' | xargs git apply
+  - find /patches -name '*.patch' | xargs git apply --verbose
   - go generate -tags plugins ./plugins
   - /bin/promu build --prefix /prometheus/prometheus
   - mkdir -p /consoles

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -29,7 +29,7 @@ git:
   - '**/*.patch'
   stageDependencies:
     install:
-    - '**/*.patch'
+    - '**/*'
 shell:
   install:
   - export NODE_MAJOR=20

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -42,7 +42,7 @@ shell:
   - cd /prometheus/prometheus
   - scripts/compress_assets.sh
   - go mod tidy
-  - find /patches -name '*.patch' -exec git apply {} \;
+  - find /patches -name '*.patch' | xargs git apply
   - go generate -tags plugins ./plugins
   - /bin/promu build --prefix /prometheus/prometheus
   - mkdir -p /consoles

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -13,6 +13,7 @@ shell:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_21_BULLSEYE_DEV }}
+fromCacheVersion: 2024022701
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -69,6 +70,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
+fromCacheVersion: 2024022701
 import:
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /prometheus/prometheus/prometheus

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -13,6 +13,7 @@ shell:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_21_BULLSEYE_DEV }}
+fromCacheVersion: 2024022601
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -13,7 +13,6 @@ shell:
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_21_BULLSEYE_DEV }}
-fromCacheVersion: 2024022601
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg

--- a/modules/300-prometheus/webhooks/validating/customprometheusrules
+++ b/modules/300-prometheus/webhooks/validating/customprometheusrules
@@ -37,7 +37,7 @@ function __main__() {
 
   context::jq -r '.review.request.object.spec' | yq eval -P - > "$rules_yaml"
   # Capture stderr to variable, ignoring stdout.
-  if ! check_result=$(promtool check rules "$rules_yaml" 2>&1 >/dev/null); then
+  if ! check_result=$(promtool check rules "$rules_yaml" 2>&1); then
     # Remove first line "  FAILED:" from the output.
     # Remove filename from each line of the output.
     message=$(echo "$check_result" | tail -n +2 | cut -d " " -f2-)

--- a/modules/300-prometheus/webhooks/validating/customprometheusrules
+++ b/modules/300-prometheus/webhooks/validating/customprometheusrules
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
-
-# Copyright 2021 Flant CJSC
+# Copyright 2023 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/300-prometheus/webhooks/validating/customprometheusrules
+++ b/modules/300-prometheus/webhooks/validating/customprometheusrules
@@ -38,7 +38,10 @@ function __main__() {
   context::jq -r '.review.request.object.spec' | yq eval -P - > "$rules_yaml"
   # Capture stderr to variable, ignoring stdout.
   if ! check_result=$(promtool check rules "$rules_yaml" 2>&1); then
-    jq -nc --arg message "$check_result" '
+    # Remove first line "  FAILED:" from the output.
+    # Remove filename from each line of the output.
+    message=$(echo "$check_result" | tail -n +2 | cut -d " " -f2-)
+    jq -nc --arg message "$message" '
       {
         "allowed": false,
         "message": $message

--- a/modules/300-prometheus/webhooks/validating/customprometheusrules
+++ b/modules/300-prometheus/webhooks/validating/customprometheusrules
@@ -38,10 +38,7 @@ function __main__() {
   context::jq -r '.review.request.object.spec' | yq eval -P - > "$rules_yaml"
   # Capture stderr to variable, ignoring stdout.
   if ! check_result=$(promtool check rules "$rules_yaml" 2>&1); then
-    # Remove first line "  FAILED:" from the output.
-    # Remove filename from each line of the output.
-    message=$(echo "$check_result" | tail -n +2 | cut -d " " -f2-)
-    jq -nc --arg message "$message" '
+    jq -nc --arg message "$check_result" '
       {
         "allowed": false,
         "message": $message


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. Fix validating webhook build for promtool work.
2. Fix prometheus build to return sample limit patch.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: Fix validating webhook build for promtool work.
impact_level: default
---
section: prometheus
type: Fix Prometheus build to return sample limit patch.
summary: impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
