### PR TITLE
[flow-schema] apiVersion for FlowSchema and PriorityLevelConfiguration changed to the minimum available

### DIFF
--- a/modules/011-flow-schema/template_tests/module_test.go
+++ b/modules/011-flow-schema/template_tests/module_test.go
@@ -51,6 +51,11 @@ discovery:
   kubernetesVersion: "1.29.1"
 `
 
+	globalValuesK8s130 = `
+discovery:
+  kubernetesVersion: "1.30.0"
+`
+
 	moduleEmptyValuesForFlowSchemaModule = `
 internal:
   namespaces: []
@@ -128,6 +133,36 @@ var _ = Describe("Module :: flow-schema :: helm template ::", func() {
 			pl := f.KubernetesResource("PriorityLevelConfiguration", "", "d8-serviceaccounts")
 			Expect(fs.Exists()).To(BeTrue())
 			Expect(pl.Exists()).To(BeTrue())
+			Expect(fs.Field("apiVersion").String()).To(Equal("flowcontrol.apiserver.k8s.io/v1beta1"))
+			Expect(fs.Field("spec.rules.0.subjects").String()).To(MatchYAML(`
+- kind: ServiceAccount
+  serviceAccount:
+    name: '*'
+    namespace: test1
+- kind: ServiceAccount
+  serviceAccount:
+    name: '*'
+    namespace: test2
+`))
+			Expect(pl.Field("apiVersion").String()).To(Equal("flowcontrol.apiserver.k8s.io/v1beta1"))
+			Expect(pl.Field("spec.limited.assuredConcurrencyShares").String()).To(Equal("5"))
+		})
+	})
+
+	Context("Cluster with deckhouse namespaces, kubernetes 1.26", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValuesK8s126)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("flowSchema", moduleValuesForFlowSchemaModule)
+			f.HelmRender()
+		})
+
+		It("Everything must render properly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			fs := f.KubernetesResource("FlowSchema", "", "d8-serviceaccounts")
+			pl := f.KubernetesResource("PriorityLevelConfiguration", "", "d8-serviceaccounts")
+			Expect(fs.Exists()).To(BeTrue())
+			Expect(pl.Exists()).To(BeTrue())
 			Expect(fs.Field("apiVersion").String()).To(Equal("flowcontrol.apiserver.k8s.io/v1beta2"))
 			Expect(fs.Field("spec.rules.0.subjects").String()).To(MatchYAML(`
 - kind: ServiceAccount
@@ -140,13 +175,13 @@ var _ = Describe("Module :: flow-schema :: helm template ::", func() {
     namespace: test2
 `))
 			Expect(pl.Field("apiVersion").String()).To(Equal("flowcontrol.apiserver.k8s.io/v1beta2"))
-			Expect(pl.Field("spec.limited.assuredConcurrencyShares").String()).To(Equal("5"))
+			Expect(pl.Field("spec.limited.nominalConcurrencyShares").String()).To(Equal("5"))
 		})
 	})
 
