### PR TITLE
[network-policy-engine] Deny module setup if the cni-cilium module is enabled

### DIFF
--- a/modules/050-network-policy-engine/enabled
+++ b/modules/050-network-policy-engine/enabled
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 Flant JSC
+# Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,4 +25,4 @@ function __main__() {
   fi
 }
 
-enabled::run "$@"
+enabled::run $@

--- a/modules/050-network-policy-engine/enabled
+++ b/modules/050-network-policy-engine/enabled
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,11 @@ source /deckhouse/shell_lib.sh
 
 function __main__() {
   enabled::disable_module_if_cluster_is_not_bootstraped
-  echo "true" > $MODULE_ENABLED_RESULT
+  if values::array_has global.enabledModules "cni-cilium" ; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+  else
+    echo "true" > "$MODULE_ENABLED_RESULT"
+  fi
 }
 
-enabled::run $@
+enabled::run "$@"


### PR DESCRIPTION
## Description
Disable network-policy-engine module if cni-cilium module is enabled.

## Why do we need it, and what problem does it solve?
When the CNI-Cilium module is enabled, its own Network Policies are in place. If the Network Policy Engine module is also activated concurrently, conflicts and ambiguity can occur. To prevent this, a verification check will be added to the module activation script to ensure if the CNI-Cilium module is already enabled.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: network-policy-engine
type: chore
summary: Deny module setup if the cni-cilium module is enabled
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
