### PR TITLE
[docs][cloud-provider-yandex] Add warnings in doc and quickstart

### DIFF
--- a/candi/cloud-providers/yandex/docs/LAYOUTS.md
+++ b/candi/cloud-providers/yandex/docs/LAYOUTS.md
@@ -7,7 +7,9 @@ Three layouts are supported. Below is more information about each of them.
 
 ## Standard
 
+{% alert level="danger" %}
 In this placement strategy, nodes do not have public IP addresses allocated to them; they use NAT gateway service in Yandex Cloud to connect to the Internet.
+{% endalert %}
 
 ![Yandex Cloud Standard Layout scheme](../../images/030-cloud-provider-yandex/layout-standard.png)
 <!--- Source: https://docs.google.com/drawings/d/1WI8tu-QZYcz3DvYBNlZG4s5OKQ9JKyna7ESHjnjuCVQ/edit --->

--- a/candi/cloud-providers/yandex/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/yandex/docs/LAYOUTS_RU.md
@@ -7,7 +7,9 @@ description: "Описание схем размещения и взаимоде
 
 ## Standard
 
+{% alert level="danger" %}
 В данной схеме размещения узлы не будут иметь публичных IP-адресов, а будут выходить в интернет через NAT-шлюз (NAT Gateway) Yandex Cloud.
+{% endalert %}
 
 ![Схема размещения Standard в Yandex Cloud](../../images/030-cloud-provider-yandex/layout-standard.png)
 <!--- Исходник: https://docs.google.com/drawings/d/1WI8tu-QZYcz3DvYBNlZG4s5OKQ9JKyna7ESHjnjuCVQ/edit --->

--- a/docs/site/_includes/getting_started/yandex/layouts/STANDARD.md
+++ b/docs/site/_includes/getting_started/yandex/layouts/STANDARD.md
@@ -1,4 +1,5 @@
 ![resources](https://docs.google.com/drawings/d/e/2PACX-1vTSpvzjcEBpD1qad9u_UgvsOrYT_Xtnxwg6Pzb64HQHLqQWcZi6hhCNRPKVUdYKX32nXEVJeCzACVRG/pub?w=812&h=655)
 <!--- Source: https://docs.google.com/drawings/d/1WI8tu-QZYcz3DvYBNlZG4s5OKQ9JKyna7ESHjnjuCVQ/edit --->
-
+{% alert level="danger" %}
 Under this placement strategy, virtual machines access the Internet using a NAT gateway service in Yandex Cloud with a public (and single) source IP.
+{% endalert %}

--- a/docs/site/_includes/getting_started/yandex/layouts/STANDARD_RU.md
+++ b/docs/site/_includes/getting_started/yandex/layouts/STANDARD_RU.md
@@ -1,4 +1,6 @@
 ![resources](https://docs.google.com/drawings/d/e/2PACX-1vTSpvzjcEBpD1qad9u_UgvsOrYT_Xtnxwg6Pzb64HQHLqQWcZi6hhCNRPKVUdYKX32nXEVJeCzACVRG/pub?w=812&h=655)
 <!--- Исходник: https://docs.google.com/drawings/d/1WI8tu-QZYcz3DvYBNlZG4s5OKQ9JKyna7ESHjnjuCVQ/edit --->
 
+{% alert level="danger" %}
 В данной схеме размещения узлы не будут иметь публичных адресов, а будут выходить в интернет через NAT-шлюз (NAT Gateway) Yandex Cloud.
+{% endalert %}


### PR DESCRIPTION
## Description

Add warnings in doc and quickstart for YC - use of an external address is not provided in Standart laoyout

```changes
section: docs
type: chore
summary: doc fix
impact_level: low
```
