### PR TITLE
[dhctl] fix FindTerraNodeGroup

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -190,15 +190,27 @@ func (m *MetaConfig) GetTerraNodeGroups() []TerraNodeGroupSpec {
 }
 
 func (m *MetaConfig) FindTerraNodeGroup(nodeGroupName string) []byte {
-	for index, ng := range m.TerraNodeGroupSpecs {
-		if ng.Name == nodeGroupName {
+	for _, ngs := range m.TerraNodeGroupSpecs {
+		if ngs.Name == nodeGroupName {
 			var terraNodeGroups []json.RawMessage
 			err := json.Unmarshal(m.ProviderClusterConfig["nodeGroups"], &terraNodeGroups)
 			if err != nil {
-				log.ErrorLn(err)
+				log.ErrorLn(fmt.Sprintf("unmarshalling nodeGroups config: %v", err))
 				return nil
 			}
-			return terraNodeGroups[index]
+
+			for _, terraNodeGroup := range terraNodeGroups {
+				var ng TerraNodeGroupSpec
+				err = json.Unmarshal(terraNodeGroup, &ng)
+				if err != nil {
+					log.ErrorLn(fmt.Sprintf("unmarshalling nodeGroup name: %v", err))
+					return nil
+				}
+
+				if ng.Name == nodeGroupName {
+					return terraNodeGroup
+				}
+			}
 		}
 	}
 	return nil

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-
 	"testing"
 	"text/template"
 
@@ -122,6 +121,15 @@ masterNodeGroup:
     diskSizeGB: 50
     externalIPAddresses:
       - Auto
+nodeGroups:
+  - name: worker
+    replicas: 1
+    instanceClass:
+      cores: 4
+      memory: 8192
+      imageID: id
+      externalIPAddresses:
+        - "Auto"
 sshPublicKey: ssh-rsa AAAA
 nodeNetworkCIDR: 10.100.0.0/21
 provider:
@@ -439,5 +447,33 @@ func TestEnrichProxyData(t *testing.T) {
 			"httpsProxy": "https://2.3.4.5",
 			"noProxy":    []string{"example.com", ".example.com", "127.0.0.1", "169.254.169.254", "cluster.local", "10.111.0.0/16", "10.222.0.0/16"},
 		})
+	})
+}
+
+func TestFindTerraNodeGroup(t *testing.T) {
+	t.Run("dockerCfg in current format (has auth)", func(t *testing.T) {
+		user, password := "user", "password"
+		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{
+			"dockerCfg":  generateDockerCfg("r.example.com", user, password),
+			"imagesRepo": "r.example.com/deckhouse/ce/",
+		})
+
+		ng := cfg.FindTerraNodeGroup("worker")
+		require.JSONEq(t, `
+			{
+			   "instanceClass":{
+				  "cores":4,
+				  "externalIPAddresses":[
+					 "Auto"
+				  ],
+				  "imageID":"id",
+				  "memory":8192,
+				  "platform":"standard-v2"
+			   },
+			   "name":"worker",
+			   "replicas":1
+			}`,
+			string(ng),
+		)
 	})
 }

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -451,7 +451,7 @@ func TestEnrichProxyData(t *testing.T) {
 }
 
 func TestFindTerraNodeGroup(t *testing.T) {
-	t.Run("dockerCfg in current format (has auth)", func(t *testing.T) {
+	t.Run("node exists", func(t *testing.T) {
 		user, password := "user", "password"
 		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{
 			"dockerCfg":  generateDockerCfg("r.example.com", user, password),
@@ -475,5 +475,16 @@ func TestFindTerraNodeGroup(t *testing.T) {
 			}`,
 			string(ng),
 		)
+	})
+
+	t.Run("node does not exist", func(t *testing.T) {
+		user, password := "user", "password"
+		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{
+			"dockerCfg":  generateDockerCfg("r.example.com", user, password),
+			"imagesRepo": "r.example.com/deckhouse/ce/",
+		})
+
+		ng := cfg.FindTerraNodeGroup("worker-1")
+		require.Nil(t, ng)
 	})
 }


### PR DESCRIPTION
```
panic: runtime error: index out of range [2] with length 1

goroutine 303 [running]:
github.com/deckhouse/deckhouse/dhctl/pkg/config.(*MetaConfig).FindTerraNodeGroup(0xc000367180, {0xc000f555c6, 0x6})
	/go/pkg/mod/github.com/deckhouse/deckhouse/dhctl@v0.0.0-20240229021302-d736890b4b64/pkg/config/meta.go:201 +0x1b4
```