### PR TITLE
[deckhouse-controller] Module life cycle stage

### DIFF
--- a/deckhouse-controller/crds/doc-ru-module.yaml
+++ b/deckhouse-controller/crds/doc-ru-module.yaml
@@ -17,5 +17,7 @@ spec:
                   description: 'Состояние модуля (включен или выключен).'
                 source:
                   description: 'Имя ModuleSource, если модуль скачан из него (иначе пусто).'
+                stage: 
+                  description: 'Текущая стадия жизненного цикла модуля.'
                 description:
                   description: 'Описание модуля.'

--- a/deckhouse-controller/crds/module.yaml
+++ b/deckhouse-controller/crds/module.yaml
@@ -41,6 +41,14 @@ spec:
                 source:
                   type: string
                   description: 'ModuleSource name of the module if provided by one (otherwise empty).'
+                stage:
+                  type: string
+                  description: 'The current stage of the module life cycle.'
+                  enum:
+                    - Sandbox
+                    - Incubating
+                    - Graduated
+                    - Deprecated
                 description:
                   type: string
                   description: 'Module description.'
@@ -65,6 +73,10 @@ spec:
           jsonPath: .properties.source
           type: string
           description: 'ModuleSource name of the module if provided by one (otherwise empty).'
+        - name: stage
+          jsonPath: .properties.stage
+          type: string
+          description: 'The current stage of the module life cycle'
         - name: Status
           type: string
           description: "Module state explanation or last error"

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -47,6 +47,7 @@ type ModuleProperties struct {
 	Weight      uint32 `json:"weight"`
 	State       string `json:"state,omitempty"`
 	Source      string `json:"source,omitempty"`
+	Stage       string `json:"stage,omitempty"`
 	Description string `json:"description,omitempty"`
 }
 

--- a/deckhouse-controller/pkg/controller/loader.go
+++ b/deckhouse-controller/pkg/controller/loader.go
@@ -130,17 +130,14 @@ func (dml *DeckhouseController) findModulesInDir(modulesDir string) ([]models.De
 			continue
 		}
 
-		definition, err := dml.moduleFromFile(absPath)
+		definition, err := dml.moduleFromDirName(name, absPath)
 		if err != nil {
 			return nil, err
 		}
 
-		if definition == nil {
-			log.Debugf("module.yaml for module %q does not exist", name)
-			definition, err = dml.moduleFromDirName(name, absPath)
-			if err != nil {
-				return nil, err
-			}
+		definition, err = dml.overwriteModuleFromModuleYamlFile(absPath, definition)
+		if err != nil {
+			return nil, err
 		}
 
 		definitions = append(definitions, *definition)
@@ -157,11 +154,11 @@ const (
 	ModuleNameIdx  = 3
 )
 
-func (dml *DeckhouseController) moduleFromFile(absPath string) (*models.DeckhouseModuleDefinition, error) {
+func (dml *DeckhouseController) overwriteModuleFromModuleYamlFile(absPath string, definition *models.DeckhouseModuleDefinition) (*models.DeckhouseModuleDefinition, error) {
 	mFilePath := filepath.Join(absPath, models.ModuleDefinitionFile)
 	if _, err := os.Stat(mFilePath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return definition, nil
 		}
 
 		return nil, err
@@ -179,13 +176,16 @@ func (dml *DeckhouseController) moduleFromFile(absPath string) (*models.Deckhous
 		return nil, err
 	}
 
-	if def.Name == "" || def.Weight == 0 {
-		return nil, nil
+	if def.Name != "" {
+		definition.Name = def.Name
 	}
+	if def.Weight != 0 {
+		definition.Weight = def.Weight
+	}
+	definition.Description = def.Description
+	definition.Stage = def.Stage
 
-	def.Path = absPath
-
-	return &def, nil
+	return definition, nil
 }
 
 // moduleFromDirName returns Module instance filled with name, order and its absolute path.

--- a/deckhouse-controller/pkg/controller/models/definition.go
+++ b/deckhouse-controller/pkg/controller/models/definition.go
@@ -24,6 +24,7 @@ type DeckhouseModuleDefinition struct {
 	Name        string   `yaml:"name"`
 	Weight      uint32   `yaml:"weight,omitempty"`
 	Tags        []string `yaml:"tags"`
+	Stage       string   `yaml:"stage"`
 	Description string   `yaml:"description"`
 
 	Path string `yaml:"-"`

--- a/deckhouse-controller/pkg/controller/models/module.go
+++ b/deckhouse-controller/pkg/controller/models/module.go
@@ -31,6 +31,7 @@ type DeckhouseModule struct {
 	basic *modules.BasicModule
 
 	description string
+	stage       string
 	labels      map[string]string
 }
 
@@ -50,6 +51,7 @@ func NewDeckhouseModule(def DeckhouseModuleDefinition, staticValues utils.Values
 		basic:       basic,
 		labels:      labels,
 		description: def.Description,
+		stage:       def.Stage,
 	}
 }
 
@@ -74,6 +76,7 @@ func (dm DeckhouseModule) AsKubeObject(source string) *v1alpha1.Module {
 			Weight:      dm.basic.Order,
 			Source:      source,
 			State:       "Disabled",
+			Stage:       dm.stage,
 			Description: dm.description,
 		},
 	}


### PR DESCRIPTION
## Description

Added ability to set and display the current life cycle stage for modules. In addition, the "description" field has been fixed.

![screen-1](https://github.com/deckhouse/deckhouse/assets/52157046/ada0027d-c4b2-45f9-bc45-4a2c4d63b197)

![screen-2](https://github.com/deckhouse/deckhouse/assets/52157046/5f8ec9cd-ee0f-45a9-93ef-595b5b245e4b)


## Why do we need it, and what problem does it solve?

Makes it more transparent to work with the life cycle stages of modules.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary:  Ability to set and display the current life cycle stage for modules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
