### PR TITLE
[docs] added info for clientSecret Azure layout

### DIFF
--- a/candi/cloud-providers/azure/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT.md
@@ -20,7 +20,7 @@ You have to create a service account with Microsoft Azure so that Deckhouse can 
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
 
-   > This step issues a default [clientSecret](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Official documentation for [certificate renewal](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
+   > This step issues a default [clientSecret](cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Read more about certificate renewal in the [official documentation](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).
 
 You have to be logged in for further work with the `az` tool. Use the service account username, password, and tenant to log in:
 

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT.md
@@ -19,6 +19,7 @@ You have to create a service account with Microsoft Azure so that Deckhouse can 
    ```shell
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
+   > This step issues a default [clientSecret](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Official documentation for [certificate renewal](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 
 You have to be logged in for further work with the `az` tool. Use the service account username, password, and tenant to log in:
 

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT.md
@@ -19,6 +19,7 @@ You have to create a service account with Microsoft Azure so that Deckhouse can 
    ```shell
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
+
    > This step issues a default [clientSecret](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Official documentation for [certificate renewal](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 
 You have to be logged in for further work with the `az` tool. Use the service account username, password, and tenant to log in:

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT.md
@@ -20,7 +20,18 @@ You have to create a service account with Microsoft Azure so that Deckhouse can 
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
 
-   > This step issues a default [clientSecret](cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Read more about certificate renewal in the [official documentation](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).
+   Example output of the command:
+
+   ```console
+   {
+     "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",     <-- used in the clientId parameter of the AzureClusterConfiguration resource 
+     "displayName": "DeckhouseCANDI",
+     "password": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", <-- used in the clientSecret parameter of the AzureClusterConfiguration resource
+     "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"    <-- used in the tenantId parameter of the AzureClusterConfiguration resource
+   }
+   ```
+
+   > By default, service account will be created with a secret (used in the [clientSecret](cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) parameter of the `AzureClusterConfiguration` resource) validity period of one year without automatic renewal. Refer to the [official documentation](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate) to create a service account with a longer secret expiration date.
 
 You have to be logged in for further work with the `az` tool. Use the service account username, password, and tenant to log in:
 

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
@@ -20,7 +20,7 @@ description: "Настройка Azure для работы облачного п
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
 
-   > На этом этапе выдается [clientSecret](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на 1 год. Официальная документация для [обновления сертификата](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
+   > На этом этапе выдается [clientSecret](cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на один год. Подробнее об обновления сертификата читайте в [официальной документации](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).
 
 Для дальнейшей работы с утилитой `az` необходимо авторизоваться, используя данные (login, password, tenant) созданного service account:
 

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
@@ -20,7 +20,18 @@ description: "Настройка Azure для работы облачного п
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
 
-   > На этом этапе выдается [clientSecret](cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на один год. Подробнее об обновления сертификата читайте в [официальной документации](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).
+   Пример вывода команды:
+
+   ```console
+   {
+     "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",     <-- используется в параметре clientId ресурса AzureClusterConfiguration 
+     "displayName": "DeckhouseCANDI",
+     "password": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", <-- используется в параметре clientSecret ресурса AzureClusterConfiguration
+     "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"    <-- используется в параметре tenantId ресурса AzureClusterConfiguration
+   }
+   ```
+
+   > По умолчанию срок действия секрета созданного service account (используется в параметре [clientSecret](cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) ресурса `AzureClusterConfiguration`) — один год без автоматического продления. Чтобы создать service account с большим сроком действия секрета обратитесь к [официальной документации](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).
 
 Для дальнейшей работы с утилитой `az` необходимо авторизоваться, используя данные (login, password, tenant) созданного service account:
 

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
@@ -19,6 +19,7 @@ description: "Настройка Azure для работы облачного п
    ```shell
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
+
    > На этом этапе выдается [clientSecret](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на 1 год. Официальная документация для [обновления сертификата](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 
 Для дальнейшей работы с утилитой `az` необходимо авторизоваться, используя данные (login, password, tenant) созданного service account:

--- a/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/azure/docs/ENVIRONMENT_RU.md
@@ -19,6 +19,7 @@ description: "Настройка Azure для работы облачного п
    ```shell
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "DeckhouseCANDI"
    ```
+   > На этом этапе выдается [clientSecret](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на 1 год. Официальная документация для [обновления сертификата](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 
 Для дальнейшей работы с утилитой `az` необходимо авторизоваться, используя данные (login, password, tenant) созданного service account:
 

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -365,7 +365,7 @@ apiVersions:
             type: string
           clientSecret:
             description: |
-              The client's secret. Issued by default: for 1 year.
+              The client's secret. Issued by default for one year.
             type: string
           tenantId:
             description: |

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -365,7 +365,7 @@ apiVersions:
             type: string
           clientSecret:
             description: |
-              The client's secret.
+              The client's secret. Issued by default: for 1 year.
             type: string
           tenantId:
             description: |

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -365,7 +365,9 @@ apiVersions:
             type: string
           clientSecret:
             description: |
-              The client's secret. Issued by default for one year.
+              The client's secret.
+
+              Keep in mind the expiration date of the secret. By default, it is valid for one year. Refer to the [official documentation](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate) to create a service account with a longer secret expiration date.
             type: string
           tenantId:
             description: |

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -208,7 +208,9 @@ apiVersions:
               Идентификатор клиента.
           clientSecret:
             description: |
-              Secret клиента. Выдается по умолчанию на один год.
+              Секрет (secret) клиента.
+
+              Помните о сроке действия секрета. По умолчанию он действителен один год. Чтобы создать service account с большим сроком действия секрета обратитесь к [официальной документации](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).
           tenantId:
             description: |
               Идентификатор tenant'а.

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -208,7 +208,7 @@ apiVersions:
               Идентификатор клиента.
           clientSecret:
             description: |
-              Secret клиента. Выдается по умолчанию: на 1 год.
+              Secret клиента. Выдается по умолчанию на один год.
           tenantId:
             description: |
               Идентификатор tenant'а.

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -208,7 +208,7 @@ apiVersions:
               Идентификатор клиента.
           clientSecret:
             description: |
-              Secret клиента.
+              Secret клиента. Выдается по умолчанию: на 1 год.
           tenantId:
             description: |
               Идентификатор tenant'а.

--- a/docs/site/_includes/getting_started/azure/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/azure/STEP_ENV.md
@@ -16,6 +16,7 @@ export SUBSCRIPTION_ID=$(az login | jq -r '.[0].id')
 
 Create a service account:
 This step issues a default [clientSecret](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Official documentation for [certificate renewal](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
+
 {% snippetcut %}
 ```shell
 az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "account_name"

--- a/docs/site/_includes/getting_started/azure/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/azure/STEP_ENV.md
@@ -15,10 +15,11 @@ export SUBSCRIPTION_ID=$(az login | jq -r '.[0].id')
 {% endsnippetcut %}
 
 Create a service account:
-This step issues a default [clientSecret](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Official documentation for [certificate renewal](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 
 {% snippetcut %}
 ```shell
 az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "account_name"
 ```
 {% endsnippetcut %}
+
+At this step, a service account will be created, with a secret (used in the [clientSecret](/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) parameter of the `AzureClusterConfiguration` resource) validity period of one year without automatic renewal. Refer to the [official documentation](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate) to create a service account with a longer secret expiration date.

--- a/docs/site/_includes/getting_started/azure/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/azure/STEP_ENV.md
@@ -15,6 +15,7 @@ export SUBSCRIPTION_ID=$(az login | jq -r '.[0].id')
 {% endsnippetcut %}
 
 Create a service account:
+This step issues a default [clientSecret](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret): for 1 year. Official documentation for [certificate renewal](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 {% snippetcut %}
 ```shell
 az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "account_name"

--- a/docs/site/_includes/getting_started/azure/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/azure/STEP_ENV_RU.md
@@ -15,6 +15,7 @@ export SUBSCRIPTION_ID=$(az login | jq -r '.[0].id')
 {% endsnippetcut %}
 
 Создайте service account:
+На этом этапе выдается [clientSecret](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на 1 год. Официальная документация для [обновления сертификата](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 {% snippetcut %}
 ```shell
 az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "account_name"

--- a/docs/site/_includes/getting_started/azure/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/azure/STEP_ENV_RU.md
@@ -16,6 +16,7 @@ export SUBSCRIPTION_ID=$(az login | jq -r '.[0].id')
 
 Создайте service account:
 На этом этапе выдается [clientSecret](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на 1 год. Официальная документация для [обновления сертификата](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
+
 {% snippetcut %}
 ```shell
 az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "account_name"

--- a/docs/site/_includes/getting_started/azure/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/azure/STEP_ENV_RU.md
@@ -15,10 +15,11 @@ export SUBSCRIPTION_ID=$(az login | jq -r '.[0].id')
 {% endsnippetcut %}
 
 Создайте service account:
-На этом этапе выдается [clientSecret](https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) по умолчанию на 1 год. Официальная документация для [обновления сертификата](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate)
 
 {% snippetcut %}
 ```shell
 az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$SUBSCRIPTION_ID" --name "account_name"
 ```
 {% endsnippetcut %}
+
+На этом этапе будет создан service account, срок действия секрета которого (используется в параметре [clientSecret](/documentation/v1/modules/030-cloud-provider-azure/cluster_configuration.html#azureclusterconfiguration-provider-clientsecret) ресурса `AzureClusterConfiguration`) — один год без автоматического продления. Чтобы создать service account с большим сроком действия секрета обратитесь к [официальной документации](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate?tabs=portal#renew-an-app-service-certificate).


### PR DESCRIPTION
## Description

Adding information about clientSecret issued for 1 year to Azure layout.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: docs
summary: Add info about using client secrets in Azure.
type: fix
impact_level: low
```
