### PR TITLE
[monitoring] hide labels instance/pod alerts

### DIFF
--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -107,6 +107,7 @@
       severity_level: "6"
     annotations:
       plk_protocol_version: "1"
+      plk_labels_as_annotations: "instance,pod"
       plk_markup_format: "markdown"
       plk_create_group_if_not_exists__controllers_malfunctioning: "NginxIngressControllersMalfunctioning,prometheus=deckhouse,daemonset={{ $labels.daemonset }},kubernetes=~kubernetes"
       plk_grouped_by__controllers_malfunctioning: "NginxIngressControllersMalfunctioning,prometheus=deckhouse,daemonset={{ $labels.daemonset }},kubernetes=~kubernetes"
@@ -131,6 +132,7 @@
       severity_level: "4"
     annotations:
       plk_protocol_version: "1"
+      plk_labels_as_annotations: "instance,pod"
       plk_markup_format: "markdown"
       plk_create_group_if_not_exists__controllers_malfunctioning: "NginxIngressControllersMalfunctioning,prometheus=deckhouse,daemonset={{ $labels.daemonset }},kubernetes=~kubernetes"
       plk_grouped_by__controllers_malfunctioning: "NginxIngressControllersMalfunctioning,prometheus=deckhouse,daemonset={{ $labels.daemonset }},kubernetes=~kubernetes"


### PR DESCRIPTION
## Description

Add information of instance and pod to labels of the NginxIngressDaemonSetReplicasUnavailable alert.

This is for so that the number alerts does not equal the number of  kruise-controller replicas, but only 1, as for example for upmeter.

## Why do we need it, and what problem does it solve?

Reducing the number of alerts in monitoring system.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
summary: Add information of instance and pod to labels of the NginxIngressDaemonSetReplicasUnavailable alert.
type: fix 
impact_level: low
```
