### PR TITLE
[cilium] Remove CiliumAgentMapOperationFailures alert.

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -51,25 +51,6 @@
       summary: eBPF map {{ $labels.map_name }} is more than 90% full in agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: We've reached resource limit of eBPF maps. Consult with vendor for possible remediation steps.
 
-  - alert: CiliumAgentMapOperationFailures
-    expr: sum by (namespace, pod, map_name, operation) (increase(cilium_bpf_map_ops_total{outcome="fail"}[5m])) > 0
-    for: 20m
-    labels:
-      d8_module: cni-cilium
-      d8_component: agent
-      severity_level: "9"
-      experimental: "true"
-      tier: cluster
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Errors occurred during {{ $labels.map_name }} eBPF map update by operation {{ $labels.operation }} in agent {{ $labels.namespace }}/{{ $labels.pod }}.
-      description: |
-        Cilium Agent is experiencing errors updating BPF maps on Agent Pod {{ $labels.pod }}.
-        Effects may vary depending on map type(s) being affected however this is likely to cause issues with Cilium.
-
   - alert: CiliumAgentPolicyImportErrors
     expr: sum by (namespace, pod) (rate(cilium_policy_import_errors_total[2m]) > 0)
     for: 5m


### PR DESCRIPTION
## Description
Removing CiliumAgentMapOperationFailures alert

## Why do we need it, and what problem does it solve?
There are many spamming alerts in different clusters with maps which are not described in official docs. We are not reaping any real benefits from using this alert.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cilium
type: chore
summary: remove CiliumAgentMapOperationFailures alert
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
