### PR TITLE
[istio] Getting rid of istioMinimalVersion requirement in release.yaml

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -27,7 +27,9 @@ requirements:
   "ingressNginx": "1.1" # modules/402-ingress-nginx/requirements/check.go
   "nodesMinimalOSVersionUbuntu": "18.04" # modules/040-node-manager/requirements/check.go
   "containerdOnAllNodes": "true" # modules/040-node-manager/requirements/check.go
-  "istioMinimalVersion": "1.16" # modules/110-istio/requirements/check.go
+
+  # Commented only for d8 v1.58.
+  # "istioMinimalVersion": "1.16" # modules/110-istio/requirements/check.go
 
   # TODO: Delete in D8 1.60, migrating to istioMinimalVersion
   "istioVer": "1.16" # modules/110-istio/requirements/check.go


### PR DESCRIPTION
## Description
Getting rid of istioMinimalVersion requirement in release.yaml

## Why do we need it in the patch release (if we do)?

Users can't upgrade their deckhouses:
```
% k get deckhousereleases.deckhouse.io                
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.57.5   Deployed   3h42m            
v1.58.4   Pending    10m              "istioMinimalVersion" requirement is not registered
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Got rid of istioMinimalVersion requirement in release.yaml to fix upgrading issue.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
