### PR TITLE
[ingress-nginx] fix-https-port-validation

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -222,6 +222,9 @@ spec:
 
                         This parameter is mandatory if `httpPort` is not set.
                       x-doc-examples: ['443']
+                      x-kubernetes-validations:
+                        - message: .spec.hostPort.httpsPort can't be 6443, it's reserved for kube-apiserver
+                          rule: 'self != 6443'
                     behindL7Proxy:
                       type: boolean
                       description: |
@@ -262,6 +265,9 @@ spec:
 
                         This parameter is mandatory if `httpPort` is not set.
                       x-doc-examples: ['443']
+                      x-kubernetes-validations:
+                        - message: .spec.hostPortWithProxyProtocol.httpsPort can't be 6443, it's reserved for kube-apiserver
+                          rule: 'self != 6443'
                 acceptRequestsFrom:
                   type: array
                   description: |
@@ -812,6 +818,9 @@ spec:
 
                         This parameter is mandatory if `httpPort` is not set.
                       x-doc-examples: ['443']
+                      x-kubernetes-validations:
+                        - message: .spec.hostPortWithProxyProtocol.httpsPort can't be 6443, it's reserved for kube-apiserver
+                          rule: 'self != 6443'
                 acceptRequestsFrom:
                   type: array
                   description: |

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -203,9 +203,6 @@ spec:
                   anyOf:
                   - {required: ["httpPort"]}
                   - {required: ["httpsPort"]}
-                  x-kubernetes-validations:
-                    - message: .spec.httpsPort can't be 6443, it's reserved for kube-apiserver
-                      rule: 'self.httpsPort != 6443'
                   properties:
                     httpPort:
                       type: integer
@@ -753,9 +750,6 @@ spec:
                   anyOf:
                     - {required: ["httpPort"]}
                     - {required: ["httpsPort"]}
-                  x-kubernetes-validations:
-                    - message: .spec.httpsPort can't be 6443, it's reserved for kube-apiserver
-                      rule: 'self.httpsPort != 6443'
                   properties:
                     httpPort:
                       type: integer
@@ -775,6 +769,9 @@ spec:
 
                         This parameter is mandatory if `httpPort` is not set.
                       x-doc-examples: ['443']
+                      x-kubernetes-validations:
+                        - message: .spec.hostPort.httpsPort can't be 6443, it's reserved for kube-apiserver
+                          rule: 'self != 6443'
                     behindL7Proxy:
                       type: boolean
                       description: |


### PR DESCRIPTION
## Description
Provides https port validation fix.

## Why do we need it, and what problem does it solve?
Closes #7657

## What is the expected result?
You can use httpPort field without httpsPort field. You can remove httpsPort field for hostPort. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: Fix HTTPS port validation for HostPort inlet.
```
