### PR TITLE
[doc] add example of binding IP to ingress controller

### DIFF
--- a/ee/se/modules/380-metallb/docs/EXAMPLES_RU.md
+++ b/ee/se/modules/380-metallb/docs/EXAMPLES_RU.md
@@ -1,139 +1,162 @@
 ---
-title: "The metallb module: пример"
+title: "The metallb module: примеры"
 ---
+
+Metallb можно использовать в статических кластерах (bare metal), когда облачный провайдер не предоставляет балансировщик (load balancer). Metallb может работать в L2- или BGP-режиме.
+
+## Пример использования metallb в L2-режиме
 
 {% raw %}
+Пример включения модуля metallb, создания Ingress-контроллера с `inlet: LoadBalancer` и предоставления доступа к отдельно запущенному веб-серверу Nginx.
 
-Metallb можно использовать в статических (bare-metal) кластерах, когда вы не можете заказать балансировщик (load balancer) у облачного провайдера. Metallb может работать в L2- или BGP-режиме.
+1. Задайте группы узлов ([_NodeGroup_](../040-node-manager/cr.html#nodegroup)) для запуска приложений, к которым предоставляется доступ.
 
-Ниже представлен пример использования Metallb в L2-режиме.
-Мы создадим Ingress-контроллер с inlet `LoadBalancer`, а также дадим доступ к отдельно запущенному веб серверу Nginx, используя сервис с типом `LoadBalancer`.
+   Например, Ingress-контроллеры запускаются на frontend-узлах, а веб-сервер Nginx — на worker-узле. У всех узлов есть общий лейбл `node-role/metallb=""`.
 
-Во-первых, необходимо определить, какие NodeGroup'ы будут использоваться для запуска приложений, к которым будет предоставлен доступ.
-В этом примере Ingress-контроллеры запускаются на frontend-узлах, а веб сервер Nginx — на worker-узле. У всех узлов есть общий лейбл `node-role/metallb=""`.
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: frontend
+   spec:
+     disruptions:
+       approvalMode: Manual
+     nodeTemplate:
+       labels:
+         node-role.deckhouse.io/frontend: ""
+         node-role/metallb: ""
+       taints:
+       - effect: NoExecute
+         key: dedicated.deckhouse.io
+         value: frontend
+     nodeType: Static
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: worker
+   spec:
+     disruptions:
+       approvalMode: Manual
+     nodeTemplate:
+       labels:
+         node-role/metallb: ""
+     nodeType: Static
+   ```
 
-```yaml
-apiVersion: deckhouse.io/v1
-kind: NodeGroup
-metadata:
-  name: frontend
-spec:
-  disruptions:
-    approvalMode: Manual
-  nodeTemplate:
-    labels:
-      node-role.deckhouse.io/frontend: ""
-      node-role/metallb: ""
-    taints:
-    - effect: NoExecute
-      key: dedicated.deckhouse.io
-      value: frontend
-  nodeType: Static
----
-apiVersion: deckhouse.io/v1
-kind: NodeGroup
-metadata:
-  name: worker
-spec:
-  disruptions:
-    approvalMode: Manual
-  nodeTemplate:
-    labels:
-      node-role/metallb: ""
-  nodeType: Static
-```
+1. Проверьте, что на узлах проставлен корректный лейбл:
 
-Проверьте, что на узлах проставлен корректный лейбл.
+   ```bash
+   kubectl get nodes -l node-role/metallb
+   ```
 
-```bash
-kubectl get nodes -l node-role/metallb
-NAME              STATUS   ROLES      AGE   VERSION
-demo-frontend-0   Ready    frontend   61d   v1.21.14
-demo-frontend-1   Ready    frontend   61d   v1.21.14
-demo-worker-0     Ready    worker     61d   v1.21.14
-```
+   Пример вывода:
 
-Модуль `metallb` отключен по умолчанию, поэтому его необходимо включить явно. Также необходимо задать корректные `nodeSelector` и `tolerations` для Metallb speaker'ов.
+   ```bash
+   $ kubectl get nodes -l node-role/metallb
+   NAME              STATUS   ROLES      AGE   VERSION
+   demo-frontend-0   Ready    frontend   61d   v1.21.14
+   demo-frontend-1   Ready    frontend   61d   v1.21.14
+   demo-worker-0     Ready    worker     61d   v1.21.14
+   ```
 
-Пример конфигурации модуля:
+1. Включите модуль metallb и задайте параметры `nodeSelector` и `tolerations` для спикеров MetalLB.
 
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: metallb
-spec:
-  version: 1
-  enabled: true
-  settings:
-    addressPools:
-    - addresses:
-      - 192.168.199.100-192.168.199.102
-      name: frontend-pool
-      protocol: layer2
-    speaker:
-      nodeSelector:
-        node-role/metallb: ""
-      tolerations:
-      - effect: NoExecute
-        key: dedicated.deckhouse.io
-        operator: Equal
-        value: frontend
-```
+   Пример конфигурации модуля:
+  
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: metallb
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       addressPools:
+       - addresses:
+         - 192.168.199.100-192.168.199.102
+         name: frontend-pool
+         protocol: layer2
+       speaker:
+         nodeSelector:
+           node-role/metallb: ""
+         tolerations:
+         - effect: NoExecute
+           key: dedicated.deckhouse.io
+           operator: Equal
+           value: frontend
+   ```
 
-Создайте `IngressNginxController`.
+1. Создайте кастомный ресурс _IngressNginxController_.
 
-```yaml
-apiVersion: deckhouse.io/v1
-kind: IngressNginxController
-metadata:
-  name: main
-spec:
-  ingressClass: nginx
-  inlet: LoadBalancer
-  nodeSelector:
-    node-role.deckhouse.io/frontend: ""
-  tolerations:
-  - effect: NoExecute
-    key: dedicated.deckhouse.io
-    value: frontend
-```
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: IngressNginxController
+   metadata:
+     name: main
+   spec:
+     ingressClass: nginx
+     inlet: LoadBalancer
+     nodeSelector:
+       node-role.deckhouse.io/frontend: ""
+     tolerations:
+     - effect: NoExecute
+       key: dedicated.deckhouse.io
+       value: frontend
+   ```
 
-Проверьте, что сервис с типом `LoadBalancer` создан в namespace `d8-ingress-nginx`.
+1. Проверьте, что сервис с типом `LoadBalancer` создан в _Namespace_ `d8-ingress-nginx`:
 
-```shell
-kubectl -n d8-ingress-nginx get svc main-load-balancer 
-NAME                 TYPE           CLUSTER-IP       EXTERNAL-IP       PORT(S)                      AGE
-main-load-balancer   LoadBalancer   10.222.255.194   192.168.199.100   80:30236/TCP,443:32292/TCP   30s
-```
+   ```shell
+   kubectl -n d8-ingress-nginx get svc main-load-balancer
+   ```
 
-Ваш Ingress-контроллер доступен по внешнему IP-адресу.
+   Пример вывода:
 
-```shell
-curl -s -o /dev/null -w "%{http_code}" 192.168.199.100
-404
-```
+   ```shell
+   $ kubectl -n d8-ingress-nginx get svc main-load-balancer 
+   NAME                 TYPE           CLUSTER-IP       EXTERNAL-IP       PORT(S)                      AGE
+   main-load-balancer   LoadBalancer   10.222.255.194   192.168.199.100   80:30236/TCP,443:32292/TCP   30s
+   ```
 
-Теперь предоставим доступ к веб-серверу Nginx на порту `8080`.
+1. Проверьте, что Ingress-контроллер доступен по внешнему IP-адресу.
 
-```shell
-kubectl create deploy nginx --image=nginx
-kubectl create svc loadbalancer nginx --tcp=8080:80
-```
+   Пример:
 
-Проверьте сервис.
+   ```console
+   $ curl -s -o /dev/null -w "%{http_code}" 192.168.199.100
+   404
+   ```
 
-```shell
-kubectl get svc nginx
-NAME    TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)          AGE
-nginx   LoadBalancer   10.222.9.190   192.168.199.101   8080:31689/TCP   3m11s
-```
+1. Предоставьте доступ к веб-серверу Nginx на порту `8080`:
 
-Теперь вы можете получить доступ к приложению, используя curl.
+   ```shell
+   kubectl create deploy nginx --image=nginx
+   kubectl create svc loadbalancer nginx --tcp=8080:80
+   ```
 
-```shell
-curl -s -o /dev/null -w "%{http_code}" 192.168.199.101:8080
-200
-```
+1. Проверьте, что сервис создан:
+
+   ```shell
+   kubectl get svc nginx
+   ```
+
+   Пример вывода:
+
+   ```shell
+   $ kubectl get svc nginx
+   NAME    TYPE           CLUSTER-IP     EXTERNAL-IP       PORT(S)          AGE
+   nginx   LoadBalancer   10.222.9.190   192.168.199.101   8080:31689/TCP   3m11s
+   ```
+
+1. Проверьте доступ к приложению.
+
+   Пример:
+
+   ```console
+   $ curl -s -o /dev/null -w "%{http_code}" 192.168.199.101:8080
+   200
+   ```
 
 {% endraw %}


### PR DESCRIPTION
## Description
Add example of binding specific IP address from MetalLB pool to ingress-controller

```changes
section: doc
type: chore
summary: Add the example of binding IP to Ingress controller.
impact_level: low
```