-	Context("Cluster with deckhouse namespaces, kubernetes 1.26", func() {
+	Context("Cluster with deckhouse namespaces, kubernetes 1.29", func() {
 		BeforeEach(func() {
-			f.ValuesSetFromYaml("global", globalValuesK8s126)
+			f.ValuesSetFromYaml("global", globalValuesK8s129)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
 			f.ValuesSetFromYaml("flowSchema", moduleValuesForFlowSchemaModule)
 			f.HelmRender()
@@ -174,9 +209,9 @@ var _ = Describe("Module :: flow-schema :: helm template ::", func() {
 		})
 	})
 
-	Context("Cluster with deckhouse namespaces, kubernetes 1.29", func() {
+	Context("Cluster with deckhouse namespaces, kubernetes 1.30", func() {
 		BeforeEach(func() {
-			f.ValuesSetFromYaml("global", globalValuesK8s129)
+			f.ValuesSetFromYaml("global", globalValuesK8s130)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
 			f.ValuesSetFromYaml("flowSchema", moduleValuesForFlowSchemaModule)
 			f.HelmRender()

--- a/modules/011-flow-schema/templates/flowschema.yaml
+++ b/modules/011-flow-schema/templates/flowschema.yaml
@@ -4,7 +4,7 @@
 apiVersion: flowcontrol.apiserver.k8s.io/v1
   {{- else if semverCompare "> 1.26" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
-  {{- else if semverCompare "> 1.23" .Values.global.discovery.kubernetesVersion }}
+  {{- else if semverCompare ">= 1.25" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
   {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta1

--- a/modules/011-flow-schema/templates/flowschema.yaml
+++ b/modules/011-flow-schema/templates/flowschema.yaml
@@ -1,10 +1,10 @@
 {{- if gt (len .Values.flowSchema.internal.namespaces) 0 }}
 ---
-  {{- if semverCompare ">= 1.29" .Values.global.discovery.kubernetesVersion }}
+  {{- if semverCompare "> 1.29" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1
-  {{- else if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+  {{- else if semverCompare "> 1.26" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
-  {{- else if semverCompare ">= 1.23" .Values.global.discovery.kubernetesVersion }}
+  {{- else if semverCompare "> 1.23" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
   {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta1

--- a/modules/011-flow-schema/templates/prioritylevelconfiguration.yaml
+++ b/modules/011-flow-schema/templates/prioritylevelconfiguration.yaml
@@ -1,9 +1,9 @@
 ---
-  {{- if semverCompare ">= 1.29" .Values.global.discovery.kubernetesVersion }}
+  {{- if semverCompare "> 1.29" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1
-  {{- else if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+  {{- else if semverCompare "> 1.26" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
-{{- else if semverCompare ">= 1.23" .Values.global.discovery.kubernetesVersion }}
+{{- else if semverCompare "> 1.23" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
 {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta1

--- a/modules/011-flow-schema/templates/prioritylevelconfiguration.yaml
+++ b/modules/011-flow-schema/templates/prioritylevelconfiguration.yaml
@@ -3,7 +3,7 @@
 apiVersion: flowcontrol.apiserver.k8s.io/v1
   {{- else if semverCompare "> 1.26" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
-{{- else if semverCompare "> 1.23" .Values.global.discovery.kubernetesVersion }}
+{{- else if semverCompare ">= 1.25" .Values.global.discovery.kubernetesVersion }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
 {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
apiVersion for FlowSchema and PriorityLevelConfiguration changed to the minimum available

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In rare cases, when rolling back a k8s version, a situation arises that makes it impossible to apply the new flow-schema release

## Manual tests

```shell
# bootstrap 1.26
root@dev-master-0:~# kubectl version -o json | jq '.serverVersion.gitVersion'
"v1.26.14"
root@dev-master-0:~# kubectl -n d8-system get secret sh.helm.release.v1.flow-schema.v3 -o json | jq -r '.data.release' | base64 -d | base64 -d | gzip -d | jq -r '.manifest' | grep "^apiVersion: f" -A1
apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
kind: FlowSchema
--
apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
kind: PriorityLevelConfiguration


# update to 1.27
root@dev-master-0:~# kubectl version -o json | jq '.serverVersion.gitVersion'
"v1.27.11"
root@dev-master-0:~# kubectl -n d8-system get secret sh.helm.release.v1.flow-schema.v4 -o json | jq -r '.data.release' | base64 -d | base64 -d | gzip -d | jq -r '.manifest' | grep "^apiVersion: f" -A1
apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
kind: FlowSchema
--
apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
kind: PriorityLevelConfiguration

# rollback to 1.26
root@dev-master-0:~# kubectl version -o json | jq '.serverVersion.gitVersion'
"v1.26.14"
root@dev-master-0:~# kubectl -n d8-system get secret sh.helm.release.v1.flow-schema.v5 -o json | jq -r '.data.release' | base64 -d | base64 -d | gzip -d | jq -r '.manifest' | grep "^apiVersion: f" -A1
apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
kind: FlowSchema
--
apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
kind: PriorityLevelConfiguration

# switch d8 image from pr to main
sh.helm.release.v1.flow-schema.v4  sh.helm.release.v1.flow-schema.v5  sh.helm.release.v1.flow-schema.v6  
root@dev-master-0:~# kubectl -n d8-system get secret sh.helm.release.v1.flow-schema.v6 -o json | jq -r '.data.release' | base64 -d | base64 -d | gzip -d | jq -r '.manifest' | grep "^apiVersion: f" -A1
apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
kind: FlowSchema
--
apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
kind: PriorityLevelConfiguration


# switch d8 image from main to pr
sh.helm.release.v1.flow-schema.v5  sh.helm.release.v1.flow-schema.v6  sh.helm.release.v1.flow-schema.v7  
root@dev-master-0:~# kubectl -n d8-system get secret sh.helm.release.v1.flow-schema.v7 -o json | jq -r '.data.release' | base64 -d | base64 -d | gzip -d | jq -r '.manifest' | grep "^apiVersion: f" -A1
apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
kind: FlowSchema
--
apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
kind: PriorityLevelConfiguration
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: flow-schema
type: fix
summary: "apiVersion for `FlowSchema` and `PriorityLevelConfiguration` changed to the minimum available."
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
