### PR TITLE
[core] change go get -u to go get for build immutability

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -28,7 +28,7 @@ RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
     patch -p1 < 004-scan-job-registry-ca.patch && \
     patch -p1 < 005-cis-benchmark-on-startup.patch
 
-RUN go get -u golang.org/x/net@v0.17.0 && go mod tidy && go mod vendor
+RUN go get golang.org/x/net@v0.17.0 && go mod tidy && go mod vendor
 RUN go build -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go
 
 RUN chown 64535:64535 operator-trivy

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/Dockerfile
@@ -14,9 +14,10 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src
 RUN git clone -c advice.detachedHead=false --branch 2.28.0 --depth 1 ${SOURCE_REPO}/falcosecurity/falcosidekick.git . && \
-    go get -u github.com/nats-io/nkeys@v0.4.6 && \
-    go get -u golang.org/x/net@v0.17.0 && \
-    go get -u google.golang.org/grpc@v1.56.3 && \
+    go get github.com/nats-io/nkeys@v0.4.6 && \
+    go get golang.org/x/net@v0.17.0 && \
+    go get google.golang.org/grpc@v1.56.3 && \
+    go mod tidy && \
     make falcosidekick && \
     chown -R 64535:64535 /src/falcosidekick && \
     chmod 0755 /src/falcosidekick

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -22,8 +22,9 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
     {{- if semverCompare "<1.29" $version }}
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u google.golang.org/grpc@v1.57.2
+    - go get golang.org/x/net@v0.17.0
+    - go get google.golang.org/grpc@v1.57.2
+    - go mod tidy
     - go mod vendor
     {{- end }}
     - make build

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -22,8 +22,8 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
     {{- if semverCompare "<1.29" $version }}
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u google.golang.org/grpc@v1.56.3
+    - go get golang.org/x/net@v0.17.0
+    - go get google.golang.org/grpc@v1.56.3
     - go mod tidy
     - go mod vendor
     - go mod edit -dropreplace google.golang.org/grpc

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -21,8 +21,9 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u google.golang.org/grpc@v1.56.3
+    - go get golang.org/x/net@v0.17.0
+    - go get google.golang.org/grpc@v1.56.3
+    - go mod tidy
     - go mod vendor
     - make build
     - cp bin/csi-resizer /csi-resizer

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -21,10 +21,12 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
+    {{- if semverCompare "<1.29" $version }}
     - go get golang.org/x/net@v0.17.0
     - go get google.golang.org/grpc@v1.56.3
     - go mod tidy
     - go mod vendor
+    {{- end }}
     - make build
     - cp bin/csi-resizer /csi-resizer
     - chown 64535:64535 /csi-resizer

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -21,9 +21,11 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
+    {{- if semverCompare "<1.29" $version }}
     - go get google.golang.org/grpc@v1.56.3 && \
     - go mod tidy && \
     - go mod vendor && \
+    {{- end }}
     - make build
     - cp bin/csi-snapshotter /csi-snapshotter
     - chown 64535:64535 /csi-snapshotter

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -21,7 +21,8 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
-    - go get -u google.golang.org/grpc@v1.56.3 && \
+    - go get google.golang.org/grpc@v1.56.3 && \
+    - go mod tidy && \
     - go mod vendor && \
     - make build
     - cp bin/csi-snapshotter /csi-snapshotter

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -21,10 +21,12 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
+    {{- if semverCompare "<1.29" $version }}
     - go get golang.org/x/net@v0.17.0
     - go get google.golang.org/grpc@v1.56.3
     - go mod tidy
     - go mod vendor
+    {{- end }}
     - make build
     - cp bin/livenessprobe /livenessprobe
     - chown 64535:64535 /livenessprobe

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -21,8 +21,9 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u google.golang.org/grpc@v1.56.3
+    - go get golang.org/x/net@v0.17.0
+    - go get google.golang.org/grpc@v1.56.3
+    - go mod tidy
     - go mod vendor
     - make build
     - cp bin/livenessprobe /livenessprobe

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -21,10 +21,12 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
+    {{- if semverCompare "<1.29" $version }}
     - go get golang.org/x/net@v0.17.0
     - go get google.golang.org/grpc@v1.56.3
     - go mod tidy
     - go mod vendor
