### PR TITLE
[global] preventing rendering of unavailable components

### DIFF
--- a/modules/015-admission-policy-engine/templates/podmonitor.yaml
+++ b/modules/015-admission-policy-engine/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -66,3 +67,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-{{ .Chart.Name }}
+{{- end }}

--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,5 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +37,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-aws
+{{- end }}

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,5 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +37,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-azure
+{{- end }}

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,5 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +37,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-gcp
+{{- end }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/pod-monitor.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/pod-monitor.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.cloudProviderYandex.internal.providerDiscoveryData.natInstanceName .Values.cloudProviderYandex.internal.providerDiscoveryData.monitoringAPIKey }}
+  {{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,4 +37,5 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-yandex
+  {{- end }}
 {{- end }}

--- a/modules/040-node-manager/templates/early-oom/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/early-oom/pod-monitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.nodeManager.earlyOomEnabled }}
+  {{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -30,4 +31,5 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-cloud-instance-manager
-{{- end }}
+  {{- end }}
+{{- end}}

--- a/modules/200-operator-prometheus/templates/podmonitor.yaml
+++ b/modules/200-operator-prometheus/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -29,3 +30,4 @@ spec:
   selector:
     matchLabels:
       app: prometheus-operator
+{{- end }}

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
 		hec.ValuesSet("global.modules.https.mode", "CertManager")
 		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
 		hec.ValuesSet("global.modulesImages.registry.base", "registry.deckhouse.io/deckhouse/fe")
-		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler-crd"})
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler-crd", "operator-prometheus-crd"})
 		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
 
 		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.1")

--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -11,7 +12,7 @@ spec:
       rules:
         - record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
           expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet", namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m]) * 100))
-
+{{- end }}
 
 {{- define "ingress-controller-lb-hpa" }}
 {{- $context := index . 0 }}

--- a/modules/402-ingress-nginx/templates/kruise/podmonitor.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -25,3 +26,4 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}
+{{- end }}


### PR DESCRIPTION
## Description
Provides an additional check to prevent rendering of components that require CRDs from operator-prometheus-crd module, if this module is disabled.

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/7433

Some modules use CRDs from operator-prometheus-crd module in their components(PodMonitor, PrometheusRules). But if operator-prometheus-crd is disabled, the modules cannot be deployed because they are trying to deploy unavailable resources. Adding an additional condition will fix the problem, modules will be deployed without unavailable components. 

## Why do we need it in the patch release (if we do)?
It allows to use the modules whose components use CRDs from operator-prometheus-crd module without it.

## What is the expected result?
Using some modules (for example ingress-nginx) without the operator-prometheus-crd module. The modules will be deployed without PodMonitors and PrometheusRules components.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: global
type: fix
summary: Preventing rendering of unavailable components.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
