### PR TITLE
[dhctl] Reduce log level for deckhouse converging error

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -189,7 +189,7 @@ func (d *LogPrinter) printErrorsForTask(taskID string, errorTaskTime time.Time) 
 		}
 
 		if line.Level == "error" || line.Output == "stderr" {
-			log.InfoF("Warning during Deckhouse converge", line.String())
+			log.InfoF("Warning during Deckhouse converge: %s", line.String())
 		}
 		return true
 	})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -77,6 +77,10 @@ func isErrorLine(line *logLine) bool {
 			// often we get only one error message per module
 			// it confuses users and we want hide it
 			"is not supported by cluster",
+			// all bootstrapped cloud clusters has this message
+			// it is normal because wait_for_all_master_nodes_to_become_initialized hook
+			// blocks main queue with this error
+			"waiting for master nodes to become initialized by cloud provider",
 		}
 		for _, p := range badSubStrings {
 			if strings.Contains(line.Message, p) {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -73,9 +73,10 @@ func isErrorLine(line *logLine) bool {
 			// We cannot skip this error in hook,
 			// because kube version needs for next installation steps
 			"Not found k8s versions",
-			// hook with creating master run immediately after deploy crd
-			// and we can get this message one time
-			"Create object: deckhouse.io/v1/NodeGroup//master: apiVersion 'deckhouse.io/v1', kind 'NodeGroup' is not supported by cluster",
+			// we can race between creating resources and deploy crds
+			// often we get only one error message per module
+			// it confuses users and we want hide it
+			"is not supported by cluster",
 		}
 		for _, p := range badSubStrings {
 			if strings.Contains(line.Message, p) {
@@ -188,7 +189,7 @@ func (d *LogPrinter) printErrorsForTask(taskID string, errorTaskTime time.Time) 
 		}
 
 		if line.Level == "error" || line.Output == "stderr" {
-			log.ErrorF(line.String())
+			log.InfoF("Warning during Deckhouse converge", line.String())
 		}
 		return true
 	})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -80,7 +80,7 @@ func isErrorLine(line *logLine) bool {
 			// all bootstrapped cloud clusters has this message
 			// it is normal because wait_for_all_master_nodes_to_become_initialized hook
 			// blocks main queue with this error
-			"waiting for master nodes to become initialized by cloud provider",
+			"timeout waiting for master nodes",
 		}
 		for _, p := range badSubStrings {
 			if strings.Contains(line.Message, p) {

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -81,7 +81,7 @@ func (k *KubernetesClient) Init(params *KubernetesInitParams) error {
 	kubeClient := klient.New()
 	kubeClient.WithRateLimiterSettings(5, 10)
 	// pass all klog messages to our logger
-	klog.SetOutput(&klogWriter{})
+	klog.SetOutputBySeverity("INFO", &klogWriter{})
 
 	switch {
 	case params.KubeConfigInCluster:

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -76,7 +76,7 @@ func (k *KubernetesClient) WithSSHClient(client *ssh.Client) *KubernetesClient {
 // Init initializes kubernetes client
 func (k *KubernetesClient) Init(params *KubernetesInitParams) error {
 	kubeClient := klient.New()
-	kubeClient.WithRateLimiterSettings(5, 10)
+	kubeClient.WithRateLimiterSettings(15, 30)
 
 	switch {
 	case params.KubeConfigInCluster:

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -76,7 +76,7 @@ func (k *KubernetesClient) WithSSHClient(client *ssh.Client) *KubernetesClient {
 // Init initializes kubernetes client
 func (k *KubernetesClient) Init(params *KubernetesInitParams) error {
 	kubeClient := klient.New()
-	kubeClient.WithRateLimiterSettings(15, 30)
+	kubeClient.WithRateLimiterSettings(30, 60)
 
 	switch {
 	case params.KubeConfigInCluster:

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -16,14 +16,16 @@ package client
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
-
-	"k8s.io/client-go/kubernetes"
 
 	klient "github.com/flant/kube-client/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	// oidc allows using oidc provider in kubeconfig
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -78,6 +80,8 @@ func (k *KubernetesClient) WithSSHClient(client *ssh.Client) *KubernetesClient {
 func (k *KubernetesClient) Init(params *KubernetesInitParams) error {
 	kubeClient := klient.New()
 	kubeClient.WithRateLimiterSettings(5, 10)
+	// pass all klog messages to our logger
+	klog.SetOutput(&klogWriter{})
 
 	switch {
 	case params.KubeConfigInCluster:
@@ -139,4 +143,28 @@ func AppKubernetesInitParams() *KubernetesInitParams {
 		KubeConfigContext:   app.KubeConfigContext,
 		KubeConfigInCluster: app.KubeConfigInCluster,
 	}
+}
+
+type klogWriter struct{}
+
+func (w *klogWriter) Write(msg []byte) (n int, err error) {
+	msgStr := string(msg)
+
+	// suppress throttling log from klog
+	if strings.Contains(msgStr, "due to client-side throttling, not priority and fairness") {
+		return 0, nil
+	}
+
+	switch msg[0] {
+	case 'W':
+		log.WarnLn(msgStr)
+	case 'E':
+		log.ErrorLn(msgStr)
+	case 'F':
+		log.ErrorLn(msgStr)
+		os.Exit(1)
+	default:
+		log.InfoLn(msgStr)
+	}
+	return 0, nil
 }

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -22,13 +22,12 @@ import (
 	"io"
 	"os"
 
-	"k8s.io/klog"
-
 	"github.com/gookit/color"
 	"github.com/sirupsen/logrus"
 	"github.com/werf/logboek"
 	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/logboek/pkg/types"
+	"k8s.io/klog"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 )

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -75,8 +75,9 @@ func InitLoggerWithOptions(loggerType string, opts LoggerOptions) {
 		"-stderrthreshold=FATAL",
 	}
 
+	severity := "-v=1"
 	if opts.IsDebug {
-		args = append(args, "-v=10")
+		severity = "-v=10"
 		// Enable shell-operator log, because it captures klog output
 		// todo: capture output of klog with default logger instead
 		logrus.SetLevel(logrus.DebugLevel)
@@ -84,6 +85,7 @@ func InitLoggerWithOptions(loggerType string, opts LoggerOptions) {
 		logrus.SetOutput(defaultLogger)
 	}
 
+	args = append(args, severity)
 	_ = klogFlagSet.Parse(args)
 }
 

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -24,12 +24,13 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/gookit/color"
 	"github.com/sirupsen/logrus"
 	"github.com/werf/logboek"
 	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/logboek/pkg/types"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 )
 
 var (
@@ -65,16 +66,25 @@ func InitLoggerWithOptions(loggerType string, opts LoggerOptions) {
 
 	// Mute Shell-Operator logs
 	logrus.SetLevel(logrus.PanicLevel)
+
+	// klog
+	klogFlagSet := flag.NewFlagSet("klog", flag.ContinueOnError)
+	klog.InitFlags(klogFlagSet)
+	args := []string{
+		"-logtostderr=false",
+		"-stderrthreshold=FATAL",
+	}
+
 	if opts.IsDebug {
+		args = append(args, "-v=10")
 		// Enable shell-operator log, because it captures klog output
 		// todo: capture output of klog with default logger instead
 		logrus.SetLevel(logrus.DebugLevel)
-		klog.InitFlags(nil)
-		_ = flag.CommandLine.Parse([]string{"-v=10"})
-
 		// Wrap them with our default logger
 		logrus.SetOutput(defaultLogger)
 	}
+
+	_ = klogFlagSet.Parse(args)
 }
 
 type ProcessLogger interface {

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -87,6 +87,31 @@ func InitLoggerWithOptions(loggerType string, opts LoggerOptions) {
 
 	args = append(args, severity)
 	_ = klogFlagSet.Parse(args)
+
+	klog.SetOutputBySeverity("INFO", &writer{})
+}
+
+type writer struct {
+}
+
+func (w *writer) Write(msg []byte) (n int, err error) {
+	if len(msg) == 0 {
+		return 0, nil
+	}
+	switch msg[0] {
+	case 'W':
+		defaultLogger.LogWarnLn(string(msg))
+	case 'E':
+		defaultLogger.LogErrorLn(string(msg))
+	case 'F':
+
+		defaultLogger.LogErrorLn(string(msg))
+		os.Exit(1)
+	default:
+
+		defaultLogger.LogInfoLn(string(msg))
+	}
+	return 0, nil
 }
 
 type ProcessLogger interface {


### PR DESCRIPTION
## Description
Reduce log level for deckhouse converging error

## Why do we need it, and what problem does it solve?
Often we have one-shot errors which they do not govern for bootstrap process and it confuses users.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
![image](https://github.com/deckhouse/deckhouse/assets/30695496/0658bfe6-9913-4539-b3eb-6f6343b0a0b3)
![image](https://github.com/deckhouse/deckhouse/assets/30695496/1a4b83cf-2939-422f-b091-31395c0ba88d)


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Reduce log level for deckhouse converging error
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
