### PR TITLE
[operator-trivy] update trivy tag

### DIFF
--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -15,13 +15,9 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
-    git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git
-
-WORKDIR trivy
-
-RUN go mod tidy && go mod vendor
-
-RUN go build -mod vendor -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+    git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
+    cd trivy && go mod tidy &&  go mod vendor &&  \
+    go build -mod vendor -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -3,8 +3,8 @@ ARG BASE_GOLANG_19_BULLSEYE
 
 FROM $BASE_GOLANG_19_BULLSEYE AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
-ARG TRIVY_VERSION=v0.44.0-flant.2
-ARG TRIVY_DB_VERSION=flant-latest
+ARG TRIVY_VERSION=flant-stable
+ARG TRIVY_DB_VERSION=flant-stable
 ARG GOPROXY
 ARG SOURCE_REPO
 ENV GOPROXY=${GOPROXY} \

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -3,8 +3,8 @@ ARG BASE_GOLANG_19_BULLSEYE
 
 FROM $BASE_GOLANG_19_BULLSEYE AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
-ARG TRIVY_VERSION=feature/add-new-os
-ARG TRIVY_DB_VERSION=feature/add-new-os
+ARG TRIVY_VERSION=v0.44.0-flant.3
+ARG TRIVY_DB_VERSION=flant-latest
 ARG GOPROXY
 ARG SOURCE_REPO
 ENV GOPROXY=${GOPROXY} \
@@ -16,7 +16,8 @@ ENV GOPROXY=${GOPROXY} \
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
-    cd trivy && go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+    cd trivy && \
+    go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_DISTROLESS
 ARG BASE_GOLANG_20_BULLSEYE
 
-FROM $BASE_GOLANG_20_BULLSEYE AS build
+FROM golang:1.22.0-bullseye AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
 ARG TRIVY_VERSION=flant-stable
 ARG TRIVY_DB_VERSION=flant-stable
@@ -16,8 +16,11 @@ ENV GOPROXY=${GOPROXY} \
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
-    cd trivy && \
-    go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+    cd trivy
+
+RUN go mod download
+
+RUN go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -15,12 +15,13 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
-    git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
-    cd trivy
+    git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git &&
 
-RUN go mod download
+WORKDIR trivy
 
-RUN go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+RUN go mod tidy && go mod vendor
+
+RUN go build -mod vendor -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -16,8 +16,7 @@ ENV GOPROXY=${GOPROXY} \
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
-    cd trivy && \
-    go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+    cd trivy && go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -15,7 +15,7 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
-    git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git &&
+    git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git
 
 WORKDIR trivy
 

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -3,8 +3,8 @@ ARG BASE_GOLANG_19_BULLSEYE
 
 FROM $BASE_GOLANG_19_BULLSEYE AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
-ARG TRIVY_VERSION=feature/add-alt-linux
-ARG TRIVY_DB_VERSION=feature/add-alt-linux
+ARG TRIVY_VERSION=feature/add-new-os
+ARG TRIVY_DB_VERSION=feature/add-new-os
 ARG GOPROXY
 ARG SOURCE_REPO
 ENV GOPROXY=${GOPROXY} \

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_DISTROLESS
 ARG BASE_GOLANG_20_BULLSEYE
 
-FROM golang:1.22 AS build
+FROM $BASE_GOLANG_20_BULLSEYE AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
 ARG TRIVY_VERSION=flant-stable
 ARG TRIVY_DB_VERSION=flant-stable

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_DISTROLESS
-ARG BASE_GOLANG_19_BULLSEYE
+ARG BASE_GOLANG_20_BULLSEYE
 
-FROM $BASE_GOLANG_19_BULLSEYE AS build
+FROM golang:1.22 AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
 ARG TRIVY_VERSION=flant-stable
 ARG TRIVY_DB_VERSION=flant-stable

--- a/ee/modules/500-operator-trivy/images/trivy/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/trivy/Dockerfile
@@ -1,10 +1,10 @@
 ARG BASE_DISTROLESS
-ARG BASE_GOLANG_20_BULLSEYE
+ARG BASE_GOLANG_19_BULLSEYE
 
-FROM golang:1.22.0-bullseye AS build
+FROM $BASE_GOLANG_19_BULLSEYE AS build
 # Also check operator image version and admission-policy-engine module trivy-provider image "github.com/aquasecurity/trivy" library version
-ARG TRIVY_VERSION=flant-stable
-ARG TRIVY_DB_VERSION=flant-stable
+ARG TRIVY_VERSION=feature/add-alt-linux
+ARG TRIVY_DB_VERSION=feature/add-alt-linux
 ARG GOPROXY
 ARG SOURCE_REPO
 ENV GOPROXY=${GOPROXY} \
@@ -16,8 +16,8 @@ ENV GOPROXY=${GOPROXY} \
 WORKDIR /src
 RUN git clone --depth 1 --branch ${TRIVY_DB_VERSION} ${SOURCE_REPO}/aquasecurity/trivy-db.git && \
     git clone --depth 1 --branch ${TRIVY_VERSION} ${SOURCE_REPO}/aquasecurity/trivy.git && \
-    cd trivy && go mod tidy &&  go mod vendor &&  \
-    go build -mod vendor -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
+    cd trivy && \
+    go build -ldflags '-s -w -extldflags "-static"' -o trivy ./cmd/trivy/main.go
 
 RUN chown 64535:64535 trivy
 RUN chmod 0700 trivy

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{ $trivyServerURL := printf "http://trivy-server.d8-%s:4954" .Chart.Name | quote }}
-{{ $dbRepository := printf "%s/security/trivy-test-db" .Values.global.modulesImages.registry.base | quote }}
+{{ $dbRepository := printf "%s/security/trivy-db" .Values.global.modulesImages.registry.base | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{ $trivyServerURL := printf "http://trivy-server.d8-%s:4954" .Chart.Name | quote }}
-{{ $dbRepository := printf "%s/security/trivy-db" .Values.global.modulesImages.registry.base | quote }}
+{{ $dbRepository := printf "%s/security/trivy-test-db" .Values.global.modulesImages.registry.base | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Description
Contains an update for trivy. This update adds scanning support for new os.

## Why do we need it, and what problem does it solve?
It allows trivy to scan new os.

## What is the expected result?
Trivy can scan more os.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature
summary: Adding new os to trivy
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
