### PR TITLE
[dhctl] fix(dhctl-for-commander): abandoned node should be treated as destructive check status

### DIFF
--- a/dhctl/pkg/operations/check/checker.go
+++ b/dhctl/pkg/operations/check/checker.go
@@ -165,11 +165,11 @@ func resolveStatisticsStatus(status string) CheckStatus {
 		// NOTE: Regular out-of-sync state, which can be fixed by the converge run
 		return CheckStatusOutOfSync
 	case converge.DestructiveStatus:
-		// NOTE: Critical error, cannot be healed by the converge run
+		// NOTE: Something will be destroyed by the converge run, such change should be approved
 		return CheckStatusDestructiveOutOfSync
 	case converge.AbandonedStatus:
-		// NOTE: Excess node — treat as out-of-sync for now
-		return CheckStatusOutOfSync
+		// NOTE: Excess node — treat as destructive out-of-sync, because this node will be destroyed during converge run
+		return CheckStatusDestructiveOutOfSync
 	case converge.AbsentStatus:
 		// NOTE: Lost node — treat as out-of-sync for now
 		return CheckStatusOutOfSync


### PR DESCRIPTION
## Description

Abandoned nodes will be destroyed in the converge, so give DestructiveOutOfSync status in such case.

## Why do we need it, and what problem does it solve?

This fixes current behaviour where abandoned nodes treated as a regular out-of-sync.
