### PR TITLE
[node-manager] kubelet resource reservation fix

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -2046,7 +2046,7 @@ spec:
                             Note that currently we do not use a dedicated cgroup for resource reservation (`-system-reserved-cgroup` is not used).
                         static:
                           type: object
-                          oneOf:
+                          anyOf:
                           - required: ["cpu"]
                           - required: ["memory"]
                           - required: ["ephemeralStorage"]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed kubelet resource reservation for Static nodes

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
kubelet resource reservation doesn't work with nodeType Static

```shell
apiVersion: deckhouse.io/v1
kind: NodeGroup
metadata:
  name: test-ng
spec:
  disruptions:
    approvalMode: Automatic
  kubelet:
    containerLogMaxFiles: 4
    containerLogMaxSize: 50Mi
    maxPods: 150
    resourceReservation:
      mode: "Static"
      static:
        cpu: 500m
        memory: 1G
  nodeType: Static
  operatingSystem:
    manageKernel: false


The NodeGroup "test-ng" is invalid: <nil>: Invalid value: "": "spec.kubelet.resourceReservation.static" must validate one and only one schema (oneOf). Found 2 valid alternatives
```


## Why do we need it in the patch release (if we do)?


## Tests

```shell
root@dev2-master-0:~# kubectl get crd nodegroups.deckhouse.io -o json | jq '.spec.versions[2].schema.openAPIV3Schema.properties.spec.properties.kubelet.properties.resourceReservation.properties.static.anyOf' 
[
  {
    "required": [
      "cpu"
    ]
  },
  {
    "required": [
      "memory"
    ]
  },
  {
    "required": [
      "ephemeralStorage"
    ]
  }
]

root@dev2-master-0:~# kubectl create -f - <<"END"
> apiVersion: deckhouse.io/v1
> kind: NodeGroup
> metadata:
>   name: test-ng-1
> spec:
>   disruptions:
>     approvalMode: Automatic
>   kubelet:
>     containerLogMaxFiles: 4
>     containerLogMaxSize: 50Mi
>     maxPods: 150
>     resourceReservation:
>       mode: "Static"
>   nodeType: Static
>   operatingSystem:
>     manageKernel: false
> END
The NodeGroup "test-ng-1" is invalid: 
* <nil>: Invalid value: "": "spec.kubelet.resourceReservation" must validate one and only one schema (oneOf). Found none valid
* spec.kubelet.resourceReservation.static: Required value

root@dev2-master-0:~# kubectl create -f - <<"END"
> apiVersion: deckhouse.io/v1
> kind: NodeGroup
> metadata:
>   name: test-ng-2
> spec:
>   disruptions:
>     approvalMode: Automatic
>   kubelet:
>     containerLogMaxFiles: 4
>     containerLogMaxSize: 50Mi
>     maxPods: 150
>     resourceReservation:
>       mode: "Static"
>       static:
>         cpu: 500m
>   nodeType: Static
>   operatingSystem:
>     manageKernel: false
> END
nodegroup.deckhouse.io/test-ng-2 created

root@dev2-master-0:~# kubectl create -f - <<"END"
> apiVersion: deckhouse.io/v1
> kind: NodeGroup
> metadata:
>   name: test-ng-3
> spec:
>   disruptions:
>     approvalMode: Automatic
>   kubelet:
>     containerLogMaxFiles: 4
>     containerLogMaxSize: 50Mi
>     maxPods: 150
>     resourceReservation:
>       mode: "Static"
>       static:
>         memory: 1G
>   nodeType: Static
>   operatingSystem:
>     manageKernel: false
> END
nodegroup.deckhouse.io/test-ng-3 created

root@dev2-master-0:~# kubectl create -f - <<"END"
> apiVersion: deckhouse.io/v1
> kind: NodeGroup
> metadata:
>   name: test-ng-4
> spec:
>   disruptions:
>     approvalMode: Automatic
>   kubelet:
>     containerLogMaxFiles: 4
>     containerLogMaxSize: 50Mi
>     maxPods: 150
>     resourceReservation:
>       mode: "Static"
>       static:
>         cpu: 500m
>         memory: 1G
>   nodeType: Static
>   operatingSystem:
>     manageKernel: false
> END
nodegroup.deckhouse.io/test-ng-4 created
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed kubelet resource reservation for Static nodes

```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
