### PR TITLE
[node-manager] kubelet resource reservation fixes

### DIFF
--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -308,14 +308,13 @@ systemReserved:
   ephemeral-storage: 1Gi
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
-  # test: "{{ typeOf .nodeGroup.kubelet.resourceReservation.static.cpu }}"
-  {{- if eq "string" (typeOf .nodeGroup.kubelet.resourceReservation.static.cpu) }}
+  {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
   {{- end }}
-  {{- if eq "string" (typeOf .nodeGroup.kubelet.resourceReservation.static.memory) }}
+  {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}
   memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory }}
   {{- end }}
-  {{- if eq "string" (typeOf .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage) }}
+  {{- if .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
   ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
   {{- end }}
 {{- end }}

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -309,13 +309,13 @@ systemReserved:
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
   {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
-  cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
+  cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu | quote }}
   {{- end }}
   {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}
-  memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory }}
+  memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory | quote }}
   {{- end }}
   {{- if .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
-  ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
+  ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage | quote }}
   {{- end }}
 {{- end }}
 volumeStatsAggPeriod: 1m0s

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -308,14 +308,20 @@ systemReserved:
   ephemeral-storage: 1Gi
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
-  {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
+  {{- if hasKey "kubelet" .nodeGroup }}
+    {{- if hasKey "resourceReservation" .nodeGroup.kubelet }}
+      {{- if hasKey "static" .nodeGroup.kubelet.resourceReservation }}
+        {{- if hasKey "cpu" .nodeGroup.kubelet.resourceReservation.static }}
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu | quote }}
-  {{- end }}
-  {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}
+        {{- end }}
+        {{- if hasKey "memory" .nodeGroup.kubelet.resourceReservation.static }}
   memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory | quote }}
-  {{- end }}
-  {{- if .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
+        {{- end }}
+        {{- if hasKey "ephemeralStorage" .nodeGroup.kubelet.resourceReservation.static }}
   ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}
 volumeStatsAggPeriod: 1m0s

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -309,7 +309,7 @@ systemReserved:
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
   {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
-  # test: "{{ .nodeGroup.kubelet.resourceReservation.static.cpu }}"
+  # test: "{{ typeOf .nodeGroup.kubelet.resourceReservation.static.cpu }}"
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
   {{- end }}
   {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -309,13 +309,13 @@ systemReserved:
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
   # test: "{{ typeOf .nodeGroup.kubelet.resourceReservation.static.cpu }}"
-  {{- if ne .nodeGroup.kubelet.resourceReservation.static.cpu 0.0 }}
+  {{- if eq "string" (typeOf .nodeGroup.kubelet.resourceReservation.static.cpu) }}
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
   {{- end }}
-  {{- if ne .nodeGroup.kubelet.resourceReservation.static.memory 0.0 }}
+  {{- if eq "string" (typeOf .nodeGroup.kubelet.resourceReservation.static.memory) }}
   memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory }}
   {{- end }}
-  {{- if ne .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage 0.0 }}
+  {{- if eq "string" (typeOf .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage) }}
   ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
   {{- end }}
 {{- end }}

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -308,14 +308,14 @@ systemReserved:
   ephemeral-storage: 1Gi
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
-  {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
   # test: "{{ typeOf .nodeGroup.kubelet.resourceReservation.static.cpu }}"
+  {{- if ne .nodeGroup.kubelet.resourceReservation.static.cpu 0.0 }}
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
   {{- end }}
-  {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}
+  {{- if ne .nodeGroup.kubelet.resourceReservation.static.memory 0.0 }}
   memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory }}
   {{- end }}
