### PR TITLE
[cloud-provider-yandex] Improve alert about migration NAT instance

### DIFF
--- a/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
+++ b/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
@@ -74,7 +74,7 @@
                   echo "DH_VERSION=$DH_VERSION DH_EDITION=$DH_EDITION"
                   ```
 
-              1. Run installer:
+              1. Run the installer:
 
                   ```
                   docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash

--- a/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
+++ b/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
@@ -40,7 +40,7 @@
 
           You can use the following instructions to migrate.
 
-          **IMPORTANT** The following actions are destructive changes and cause downtime (typically a few minutes, but may be longer depending on the response time of Yandex Cloud).
+          **IMPORTANT** The following actions are destructive changes and cause downtime (typically a several tens of minutes, also it depending on the response time of Yandex Cloud).
 
           1. Migrate NAT Instance.
 
@@ -64,11 +64,27 @@
                   kubectl -n d8-system exec -it deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
                   ```
 
-          1. Run dhctl converge
+          1. Run the appropriate edition and version of the Deckhouse installer container on the **local** machine (change the container registry address if necessary) and do converge.
 
-              ```
-              kubectl -n d8-system exec -it deploy/terraform-auto-converger -- dhctl converge --kube-client-from-cluster
-              ```
+              1. Get edition and version of the Deckhouse:
+
+                  ```
+                  DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}')
+                  DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]' )
+                  echo "DH_VERSION=$DH_VERSION DH_EDITION=$DH_EDITION"
+                  ```
+
+              1. Run installer:
+
+                  ```
+                  docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
+                  ```
+
+              1. Do converge:
+
+                  ```
+                  dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
+                  ```
 
           1. Update route table
 

--- a/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
+++ b/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
@@ -70,7 +70,7 @@
 
                   ```
                   DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}')
-                  DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]' )
+                  DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]')
                   echo "DH_VERSION=$DH_VERSION DH_EDITION=$DH_EDITION"
                   ```
 


### PR DESCRIPTION
## Description
Move step converge from cluster to local machine

## Why do we need it, and what problem does it solve?
Our master node can also have connection to internet through NAT-instance and when converge delete NAT instance we lost connection to `api.cloud.yandex.net`

## Why do we need it in the patch release (if we do)?

Not necessary.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: chore
summary: Improve alert about migration NAT instance.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
