### PR TITLE
[ingress-nginx] add needed libraries to final image

### DIFF
--- a/modules/402-ingress-nginx/docs/testing/README.md
+++ b/modules/402-ingress-nginx/docs/testing/README.md
@@ -1,0 +1,58 @@
+ # How to test ingress controller build
+ 
+Apply resources:
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: main
+spec:
+  annotationValidationEnabled: false
+  chaosMonkey: false
+  config:
+    brotli-level: "6"
+    brotli-types: text/xml image/svg+xml application/x-font-ttf image/vnd.microsoft.icon
+      application/x-font-opentype application/json font/eot application/vnd.ms-fontobject
+      application/javascript font/otf application/xml application/xhtml+xml text/javascript
+      application/x-javascript text/plain application/x-font-truetype application/xml+rss
+      image/x-icon font/opentype text/css image/x-win-bitmap
+    enable-brotli: "true"
+  controllerVersion: "1.9"
+  disableHTTP2: false
+  hsts: false
+  ingressClass: nginx
+  inlet: HostWithFailover
+  maxReplicas: 1
+  minReplicas: 1
+  underscoresInHeaders: false
+  validationEnabled: false
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location @toprod {
+          proxy_pass "https://google.com";
+          proxy_set_header Host "google.com";
+          proxy_intercept_errors off;
+          add_header x-source-s3 "prod" always;
+      }
+  name: nginx
+  namespace: default
+spec:
+  rules:
+    - host: nginx.test.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: nginx
+                port:
+                  number: 80
+            path: /
+            pathType: Exact
+```
+
+And check ingress-controller logs for errors.

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -184,7 +184,7 @@ COPY --from=controller-builder --chown=www-data:www-data /src/rootfs/etc /chroot
 
 RUN ln -s /etc/nginx/geoip /chroot/etc/ingress-controller/geoip \
   # fix simlink to proper pcre jit version
-  && ln -s libpcre.so.1.2.13 /chroot/lib64/libpcre.so.3
+  && ln -s libpcre.so.1.2.13 /chroot/lib64/libpcre.so.3 \
   && cd / \
   && patch -p1 < /balancer-lua.patch \
   && patch -p1 < /nginx-tmpl.patch \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -69,9 +69,8 @@ RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     ./configure --prefix=/usr/local/pcre --enable-utf8 --enable-unicode-properties --enable-pcre8 --enable-pcre16 --enable-pcre32 --with-match-limit-recursion=8192 --enable-jit && \
     make && \
     make install && \
-    cp -p /usr/local/pcre/include/* /usr/include && \
-    rm -f /lib64/libpcre* && \
-    cp -p /usr/local/pcre/lib/*.so* /chroot/lib64 && \
+    cp -f /usr/local/pcre/include/* /usr/include && \
+    cp -f /usr/local/pcre/lib/*.so* /chroot/lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
     /build.sh
@@ -167,7 +166,7 @@ RUN bash -eu -c ' \
   && cp -a /usr/local/nginx /chroot/usr/local/ \
   # replace pcre with version with jit support
   && rm -f /chroot/lib64/libpcre* \
-  && cp -p /usr/local/pcre/lib/*.so* /chroot/lib64
+  && cp -f /usr/local/pcre/lib/*.so* /chroot/lib64
 COPY --from=controller-builder --chown=www-data:www-data /src/rootfs/etc /chroot/etc
 RUN cd / \
   && patch -p1 < /balancer-lua.patch \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -70,7 +70,7 @@ RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     make && \
     make install && \
     cp -p /usr/local/pcre/include/* /usr/include && \
-    cp -p /usr/local/pcre/lib/* /lib64 && \
+    cp -pr /usr/local/pcre/lib/* /lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
     /build.sh

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -163,7 +163,7 @@ RUN bash -eu -c ' \
   && cp -a /usr/local/lib64 /chroot/usr/local/ \
   && cp -a /usr/local/modsecurity/bin /chroot/usr/local/modsecurity/ \
   && cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/ \
-  && cp -a /usr/local/nginx /chroot/usr/local/
+  && cp -a /usr/local/nginx /chroot/usr/local/ \
   # replace pcre with version with jit support
   && rm -f /chroot/lib64/libpcre* \
   && cp -p /usr/local/pcre/lib/*.so* /chroot/lib64

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -145,9 +145,9 @@ RUN bash -eu -c ' \
     chown -R www-data.www-data ${dir}; \
   done' \
 
-  COPY --from base-alt /usr/lib64 /chroot/usr
-  COPY --from base-alt /lib64 /chroot
-  COPY --from nginx-builder /usr/local/pcre /usr/local
+  COPY --from=base-alt /usr/lib64 /chroot/usr
+  COPY --from=base-alt /lib64 /chroot
+  COPY --from=nginx-builder /usr/local/pcre /usr/local
 
   && mkdir -p /chroot/lib /chroot/lib64 /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/lib64 /chroot/usr/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share \
   && cp /etc/passwd /etc/group /etc/hosts /chroot/etc/ \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -53,7 +53,6 @@ RUN git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/in
     patch -p1 < /geoip.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
-
 # Build nginx for ingress controller
 FROM $BASE_ALT_DEV as nginx-builder
 ARG CONTROLLER_BRANCH
@@ -63,9 +62,15 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 COPY --from=controller-builder /src/images/nginx/rootfs/ /
 COPY rootfs/etc /etc/
 COPY patches/nginx-build.patch /
-RUN patch build.sh < nginx-build.patch
-RUN /build.sh
-
+# build pcre library with jit support due to lack of jit support in standard alt pcre library
+RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
+    cd pcre && \
+    ./configure --prefix=/usr --enable-utf8 --enable-unicode-properties --enable-pcre8 --enable-pcre16 --enable-pcre32 --with-match-limit-recursion=8192 --enable-jit --libdir=/lib64 --includedir=/usr/include && \
+    make && \
+    make install && \
+    cd / && \
+    patch build.sh < nginx-build.patch && \
+    /build.sh
 
 # This intermediary image will be used only to copy all the required files to the chroot
 # Based on tag "controller-v1.9.5":
@@ -158,13 +163,15 @@ RUN bash -eu -c ' \
   && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
   && cp -a /lib64/libgcc_s.* /chroot/lib64/ \
   && cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libbrotlienc.* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libmaxminddb.* /chroot/usr/lib64/ \
   && cp -a /usr/lib64/gconv /chroot/usr/lib64/ \
   && cp -a /usr/local/bin /chroot/usr/local/ \
   && cp -a /usr/local/lib /chroot/usr/local/ \
   && cp -a /usr/local/share/lua* /chroot/usr/local/share/ \
   && cp -a /usr/local/lib64 /chroot/usr/local/ \
   && cp -a /usr/local/modsecurity/bin /chroot/usr/local/modsecurity/ \
-  && cp -a /usr/local/modsecurity/lib /chroot/usr/local/modsecurity/ \
+  && cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/ \
   && cp -a /usr/local/nginx /chroot/usr/local/
 COPY --from=controller-builder --chown=www-data:www-data /src/rootfs/etc /chroot/etc
 RUN cd / \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -153,17 +153,19 @@ RUN bash -eu -c ' \
   && cp -a /lib64/libpthread-* /lib64/libpthread.* /chroot/lib64/ \
   && cp -a /lib64/libcrypt.* /chroot/lib64/ \
   && cp -a /lib64/libcrypto.* /chroot/lib64/ \
-  && cp -a /lib64/libpcre* /chroot/lib64/ \
   && cp -a /lib64/libssl* /chroot/lib64/ \
   && cp -a /lib64/libz.* /chroot/lib64/ \
   && cp -a /usr/lib64/libGeoIP* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libcurl* /chroot/usr/lib64/ \
   && cp -a /lib64/libc-* /lib64/libc.* /chroot/lib64/ \
   && cp -a /lib64/ld-* /chroot/lib64/ \
   && cp -a /lib64/libm-* /lib64/libm.* /chroot/lib64/ \
   && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
   && cp -a /lib64/libgcc_s.* /chroot/lib64/ \
   && cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/libbrotlienc.* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libbrotli* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libxml2.so* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libyajl.so* /chroot/usr/lib64/ \
   && cp -a /usr/lib64/libmaxminddb.* /chroot/usr/lib64/ \
   && cp -a /usr/lib64/gconv /chroot/usr/lib64/ \
   && cp -a /usr/local/bin /chroot/usr/local/ \
@@ -173,6 +175,7 @@ RUN bash -eu -c ' \
   && cp -a /usr/local/modsecurity/bin /chroot/usr/local/modsecurity/ \
   && cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/ \
   && cp -a /usr/local/nginx /chroot/usr/local/
+COPY --from=nginx-builder /lib64/libpcre* /chroot/lib64/
 COPY --from=controller-builder --chown=www-data:www-data /src/rootfs/etc /chroot/etc
 RUN cd / \
   && patch -p1 < /balancer-lua.patch \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -12,7 +12,6 @@ ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 RUN git clone --branch v1.2.5 --depth 1 ${SOURCE_REPO}/yelp/dumb-init.git && cd dumb-init && cc -std=gnu99 -static -s -Wall -Werror -O3 -o dumb-init dumb-init.c
 
-
 # Build luarocks assets
 FROM $BASE_ALT_DEV as luarocks-builder
 ARG SOURCE_REPO
@@ -25,7 +24,6 @@ RUN cd / && \
     git clone --branch 7-3 ${SOURCE_REPO}/luarocks-sorces/lua-iconv \
     && cd lua-iconv/ \
     && luarocks-5.1 install lua-iconv-7-3.src.rock
-
 
 # Build ingress controller, debug tool and pre-stop hook
 FROM $BASE_GOLANG_21_BULLSEYE_DEV as controller-builder
@@ -104,7 +102,6 @@ COPY patches/auth-cookie-always.patch /
 # copy complete set of libs
 COPY --from=base-alt /usr/lib64 /chroot/usr/lib64
 COPY --from=base-alt /lib64 /chroot/lib64
-COPY --from=nginx-builder /usr/local/pcre/lib/libpcre.so.1.2.13 /usr/local/pcre/lib/libpcre16.so.0.2.13 /usr/local/pcre/lib/libpcre32.so.0.0.13  /usr/local/pcre/lib/libpcrecpp.so.0.0.2 /usr/local/pcre/lib/libpcreposix.so.0.0.7 /chroot/lib64/
 
 RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
   && adduser -r -U -u 101 -d /usr/local/nginx \
@@ -156,7 +153,21 @@ RUN bash -eu -c ' \
   && touch /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml \
   && chown -R www-data.www-data /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml \
   && mkdir -p /chroot/etc/nginx/geoip \
-  && ln -s /chroot/etc/nginx/geoip /chroot/etc/ingress-controller/geoip \
+  && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
+  && cp -a /lib64/libpthread-* /lib64/libpthread.* /chroot/lib64/ \
+  && cp -a /lib64/libcrypt.* /chroot/lib64/ \
+  && cp -a /lib64/libcrypto.* /chroot/lib64/ \
+  && cp -a /lib64/libpcre* /chroot/lib64/ \
+  && cp -a /lib64/libssl* /chroot/lib64/ \
+  && cp -a /lib64/libz.* /chroot/lib64/ \
+  && cp -a /usr/lib64/libGeoIP* /chroot/usr/lib64/ \
+  && cp -a /lib64/libc-* /lib64/libc.* /chroot/lib64/ \
+  && cp -a /lib64/ld-* /chroot/lib64/ \
+  && cp -a /lib64/libm-* /lib64/libm.* /chroot/lib64/ \
+  && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
+  && cp -a /lib64/libgcc_s.* /chroot/lib64/ \
+  && cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/gconv /chroot/usr/lib64/ \
   && cp -a /etc/nginx/* /chroot/etc/nginx/ \
   && cp -a /usr/local/bin /chroot/usr/local/ \
   && cp -a /usr/local/lib /chroot/usr/local/ \
@@ -166,10 +177,15 @@ RUN bash -eu -c ' \
   && cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/ \
   && cp -a /usr/local/nginx /chroot/usr/local/ \
   # replace pcre with version with jit support
-  && rm -f /chroot/lib64/libpcre* \
-  && cp -f /usr/local/pcre/lib/*.so* /chroot/lib64
+  && rm -f /chroot/lib64/libpcre*
+
+COPY --from=nginx-builder /usr/local/pcre/lib/libpcre.so.1.2.13 /usr/local/pcre/lib/libpcre16.so.0.2.13 /usr/local/pcre/lib/libpcre32.so.0.0.13  /usr/local/pcre/lib/libpcrecpp.so.0.0.2 /usr/local/pcre/lib/libpcreposix.so.0.0.7 /chroot/lib64/
 COPY --from=controller-builder --chown=www-data:www-data /src/rootfs/etc /chroot/etc
-RUN cd / \
+
+RUN ln -s /etc/nginx/geoip /chroot/etc/ingress-controller/geoip \
+  # fix simlink to proper pcre jit version
+  && ln -s libpcre.so.1.2.13 /chroot/lib64/libpcre.so.3
+  && cd / \
   && patch -p1 < /balancer-lua.patch \
   && patch -p1 < /nginx-tmpl.patch \
   && patch -p1 < /auth-cookie-always.patch

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -67,9 +67,6 @@ RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     ./configure --prefix=/usr/local/pcre --enable-utf8 --enable-unicode-properties --enable-pcre8 --enable-pcre16 --enable-pcre32 --with-match-limit-recursion=8192 --enable-jit && \
     make && \
     make install && \
-    cp -f /usr/local/pcre/include/* /usr/include && \
-    rm -f /lib64/libpcre* && \
-    cp -f /usr/local/pcre/lib/*.so* /lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
     /build.sh

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_ALPINE_DEV
 ARG BASE_GOLANG_21_BULLSEYE_DEV
 ARG CONTROLLER_BRANCH=controller-v1.9.5
 
+FROM $BASE_ALT as base-alt
 
 # Build dumb-init binary
 FROM $BASE_ALPINE_DEV as dumb-init-builder
@@ -65,9 +66,11 @@ COPY patches/nginx-build.patch /
 # build pcre library with jit support due to lack of jit support in standard alt pcre library
 RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     cd pcre && \
-    ./configure --prefix=/usr --enable-utf8 --enable-unicode-properties --enable-pcre8 --enable-pcre16 --enable-pcre32 --with-match-limit-recursion=8192 --enable-jit --libdir=/lib64 --includedir=/usr/include && \
+    ./configure --prefix=/usr/local/pcre --enable-utf8 --enable-unicode-properties --enable-pcre8 --enable-pcre16 --enable-pcre32 --with-match-limit-recursion=8192 --enable-jit && \
     make && \
     make install && \
+    cp -p /usr/local/pcre/include/* /usr/include && \
+    cp -p /usr/local/pcre/lib/* /lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
     /build.sh
@@ -141,6 +144,11 @@ RUN bash -eu -c ' \
     mkdir -p ${dir}; \
     chown -R www-data.www-data ${dir}; \
   done' \
+
+  COPY --from base-alt /usr/lib64 /chroot/usr
+  COPY --from base-alt /lib64 /chroot
+  COPY --from nginx-builder /usr/local/pcre /usr/local
+
   && mkdir -p /chroot/lib /chroot/lib64 /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/lib64 /chroot/usr/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share \
   && cp /etc/passwd /etc/group /etc/hosts /chroot/etc/ \
   # Create opentelemetry.toml file as it doesn't present in controller_image
@@ -149,25 +157,6 @@ RUN bash -eu -c ' \
   && mkdir -p /chroot/etc/nginx/geoip \
   && ln -s /chroot/etc/nginx/geoip /chroot/etc/ingress-controller/geoip \
   && cp -a /etc/nginx/* /chroot/etc/nginx/ \
-  && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
-  && cp -a /lib64/libpthread-* /lib64/libpthread.* /chroot/lib64/ \
-  && cp -a /lib64/libcrypt.* /chroot/lib64/ \
-  && cp -a /lib64/libcrypto.* /chroot/lib64/ \
-  && cp -a /lib64/libssl* /chroot/lib64/ \
-  && cp -a /lib64/libz.* /chroot/lib64/ \
-  && cp -a /usr/lib64/libGeoIP* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/libcurl* /chroot/usr/lib64/ \
-  && cp -a /lib64/libc-* /lib64/libc.* /chroot/lib64/ \
-  && cp -a /lib64/ld-* /chroot/lib64/ \
-  && cp -a /lib64/libm-* /lib64/libm.* /chroot/lib64/ \
-  && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
-  && cp -a /lib64/libgcc_s.* /chroot/lib64/ \
-  && cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/libbrotli* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/libxml2.so* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/libyajl.so* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/libmaxminddb.* /chroot/usr/lib64/ \
-  && cp -a /usr/lib64/gconv /chroot/usr/lib64/ \
   && cp -a /usr/local/bin /chroot/usr/local/ \
   && cp -a /usr/local/lib /chroot/usr/local/ \
   && cp -a /usr/local/share/lua* /chroot/usr/local/share/ \
@@ -175,7 +164,9 @@ RUN bash -eu -c ' \
   && cp -a /usr/local/modsecurity/bin /chroot/usr/local/modsecurity/ \
   && cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/ \
   && cp -a /usr/local/nginx /chroot/usr/local/
-COPY --from=nginx-builder /lib64/libpcre* /chroot/lib64/
+  # replace pcre with version with jit support
+  && rm -f /chroot/lib64/libpcre* \
+  && cp -p /usr/local/pcre/lib/*.so* /chroot/lib64
 COPY --from=controller-builder --chown=www-data:www-data /src/rootfs/etc /chroot/etc
 RUN cd / \
   && patch -p1 < /balancer-lua.patch \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -154,16 +154,20 @@ RUN bash -eu -c ' \
   && cp -a /lib64/libpthread-* /lib64/libpthread.* /chroot/lib64/ \
   && cp -a /lib64/libcrypt.* /chroot/lib64/ \
   && cp -a /lib64/libcrypto.* /chroot/lib64/ \
-  && cp -a /lib64/libpcre* /chroot/lib64/ \
   && cp -a /lib64/libssl* /chroot/lib64/ \
   && cp -a /lib64/libz.* /chroot/lib64/ \
-  && cp -a /usr/lib64/libGeoIP* /chroot/usr/lib64/ \
   && cp -a /lib64/libc-* /lib64/libc.* /chroot/lib64/ \
   && cp -a /lib64/ld-* /chroot/lib64/ \
   && cp -a /lib64/libm-* /lib64/libm.* /chroot/lib64/ \
   && cp -a /lib64/libdl-* /lib64/libdl.* /chroot/lib64/ \
   && cp -a /lib64/libgcc_s.* /chroot/lib64/ \
+  && cp -a /usr/lib64/libGeoIP* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libcurl* /chroot/usr/lib64/ \
   && cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libbrotli* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libxml2.so* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libyajl.so* /chroot/usr/lib64/ \
+  && cp -a /usr/lib64/libmaxminddb.* /chroot/usr/lib64/ \
   && cp -a /usr/lib64/gconv /chroot/usr/lib64/ \
   && cp -a /etc/nginx/* /chroot/etc/nginx/ \
   && cp -a /usr/local/bin /chroot/usr/local/ \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -101,9 +101,9 @@ COPY patches/nginx-tmpl.patch /
 COPY patches/auth-cookie-always.patch /
 
 # copy complete set of libs
-COPY --from=base-alt /usr/lib64 /chroot/usr
-COPY --from=base-alt /lib64 /chroot
-COPY --from=nginx-builder /usr/local/pcre /usr/local
+COPY --from=base-alt /usr/lib64 /chroot/usr/lib64
+COPY --from=base-alt /lib64 /chroot/lib64
+COPY --from=nginx-builder /usr/local/pcre /usr/local/pcre
 
 RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
   && adduser -r -U -u 101 -d /usr/local/nginx \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -70,7 +70,8 @@ RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     make && \
     make install && \
     cp -p /usr/local/pcre/include/* /usr/include && \
-    cp -pr /usr/local/pcre/lib/* /lib64 && \
+    rm -f /lib64/libpcre* && \
+    cp -p /usr/local/pcre/lib/*.so* /chroot/lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
     /build.sh

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -70,6 +70,7 @@ RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     make && \
     make install && \
     cp -f /usr/local/pcre/include/* /usr/include && \
+    rm -f /lib64/libpcre* && \
     cp -f /usr/local/pcre/lib/*.so* /lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
@@ -103,7 +104,7 @@ COPY patches/auth-cookie-always.patch /
 # copy complete set of libs
 COPY --from=base-alt /usr/lib64 /chroot/usr/lib64
 COPY --from=base-alt /lib64 /chroot/lib64
-COPY --from=nginx-builder /usr/local/pcre /usr/local/pcre
+COPY --from=nginx-builder /usr/local/pcre/lib/libpcre.so.1.2.13 /usr/local/pcre/lib/libpcre16.so.0.2.13 /usr/local/pcre/lib/libpcre32.so.0.0.13  /usr/local/pcre/lib/libpcrecpp.so.0.0.2 /usr/local/pcre/lib/libpcreposix.so.0.0.7 /chroot/lib64/
 
 RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
   && adduser -r -U -u 101 -d /usr/local/nginx \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -100,6 +100,11 @@ COPY patches/balancer-lua.patch /
 COPY patches/nginx-tmpl.patch /
 COPY patches/auth-cookie-always.patch /
 
+# copy complete set of libs
+COPY --from=base-alt /usr/lib64 /chroot/usr
+COPY --from=base-alt /lib64 /chroot
+COPY --from=nginx-builder /usr/local/pcre /usr/local
+
 RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
   && adduser -r -U -u 101 -d /usr/local/nginx \
     -s /sbin/nologin -c www-data www-data \
@@ -144,11 +149,6 @@ RUN bash -eu -c ' \
     mkdir -p ${dir}; \
     chown -R www-data.www-data ${dir}; \
   done' \
-
-  COPY --from=base-alt /usr/lib64 /chroot/usr
-  COPY --from=base-alt /lib64 /chroot
-  COPY --from=nginx-builder /usr/local/pcre /usr/local
-
   && mkdir -p /chroot/lib /chroot/lib64 /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/lib64 /chroot/usr/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share \
   && cp /etc/passwd /etc/group /etc/hosts /chroot/etc/ \
   # Create opentelemetry.toml file as it doesn't present in controller_image

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -70,7 +70,7 @@ RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
     make && \
     make install && \
     cp -f /usr/local/pcre/include/* /usr/include && \
-    cp -f /usr/local/pcre/lib/*.so* /chroot/lib64 && \
+    cp -f /usr/local/pcre/lib/*.so* /lib64 && \
     cd / && \
     patch build.sh < nginx-build.patch && \
     /build.sh

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -63,8 +63,8 @@ ENV SOURCE_REPO=${SOURCE_REPO}
 COPY --from=controller-builder /src/images/nginx/rootfs/ /
 COPY rootfs/etc /etc/
 COPY patches/nginx-build.patch /
-# build pcre library with jit support due to lack of jit support in standard alt pcre library
 RUN git clone --branch 8.45 --depth 1 ${SOURCE_REPO}/pcre/pcre.git && \
+    # build pcre library with jit support due to lack of jit support in standard alt pcre library
     cd pcre && \
     ./configure --prefix=/usr/local/pcre --enable-utf8 --enable-unicode-properties --enable-pcre8 --enable-pcre16 --enable-pcre32 --with-match-limit-recursion=8192 --enable-jit && \
     make && \

--- a/werf.yaml
+++ b/werf.yaml
@@ -199,7 +199,7 @@ import:
   - lib64/libexpat.so*
   - lib64/libssl.so.*
   - lib64/libcrypto.so.*
-  - etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  - etc/pki
   - usr/share/ca-certificates/ca-bundle.crt
   - usr/bin/python3
   - usr/bin/python3.9


### PR DESCRIPTION
## Description
Add needed libraries to the final image.

When we refactored the build to use distroless images we lost some necessary libraries.

## Why do we need it in the patch release (if we do)?
There is a bug in the Ingress controller.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Add libraries to the final image.
impact: ingress nginx controller will restart.
impact_level: default
```
