### PR TITLE
[dhctl] fix(dhctl-for-commander): add destructive detalization  for abandoned node and terraform plans into check result

### DIFF
--- a/dhctl/pkg/terraform/runner.go
+++ b/dhctl/pkg/terraform/runner.go
@@ -628,6 +628,8 @@ func (r *Runner) execTerraform(args ...string) (int, error) {
 	return exitCode, err
 }
 
+type TerraformPlan map[string]any
+
 type PlanDestructiveChanges struct {
 	ResourcesDeleted   []ValueChange `json:"resources_deleted,omitempty"`
 	ResourcesRecreated []ValueChange `json:"resourced_recreated,omitempty"`


### PR DESCRIPTION
## Description

Added detalization about abandoned node which will be deleted during next converge.

## Why do we need it, and what problem does it solve?

Currently check result destructive detalization lacks info about abandoned nodes.
