### PR TITLE
fix(dhctl-for-commander): disable local-bootstraper converge-lock in commander-mode

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -406,7 +406,14 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 			return nil
 		}
 
-		err := converge.NewInLockLocalRunner(kubeCl, "local-bootstraper").Run(func() error {
+		localBootstraper := func(f func() error) error {
+			if b.CommanderMode {
+				return f()
+			}
+			return converge.NewInLockLocalRunner(kubeCl, "local-bootstraper").Run(f)
+		}
+
+		err := localBootstraper(func() error {
 			return bootstrapAdditionalNodesForCloudCluster(kubeCl, metaConfig, masterAddressesForSSH, b.TerraformContext)
 		})
 		if err != nil {


### PR DESCRIPTION
## Description

This PR disables converge-lock when running bootstrap operation in commander-mode.
It is totally safe to remove this lock in commander mode because:
* terraform-manager (auto-converge) is disabled in commander;
* converge runs outside of target cluster and commander ensures no parallel converges are running;
* it is supposed that user never runs dhctl-converge from cli manually, user always uses commander ui to change configuration.

So we don't need this lock in commander mode at all.

## Why do we need it, and what problem does it solve?

If bootstrap has been terminated at InstallAdditionalMastersAndStaticNodes for example, then converge-lock lease remains to exist in the target cluster. On the next bootstrap retry, which is automatic in commander, bootstrap will hang in deadlock.