### PR TITLE
[node-manager](caps) Check the `StaticInstance` address by establishing a TCP connection

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
+	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha1"
@@ -36,36 +40,136 @@ import (
 	"caps-controller-manager/internal/ssh"
 )
 
+const RequeueForStaticInstanceBootstrapping = 60 * time.Second
+
 // Bootstrap runs the bootstrap script on StaticInstance.
-func (c *Client) Bootstrap(ctx context.Context, instanceScope *scope.InstanceScope) error {
-	switch instanceScope.GetPhase() {
-	case deckhousev1.StaticInstanceStatusCurrentStatusPhasePending:
-		_, err := c.bootstrap(ctx, instanceScope)
-		if err != nil {
-			return errors.Wrap(err, "failed to bootstrap StaticInstance from pending phase")
-		}
-	case deckhousev1.StaticInstanceStatusCurrentStatusPhaseBootstrapping:
-		err := c.bootstrapFromBootstrappingPhase(ctx, instanceScope)
-		if err != nil {
-			return errors.Wrap(err, "failed to bootstrap StaticInstance from bootstrapping phase")
-		}
-	default:
-		return errors.New("StaticInstance is not pending or bootstrapping")
+func (c *Client) Bootstrap(ctx context.Context, instanceScope *scope.InstanceScope) (ctrl.Result, error) {
+	result, err := c.bootstrap(ctx, instanceScope)
+	if err != nil {
+		return result, err
 	}
 
-	return nil
+	if result.IsZero() {
+		result.RequeueAfter = RequeueForStaticInstanceBootstrapping
+	}
+
+	return result, nil
 }
 
-// bootstrapFromBootstrappingPhase finishes the bootstrap process by waiting for bootstrapping Node to appear and patching StaticMachine and StaticInstance.
-func (c *Client) bootstrapFromBootstrappingPhase(ctx context.Context, instanceScope *scope.InstanceScope) error {
-	done, err := c.bootstrap(ctx, instanceScope)
-	if err != nil {
-		return errors.Wrap(err, "failed to bootstrap")
-	}
-	if !done {
-		return nil
+func (c *Client) bootstrap(ctx context.Context, instanceScope *scope.InstanceScope) (ctrl.Result, error) {
+	phase := instanceScope.GetPhase()
+
+	if phase != deckhousev1.StaticInstanceStatusCurrentStatusPhasePending &&
+		phase != deckhousev1.StaticInstanceStatusCurrentStatusPhaseBootstrapping {
+		return ctrl.Result{}, errors.New("StaticInstance is not pending or bootstrapping")
 	}
 
+	result, err := c.bootstrapStaticInstance(ctx, instanceScope)
+	if err != nil {
+		return result, errors.Wrapf(err, "failed to bootstrap StaticInstance from '%s' phase", phase)
+	}
+
+	return result, nil
+}
+
+func (c *Client) bootstrapStaticInstance(ctx context.Context, instanceScope *scope.InstanceScope) (ctrl.Result, error) {
+	bootstrapScript, err := getBootstrapScript(ctx, instanceScope)
+	if err != nil {
+		c.recorder.SendWarningEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "BootstrapScriptFetchingFailed", "Bootstrap script unreachable")
+
+		return ctrl.Result{}, errors.Wrap(err, "failed to get bootstrap script")
+	}
+
+	if instanceScope.GetPhase() == deckhousev1.StaticInstanceStatusCurrentStatusPhasePending {
+		result, err := c.setStaticInstancePhaseToBootstrapping(ctx, instanceScope)
+		if err != nil {
+			return result, err
+		}
+		if !result.IsZero() {
+			return result, nil
+		}
+	}
+
+	done := c.bootstrapTaskManager.spawn(taskID(instanceScope.MachineScope.StaticMachine.Spec.ProviderID), func() bool {
+		err := ssh.ExecSSHCommand(instanceScope, fmt.Sprintf("mkdir -p /var/lib/bashible && echo '%s' > /var/lib/bashible/node-spec-provider-id && echo '%s' > /var/lib/bashible/machine-name && echo '%s' | base64 -d | bash", instanceScope.MachineScope.StaticMachine.Spec.ProviderID, instanceScope.MachineScope.Machine.Name, base64.StdEncoding.EncodeToString(bootstrapScript)), nil)
+		if err != nil {
+			// If Node reboots, the ssh connection will close, and we will get an error.
+			instanceScope.Logger.Error(err, "Failed to bootstrap StaticInstance: failed to exec ssh command")
+
+			return false
+		}
+
+		return true
+	})
+	if !done {
+		instanceScope.Logger.Info("Bootstrapping is not finished yet, waiting...")
+
+		return ctrl.Result{}, nil
+	}
+
+	c.recorder.SendNormalEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "BootstrapScriptSucceeded", "Bootstrap script executed successfully")
+
+	if instanceScope.GetPhase() == deckhousev1.StaticInstanceStatusCurrentStatusPhaseBootstrapping {
+		err := c.setStaticInstancePhaseToRunning(ctx, instanceScope)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *Client) setStaticInstancePhaseToBootstrapping(ctx context.Context, instanceScope *scope.InstanceScope) (ctrl.Result, error) {
+	address := net.JoinHostPort(instanceScope.Instance.Spec.Address, strconv.Itoa(instanceScope.Credentials.Spec.SSHPort))
+
+	delay := c.tcpCheckRateLimiter.When(address)
+
+	done := c.tcpCheckTaskManager.spawn(taskID(address), func() bool {
+		conn, err := net.DialTimeout("tcp", address, delay)
+		if err != nil {
+			instanceScope.Logger.Error(err, "Failed to check the StaticInstance address by establishing a tcp connection", "address", address)
+
+			return false
+		}
+		defer conn.Close()
+
+		return true
+	})
+	if !done {
+		return ctrl.Result{RequeueAfter: delay}, nil
+	}
+
+	c.tcpCheckRateLimiter.Forget(address)
+
+	providerID := providerid.GenerateProviderID(instanceScope.Instance.Name)
+
+	instanceScope.MachineScope.StaticMachine.Spec.ProviderID = providerID
+
+	err := instanceScope.MachineScope.Patch(ctx)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to set StaticMachine provider id to '%s'", providerID)
+	}
+
+	instanceScope.Instance.Status.MachineRef = &corev1.ObjectReference{
+		APIVersion: instanceScope.MachineScope.StaticMachine.APIVersion,
+		Kind:       instanceScope.MachineScope.StaticMachine.Kind,
+		Namespace:  instanceScope.MachineScope.StaticMachine.Namespace,
+		Name:       instanceScope.MachineScope.StaticMachine.Name,
+		UID:        instanceScope.MachineScope.StaticMachine.UID,
+	}
+
+	instanceScope.SetPhase(deckhousev1.StaticInstanceStatusCurrentStatusPhaseBootstrapping)
+
+	err = instanceScope.Patch(ctx)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to patch StaticInstance MachineRef and Phase")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// setStaticInstancePhaseToRunning finishes the bootstrap process by waiting for bootstrapping Node to appear and patching StaticMachine and StaticInstance.
+func (c *Client) setStaticInstancePhaseToRunning(ctx context.Context, instanceScope *scope.InstanceScope) error {
 	node, err := waitForNode(ctx, instanceScope)
 	if err != nil {
 		return errors.Wrap(err, "failed to wait for Node to appear")
@@ -101,60 +205,6 @@ func (c *Client) bootstrapFromBootstrappingPhase(ctx context.Context, instanceSc
 	}
 
 	return nil
-}
-
-func (c *Client) bootstrap(ctx context.Context, instanceScope *scope.InstanceScope) (bool, error) {
-	bootstrapScript, err := getBootstrapScript(ctx, instanceScope)
-	if err != nil {
-		c.recorder.SendWarningEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "BootstrapScriptFetchingFailed", "Bootstrap script unreachable")
-
-		return false, errors.Wrap(err, "failed to get bootstrap script")
-	}
-
-	if instanceScope.GetPhase() == deckhousev1.StaticInstanceStatusCurrentStatusPhasePending {
-		providerID := providerid.GenerateProviderID(instanceScope.Instance.Name)
-
-		instanceScope.MachineScope.StaticMachine.Spec.ProviderID = providerID
-
-		err := instanceScope.MachineScope.Patch(ctx)
-		if err != nil {
-			return false, errors.Wrapf(err, "failed to set StaticMachine provider id to '%s'", providerID)
-		}
-
-		instanceScope.Instance.Status.MachineRef = &corev1.ObjectReference{
-			APIVersion: instanceScope.MachineScope.StaticMachine.APIVersion,
-			Kind:       instanceScope.MachineScope.StaticMachine.Kind,
-			Namespace:  instanceScope.MachineScope.StaticMachine.Namespace,
-			Name:       instanceScope.MachineScope.StaticMachine.Name,
-			UID:        instanceScope.MachineScope.StaticMachine.UID,
-		}
-
-		instanceScope.SetPhase(deckhousev1.StaticInstanceStatusCurrentStatusPhaseBootstrapping)
-
-		err = instanceScope.Patch(ctx)
-		if err != nil {
-			return false, errors.Wrap(err, "failed to patch StaticInstance MachineRef and Phase")
-		}
-	}
-
-	done := c.bootstrapTaskManager.spawn(instanceScope.MachineScope.StaticMachine.Spec.ProviderID, func() bool {
-		err := ssh.ExecSSHCommand(instanceScope, fmt.Sprintf("mkdir -p /var/lib/bashible && echo '%s' > /var/lib/bashible/node-spec-provider-id && echo '%s' > /var/lib/bashible/machine-name && echo '%s' | base64 -d | bash", instanceScope.MachineScope.StaticMachine.Spec.ProviderID, instanceScope.MachineScope.Machine.Name, base64.StdEncoding.EncodeToString(bootstrapScript)), nil)
-		if err != nil {
-			// If Node reboots, the ssh connection will close, and we will get an error.
-			instanceScope.Logger.Error(err, "Failed to bootstrap StaticInstance: failed to exec ssh command")
-
-			return false
-		}
-
-		return true
-	})
-	if done {
-		c.recorder.SendNormalEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "BootstrapScriptSucceeded", "Bootstrap script executed successfully")
-	} else {
-		instanceScope.Logger.Info("Bootstrapping is not finished yet, waiting...")
-	}
-
-	return done, nil
 }
 
 // waitForNode waits for the node to appear and checks that it has 'node.deckhouse.io/configuration-checksum' annotation.

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
@@ -77,7 +77,7 @@ func (c *Client) cleanupFromCleaningPhase(ctx context.Context, instanceScope *sc
 }
 
 func (c *Client) cleanup(instanceScope *scope.InstanceScope) bool {
-	done := c.cleanupTaskManager.spawn(instanceScope.MachineScope.StaticMachine.Spec.ProviderID, func() bool {
+	done := c.cleanupTaskManager.spawn(taskID(instanceScope.MachineScope.StaticMachine.Spec.ProviderID), func() bool {
 		err := ssh.ExecSSHCommand(instanceScope, "if [[ ! -f /var/lib/bashible/cleanup_static_node.sh ]]; then rm -rf /var/lib/bashible; (sleep 5 && shutdown -r now) & else bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing; fi", nil)
 		if err != nil {
 			instanceScope.Logger.Error(err, "Failed to clean up StaticInstance: failed to exec ssh command")

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/client.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/client.go
@@ -17,7 +17,11 @@ limitations under the License.
 package client
 
 import (
+	"time"
+
 	"caps-controller-manager/internal/event"
+
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Client is a client that executes commands on hosts using the OpenSSH client.
@@ -25,6 +29,8 @@ import (
 type Client struct {
 	bootstrapTaskManager *taskManager
 	cleanupTaskManager   *taskManager
+	tcpCheckTaskManager  *taskManager
+	tcpCheckRateLimiter  workqueue.RateLimiter
 
 	recorder *event.Recorder
 }
@@ -34,6 +40,8 @@ func NewClient(recorder *event.Recorder) *Client {
 	return &Client{
 		bootstrapTaskManager: newTaskManager(),
 		cleanupTaskManager:   newTaskManager(),
+		tcpCheckTaskManager:  newTaskManager(),
+		tcpCheckRateLimiter:  workqueue.NewItemExponentialFailureRateLimiter(250*time.Millisecond, time.Minute),
 		recorder:             recorder,
 	}
 }

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -51,7 +51,6 @@ const (
 	DefaultStaticInstanceBootstrapTimeout = 20 * time.Minute
 	DefaultStaticInstanceCleanupTimeout   = 10 * time.Minute
 	RequeueForStaticInstancePending       = 10 * time.Second
-	RequeueForStaticInstanceBootstrapping = 60 * time.Second
 	RequeueForStaticInstanceCleaning      = 30 * time.Second
 	RequeueForStaticMachineDeleting       = 5 * time.Second
 )
@@ -210,12 +209,12 @@ func (r *StaticMachineReconciler) reconcileNormal(
 		r.Recorder.SendNormalEvent(instanceScope.Instance, machineScope.StaticMachine.Labels["node-group"], "StaticInstanceAttachSucceeded", fmt.Sprintf("Attached to StaticMachine %s", machineScope.StaticMachine.Name))
 		r.Recorder.SendNormalEvent(machineScope.StaticMachine, machineScope.StaticMachine.Labels["node-group"], "StaticInstanceAttachSucceeded", fmt.Sprintf("Attached StaticInstance %s", instanceScope.Instance.Name))
 
-		err = r.HostClient.Bootstrap(ctx, instanceScope)
+		result, err := r.HostClient.Bootstrap(ctx, instanceScope)
 		if err != nil {
 			instanceScope.Logger.Error(err, "failed to bootstrap StaticInstance")
 		}
 
-		return ctrl.Result{RequeueAfter: RequeueForStaticInstanceBootstrapping}, nil
+		return result, nil
 	}
 
 	return r.reconcileStaticInstancePhase(ctx, instanceScope)
@@ -361,12 +360,12 @@ func (r *StaticMachineReconciler) reconcileStaticInstancePhase(
 			return ctrl.Result{}, errors.New("timed out waiting to bootstrap StaticInstance")
 		}
 
-		err := r.HostClient.Bootstrap(ctx, instanceScope)
+		result, err := r.HostClient.Bootstrap(ctx, instanceScope)
 		if err != nil {
 			instanceScope.Logger.Error(err, "failed to bootstrap StaticInstance")
 		}
 
-		return ctrl.Result{RequeueAfter: RequeueForStaticInstanceBootstrapping}, nil
+		return result, nil
 	case deckhousev1.StaticInstanceStatusCurrentStatusPhaseRunning:
 		instanceScope.MachineScope.SetReady()
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Check the `StaticInstance` address by establishing a TCP connection before setting the `StaticInstance` phase to `Bootstrapping`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If we specify the wrong address for `StaticInstance`, then we need to wait for the bootstrap timeout(20 minutes) and cleanup timeout(10 minutes) to expire before we can delete the `StaticInstance`.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Check the `StaticInstance` address by establishing a TCP connection.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
