### PR TITLE
[admission-policy-engine] security policy: AllowedClusterRoles

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-cluster-roles.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-cluster-roles.yaml
@@ -1,0 +1,64 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: d8allowedclusterroles
+  labels:
+    heritage: deckhouse
+    module: admission-policy-engine
+    security.deckhouse.io: security-policy
+  annotations:
+    metadata.gatekeeper.sh/title: "Allowed cluster roles"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      TODO
+spec:
+  crd:
+    spec:
+      names:
+        kind: D8AllowedClusterRoles
+      validation:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            TODO
+          properties:
+            allowedClusterRoles:
+              type: array
+              description: "The list of allowed cluster roles."
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package d8.security_policies
+
+        violation[{"msg": msg, "details": {}}] {
+          input.review.object.kind == "RoleBinding"
+          input.review.object.roleRef.kind == "ClusterRole"
+
+          allowedRoles := get_allowed_roles(input)
+          roleRefName := input.review.object.roleRef.name
+          not input_parameters_allowed_roles(allowedRoles, roleRefName)
+
+          msg := sprintf("ClusterRole %v is not in list of allowed roles %v", [roleRefName, allowedRoles])
+        }
+
+        get_allowed_roles(arg) = out {
+          not arg.parameters
+          out = []
+        }
+        get_allowed_roles(arg) = out {
+          not arg.parameters.allowedClusterRoles
+          out = []
+        }
+        get_allowed_roles(arg) = out {
+          out = arg.parameters.allowedClusterRoles
+        }
+
+        input_parameters_allowed_roles(allowedRoles, roleRefName) {
+          # An empty list means all Roles are blocked
+          allowedRoles == []
+        }
+        input_parameters_allowed_roles(allowedRoles, roleRefName) {
+          allowedRoles[_] == roleRefName  
+        }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-cluster-roles.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-cluster-roles.yaml
@@ -10,7 +10,7 @@ metadata:
     metadata.gatekeeper.sh/title: "Allowed cluster roles"
     metadata.gatekeeper.sh/version: 1.0.0
     description: >-
-      TODO
+      Controls what cluster roles are allowed to be bind to users.
 spec:
   crd:
     spec:
@@ -20,11 +20,11 @@ spec:
         openAPIV3Schema:
           type: object
           description: >-
-            TODO
+            Controls what cluster roles are allowed to be bind to users.
           properties:
             allowedClusterRoles:
               type: array
-              description: "The list of allowed cluster roles."
+              description: "A list of allowed cluster roles to bind to users."
               items:
                 type: string
   targets:
@@ -40,7 +40,7 @@ spec:
           roleRefName := input.review.object.roleRef.name
           not input_parameters_allowed_roles(allowedRoles, roleRefName)
 
