### PR TITLE
[cloud-provider-yandex] Add additional logs for lb methods

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -59,7 +59,8 @@ k8s:
     clusterAutoscalerPatch: '0'
     ccm:
       openstack: v1.27.1
-      yandex: v0.27.0
+      # todo change after test
+      yandex: add-logs-for-load-balanser-operation
       aws: v1.27.1
       vsphere: 4e80a0c86d2ae8a1b843b4ba9e5ac31707758912
       azure: v1.27.11

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -20,7 +20,7 @@ k8s:
     ccm:
       openstack: v1.25.3
       # todo change after test
-      yandex: add-logs-for-load-balanser-operation
+      yandex: 0-25-add-additional-logs
       aws: v1.25.1
       vsphere: v1.25.0
       azure: v1.25.22

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -19,7 +19,8 @@ k8s:
     clusterAutoscalerPatch: 3
     ccm:
       openstack: v1.25.3
-      yandex: v0.25.2
+      # todo change after test
+      yandex: add-logs-for-load-balanser-operation
       aws: v1.25.1
       vsphere: v1.25.0
       azure: v1.25.22
@@ -59,8 +60,7 @@ k8s:
     clusterAutoscalerPatch: '0'
     ccm:
       openstack: v1.27.1
-      # todo change after test
-      yandex: add-logs-for-load-balanser-operation
+      yandex: v0.27.0
       aws: v1.27.1
       vsphere: 4e80a0c86d2ae8a1b843b4ba9e5ac31707758912
       azure: v1.27.11

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -35,8 +35,7 @@ shell:
   install:
     - git clone https://github.com/deckhouse/yandex-cloud-controller-manager.git /src
     - cd /src
-    # todo change after testing
-    - git checkout add-logs-for-load-balanser-operation
+    - git checkout {{ $value.ccm.yandex }}
     - test -d /patches/{{ $version }} && for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o yandex-cloud-controller-manager cmd/yandex-cloud-controller-manager/main.go
     - chown 64535:64535 /src/yandex-cloud-controller-manager

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -35,7 +35,8 @@ shell:
   install:
     - git clone https://github.com/deckhouse/yandex-cloud-controller-manager.git /src
     - cd /src
-    - git checkout {{ $value.ccm.yandex }}
+    # todo change after testing
+    - git checkout add-logs-for-load-balanser-operation
     - test -d /patches/{{ $version }} && for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o yandex-cloud-controller-manager cmd/yandex-cloud-controller-manager/main.go
     - chown 64535:64535 /src/yandex-cloud-controller-manager


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