+    {{- end }}
     - make build
     - cp bin/csi-node-driver-registrar /csi-node-driver-registrar
     - chown 64535:64535 /csi-node-driver-registrar

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -21,8 +21,9 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
-    - go get -u golang.org/x/net@v0.17.0
-    - go get -u google.golang.org/grpc@v1.56.3
+    - go get golang.org/x/net@v0.17.0
+    - go get google.golang.org/grpc@v1.56.3
+    - go mod tidy
     - go mod vendor
     - make build
     - cp bin/csi-node-driver-registrar /csi-node-driver-registrar

--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -29,9 +29,9 @@ shell:
   - test -d /patches && for patchfile in /patches/*.patch ; do patch -p1 < ${patchfile}; done
   - export GOPROXY={{ .GOPROXY }} GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - go mod edit -go 1.20
-  - go get -u golang.org/x/net@v0.17.0
-  - go get -u github.com/prometheus/client_golang@v1.17.0
-  - go get -u github.com/gogo/protobuf@v1.3.2
+  - go get golang.org/x/net@v0.17.0
+  - go get github.com/prometheus/client_golang@v1.17.0
+  - go get github.com/gogo/protobuf@v1.3.2
   - go mod tidy
   - make build
   - cp /src/_output/kube-rbac-proxy-linux-$(go env GOARCH) /kube-rbac-proxy

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -28,7 +28,7 @@ shell:
     - git clone --depth 1 --branch v{{$localPathProvisionerVersion}} {{ $.SOURCE_REPO }}/rancher/local-path-provisioner.git /src
     - cd /src
     - for ifile in $(ls /patches/*.patch); do git apply $ifile; done
-    - go get -u github.com/prometheus/client_golang@v1.17.0
+    - go get github.com/prometheus/client_golang@v1.17.0
     - go mod tidy
     - go mod vendor
     - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.VERSION={{$localPathProvisionerVersion}} -extldflags -static -s -w" -o /local-path-provisioner

--- a/modules/042-kube-dns/images/coredns/patches/README.md
+++ b/modules/042-kube-dns/images/coredns/patches/README.md
@@ -11,6 +11,7 @@ Upstream [PR](https://github.com/coredns/coredns/pull/5491).
 To create this patch run commands:
 
 ```shell
-go get -u google.golang.org/grpc@v1.57.1
+go get google.golang.org/grpc@v1.57.1
+go mod tidy
 git diff
 ```

--- a/modules/150-user-authn/images/dex-authenticator/Dockerfile
+++ b/modules/150-user-authn/images/dex-authenticator/Dockerfile
@@ -15,8 +15,9 @@ RUN git clone --depth 1 --branch v7.5.1 ${SOURCE_REPO}/oauth2-proxy/oauth2-proxy
 ADD patches/cookie-refresh.patch patches/remove-groups.patch /
 RUN patch -p1 < /cookie-refresh.patch && \
   patch -p1 < /remove-groups.patch && \
-  go get -u golang.org/x/net@v0.17.0 && \
-  go get -u google.golang.org/grpc@v1.56.3 && \
+  go get golang.org/x/net@v0.17.0 && \
+  go get google.golang.org/grpc@v1.56.3 && \
+  go mod tidy && \
   go build -ldflags '-s -w' -o oauth2-proxy github.com/oauth2-proxy/oauth2-proxy/v7
 
 RUN chown 64535:64535 oauth2-proxy

--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -16,7 +16,7 @@ RUN git clone --branch v2.35.3 --depth 1 ${SOURCE_REPO}/dexidp/dex.git . \
   && git apply /robots-txt.patch \
   && git apply /401-password-auth.patch
 
-RUN go get -u google.golang.org/grpc@v1.56.3 && \
+RUN go get google.golang.org/grpc@v1.56.3 && \
     go mod tidy && \
     go mod vendor && \
     CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex

--- a/modules/150-user-authn/images/kubeconfig-generator/Dockerfile
+++ b/modules/150-user-authn/images/kubeconfig-generator/Dockerfile
@@ -18,11 +18,11 @@ RUN git clone ${SOURCE_REPO}/mintel/dex-k8s-authenticator.git . && \
   git checkout 378a39dd93bed9f56a5a1b1a799a208c61ead83f && \
   git apply --whitespace=fix /already_logged.patch && \
   go mod edit -go=1.20 && \
+  go get golang.org/x/crypto@v0.15.0 && \
+  go get golang.org/x/net@v0.17.0 && \
+  go get golang.org/x/text@v0.14.0 && \
+  go get gopkg.in/yaml.v2@v2.4.0 && \
   go mod tidy && \
-  go get -u golang.org/x/crypto@v0.15.0 && \
-  go get -u golang.org/x/net@v0.17.0 && \
-  go get -u golang.org/x/text@v0.14.0 && \
-  go get -u gopkg.in/yaml.v2@v2.4.0 && \
   mkdir -p /app/app/bin && \
   go build -ldflags '-s -w' -o /app/app/bin/dex-k8s-authenticator .
 

--- a/modules/200-operator-prometheus/images/prometheus-operator/werf.inc.yaml
+++ b/modules/200-operator-prometheus/images/prometheus-operator/werf.inc.yaml
@@ -31,7 +31,7 @@ shell:
     - export VERSION=$(cat VERSION | tr -d " \t\n\r")
     - export GO_BUILD_LDFLAGS="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildUser=deckhouse"
     - test -d /patches && for patchfile in /patches/*.patch ; do patch -p1 < ${patchfile}; done
-    - go get -u golang.org/x/net@v0.17.0
+    - go get golang.org/x/net@v0.17.0
     - go mod tidy
     - go build -ldflags="-s -w ${GO_BUILD_LDFLAGS}" -o operator cmd/operator/main.go
     - chmod 0700 /prometheus-operator/operator

--- a/modules/300-prometheus/images/alertmanager/Dockerfile
+++ b/modules/300-prometheus/images/alertmanager/Dockerfile
@@ -16,7 +16,8 @@ RUN git clone --depth 1 --branch v0.25.0 ${SOURCE_REPO}/prometheus/alertmanager.
 WORKDIR /alertmanager/
 
 RUN go mod edit -go 1.20 \
-    && go get -u golang.org/x/net@v0.17.0
+    && go get golang.org/x/net@v0.17.0 \
+    && go mod tidy
 
 RUN go build -ldflags="-s -w" -o alertmanager cmd/alertmanager/main.go && \
     chown -R 64535:64535 /alertmanager/ && \

--- a/modules/300-prometheus/images/trickster/Dockerfile
+++ b/modules/300-prometheus/images/trickster/Dockerfile
@@ -17,8 +17,9 @@ RUN git clone --depth 1 --branch v1.1.5 ${SOURCE_REPO}/trickstercache/trickster.
 WORKDIR /trickster/
 
 RUN go mod edit -go 1.20 \
-    && go get -u golang.org/x/net@v0.17.0 \
-    && go get -u github.com/prometheus/client_golang@v1.17.0
+    && go get golang.org/x/net@v0.17.0 \
+    && go get github.com/prometheus/client_golang@v1.17.0 \
+    && go mod tidy
 RUN make build && \
     chown -R 64535:64535 /trickster/ && \
     chmod 0700 /trickster/OPATH/trickster

--- a/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
@@ -9,10 +9,10 @@ ENV GOPROXY=${GOPROXY}
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.9.1 ${SOURCE_REPO}/kubernetes-sigs/prometheus-adapter.git .
 
-RUN go get -u golang.org/x/net@v0.17.0 \
-    && go get -u github.com/prometheus/client_golang@v1.11.1 \
-    && go get -u gopkg.in/yaml.v3@v3.0.1 \
-    && go get -u github.com/emicklei/go-restful@v2.16.0 \
+RUN go get golang.org/x/net@v0.17.0 \
+    && go get github.com/prometheus/client_golang@v1.11.1 \
+    && go get gopkg.in/yaml.v3@v3.0.1 \
+    && go get github.com/emicklei/go-restful@v2.16.0 \
     && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o adapter ./cmd/adapter/adapter.go
 

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -15,8 +15,9 @@ RUN mkdir -p /src/kube-state-metrics && \
   git clone --depth 1 --branch v2.7.0 ${SOURCE_REPO}/kubernetes/kube-state-metrics/ /src/kube-state-metrics
 WORKDIR /src/kube-state-metrics
 RUN go mod edit -go 1.20 \
-    && go get -u golang.org/x/net@v0.17.0 \
-    && go get -u github.com/emicklei/go-restful@v2.16.0 \
+    && go get golang.org/x/net@v0.17.0 \
+    && go get github.com/emicklei/go-restful@v2.16.0 \
+    && go mod tidy \
     && make build-local && \
     chown -R 64535:64535 /src/kube-state-metrics && \
     chmod 0700 /src/kube-state-metrics/kube-state-metrics

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -14,7 +14,7 @@ ENV GOPROXY=${GOPROXY} \
 
 WORKDIR /src/
 COPY exporter/ /src/
-RUN go get -u golang.org/x/net@v0.17.0 \
+RUN go get golang.org/x/net@v0.17.0 \
     && go mod tidy \
     && go build -ldflags="-s -w" -o loop main.go && \
     chown -R 64535:64535 /src/ && \

--- a/modules/402-ingress-nginx/images/kruise-state-metrics/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise-state-metrics/patches/README.md
@@ -6,9 +6,10 @@ To create this patch run commands:
 
 ```shell
 go mod edit -go 1.20
-go get -u golang.org/x/net@v0.17.0
-go get -u gopkg.in/yaml.v3@v3.0.1
-go get -u github.com/prometheus/client_golang@v1.17.0
-go get -u golang.org/x/crypto@v0.14.0
+go get golang.org/x/net@v0.17.0
+go get gopkg.in/yaml.v3@v3.0.1
+go get github.com/prometheus/client_golang@v1.17.0
+go get golang.org/x/crypto@v0.14.0
+go mod tidy
 git diff
 ```

--- a/modules/402-ingress-nginx/images/kruise/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise/patches/README.md
@@ -29,11 +29,12 @@ Updates library versions.
 To create this patch run:
 ```shell
 go mod edit -go 1.20
-go get -u golang.org/x/net@v0.17.0
-go get -u github.com/docker/distribution@v2.8.3
-go get -u github.com/docker/docker@v20.10.24
-go get -u github.com/opencontainers/runc@v1.1.5
-go get -u gopkg.in/yaml.v3@v3.0.1
+go get golang.org/x/net@v0.17.0
+go get github.com/docker/distribution@v2.8.3
+go get github.com/docker/docker@v20.10.24
+go get github.com/opencontainers/runc@v1.1.5
+go get gopkg.in/yaml.v3@v3.0.1
+go mod tidy
 git diff
 ```
 

--- a/modules/402-ingress-nginx/images/nginx-exporter/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/nginx-exporter/werf.inc.yaml
@@ -10,7 +10,7 @@ shell:
   - cd /src
   - git clone --depth 1 --branch v0.8.0 {{ $.SOURCE_REPO }}/nginxinc/nginx-prometheus-exporter.git .
   - go mod edit -go 1.20
-  - go get -u github.com/prometheus/client_golang@v1.17.0
+  - go get github.com/prometheus/client_golang@v1.17.0
   - go mod tidy
   - go mod vendor
   - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -X main.version=0.8.0 -X main.gitCommit=f0173677183c840e90a56e48082e36ac687e1a30' -o exporter .

--- a/modules/462-loki/images/loki/Dockerfile
+++ b/modules/462-loki/images/loki/Dockerfile
@@ -15,7 +15,7 @@ ENV GOPROXY=${GOPROXY} \
 RUN git clone --depth 1 --branch v2.7.7 ${SOURCE_REPO}/grafana/loki.git /loki
 WORKDIR /loki/
 
-RUN go get -u golang.org/x/net@v0.17.0 \
+RUN go get golang.org/x/net@v0.17.0 \
     && go mod tidy \
     && go mod vendor
 RUN go build -ldflags="-s -w" -o loki cmd/loki/main.go && \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change `go get -u` to `go get` + `go mod tidy` for build immutability.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When we use `go get -u`, we are updating dependencies to the latest version, not the preferred version.
This causes problems with resolv of go packages.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: change go get -u to go get for build immutability
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