-          msg := sprintf("ClusterRole %v is not in list of allowed roles %v", [roleRefName, allowedRoles])
+          msg := sprintf("ClusterRole \"%v\" is not in list of allowed roles %v", [roleRefName, allowedRoles])
         }
 
         get_allowed_roles(arg) = out {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/constraint-allowed-admin.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/constraint-allowed-admin.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8AllowedClusterRoles
+metadata:
+  name: test
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+    - kinds:
+      - RoleBinding
+    namespaceSelector:
+      matchLabels:
+        enforce: mypolicy
+    scope: Namespaced
+  parameters:
+    allowedClusterRoles:
+    - admin

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/constraint-allowed-admin.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/constraint-allowed-admin.yaml
@@ -6,8 +6,8 @@ spec:
   enforcementAction: deny
   match:
     kinds:
-    - kinds:
-      - RoleBinding
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        kinds: ["RoleBinding"]
     namespaceSelector:
       matchLabels:
         enforce: mypolicy

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/samples/allowed.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/samples/allowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: administrate
+  namespace: testns
+subjects:
+- kind: User
+  name: dave
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/samples/allowed2.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/samples/allowed2.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: superUser
+  namespace: testns
+subjects:
+- kind: User
+  name: dave
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: SuperUser
+  apiGroup: rbac.authorization.k8s.io

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/samples/disallowed.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/samples/disallowed.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-secrets
+  namespace: testns
+subjects:
+- kind: User
+  name: dave
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: secret-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/suite.yaml
@@ -1,0 +1,27 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: d8-allowed-cluster-roles
+tests:
+  - name: security-policy
+    template: ../../templates/security/allowed-cluster-roles.yaml
+    constraint: constraint-allowed-admin.yaml
+    cases:
+      - name: allowed
+        inventory:
+          - ../common/test_samples/ns.yaml
+        object: samples/allowed.yaml
+        assertions:
+          - violations: no
+      - name: allowed2
+        inventory:
+          - ../common/test_samples/ns.yaml
+        object: samples/allowed2.yaml
+        assertions:
+          - violations: no
+      - name: disallowed
+        inventory:
+          - ../common/test_samples/ns.yaml
+        object: samples/disallowed.yaml
+        assertions:
+          - violations: yes

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/common/test_samples/ns.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/common/test_samples/ns.yaml
@@ -4,3 +4,4 @@ metadata:
   name: testns
   labels:
     security.deckhouse.io/pod-policy: restricted
+    enforce: mypolicy

--- a/modules/015-admission-policy-engine/crds/doc-ru-security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-security-policy.yaml
@@ -166,7 +166,7 @@ spec:
                     allowedVolumes:
                       description: "Список volume-плагинов, доступных к использованию."
                     allowedClusterRoles:
-                      description: "TODO"
+                      description: "Список разрешенных ролей кластера для связывания с пользователями."
                 match:
                   properties:
                     namespaceSelector:

--- a/modules/015-admission-policy-engine/crds/doc-ru-security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-security-policy.yaml
@@ -165,6 +165,8 @@ spec:
                             description: "Значения для SELinux user-меток."
                     allowedVolumes:
                       description: "Список volume-плагинов, доступных к использованию."
+                    allowedClusterRoles:
+                      description: "TODO"
                 match:
                   properties:
                     namespaceSelector:

--- a/modules/015-admission-policy-engine/crds/security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/security-policy.yaml
@@ -339,6 +339,11 @@ spec:
                     readOnlyRootFilesystem:
                       type: boolean
                       description: "Defines if it's possible to run containers with non-read only file system."
+                    allowedClusterRoles:
+                      type: array
+                      description: "TODO"
+                      items:
+                        type: string
                     seccompProfiles:
                       type: object
                       description: "This field specifies the list of allowed profiles that may be set for the Pod or container’s seccomp annotations."

--- a/modules/015-admission-policy-engine/crds/security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/security-policy.yaml
@@ -341,7 +341,7 @@ spec:
                       description: "Defines if it's possible to run containers with non-read only file system."
                     allowedClusterRoles:
                       type: array
-                      description: "TODO"
+                      description: "A list of allowed cluster roles to bind to users."
                       items:
                         type: string
                     seccompProfiles:

--- a/modules/015-admission-policy-engine/hooks/handle_security_policies.go
+++ b/modules/015-admission-policy-engine/hooks/handle_security_policies.go
@@ -123,6 +123,10 @@ func (sp *securityPolicy) preprocesSecurityPolicy() {
 		sp.Spec.Policies.SeccompProfiles.AllowedProfiles = nil
 		sp.Spec.Policies.SeccompProfiles.AllowedLocalhostFiles = nil
 	}
+	// Having rules allowing '*' volumes makes no sense
+	if hasItem(sp.Spec.Policies.AllowedClusterRoles, "*") {
+		sp.Spec.Policies.AllowedClusterRoles = nil
+	}
 }
 
 type securityPolicy struct {

--- a/modules/015-admission-policy-engine/hooks/handle_security_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_security_policies_test.go
@@ -108,6 +108,9 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: handle security
 						"rule": "RunAsAny"
 					},
 					"readOnlyRootFilesystem": true,
+					"allowedClusterRoles": [
+						"*"
+					],
 					"requiredDropCapabilities": [
 						"ALL"
 					],
@@ -206,6 +209,7 @@ spec:
     fsGroup:
       rule: RunAsAny
     readOnlyRootFilesystem: true