-  {{- if .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
+  {{- if ne .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage 0.0 }}
   ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
   {{- end }}
 {{- end }}

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -308,16 +308,16 @@ systemReserved:
   ephemeral-storage: 1Gi
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
-  {{- if hasKey "kubelet" .nodeGroup }}
-    {{- if hasKey "resourceReservation" .nodeGroup.kubelet }}
-      {{- if hasKey "static" .nodeGroup.kubelet.resourceReservation }}
-        {{- if hasKey "cpu" .nodeGroup.kubelet.resourceReservation.static }}
+  {{- if hasKey .nodeGroup "kubelet" }}
+    {{- if hasKey .nodeGroup.kubelet "resourceReservation" }}
+      {{- if hasKey .nodeGroup.kubelet.resourceReservation "static" }}
+        {{- if hasKey .nodeGroup.kubelet.resourceReservation.static "cpu" }}
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu | quote }}
         {{- end }}
-        {{- if hasKey "memory" .nodeGroup.kubelet.resourceReservation.static }}
+        {{- if hasKey .nodeGroup.kubelet.resourceReservation.static "memory" }}
   memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory | quote }}
         {{- end }}
-        {{- if hasKey "ephemeralStorage" .nodeGroup.kubelet.resourceReservation.static }}
+        {{- if hasKey .nodeGroup.kubelet.resourceReservation.static "ephemeralStorage" }}
   ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage | quote }}
         {{- end }}
       {{- end }}

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -309,13 +309,14 @@ systemReserved:
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
   {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
-  cpu: {{ dig "kubelet" "resourceReservation" "static" "cpu" 0 .nodeGroup }}
+  # test
+  cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
   {{- end }}
   {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}
-  memory: {{ dig "kubelet" "resourceReservation" "static" "memory" 0 .nodeGroup }}
+  memory: {{ .nodeGroup.kubelet.resourceReservation.static.memory }}
   {{- end }}
   {{- if .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
-  ephemeral-storage: {{ dig "kubelet" "resourceReservation" "static" "ephemeralStorage" 0 .nodeGroup }}
+  ephemeral-storage: {{ .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
   {{- end }}
 {{- end }}
 volumeStatsAggPeriod: 1m0s

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -308,9 +308,15 @@ systemReserved:
   ephemeral-storage: 1Gi
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
+  {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
   cpu: {{ dig "kubelet" "resourceReservation" "static" "cpu" 0 .nodeGroup }}
+  {{- end }}
+  {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}
   memory: {{ dig "kubelet" "resourceReservation" "static" "memory" 0 .nodeGroup }}
+  {{- end }}
+  {{- if .nodeGroup.kubelet.resourceReservation.static.ephemeralStorage }}
   ephemeral-storage: {{ dig "kubelet" "resourceReservation" "static" "ephemeralStorage" 0 .nodeGroup }}
+  {{- end }}
 {{- end }}
 volumeStatsAggPeriod: 1m0s
 healthzBindAddress: 127.0.0.1

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -309,7 +309,7 @@ systemReserved:
 {{- else if eq $resourceReservationMode "Static" }}
 systemReserved:
   {{- if .nodeGroup.kubelet.resourceReservation.static.cpu }}
-  # test
+  # test: "{{ .nodeGroup.kubelet.resourceReservation.static.cpu }}"
   cpu: {{ .nodeGroup.kubelet.resourceReservation.static.cpu }}
   {{- end }}
   {{- if .nodeGroup.kubelet.resourceReservation.static.memory }}

--- a/modules/040-node-manager/hooks/internal/v1/nodegroup.go
+++ b/modules/040-node-manager/hooks/internal/v1/nodegroup.go
@@ -319,9 +319,9 @@ type KubeletResourceReservation struct {
 }
 
 type KubeletStaticResourceReservation struct {
-	CPU              resource.Quantity `json:"cpu"`
-	Memory           resource.Quantity `json:"memory"`
-	EphemeralStorage resource.Quantity `json:"ephemeralStorage"`
+	CPU              resource.Quantity `json:"cpu,omitempty"`
+	Memory           resource.Quantity `json:"memory,omitempty"`
+	EphemeralStorage resource.Quantity `json:"ephemeralStorage,omitempty"`
 }
 
 type KubeletResourceReservationMode string

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -109,8 +109,9 @@ func systemReserve(input *go_hook.HookInput) error {
 	ngsSnapshot := input.Snapshots["ngs"]
 	for _, ngRaw := range ngsSnapshot {
 		ng := ngRaw.(*NodeGroup)
-		input.LogEntry.Println("NodeGroupName: ", ng.Name, "KubeletResourceReservationMode: ", ng.ResourceReservationMode)
-		if ng.ResourceReservationMode != "" {
+		skipMigration := ng.ResourceReservationMode != ""
+		input.LogEntry.Printf("NodeGroupName: %s, KubeletResourceReservationMode: %s, skipMigration: %t", ng.Name, ng.ResourceReservationMode, skipMigration)
+		if skipMigration {
 			continue
 		}
 		input.PatchCollector.Filter(func(u *unstructured.Unstructured) (*unstructured.Unstructured, error) {

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -69,7 +69,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, systemReserve)
 
 type NodeGroup struct {
-	Name string
+	Name                    string
+	ResourceReservationMode string
 }
 
 func ngFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -80,7 +81,8 @@ func ngFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	}
 
 	return &NodeGroup{
-		Name: ng.Name,
+		Name:                    ng.Name,
+		ResourceReservationMode: string(ng.Spec.Kubelet.ResourceReservation.Mode),
 	}, nil
 }
 
@@ -107,6 +109,10 @@ func systemReserve(input *go_hook.HookInput) error {
 	ngsSnapshot := input.Snapshots["ngs"]
 	for _, ngRaw := range ngsSnapshot {
 		ng := ngRaw.(*NodeGroup)
+		input.LogEntry.Println("NodeGroupName: ", ng.Name, "KubeletResourceReservationMode: ", ng.ResourceReservationMode)
+		if ng.ResourceReservationMode != "" {
+			continue
+		}
 		input.PatchCollector.Filter(func(u *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 			objCopy := u.DeepCopy()
 			err := unstructured.SetNestedField(objCopy.Object, "Off", "spec", "kubelet", "resourceReservation", "mode")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Fixed migration. NodeGroup's that have the `.spec.resourceReservation.mode` parameter set will be ignored.
- Fixed an issue resulting in the kubelet being unable to start if only one of the `cpu`, `memory` or `ephemeral-storage` parameters is specified in `NodeGroup.spec.resourceReservation.static`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checks

* Verified that migration ignores nodegroups with `.spec.resourceReservation.mode`.
* Verified that `.spec.resourceReservation.static` can be set for all `cpu`, `memory` and `ephemeral-storage` or only some.

part of NodeGroup spec 
```
  kubelet:
    resourceReservation:
      mode: Auto
```

result
```
d8 logs
"040-node-manager/hooks/migration/migrate_system_reserve.go NodeGroupName: worker, KubeletResourceReservationMode: Static, skipMigration: true"
```

part of NodeGroup spec 
```
  kubelet:
    resourceReservation:
      mode: Static
      static:
        ephemeralStorage: 1Gi
        memory: 500Mi
```

result
```
root@dev2-worker-b2e0a50b-c9b4c-vrd27:~# cat /var/lib/kubelet/config.yaml  | grep systemReserved -A2
systemReserved:
  memory: "500Mi"
  ephemeral-storage: "1Gi"
```

part of NodeGroup spec 
```
  kubelet:
    resourceReservation:
      mode: Static
      static:
        cpu: 1
        ephemeralStorage: 1Gi
        memory: 500Mi
```

result
```
root@dev2-worker-b2e0a50b-c9b4c-vrd27:~# cat /var/lib/kubelet/config.yaml  | grep systemReserved -A3
systemReserved:
  cpu: "1"
  memory: "500Mi"
  ephemeral-storage: "1Gi"
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: kubelet resource reservation fixes.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
