### PR TITLE
[core] change go get

### DIFF
--- a/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone --depth 1 --branch v0.9.1 ${SOURCE_REPO}/kubernetes-sigs/prometheu
 RUN go get golang.org/x/net@v0.17.0 \
     && go get github.com/prometheus/client_golang@v1.11.1 \
     && go get gopkg.in/yaml.v3@v3.0.1 \
-    && go get github.com/emicklei/go-restful@v2.16.0 \
+    && go get github.com/emicklei/go-restful@v2.16.0+incompatible \
     && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o adapter ./cmd/adapter/adapter.go
 

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /src/kube-state-metrics && \
 WORKDIR /src/kube-state-metrics
 RUN go mod edit -go 1.20 \
     && go get golang.org/x/net@v0.17.0 \
-    && go get github.com/emicklei/go-restful@v2.16.0 \
+    && go get github.com/emicklei/go-restful@v2.16.0+incompatible \
     && go mod tidy \
     && make build-local && \
     chown -R 64535:64535 /src/kube-state-metrics && \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change go get for modules.

## Why do we need it in the patch release (if we do)?
It fixes the bug.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: Change go get.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