+    allowedClusterRoles: ["*"]
     runAsGroup:
       ranges:
       - max: 500

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -72,6 +72,7 @@ type SecurityPolicySpec struct {
 		} `json:"allowedFlexVolumes,omitempty"`
 		AllowedVolumes         []string           `json:"allowedVolumes,omitempty"`
 		ReadOnlyRootFilesystem bool               `json:"readOnlyRootFilesystem,omitempty"`
+		AllowedClusterRoles    []string           `json:"allowedClusterRoles,omitempty"`
 		FsGroup                *SelectUIDStrategy `json:"fsGroup,omitempty"`
 		RunAsUser              *SelectUIDStrategy `json:"runAsUser,omitempty"`
 		RunAsGroup             *SelectUIDStrategy `json:"runAsGroup,omitempty"`

--- a/modules/015-admission-policy-engine/template_tests/security_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/security_policies_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: security p
 				"requiredDropCapabilities": ["ALL"],
 				"allowedAppArmor": ["unconfined"],
 				"readOnlyRootFilesystem": "true",
+				"allowedClusterRoles": ["*"],
 				"runAsUser": {"ranges": [{"max": 500,"min": 300}],"rule": "MustRunAs"},
 				"seLinux": [{"role": "role","user": "user"},{"level": "level","type": "type"}],
 				"seccompProfiles": {"allowedLocalhostFiles": ["*"],"allowedProfiles": ["RuntimeDefault","Localhost"]},
@@ -77,6 +78,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: security p
 			Expect(f.KubernetesGlobalResource("D8HostProcesses", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8PrivilegedContainer", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8ReadOnlyRootFilesystem", testPolicyName).Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("D8AllowedClusterRoles", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8SeLinux", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8AppArmor", testPolicyName).Exists()).To(BeTrue())
 		})

--- a/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
@@ -18,6 +18,9 @@
   {{- if hasKey $cr.spec.policies "readOnlyRootFilesystem" }}
     {{- include "read_only_root_filesystem" (list $context $cr) }}
   {{- end }}
+  {{- if hasKey $cr.spec.policies "allowedClusterRoles" }}
+    {{- include "allowed_cluster_roles" (list $context $cr) }}
+  {{- end }}
   {{- if hasKey $cr.spec.policies "allowedFlexVolumes" }}
     {{- include "allowed_flex_volumes" (list $context $cr) }}
   {{- end }}
@@ -163,6 +166,27 @@ spec:
         kinds: ["Pod"]
     scope: Namespaced
     {{- include "constraint_selector" (list $cr) }}
+{{- end }}
+
+{{- define "allowed_cluster_roles" }}
+  {{- $context := index . 0 }}
+  {{- $cr := index . 1 }}
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8AllowedClusterRoles
+metadata:
+  name: {{$cr.metadata.name}}
+  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/security-policy" "")) | nindent 2 }}
+spec:
+  enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
+  match:
+    kinds:
+      - kinds: ["RoleBinding"]
+    scope: Namespaced
+    {{- include "constraint_selector" (list $cr) }}
+  parameters:
+    allowedClusterRoles:
+      {{- $cr.spec.policies.allowedClusterRoles | toYaml | nindent 6 }}
 {{- end }}
 
 {{- define "allowed_flex_volumes" }}

--- a/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
@@ -181,7 +181,8 @@ spec:
   enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
   match:
     kinds:
-      - kinds: ["RoleBinding"]
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        kinds: ["RoleBinding"]
     scope: Namespaced
     {{- include "constraint_selector" (list $cr) }}
   parameters:


### PR DESCRIPTION
## Description

Added the ability to specify restrictions on applying cluster roles to users.
In CRD "security-policy" added new parameter: "allowedClusterRoles". A list of cluster roles that are allowed to be bound to users.
Attempting to bind unresolved cluster roles will result in an error:
```
kubectl apply -f disallowed-rolebinding.yaml
Error from server (Forbidden): error when creating "disallowed-rolebinding.yaml": admission webhook "admission-policy-engine.deckhouse.io" denied the request: [mypolicy] ClusterRole secret-reader is not in list of allowed roles ["admin"]
```

## Why do we need it, and what problem does it solve?

close issue #7375 

## What is the expected result?

Attempting to bind unresolved cluster roles will result in an error.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Added the ability to specify restrictions on applying cluster roles to users.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
