### PR TITLE
[core] add ca-certificates to alt-based images

### DIFF
--- a/modules/460-log-shipper/images/vector/werf.inc.yaml
+++ b/modules/460-log-shipper/images/vector/werf.inc.yaml
@@ -99,7 +99,8 @@ shell:
   - cp target/release/vector /usr/bin/vector
   - export LD_LIBRARY_PATH="/usr/local/lib"
   - /binary_replace.sh -i /usr/bin/vector -o /relocate
-
+  - mkdir -p /relocate/etc
+  - cp -pr /etc/pki /relocate/etc
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-reloader-artifact
 from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}

--- a/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
+++ b/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
@@ -7,6 +7,8 @@ shell:
     - apt-get update
     - apt-get install -y openvpn
     - /binary_replace.sh -i "/usr/sbin/openvpn /bin/bash" -o /relocate
+    - mkdir -p /relocate/etc
+    - cp -pr /etc/pki /relocate/etc
 ---
 artifact: {{ .ModuleName }}/ovpn-admin-backend-artifact
 from: {{ .Images.BASE_GOLANG_20_ALPINE }}

--- a/werf.yaml
+++ b/werf.yaml
@@ -632,7 +632,7 @@ import:
   to: /
   before: setup
   includePaths:
-  - etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  - etc/pki
   - usr/share/ca-certificates/ca-bundle.crt
   - usr/share/vim
   - etc/vim


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added missing ca-certs to images based on alt:p10 to prevent errors with HTTPS connections.

## Why do we need it in the patch release (if we do)?
Bug fix.

## What is the expected result?
Before this PR:

LogShipper:
```
2024-03-01T09:46:09.439636Z  WARN sink{component_kind="sink" component_id=destination/cluster/dop-flant-com component_type=loki component_name=destination/cluster/dop-flant-com}:request{request_id=1}:http: vector::internal_events::http_client: HTTP error. error=error trying to connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1919:: unable to get local issuer certificate error_type="request_failed" stage="processing" internal_log_rate_limit=true
2024-03-01T09:46:09.439728Z  WARN sink{component_kind="sink" component_id=destination/cluster/dop-flant-com component_type=loki component_name=destination/cluster/dop-flant-com}:request{request_id=1}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: Failed to make HTTP(S) request: error trying to connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1919:: unable to get local issuer certificate internal_log_rate_limit=true
```

After:
No errors about https requests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: Add missing ca-certs to images based on alt:p10 to prevent errors with HTTPS connections.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
