### PR TITLE
[cloud-provider-vcd] Add validation for virtual application name

### DIFF
--- a/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
@@ -241,6 +241,9 @@ apiVersions:
             Vcloud Director Virtual Data Center name (belongs to Organization).
         virtualApplicationName:
           type: string
+          # cluster api getting app by VCDCluster name and we should create app with kubernetes resources name restrictions
+          # base on this answer https://stackoverflow.com/a/67387967
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
           description: |
             Vcloud Director Virtual Application name (belongs to Virtual Data Center).
         mainNetwork:

--- a/ee/modules/030-cloud-provider-vcd/capi/cluster.yaml
+++ b/ee/modules/030-cloud-provider-vcd/capi/cluster.yaml
@@ -1,4 +1,5 @@
 {{- $providerClusterConfiguration := .vcd | required "internal.providerClusterConfiguration is required" }}
+{{- $clusterName := .clusterName | required "clusterName is required" }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,7 +17,7 @@ kind: VCDCluster
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capcd-controller-manager")) | nindent 2 }}
   namespace: d8-cloud-instance-manager
-  name: {{ lower $providerClusterConfiguration.virtualApplicationName | quote }}
+  name: {{ $clusterName | quote }}
 spec:
   site: {{ $providerClusterConfiguration.server | trimSuffix "/" | quote }} # VCD endpoint with the format https://VCD_HOST. No trailing '/'
   org: {{ $providerClusterConfiguration.organization | quote }} # VCD organization name where the cluster should be deployed

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration_test.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration_test.go
@@ -39,7 +39,7 @@ kind: VCDClusterConfiguration
 sshPublicKey: "<SSH_PUBLIC_KEY>"
 organization: My_Org
 virtualDataCenter: My_Org
-virtualApplicationName: VAPP
+virtualApplicationName: vapp
 layout: Standard
 internalNetworkCIDR: 172.16.2.0/24
 mainNetwork: internal

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -70,7 +70,7 @@ const moduleValuesA = `
         sshPublicKey: rsa-aaaa
         organization: org
         virtualDataCenter: dc
-        virtualApplicationName: Virtual-app_NAmeVcd
+        virtualApplicationName: v1rtual-app
         mainNetwork: internal
         masterNodeGroup:
           replicas: 1
@@ -111,7 +111,7 @@ var _ = Describe("Module :: cloud-provider-vcd :: helm template ::", func() {
 
 			regSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
 			Expect(regSecret.Exists()).To(BeTrue())
-			Expect(regSecret.Field("data.capiClusterName").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("virtual-app-namevcd"))))
+			Expect(regSecret.Field("data.capiClusterName").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("v1rtual-app"))))
 		})
 	})
 })

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -6,6 +6,7 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package template_tests
 
 import (
+	"encoding/base64"
 	"os"
 	"testing"
 
@@ -69,7 +70,7 @@ const moduleValuesA = `
         sshPublicKey: rsa-aaaa
         organization: org
         virtualDataCenter: dc
-        virtualApplicationName: app
+        virtualApplicationName: Virtual-app_NAmeVcd
         mainNetwork: internal
         masterNodeGroup:
           replicas: 1
@@ -107,6 +108,10 @@ var _ = Describe("Module :: cloud-provider-vcd :: helm template ::", func() {
 
 		It("Everything must render properly", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			regSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
+			Expect(regSecret.Exists()).To(BeTrue())
+			Expect(regSecret.Field("data.capiClusterName").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("virtual-app-namevcd"))))
 		})
 	})
 })

--- a/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
@@ -17,7 +17,7 @@ data:
   machineClassKind: {{ b64enc "" | quote }}
   capiClusterKind: {{ b64enc "VCDCluster" | quote }}
   capiClusterAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1beta2" | quote }}
-  capiClusterName: {{ lower $providerClusterConfiguration.virtualApplicationName | camelcase | kebabcase | b64enc | quote }}
+  capiClusterName: {{ $providerClusterConfiguration.virtualApplicationName | b64enc | quote }}
   capiMachineTemplateKind: {{ b64enc "VCDMachineTemplate" | quote }}
   capiMachineTemplateAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1beta2" | quote }}
   sshPublicKey: {{ b64enc $providerClusterConfiguration.sshPublicKey | quote }}

--- a/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
@@ -17,7 +17,7 @@ data:
   machineClassKind: {{ b64enc "" | quote }}
   capiClusterKind: {{ b64enc "VCDCluster" | quote }}
   capiClusterAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1beta2" | quote }}
-  capiClusterName: {{ lower $providerClusterConfiguration.virtualApplicationName | b64enc | quote }}
+  capiClusterName: {{ lower $providerClusterConfiguration.virtualApplicationName | camelcase | kebabcase | b64enc | quote }}
   capiMachineTemplateKind: {{ b64enc "VCDMachineTemplate" | quote }}
   capiMachineTemplateAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1beta2" | quote }}
   sshPublicKey: {{ b64enc $providerClusterConfiguration.sshPublicKey | quote }}

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1843,7 +1843,7 @@ internal:
 					Expect(secret.Field("data.username").String()).To(Equal("dXNlcg==")) // user
 					Expect(secret.Field("data.password").String()).To(Equal("cGFzcw==")) // pass
 
