### PR TITLE
[cilium] Fixup safe_agent_updater

### DIFF
--- a/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       terminationGracePeriodSeconds: 1
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: safe-agent-updater

--- a/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       terminationGracePeriodSeconds: 1
+      hostNetwork: true
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: safe-agent-updater
@@ -80,6 +81,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "6445"
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}


### PR DESCRIPTION
## Description

Making fixes:
1) Launching pods of `safe_agent_updater` in the `hostNetwork`
2) When connecting to the k8s api-server, use the `kubernetes-api-proxy`.

## Why do we need it, and what problem does it solve?

If there are pods of `cilium-agent` in the cluster that aren't functioning correctly, we may encounter the following issue. 
The `safe_agent_updater` application may not be able to connect to the Kubernetes API server to determine if the pods of `cilium-agent` need to be restarted. 
By default, connections to the Kubernetes API server are made using the svc with type `Cluster IP` which is processed entirely by the `cilium-agents` pods. 
To prevent this situation, we can launch the `safe_agent_updater` pods with `hostNetwork` and configure it to communicate with Kubernetes API server through the `kubernetes-api-proxy`.

## Why do we need it in the patch release (if we do)?

Now, this issue occurs when you turn on or off the virtualization module.

## What is the expected result?

`safe_agent_updater` can correctly restart `cilium-agent` pods in any situation.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Run `safe_agent_updater` pods in the `hostNetwork` mode and use `kubernetes-api-proxy`.
impact: "`cilium-agent` pods will probably restart and L7 policies will flap."
impact_level: default
```
