### PR TITLE
[control-plane-manager] Hotfixed race reading between  deckhouse pod status and "minUsedControlPlaneKubernetesVersion" variable.

### DIFF
--- a/modules/040-control-plane-manager/requirements/check.go
+++ b/modules/040-control-plane-manager/requirements/check.go
@@ -34,7 +34,7 @@ func init() {
 		}
 		currentVersionStr, exists := getter.Get(minK8sVersionRequirementKey)
 		if !exists {
-			return true, nil
+			return false, errors.New("\nminUsedControlPlaneKubernetesVersion\n is not set")
 		}
 		currentVersion, err := semver.NewVersion(currentVersionStr.(string))
 		if err != nil {


### PR DESCRIPTION
## Description

Hotfixed race reading between  deckhouse pod status and "minUsedControlPlaneKubernetesVersion" variable.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix race reading between the deckhouse pod status and the `minUsedControlPlaneKubernetesVersion` variable.
impact: Prevents the Deckhouse version update error from being skipped.
```
