### PR TITLE
[ingress-nginx] add ip and hostname to ingress-nginx-controller status

### DIFF
--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -4,6 +4,16 @@ spec:
       schema: &schema
         openAPIV3Schema:
           properties:
+            status:
+              properties:
+                loadBalancer:
+                  properties:
+                    ip:
+                      description: |
+                        Выделенный внешний IP адрес балансировщика нагрузки.
+                    hostname:
+                      description: |
+                        Выделенный внешний хостнейм балансировщика нагрузки.
             spec:
               properties:
                 ingressClass:

--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -1,7 +1,321 @@
 spec:
   versions:
     - name: v1alpha1
-      schema: &schema
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                ingressClass:
+                  description: |
+                    Имя Ingress-класса для обслуживания NGINX Ingress controller.
+
+                    Позволяет создать несколько контроллеров для обслуживания одного Ingress-класса.
+
+                    **Важно!** Если указать значение "nginx", дополнительно будут обрабатываться Ingress-ресурсы без аннотации `kubernetes.io/ingress.class` или поля `spec.ingressClassName`.
+                inlet:
+                  description: |
+                    Способ поступления трафика из внешнего мира:
+                    * `LoadBalancer` — устанавливается Ingress-контроллер и заказывается сервис с типом `LoadBalancer`;
+                    * `LoadBalancerWithProxyProtocol` — устанавливается Ingress-контроллер и заказывается сервис с типом `LoadBalancer`. Ingress-контроллер использует proxy-protocol для получения настоящего IP-адреса клиента;
+                    * `HostPort` — устанавливается Ingress-контроллер, который доступен на портах узлов через `hostPort`;
+                    * `HostPortWithProxyProtocol` — устанавливается Ingress-контроллер, который доступен на портах узлов через `hostPort` и использует proxy-protocol для получения настоящего IP-адреса клиента.
+
+                      **Внимание!** При использовании этого inlet'а вы должны быть уверены, что запросы к Ingress направляются только от доверенных источников. Одним из способов настройки ограничения может служить опция `acceptRequestsFrom`;
+                    * `HostWithFailover` — устанавливаются два Ingress-контроллера — основной и резервный. Основной контроллер запускается в hostNetwork. Если поды основного контроллера недоступны, трафик уходит в резервный контроллер.
+
+                      **Внимание!** На одном хосте может быть только один контроллер с данным типом inlet'а.
+
+                      **Внимание!** Необходимо, чтобы на узле были свободны следующие порты: 80, 81, 443, 444, 10354, 10355.
+                controllerVersion:
+                  description: |
+                    Версия NGINX Ingress controller.
+
+                    **По умолчанию** используется версия из [настроек модуля](configuration.html#parameters-defaultcontrollerversion).
+                enableIstioSidecar:
+                  description: |
+                    Добавить к подам контроллера аннотации для автоматического инжекта сайдкаров Istio.
+                    При включении этого параметра к подам Ingress-контроллера добавляются аннотации `sidecar.istio.io/inject: "true"` и `traffic.sidecar.istio.io/includeOutboundIPRanges: "<Service CIDR>"`. При создании таких подов к ним автоматически будут добавлены сайдкары Istio с помощью mutating webhook. После этого весь трафик в сторону Service CIDR будет перехватываться сайдкаром.
+
+                     Чтобы воспользоваться этой функцией, необходимо доработать прикладные Ingress-ресурсы, добавив аннотации:
+                     * `nginx.ingress.kubernetes.io/service-upstream: "true"` — с этой аннотацией Ingress-контроллер будет отправлять запросы на ClusterIP сервиса (из диапазона Service CIDR) вместо того, чтобы слать их напрямую в поды приложения. Сайдкар istio-proxy перехватывает трафик только в сторону диапазона Service CIDR, остальные запросы отправляются напрямую;
+                     * `nginx.ingress.kubernetes.io/upstream-vhost: myservice.myns.svc` — с данной аннотацией сайдкар сможет идентифицировать прикладной сервис, для которого предназначен запрос.
+                waitLoadBalancerOnTerminating:
+                  description: |
+                    Количество секунд до того, как /healthz начнет возвращать код 500, когда под перейдет в статус Terminating.
+                chaosMonkey:
+                  description: |
+                    Инструмент, позволяющий систематически вызывать случайные прерывания работы подов контроллера.
+
+                    Предназначен для проверки Ingress-контроллера на реальную работу отказоустойчивости.
+                validationEnabled:
+                  description: |
+                    Включить валидацию Ingress-правил.
+                annotationValidationEnabled:
+                  description: |
+                    Включить валидацию аннотаций Ingress-правил.
+
+                    Требуется версия контроллера 1.9.
+                nodeSelector:
+                  description: |
+                    Как в `spec.nodeSelector` у подов.
+
+                    Если ничего не указано или указано `false`, будет [использоваться автоматика](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+
+                    **Формат**: стандартный список `nodeSelector`. Поды инстанса унаследуют это поле как есть.
+                tolerations:
+                  description: |
+                    Как в `spec.tolerations` у подов.
+
+                    Если ничего не указано или указано `false`, будет [использоваться автоматика](https://deckhouse.ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+
+                    **Формат**: стандартный список [toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). Поды инстанса унаследуют это поле как есть.
+                loadBalancer:
+                  description: |
+                    Секция настроек для inlet'а `LoadBalancer`.
+                  properties:
+                    sourceRanges:
+                      description: |
+                        Список адресов в формате CIDR, которым разрешен доступ на балансировщик.
+
+                        Облачный провайдер может не поддерживать данную опцию и игнорировать ее.
+                    annotations:
+                      description: |
+                        Аннотации, которые будут проставлены сервису для гибкой настройки балансировщика.
+
+                        **Внимание!** Модуль не учитывает особенности указания аннотаций в различных облаках.
+                        Если аннотации для заказа LoadBalancer'а применяются только при создании сервиса, для обновления подобных параметров необходимо будет пересоздать `IngressNginxController` (или создать новый, затем удалив старый).
+                    behindL7Proxy:
+                      description: |
+                        Включает обработку и передачу заголовков `X-Forwarded-*`.
+
+                        **Внимание!** При использовании этой опции вы должны быть уверены, что запросы к Ingress направляются только от доверенных источников.
+                    realIPHeader:
+                      description: |
+                        Заголовок, из которого будет получен настоящий IP-адрес клиента.
+
+                        Работает только при включении `behindL7Proxy`.
+                loadBalancerWithProxyProtocol:
+                  description: |
+                    Секция настроек для inlet'а `LoadBalancerWithProxyProtocol`.
+                  properties:
+                    sourceRanges:
+                      description: |
+                        Список адресов в формате CIDR, которым разрешен доступ на балансировщик.
+
+                        Облачный провайдер может не поддерживать данную опцию и игнорировать ее.
+                    annotations:
+                      description: |
+                        Аннотации, которые будут проставлены сервису для гибкой настройки балансировщика.
+
+                        **Внимание!** Модуль не учитывает особенности указания аннотаций в различных облаках. Если аннотации для заказа LoadBalancer'а применяются только при создании сервиса, для обновления подобных параметров необходимо будет пересоздать `IngressNginxController` (или создать новый, затем удалив старый).
+                hostPort:
+                  description: |
+                    Секция настроек для inlet'а `HostPort`.
+                  properties:
+                    httpPort:
+                      description: |
+                        Порт для небезопасного подключения по HTTP.
+
+                        Если параметр не указан, возможность подключения по HTTP отсутствует.
+
+                        **Обязательный параметр**, если не указан `httpsPort`.
+                    httpsPort:
+                      description: |
+                        Порт для безопасного подключения по HTTPS.
+
+                        Если параметр не указан, возможность подключения по HTTPS отсутствует.
+
+                        **Обязательный параметр**, если не указан `httpPort`.
+                    behindL7Proxy:
+                      description: |
+                        Включает обработку и передачу заголовков `X-Forwarded-*`.
+
+                        **Внимание!** При использовании этой опции необходимо быть увереным, что запросы к Ingress направляются только от доверенных источников. Одним из способов настройки ограничения может служить опция `acceptRequestsFrom`.
+                    realIPHeader:
+                      description: |
+                        Заголовок, из которого будет получен настоящий IP-адрес клиента.
+
+                        Работает **только** при включении `behindL7Proxy`.
+                hostPortWithProxyProtocol:
+                  description: |
+                    Секция настроек для inlet'а `HostPortWithProxyProtocol`.
+                  properties:
+                    httpPort:
+                      type: integer
+                      description: |
+                        Порт для небезопасного подключения по HTTP.
+
+                        Если параметр не указан, возможность подключения по HTTP отсутствует.
+
+                        **Обязательный параметр**, если не указан `httpsPort`.
+                    httpsPort:
+                      description: |
+                        Порт для безопасного подключения по HTTPS.
+
+                        Если параметр не указан, возможность подключения по HTTPS отсутствует.
+
+                        **Обязательный параметр**, если не указан `httpPort`.
+                acceptRequestsFrom:
+                  description: |
+                    Список адресов в формате CIDR, которым разрешено подключаться к контроллеру.
+
+                    Независимо от inlet'а всегда проверяется непосредственный адрес (в логах содержится в поле `original_address`), с которого производится подключение, а не «адрес клиента», который может передаваться в некоторых inlet'ах через заголовки или с использованием `proxy protocol`.
+
+                    Параметр реализован с помощью [map module](http://nginx.org/en/docs/http/ngx_http_map_module.html), и если адрес, с которого непосредственно производится подключение, не разрешен – NGINX закрывает соединение (используя return 444).
+
+                    **По умолчанию** к контроллеру можно подключаться с любых адресов.
+                hsts:
+                  description: |
+                    Включен ли `HSTS` ([подробнее...](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)).
+                hstsOptions:
+                  description: |
+                    Параметры HTTP Strict Transport Security.
+                  properties:
+                    maxAge:
+                      description: |
+                        Время в секундах, в течение которого браузер должен помнить, что сайт доступен только с помощью HTTPS.
+                    preload:
+                      description: |
+                        Добавлять ли сайт в список предзагрузки.
+
+                        Эти списки используются современными браузерами и разрешают подключение к сайту только по HTTPS.
+                    includeSubDomains:
+                      description: |
+                        Применять ли настройки `HSTS` ко всем поддоменам сайта.
+                geoIP2:
+                  description: |
+                    Опции для включения GeoIP2.
+                  properties:
+                    maxmindLicenseKey:
+                      description: |
+                        Лицензионный ключ для скачивания базы данных GeoIP2.
+
+                        Указание ключа в конфигурации включает скачивание базы GeoIP2 при каждом старте контроллера. [Подробнее](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/) о получении ключа.
+                    maxmindEditionIDs:
+                      description: |
+                        Список ревизий баз данных, которые будут скачаны при старте.
+
+                        [Подробнее...](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
+                legacySSL:
+                  description: |
+                    Включены ли старые версии TLS. Также опция разрешает legacy cipher suites для поддержки старых библиотек и программ: [OWASP Cipher String 'C' ](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html). Подробнее [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/402-ingress-nginx/templates/controller/configmap.yaml).
+
+                    **По умолчанию** включены только TLSv1.2 и самые новые cipher suites.
+                disableHTTP2:
+                  description: |
+                    Выключить ли HTTP/2.
+                config:
+                  description: |
+                    Секция настроек Ingress-контроллера, в которую в формате `ключ: значение(строка)` можно записать [любые возможные опции](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/).
+
+                    **Внимание!** Ошибка в указании опций может привести к отказу в работе Ingress-контроллера.
+
+                    **Внимание!** Не рекомендуется использовать данную опцию, так как не гарантируется обратная совместимость или работоспособность Ingress-контроллера.
+                additionalHeaders:
+                  description: |
+                    Дополнительные header'ы, которые будут добавлены к каждому запросу. Указываются в формате `ключ: значение(строка)`.
+                additionalLogFields:
+                  description: |
+                    Дополнительные поля, которые будут добавлены в логи nginx. Указываются в формате `ключ: значение(строка)`.
+                resourcesRequests:
+                  description: |
+                    Настройки максимальных значений CPU и memory, которые может запросить под при выборе узла (если VPA выключен, максимальные значения становятся значениями по умолчанию).
+                  properties:
+                    mode:
+                      description: |
+                        Режим управления реквестами ресурсов.
+                    vpa:
+                      description: |
+                        Настройки VPA режима управления.
+                      properties:
+                        mode:
+                          description: |
+                            Режим работы VPA.
+                        cpu:
+                          description: |
+                            Настройки для CPU.
+                          properties:
+                            max:
+                              description: |
+                                Максимальное значение, которое может выставить VPA для реквеста к CPU.
+                            min:
+                              description: |
+                                Минимальное значение, которое может выставить VPA для реквеста к CPU.
+                        memory:
+                          description: |
+                            Значение для запроса memory.
+                          properties:
+                            max:
+                              description: |
+                                Максимальное значение, которое может выставить VPA для реквеста к memory.
+                            min:
+                              description: |
+                                Минимальное значение, которое может выставить VPA для реквеста к memory.
+                    static:
+                      description: |
+                        Настройки статического режима управления.
+                      properties:
+                        cpu:
+                          description: |
+                            Значение для реквеста к CPU.
+                        memory:
+                          description: |
+                            Значение для реквеста к memory.
+                customErrors:
+                  description: |
+                    Секция с настройкой кастомизации HTTP-ошибок.
+
+                    Если секция определена, все параметры в ней являются обязательными, изменение любого параметра **приводит к перезапуску всех NGINX Ingress controller'ов**.
+                  properties:
+                    serviceName:
+                      description: |
+                        Имя сервиса, который будет использоваться как custom default backend.
+                    namespace:
+                      description: |
+                        Имя namespace, в котором будет находиться сервис, используемый как custom default backend.
+                    codes:
+                      description: |
+                        Список кодов ответа (массив), при которых запрос будет перенаправляться на custom default backend.
+                underscoresInHeaders:
+                  description: |
+                    Разрешены ли нижние подчеркивания в заголовках.
+
+                    [Подробнее...](http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers).
+
+                    [Почему](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#missing-disappearing-http-headers) не стоит бездумно это включать.
+                minReplicas:
+                  description: |
+                    Минимальное количество реплик `LoadBalancer` и `LoadBalancerWithProxyProtocol` для HPA.
+                maxReplicas:
+                  description: |
+                    Максимально количество реплик `LoadBalancer` и `LoadBalancerWithProxyProtocol` для HPA.
+                defaultSSLCertificate:
+                  description: |
+                    Сертификат, который используется:
+                    - при запросах на `catch-all`-сервер (подразумевается [директива server](http://nginx.org/en/docs/http/ngx_http_core_module.html#server) nginx). На `catch-all`-сервер попадают запросы, для которых нет соответствующего Ingress-ресурса;
+                    - для Ingress–ресурсов, в которых не задан `secretName` в секции `tls`.
+
+                    По умолчанию используется самоподписанный сертификат.
+
+                    **Внимание!** Параметр не влияет на сертификаты, используемые в Ingress-ресурсах модулей Deckhouse. Для указания сертификата, который будет использоваться в Ingress-ресурсах модулей Deckhouse, используйте глобальный параметр [modules.https.customCertificate](../../deckhouse-configure-global.html#parameters-modules-https-customcertificate).
+                  properties:
+                    secretRef:
+                      description: |
+                        Ссылка на Secret для передачи Ingress-контроллеру.
+                      properties:
+                        name:
+                          description: |
+                            Имя Secret'а, содержащего SSL–сертификат.
+                        namespace:
+                          description: |
+                            Имя namespace, в котором находится Secret с SSL—сертификатом.
+    - name: v1
+      served: true
+      storage: false
+      subresources:
+        status: { }
+      schema:
         openAPIV3Schema:
           properties:
             status:
@@ -320,7 +634,3 @@ spec:
                         namespace:
                           description: |
                             Имя namespace, в котором находится Secret с SSL—сертификатом.
-    - name: v1
-      served: true
-      storage: false
-      schema: *schema

--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -10,10 +10,10 @@ spec:
                   properties:
                     ip:
                       description: |
-                        Выделенный внешний IP адрес балансировщика нагрузки.
+                        IP-адрес балансировщика нагрузки.
                     hostname:
                       description: |
-                        Выделенный внешний хостнейм балансировщика нагрузки.
+                        DNS-имя балансировщика нагрузки.
             spec:
               properties:
                 ingressClass:

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -17,27 +17,11 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      subresources:
-        status: {}
-      schema: &schema
+      schema:
         openAPIV3Schema:
           type: object
           required: ['spec']
           properties:
-            status:
-              type: object
-              properties:
-                loadBalancer:
-                  type: object
-                  properties:
-                    ip:
-                      type: string
-                      description: |
-                          External IP address of external provider LoadBalancer
-                    hostname:
-                      type: string
-                      description: |
-                          External hostname of external provider LoadBalancer
             spec:
               type: object
               required: ['inlet']
@@ -551,7 +535,557 @@ spec:
               x-kubernetes-validations:
               - message: .spec.controllerVersion should be explicitly set to 1.9 for .spec.annotationValidationEnabled to make effect
                 rule: 'self.annotationValidationEnabled == true ? self.controllerVersion == ''1.9'': true'
-      additionalPrinterColumns: &additionalPrinterColumns
+      additionalPrinterColumns:
+        - jsonPath: .spec.ingressClass
+          name: Ingress Class
+          description: 'Name of served ingress class.'
+          type: string
+        - jsonPath: .spec.inlet
+          name: Inlet
+          description: 'The way traffic goes to current Ingress Controller from the outer network.'
+          type: string
+        - jsonPath: .spec.controllerVersion
+          name: Controller Version
+          description: 'Current NGINX Ingress Controller version.'
+          type: string
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ['spec']
+          properties:
+            status:
+              type: object
+              properties:
+                loadBalancer:
+                  type: object
+                  properties:
+                    ip:
+                      type: string
+                      description: |
+                        External IP address of external provider LoadBalancer
+                    hostname:
+                      type: string
+                      description: |
+                        External hostname of external provider LoadBalancer
+            spec:
+              type: object
+              required: ['inlet']
+              properties:
+                ingressClass:
+                  type: string
+                  description: |
+                    The name of the Ingress class to use with the NGINX Ingress controller.
+
+                    Using this option, you can create several controllers to use with a single ingress
+
+                    **Caution!** If you set it to "nginx", then Ingress resources lacking the `kubernetes.io/ingress.class` annotation or `spec.ingressClassName` field will also be handled.
+                  x-doc-examples: ['nginx']
+                  default: 'nginx'
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                inlet:
+                  type: string
+                  description: |
+                    The way traffic goes to cluster from the outer network.
+                    * `LoadBalancer` — Ingress controller is deployed and the service of `LoadBalancer` type is provisioned.
+                    * `LoadBalancerWithProxyProtocol` — Ingress controller is deployed and the service of `LoadBalancer` type is provisioned. Ingress controller uses proxy-protocol to get a real IP of the client.
+                    * `HostPort` — Ingress controller is deployed and available through nodes' ports via `hostPort`.
+                    * `HostPortWithProxyProtocol` — Ingress controller is deployed and available through nodes' ports via `hostPort, it uses proxy-protocol to get a real IP of the client.
+
+                      **Caution!** Make sure that requests to the Ingress are sent from trusted sources when using this inlet. The `acceptRequestsFrom` parameter can help you with defining trusted sources.
+                    * `HostWithFailover` — installs two ingress controllers, the primary and the backup one. The primary controller runs in a hostNetwork. If the pods of the primary controller are not available, the traffic is routed to the backup one;
+
+                      **Caution!** There can be only one controller with this inlet type on a host.
+
+                      **Caution!** The following ports must be available on the node: 80, 81, 443, 444, 10354, 10355.
+                  enum: ["LoadBalancer","LoadBalancerWithProxyProtocol","HostPort","HostPortWithProxyProtocol", "HostWithFailover"]
+                controllerVersion:
+                  type: string
+                  description: |
+                    One of the supported NGINX Ingress controller versions.
+
+                    **By default**: the version in the [module settings](configuration.html#parameters-defaultcontrollerversion) is used.
+                  enum: ['1.1','1.6','1.9']
+                enableIstioSidecar:
+                  type: boolean
+                  description: |
+                    Attach annotations to the controller pods to automatically inject Istio sidecar containers.
+
+                    After setting this parameter, the `sidecar.istio.io/inject: "true"` and `traffic.sidecar.istio.io/includeOutboundIPRanges: "<Service CIDR>"` annotations will be attached to the ingress-controller pods. During pod creation, the Istio's mutating webhook will add the sidecar to it. After that, the sidecar will catch the network traffic to Service CIDR.
+
+                    To use this feature in your application, you must add these annotations to your Ingress resources:
+                    * `nginx.ingress.kubernetes.io/service-upstream: "true"` — using this annotation, the ingress-controller sends requests to a single ClusterIP (from Service CIDR) while envoy load balances them. Istio sidecar containers only catching traffic directed to Service CIDR.
+                    * `nginx.ingress.kubernetes.io/upstream-vhost: myservice.myns.svc` — using this annotation, the sidecar can identify the application service that serves requests.
+                waitLoadBalancerOnTerminating:
+                  x-kubernetes-int-or-string: true
+                  type: integer
+                  description: |
+                    The number of seconds before the /healthz location will start to return a 500 code when the pod enters the Terminating state.
+                    This parameter has default values:
+                      - 0s - for HostWithFailover
+                      - 60s - for HostPort and HostPortWithProxyProtocol
+                      - 120s - for LoadBalancer and LoadBalancerWithProxyProtocol
+                chaosMonkey:
+                  type: boolean
+                  default: false
+                  description: |
+                    The instrument for unexpected and random termination of ingress controller Pods in a systemic manner. Chaos Monkey tests the resilience of ingress controller.
+                validationEnabled:
+                  type: boolean
+                  default: true
+                  description: |
+                    Enable ingress validation admission.
+                annotationValidationEnabled:
+                  type: boolean
+                  default: false
+                  description: |
+                    Enables the annotation validation feature.
+
+                    Requires a controller of 1.9 version.
+                nodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    The same as in the pods' `spec.nodeSelector` parameter in Kubernetes.
+
+                    If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/documentation/v1/#advanced-scheduling).
+
+                    **Format**: the standard `nodeSelector` list. Instance pods inherit this field as is.
+                tolerations:
+                  type: array
+                  description: |
+                    [The same](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) as in the pods' `spec.tolerations` parameter in Kubernetes;
+
+                    If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/documentation/v1/#advanced-scheduling).
+
+                    **Format**: the standard [toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) list. Instance pods inherit this field as is.
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                        enum: ["NoSchedule","PreferNoSchedule","NoExecute"]
+                      operator:
+                        type: string
+                        default: "Equal"
+                        enum: ["Exists","Equal"]
+                      key:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                loadBalancer:
+                  type: object
+                  x-doc-required: false
+                  description: |
+                    A section of parameters of the `LoadBalancer` inlet.
+                  properties:
+                    sourceRanges:
+                      type: array
+                      description: |
+                        IP ranges (CIDR) that are allowed to access the load balancer.
+
+                        The cloud provider may not support this option or ignore it.                       .
+                      items:
+                        type: string
+                        pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
+                    annotations:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: |
+                        Annotations to assign to the service for flexible configuration of the load balancer.
+
+                        **Caution!** The module does not take into account the specifics of setting annotations in different clouds.
+                        Note that you will need to recreate `IngressNginxController` (or create a new controller and then delete the old one) if annotations to provision a load balancer are only used when creating the service.
+                      additionalProperties:
+                        type: string
+                    behindL7Proxy:
+                      type: boolean
+                      description: |
+                        Accepts all the incoming `X-Forwarded-*` headers and passes them to upstreams.
+
+                        **Caution!** Make sure that requests to the Ingress are sent from trusted sources when using this option.
+                    realIPHeader:
+                      type: string
+                      description: |
+                        Sets the header field for identifying the originating IP address of a client.
+
+                        This option works only if `behindL7Proxy` is enabled.
+                      x-doc-examples: ['CF-Connecting-IP']
+                      default: 'X-Forwarded-For'
+                loadBalancerWithProxyProtocol:
+                  type: object
+                  x-doc-required: false
+                  description: |
+                    A section of parameters of the `LoadBalancerWithProxyProtocol` inlet.
+                  properties:
+                    sourceRanges:
+                      type: array
+                      description: |
+                        IP ranges (CIDR) that are allowed to access the load balancer.
+
+                        The cloud provider may not support this option or ignore it.                       .
+                      items:
+                        type: string
+                        pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
+                    annotations:
+                      type: object
+                      description: |
+                        Annotations that will be passed to service with type load balancer to configure it.
+
+                        **Caution!** The module does not take into account the specifics of setting annotations in different clouds.
+                        Note that you will need to recreate `IngressNginxController` (or create a new controller and then delete the old one) if annotations to provision a load balancer are only used when creating the service.
+                      additionalProperties:
+                        type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                hostPort:
+                  type: object
+                  description: |
+                    `HostPort` inlet settings.
+                  anyOf:
+                    - {required: ["httpPort"]}
+                    - {required: ["httpsPort"]}
+                  x-kubernetes-validations:
+                    - message: .spec.httpsPort can't be 6443, it's reserved for kube-apiserver
+                      rule: 'self.httpsPort != 6443'
+                  properties:
+                    httpPort:
+                      type: integer
+                      description: |
+                        Port for insecure HTTP connections.
+
+                        If the parameter is not set, the connection over HTTP cannot be established.
+
+                        This parameter is mandatory if `httpsPort` is not set.
+                      x-doc-examples: ['80']
+                    httpsPort:
+                      type: integer
+                      description: |
+                        Port for secure HTTPS connections.
+
+                        If the parameter is not set, the connection over HTTPS cannot be established.
+
+                        This parameter is mandatory if `httpPort` is not set.
+                      x-doc-examples: ['443']
+                    behindL7Proxy:
+                      type: boolean
+                      description: |
+                        Accepts all the incoming X-Forwarded-* headers and passes them to upstreams.
+
+                        **Caution!** Make sure that requests to the ingress are sent from trusted sources when using this option. The `acceptRequestsFrom` parameter can help you with defining trusted sources.
+                    realIPHeader:
+                      type: string
+                      description: |
+                        Sets the header field for identifying the originating IP address of a client.
+
+                        This option works only if `behindL7Proxy` is enabled.
+                      default: 'X-Forwarded-For'
+                      x-doc-examples: ['CF-Connecting-IP']
+                hostPortWithProxyProtocol:
+                  type: object
+                  description: |
+                    A section of parameters of the `HostPortWithProxyProtocol` inlet.
+                  anyOf:
+                    - {required: ['httpPort']}
+                    - {required: ['httpsPort']}
+                  properties:
+                    httpPort:
+                      type: integer
+                      description: |
+                        Port for insecure HTTP connections.
+
+                        If the parameter is not set, the connection over HTTP cannot be established.
+
+                        This parameter is mandatory if `httpsPort` is not set.
+                      x-doc-examples: ['80']
+                    httpsPort:
+                      type: integer
+                      description: |
+                        Port for secure HTTPS connections.
+
+                        If the parameter is not set, the connection over HTTPS cannot be established.
+
+                        This parameter is mandatory if `httpPort` is not set.
+                      x-doc-examples: ['443']
+                acceptRequestsFrom:
+                  type: array
+                  description: |
+                    IP or CIDR that is allowed to access the Ingress controller.
+
+                    Regardless of the inlet type, the source IP address gets always verified (the `original_address` field in logs) (the address that the connection was established from) and not the "address of the client" that can be passed in some inlets via headers or using the proxy protocol.
+
+                    This parameter is implemented using the [map module](http://nginx.org/en/docs/http/ngx_http_map_module.html). If the source address is not in the list of allowed addresses, nginx closes the connection immediately using HTTP code 444.
+
+                    By default, the connection to the controller can be made from any address.
+                  items:
+                    type: string
+                    pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
+                hsts:
+                  type: boolean
+                  description: |
+                    Determines whether hsts is enabled ([read more...](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)).
+                  default: false
+                hstsOptions:
+                  type: object
+                  description: 'Options for HTTP Strict Transport Security.'
+                  properties:
+                    maxAge:
+                      type: string
+                      description: 'The time, in seconds, that the browser should remember that a site is only to be accessed using HTTPS.'
+                      pattern: '^[1-9][0-9]*$'
+                      x-doc-examples: ["31536000"]
+                      x-doc-default: "31536000"
+                    preload:
+                      type: boolean
+                      description: 'Add your site to preload list to enforce to use SSL/TLS connections on your site.'
+                      default: false
+                    includeSubDomains:
+                      type: boolean
+                      description: 'If this optional parameter is specified, this rule applies to all of subdomains as well.'
+                      default: false
+                geoIP2:
+                  type: object
+                  description: 'Enable GeoIP2 databases.'
+                  properties:
+                    maxmindLicenseKey:
+                      type: string
+                      description: |
+                        A license key to download the GeoIP2 database.
+
+                        If the key is set, the module downloads the GeoIP2 database every time the controller is started. Click [here](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/) to learn more about obtaining a license key.
+                    maxmindEditionIDs:
+                      type: array
+                      description: |
+                        A list of database editions to download at startup.
+
+                        [More info...](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
+                      default: ["GeoLite2-City", "GeoLite2-ASN"]
+                      items:
+                        type: string
+                        enum:
+                          - GeoIP2-Anonymous-IP
+                          - GeoIP2-Country
+                          - GeoIP2-City
+                          - GeoIP2-Connection-Type
+                          - GeoIP2-Domain
+                          - GeoIP2-ISP
+                          - GeoIP2-ASN
+                          - GeoLite2-ASN
+                          - GeoLite2-Country
+                          - GeoLite2-City
+                legacySSL:
+                  type: boolean
+                  description: |
+                    Enable old TLS protocol versions and legacy cipher suites.
+
+                    Also, this options enables legacy cipher suites to support legacy libraries and software: [OWASP Cipher String 'C' ](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html). Learn more [here](https://github.com/deckhouse/deckhouse/blob/main/modules/402-ingress-nginx/templates/controller/configmap.yaml).
+
+                    By default, only TLSv1.2 and the newest cipher suites are enabled.
+                disableHTTP2:
+                  type: boolean
+                  description: |
+                    Switch off HTTP2 support.
+                  default: false
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    The section with the Ingress controller parameters.
+
+                    You can specify [any supported parameter](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/) in it in the `key: value (string)` format.
+
+                    **Caution!** An erroneous option may lead to the failure of the ingress controller;
+
+                    **Caution!** The usage of this parameter is not recommended; the backward compatibility or operability of the ingress controller that uses this option is not guaranteed
+                additionalHeaders:
+                  type: object
+                  description: |
+                    Additional headers to add to all request. (map: key (string)).
+                  additionalProperties:
+                    type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                additionalLogFields:
+                  type: object
+                  description: |
+                    Additional fields to add to nginx logs. (map: key (string)).
+                  additionalProperties:
+                    type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                resourcesRequests:
+                  required: ['mode']
+                  type: object
+                  description: |
+                    Max amounts of CPU and memory resources that the pod can request when selecting a node (if the VPA is disabled, then these values become the default ones).
+                  properties:
+                    mode:
+                      type: string
+                      description: |
+                        The mode for managing resource requests.
+                      enum: ['VPA', 'Static']
+                      default: 'VPA'
+                    vpa:
+                      type: object
+                      description: |
+                        Parameters of the vpa mode.
+                      properties:
+                        mode:
+                          type: string
+                          description: |
+                            The VPA usage mode.
+                          enum: ['Initial', 'Auto']
+                          default: 'Initial'
+                        cpu:
+                          type: object
+                          description: |
+                            CPU-related parameters.
+                          properties:
+                            max:
+                              description: |
+                                Maximum allowed CPU requests.
+                              default: '50m'
+                              type: string
+                            min:
+                              description: |
+                                Minimum allowed CPU requests.
+                              default: '10m'
+                              type: string
+                        memory:
+                          type: object
+                          description: |
+                            The amount of memory requested.
+                          properties:
+                            max:
+                              description: |
+                                Maximum allowed memory requests.
+                              default: '200Mi'
+                              type: string
+                            min:
+                              description: |
+                                Minimum allowed memory requests.
+                              default: '50Mi'
+                              type: string
+                    static:
+                      type: object
+                      description: |
+                        Static mode settings.
+                      properties:
+                        cpu:
+                          type: string
+                          description: |
+                            CPU requests.
+                          default: '350m'
+                        memory:
+                          type: string
+                          description: |
+                            Memory requests.
+                          default: '500Mi'
+                customErrors:
+                  type: object
+                  description: |
+                    The section with parameters of custom HTTP errors.
+
+                    All parameters in this section are mandatory if it is defined. Changing any parameter **leads to the restart of all NGINX Ingress controllers**.
+                  required: ['namespace', 'serviceName', 'codes']
+                  properties:
+                    serviceName:
+                      type: string
+                      description: |
+                        Name of kubernetes service that leads to custom errors backend.
+                      x-doc-examples: ['custom-errors-backend-service']
+                    namespace:
+                      type: string
+                      description: |
+                        Namespace of custom errors backend.
+                      x-doc-examples: ['default']
+                    codes:
+                      type: array
+                      description: |
+                        Error codes which should be redirected to custom errors backend.
+                      items:
+                        type: string
+                        name: 'Error code.'
+                        pattern: '^[1-5][0-9][0-9]$'
+                underscoresInHeaders:
+                  type: boolean
+                  description: |
+                    Determines whether underscores are allowed in headers. Learn [more...](http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers).
+
+                    [This tutorial](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#missing-disappearing-http-headers) sheds light on why you should not enable it without careful consideration.
+                  default: false
+                minReplicas:
+                  type: integer
+                  description: |
+                    LoadBalancer and LoadBalancerWithProxyProtocol controller's Horizontal Pod Autoscaler minimum replicas count.
+                  default: 1
+                  minimum: 1
+                maxReplicas:
+                  type: integer
+                  description: |
+                    LoadBalancer and LoadBalancerWithProxyProtocol controller's Horizontal Pod Autoscaler maximum replicas count.
+                  default: 1
+                  minimum: 1
+                defaultSSLCertificate:
+                  description: |
+                    This certificate is used:
+                    - for `catch-all` server requests (here, "catch-all server" refers to the nginx [server directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#server)). Requests for which there is no corresponding Ingress resource end up on the `catch-all` server.
+                    - for Ingress resources that do not have a `secretName` specified in the `tls` section.
+
+                    By default, a self-signed certificate is used.
+
+                    **Caution!** This parameter does not affect certificates used in the Ingress resources of the Deckhouse modules. You can specify the certificate to be used in the Ingress resources of the Deckhouse modules with the [modules.https.customCertificate](../../deckhouse-configure-global.html#parameters-modules-https-customcertificate) global parameter.
+                  type: object
+                  properties:
+                    secretRef:
+                      description: |
+                        The Secret reference to pass to the Ingress Controller.
+                      type: object
+                      properties:
+                        name:
+                          description: |
+                            Name of Secret containing SSL—certificate.
+                          type: string
+                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                        namespace:
+                          description: |
+                            Namespace, where the Secret is located.
+                          default: d8-ingress-nginx
+                          type: string
+                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+              oneOf:
+                - properties:
+                    inlet:
+                      enum: ['LoadBalancer']
+                    loadBalancer: {}
+                - properties:
+                    inlet:
+                      enum: ['LoadBalancerWithProxyProtocol']
+                    loadBalancerWithProxyProtocol: {}
+                - properties:
+                    inlet:
+                      enum: ['HostPort']
+                    hostPort: {}
+                  required: ['hostPort']
+                - properties:
+                    inlet:
+                      enum: ['HostPortWithProxyProtocol']
+                    hostPortWithProxyProtocol: {}
+                  required: ['hostPortWithProxyProtocol']
+                - properties:
+                    inlet:
+                      enum: ['HostWithFailover']
+                    hostWithFailover: {}
+              x-kubernetes-validations:
+                - message: .spec.controllerVersion should be explicitly set to 1.9 for .spec.annotationValidationEnabled to make effect
+                  rule: 'self.annotationValidationEnabled == true ? self.controllerVersion == ''1.9'': true'
+      additionalPrinterColumns:
         - jsonPath: .spec.ingressClass
           name: Ingress Class
           description: 'Name of served ingress class.'
@@ -572,8 +1106,3 @@ spec:
           name: Hostname
           description: 'Current NGINX Ingress Controller LoadBalancer hostname'
           type: string
-    - name: v1
-      served: true
-      storage: true
-      schema: *schema
-      additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -567,7 +567,7 @@ spec:
                     ip:
                       type: string
                       description: |
-                        External IP address of external provider LoadBalancer
+                        The IP address of the load balancer.
                     hostname:
                       type: string
                       description: |

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -571,7 +571,7 @@ spec:
                     hostname:
                       type: string
                       description: |
-                        External hostname of external provider LoadBalancer
+                        The hostname of the LoadBalancer.
             spec:
               type: object
               required: ['inlet']

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -27,13 +27,17 @@ spec:
             status:
               type: object
               properties:
-                loadbalancer:
+                loadBalancer:
                   type: object
                   properties:
                     ip:
                       type: string
+                      description: |
+                          External IP address of external provider LoadBalancer
                     hostname:
                       type: string
+                      description: |
+                          External hostname of external provider LoadBalancer
             spec:
               type: object
               required: ['inlet']
@@ -560,11 +564,11 @@ spec:
           name: Controller Version
           description: 'Current NGINX Ingress Controller version.'
           type: string
-        - jsonPath: .status.loadbalancer.ip
+        - jsonPath: .status.loadBalancer.ip
           name: IP
           description: 'Current NGINX Ingress Controller LoadBalancer IP'
           type: string
-        - jsonPath: .status.loadbalancer.hostname
+        - jsonPath: .status.loadBalancer.hostname
           name: Hostname
           description: 'Current NGINX Ingress Controller LoadBalancer hostname'
           type: string

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -26,13 +26,14 @@ spec:
           properties:
             status:
               type: object
-              loadbalancer:
-                type: object
-                properties:
-                  ip:
-                    type: string
-                  hostname:
-                    type: string
+              properties:
+                loadbalancer:
+                  type: object
+                  properties:
+                    ip:
+                      type: string
+                    hostname:
+                      type: string
             spec:
               type: object
               required: ['inlet']

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -17,11 +17,22 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      subresources:
+        status: {}
       schema: &schema
         openAPIV3Schema:
           type: object
           required: ['spec']
           properties:
+            status:
+              type: object
+              loadbalancer:
+                type: object
+                properties:
+                  ip:
+                    type: string
+                  hostname:
+                    type: string
             spec:
               type: object
               required: ['inlet']
@@ -547,6 +558,14 @@ spec:
         - jsonPath: .spec.controllerVersion
           name: Controller Version
           description: 'Current NGINX Ingress Controller version.'
+          type: string
+        - jsonPath: .status.loadbalancer.ip
+          name: IP
+          description: 'Current NGINX Ingress Controller LoadBalancer IP'
+          type: string
+        - jsonPath: .status.loadbalancer.hostname
+          name: Hostname
+          description: 'Current NGINX Ingress Controller LoadBalancer hostname'
           type: string
     - name: v1
       served: true

--- a/modules/402-ingress-nginx/hooks/update_ingress_address.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address.go
@@ -47,21 +47,24 @@ func filterIngressServiceAddress(obj *unstructured.Unstructured) (go_hook.Filter
 	}
 	if svc.Status.LoadBalancer.Ingress != nil && len(svc.Status.LoadBalancer.Ingress) != 0 {
 		return loadBalancerService{
+			name:     svc.Labels["name"],
 			ip:       svc.Status.LoadBalancer.Ingress[0].IP,
 			hostname: svc.Status.LoadBalancer.Ingress[0].Hostname,
 		}, nil
 	}
-	return loadBalancerService{}, nil
+	return nil, nil
 }
 
 func updateIngressAddress(input *go_hook.HookInput) error {
 	snaps := input.Snapshots["ingress-loadbalancer-service"]
-
 	for _, snap := range snaps {
+		if snap == nil {
+			continue
+		}
 		svc := snap.(loadBalancerService)
 		patch := map[string]interface{}{
 			"status": map[string]interface{}{
-				"loadbalancer": map[string]interface{}{
+				"loadBalancer": map[string]interface{}{
 					"ip":       svc.ip,
 					"hostname": svc.hostname,
 				},

--- a/modules/402-ingress-nginx/hooks/update_ingress_address.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address.go
@@ -17,8 +17,8 @@ type loadBalancerService struct {
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
-	Queue:        "/modules/ingress-nginx",
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:       "/modules/ingress-nginx",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "ingress-loadbalancer-service",

--- a/modules/402-ingress-nginx/hooks/update_ingress_address.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address.go
@@ -1,0 +1,74 @@
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type loadBalancerService struct {
+	name     string
+	hostname string
+	ip       string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/ingress-nginx",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "ingress-loadbalancer-service",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-ingress-nginx"},
+				},
+			},
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"deckhouse-service-type": "provider-managed",
+				},
+			},
+			FilterFunc: filterIngressServiceAddress,
+		},
+	},
+}, updateIngressAddress)
+
+func filterIngressServiceAddress(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var svc v12.Service
+
+	if err := sdk.FromUnstructured(obj, &svc); err != nil {
+		return nil, err
+	}
+	if svc.Status.LoadBalancer.Ingress != nil && len(svc.Status.LoadBalancer.Ingress) != 0 {
+		return loadBalancerService{
+			ip:       svc.Status.LoadBalancer.Ingress[0].IP,
+			hostname: svc.Status.LoadBalancer.Ingress[0].Hostname,
+		}, nil
+	}
+	return loadBalancerService{}, nil
+}
+
+func updateIngressAddress(input *go_hook.HookInput) error {
+	snaps := input.Snapshots["ingress-loadbalancer-service"]
+
+	for _, snap := range snaps {
+		svc := snap.(loadBalancerService)
+		patch := map[string]interface{}{
+			"status": map[string]interface{}{
+				"loadbalancer": map[string]interface{}{
+					"ip":       svc.ip,
+					"hostname": svc.hostname,
+				},
+			},
+		}
+		input.PatchCollector.MergePatch(patch, "deckhouse.io/v1", "IngressNginxController",
+			"", svc.name, object_patch.IgnoreMissingObject())
+	}
+	return nil
+}

--- a/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
@@ -18,13 +18,15 @@ package hooks
 
 import (
 	"fmt"
-	. "github.com/deckhouse/deckhouse/testing/hooks"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
-	"strings"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::", func() {

--- a/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::
 	Context("Service with LoadBalancer type and with hostname", func() {
 		BeforeEach(func() {
 			resources := []string{
-				ingressNginxControllerYAML("test"),
-				serviceYAML("test", "LoadBalancer", "", "hostname"),
+				ingressNginxControllerYAML("test2"),
+				serviceYAML("test2", "LoadBalancer", "", "hostname"),
 			}
 			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
 			f.RunHook()
@@ -61,7 +61,7 @@ var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::
 
 		It("Should set hostname", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test2")
 			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(Equal("hostname"))
 			Expect(ingress.Field("status.loadBalancer.ip").Str).To(BeEmpty())
 		})
@@ -69,8 +69,8 @@ var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::
 	Context("Service with LoadBalancer type and with ip", func() {
 		BeforeEach(func() {
 			resources := []string{
-				ingressNginxControllerYAML("test"),
-				serviceYAML("test", "LoadBalancer", "ip", ""),
+				ingressNginxControllerYAML("test3"),
+				serviceYAML("test3", "LoadBalancer", "ip", ""),
 			}
 			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
 			f.RunHook()
@@ -78,7 +78,7 @@ var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::
 
 		It("Should set ip", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test3")
 			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(BeEmpty())
 			Expect(ingress.Field("status.loadBalancer.ip").Str).To(Equal("ip"))
 		})
@@ -87,8 +87,8 @@ var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::
 	Context("Service with LoadBalancer type and with ip and hostname", func() {
 		BeforeEach(func() {
 			resources := []string{
-				ingressNginxControllerYAML("test"),
-				serviceYAML("test", "LoadBalancer", "ip", "hostname"),
+				ingressNginxControllerYAML("test4"),
+				serviceYAML("test4", "LoadBalancer", "ip", "hostname"),
 			}
 			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
 			f.RunHook()
@@ -96,7 +96,7 @@ var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::
 
 		It("Should set ip", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test4")
 			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(Equal("hostname"))
 			Expect(ingress.Field("status.loadBalancer.ip").Str).To(Equal("ip"))
 		})

--- a/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+	"strings"
+)
+
+var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::", func() {
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.1", "internal": {}}}`, "")
+	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
+
+	Context("Service with non LoadBalancer type", func() {
+		BeforeEach(func() {
+			resources := []string{
+				ingressNginxControllerYAML("test"),
+				serviceYAML("test", "HostPort", "ip", "hostname"),
+			}
+			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
+			f.RunHook()
+		})
+
+		It("Should not set anything", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(BeEmpty())
+			Expect(ingress.Field("status.loadBalancer.ip").Str).To(BeEmpty())
+		})
+	})
+
+	Context("Service with LoadBalancer type and with hostname", func() {
+		BeforeEach(func() {
+			resources := []string{
+				ingressNginxControllerYAML("test"),
+				serviceYAML("test", "LoadBalancer", "", "hostname"),
+			}
+			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
+			f.RunHook()
+		})
+
+		It("Should set hostname", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(Equal("hostname"))
+			Expect(ingress.Field("status.loadBalancer.ip").Str).To(BeEmpty())
+		})
+	})
+	Context("Service with LoadBalancer type and with ip", func() {
+		BeforeEach(func() {
+			resources := []string{
+				ingressNginxControllerYAML("test"),
+				serviceYAML("test", "LoadBalancer", "ip", ""),
+			}
+			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
+			f.RunHook()
+		})
+
+		It("Should set ip", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(BeEmpty())
+			Expect(ingress.Field("status.loadBalancer.ip").Str).To(Equal("ip"))
+		})
+	})
+
+	Context("Service with LoadBalancer type and with ip and hostname", func() {
+		BeforeEach(func() {
+			resources := []string{
+				ingressNginxControllerYAML("test"),
+				serviceYAML("test", "LoadBalancer", "ip", "hostname"),
+			}
+			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
+			f.RunHook()
+		})
+
+		It("Should set ip", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesGlobalResource("IngressNginxController", "test")
+			Expect(ingress.Field("status.loadBalancer.hostname").Str).To(Equal("hostname"))
+			Expect(ingress.Field("status.loadBalancer.ip").Str).To(Equal("ip"))
+		})
+	})
+})
+
+func serviceYAML(name, inlet, ip, hostname string) string {
+	svc := corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-load-balancer", name),
+			Namespace: "d8-ingress-nginx",
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+		},
+	}
+	if inlet == "LoadBalancer" {
+		svc.Labels["deckhouse-service-type"] = "provider-managed"
+		var loadBalancerIngress corev1.LoadBalancerIngress
+		if ip != "" {
+			loadBalancerIngress.IP = ip
+		}
+		if hostname != "" {
+			loadBalancerIngress.Hostname = hostname
+		}
+		svc.Status.LoadBalancer.Ingress = append(svc.Status.LoadBalancer.Ingress, loadBalancerIngress)
+	}
+	marshaled, _ := yaml.Marshal(svc)
+	return string(marshaled)
+}

--- a/modules/402-ingress-nginx/templates/controller/service.yaml
+++ b/modules/402-ingress-nginx/templates/controller/service.yaml
@@ -16,7 +16,7 @@ kind: Service
 metadata:
   name: {{ $crd.name }}-load-balancer
   namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $crd.name )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "controller" "name" $crd.name "deckhouse-service-type" "provider-managed" )) | nindent 2 }}
     {{- if $annotations }}
   annotations:
       {{- range $key, $value := $annotations }}


### PR DESCRIPTION
## Description
Provides an additional fields for ingress-nginx-controller status. These fields represent assigned ip and hostname of the external loadBalancer.

## Why do we need it, and what problem does it solve?
Closes #7718


## What is the expected result?
The ip and hostname are displayed when getting ingress-nginx-controller with LoadBalancer inlet. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: feature
summary: add ip and hostname to ingress-nginx-controller status
```
