### PR TITLE
[dhctl] mirror: avoid mirroring versions that were not yet released

### DIFF
--- a/dhctl/pkg/operations/mirror/versions.go
+++ b/dhctl/pkg/operations/mirror/versions.go
@@ -130,10 +130,15 @@ func getReleaseChannelVersionFromRegistry(mirrorCtx *Context, releaseChannel str
 	}
 
 	releaseInfo := &struct {
-		Version string `json:"version"`
+		Version   string `json:"version"`
+		Suspended bool   `json:"suspend"`
 	}{}
 	if err = json.Unmarshal(versionJSON.Bytes(), releaseInfo); err != nil {
 		return nil, fmt.Errorf("cannot find release channel version: %w", err)
+	}
+
+	if releaseInfo.Suspended {
+		return nil, fmt.Errorf("Cannot mirror Deckhouse: source registry contains suspended release channel %q, try again later", releaseChannel)
 	}
 
 	ver, err := semver.NewVersion(releaseInfo.Version)

--- a/dhctl/pkg/operations/mirror/versions.go
+++ b/dhctl/pkg/operations/mirror/versions.go
@@ -50,7 +50,14 @@ func VersionsToCopy(mirrorCtx *Context) ([]semver.Version, error) {
 		return nil, fmt.Errorf("get releases from github: %w", err)
 	}
 
-	versionsAboveMinimal := parseAndFilterVersionsAboveMinimal(&mirrorFromVersion, tags)
+	alphaChannelVersion := releaseChannelsVersions[0]
+	for i := range releaseChannelsToCopy {
+		if releaseChannelsToCopy[i] == "alpha" {
+			alphaChannelVersion = releaseChannelsVersions[i]
+			break
+		}
+	}
+	versionsAboveMinimal := parseAndFilterVersionsAboveMinimalAnbBelowAlpha(&mirrorFromVersion, tags, alphaChannelVersion)
 	versionsAboveMinimal = filterOnlyLatestPatches(versionsAboveMinimal)
 
 	return deduplicateVersions(append(releaseChannelsVersions, versionsAboveMinimal...)), nil
@@ -70,11 +77,15 @@ func getReleasedTagsFromRegistry(mirrorCtx *Context) ([]string, error) {
 	return tags, nil
 }
 
-func parseAndFilterVersionsAboveMinimal(minVersion *semver.Version, tags []string) []*semver.Version {
+func parseAndFilterVersionsAboveMinimalAnbBelowAlpha(
+	minVersion *semver.Version,
+	tags []string,
+	alphaChannelVersion *semver.Version,
+) []*semver.Version {
 	versionsAboveMinimal := make([]*semver.Version, 0)
 	for _, tag := range tags {
 		version, err := semver.NewVersion(tag)
-		if err != nil || minVersion.GreaterThan(version) {
+		if err != nil || minVersion.GreaterThan(version) || version.GreaterThan(alphaChannelVersion) {
 			continue
 		}
 		versionsAboveMinimal = append(versionsAboveMinimal, version)
@@ -118,14 +129,14 @@ func getReleaseChannelVersionFromRegistry(mirrorCtx *Context, releaseChannel str
 		return nil, fmt.Errorf("cannot get %s release channel version: %w", releaseChannel, err)
 	}
 
-	tmp := &struct {
+	releaseInfo := &struct {
 		Version string `json:"version"`
 	}{}
-	if err = json.Unmarshal(versionJSON.Bytes(), tmp); err != nil {
+	if err = json.Unmarshal(versionJSON.Bytes(), releaseInfo); err != nil {
 		return nil, fmt.Errorf("cannot find release channel version: %w", err)
 	}
 
-	ver, err := semver.NewVersion(tmp.Version)
+	ver, err := semver.NewVersion(releaseInfo.Version)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find release channel version: %w", err)
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Implemented a check that prevents mirroring of versions newer than version of `alpha` release channel

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes incorrect versions selection resulting in mirroring of unreleased artifacts.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This is a bugfix.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: "mirror will avoid mirroring versions that were not yet released."
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