-					vcdCluster := f.KubernetesResource("VCDCluster", "d8-cloud-instance-manager", "app")
+					vcdCluster := f.KubernetesResource("VCDCluster", "d8-cloud-instance-manager", "vcd")
 					Expect(vcdCluster.Exists()).To(BeTrue())
 					Expect(vcdCluster.Field("spec.site").String()).To(Equal("https://localhost:5000"))
 					Expect(vcdCluster.Field("spec.org").String()).To(Equal("org"))

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1788,7 +1788,7 @@ internal:
     machineClassKind: ""
     capiClusterKind: "VCDCluster"
     capiClusterAPIVersion: "infrastructure.cluster.x-k8s.io/v1beta2"
-    capiClusterName: "vcd"
+    capiClusterName: "app"
     capiMachineTemplateKind: "VCDMachineTemplate"
     capiMachineTemplateAPIVersion: "infrastructure.cluster.x-k8s.io/v1beta2"
     vcd:
@@ -1843,7 +1843,7 @@ internal:
 					Expect(secret.Field("data.username").String()).To(Equal("dXNlcg==")) // user
 					Expect(secret.Field("data.password").String()).To(Equal("cGFzcw==")) // pass
 
-					vcdCluster := f.KubernetesResource("VCDCluster", "d8-cloud-instance-manager", "vcd")
+					vcdCluster := f.KubernetesResource("VCDCluster", "d8-cloud-instance-manager", "app")
 					Expect(vcdCluster.Exists()).To(BeTrue())
 					Expect(vcdCluster.Field("spec.site").String()).To(Equal("https://localhost:5000"))
 					Expect(vcdCluster.Field("spec.org").String()).To(Equal("org"))
@@ -1865,8 +1865,8 @@ internal:
 					md := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", d.name)
 					Expect(md.Exists()).To(BeTrue())
 
-					Expect(md.Field("spec.clusterName").String()).To(Equal("vcd"))
-					Expect(md.Field("spec.template.spec.clusterName").String()).To(Equal("vcd"))
+					Expect(md.Field("spec.clusterName").String()).To(Equal("app"))
+					Expect(md.Field("spec.template.spec.clusterName").String()).To(Equal("app"))
 					Expect(md.Field("spec.template.spec.bootstrap.dataSecretName").String()).To(Equal(d.templateName))
 					Expect(md.Field("spec.template.spec.infrastructureRef.name").String()).To(Equal(d.templateName))
 
@@ -1898,7 +1898,7 @@ internal:
 				registrySecret := f.KubernetesResource("Secret", "d8-cloud-instance-manager", "deckhouse-registry")
 				Expect(registrySecret.Exists()).To(BeTrue())
 
-				assertClusterResources(f, "vcd")
+				assertClusterResources(f, "app")
 
 				assertVCDCluster(f)
 

--- a/modules/040-node-manager/templates/node-group/_capi_bootstrap_secret.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_bootstrap_secret.tpl
@@ -27,6 +27,7 @@ data:
 {{- $_ := set $tpl_context "Template" $context.Template }}
 {{- $_ := set $tpl_context "Values" $context.Values }}
 {{- $_ := set $tpl_context "vcd" $context.Values.nodeManager.internal.cloudProvider.vcd }}
+{{- $_ := set $tpl_context "clusterName" $context.Values.nodeManager.internal.cloudProvider.capiClusterName }}
 ---
 {{- $f := $context.Files.Get (printf "capi/%s/cluster.yaml" $context.Values.nodeManager.internal.cloudProvider.type)}}
 {{ tpl ($f) $tpl_context }}


### PR DESCRIPTION
## Description
Cluster API provider VCD creates virtual application (if not found) equal VCDCluster resource name. Thus, we should validate virtual application name in OpenAPI spec.

Also, in this PR we disable MachineControllerManager for cloud providers which support ClusterAPI only (today it is VCD only).

## Why do we need it, and what problem does it solve?
Validate unsupported virtual apllication names.
Disable MCM where it is unneeded.

## Why do we need it in the patch release (if we do)?
VCD provided in this relese, we need add restriction in same release.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
MCM disabled when vcd cluster-api deployed
![image](https://github.com/deckhouse/deckhouse/assets/30695496/db94d423-6a92-413f-b5e3-9da798a06078)
VCD cluster bootstrapped, cloud nodes work fine
![image](https://github.com/deckhouse/deckhouse/assets/30695496/1486a377-8f7d-4ff7-a02d-40e4349e4bad)
openstack with caps and mcm working in parallel
![image](https://github.com/deckhouse/deckhouse/assets/30695496/b2e56d00-2b68-4a2d-b494-4a47ea7f8ffb)


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix 
summary: Add validation for virtual application name
impact_level: default
---
section: node-manager
type: fix
summary: Disable MCM for unsupported cloud providers 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
