### PR TITLE
[docs] moved passwords to env for dhctl mirror examples

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -419,7 +419,7 @@ This feature is available in Enterprise Edition only.
 1. Run the Deckhouse installer version 1.56.3 or higher.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:stable bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:alpha bash
    ```
 
    Note that the directory on the host will be mounted in the installer container. This directory will contain the pulled Deckhouse tarball.
@@ -431,8 +431,7 @@ This feature is available in Enterprise Edition only.
    The command below will pull Deckhouse tarballs for versions that are on the release channels (check [flow.deckhouse.io](https://flow.deckhouse.io) for the current status of the release channels):
 
    ```shell
-    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
-   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar
+   DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>" dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > If you interrupt the download before it is finished, calling the command again will check which images have already been downloaded, and the download will continue. This will only happen if no more than 24 hours have passed since the download interruption.
@@ -443,8 +442,7 @@ This feature is available in Enterprise Edition only.
    For example, here is how you can pull all Deckhouse version images starting from version 1.45:
 
    ```shell
-    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
-   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
+   DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>" dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
    ```
 
    > Note that `--min-version` parameter will be ignored if you specify version above current rock-solid channel.
@@ -456,9 +454,7 @@ This feature is available in Enterprise Edition only.
    For example, here is how you can pull images from a third-party registry:
 
    ```shell
-    export DHCTL_CLI_MIRROR_SOURCE_LOGIN="user"
-    export DHCTL_CLI_MIRROR_SOURCE_PASSWORD="password"
-   dhctl mirror --source="corp.company.com/sys/deckhouse" --images-bundle-path /tmp/d8-images/d8.tar
+    DHCTL_CLI_MIRROR_SOURCE_LOGIN="user" DHCTL_CLI_MIRROR_SOURCE_PASSWORD="password" dhctl mirror --source="corp.company.com/sys/deckhouse" --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > Note: `--license` flag acts as a shortcut for `--source-login` and `--source-password` flags for the Deckhouse registry.
@@ -481,9 +477,7 @@ This feature is available in Enterprise Edition only.
    Example of pushing images from the `/tmp/d8-images/d8.tar` tarball:
 
    ```shell
-    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
-    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
-   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee"
+   DHCTL_CLI_MIRROR_USER="<USERNAME>" DHCTL_CLI_MIRROR_PASS="<PASSWORD>" dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee"
    ```
 
    > Please note that the images will be uploaded to the registry along the path specified in the `--registry` parameter (in the example above - /deckhouse/ee).
@@ -504,7 +498,7 @@ The steps below are necessary for manually loading images of modules connected f
 1. Run Deckhouse installer version 1.56.0 or higher:
 
   ```shell
-   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.io/deckhouse/ce/install:stable bash
+   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.io/deckhouse/ce/install:alpha bash
    ```
 
    Note that the directory from the host file system is mounted in the installer container. It will store module images and the [ModuleSource](cr.html#modulesource) YAML manifest describing the source of modules.
@@ -532,9 +526,7 @@ The steps below are necessary for manually loading images of modules connected f
    Below is an example of a command for pulling images from the `/tmp/d8-modules` directory:
 
    ```shell
-    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
-    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
-   dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules"
+   DHCTL_CLI_MIRROR_USER="<USERNAME>" DHCTL_CLI_MIRROR_PASS="<PASSWORD>" dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules"
    ```
 
    > Please note that the images will be uploaded to the registry along the path specified in the `--registry` parameter (in the example above - /deckhouse-modules).

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -419,7 +419,7 @@ This feature is available in Enterprise Edition only.
 1. Run the Deckhouse installer version 1.56.3 or higher.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:alpha bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:v1.58.4 bash
    ```
 
    Note that the directory on the host will be mounted in the installer container. This directory will contain the pulled Deckhouse tarball.
@@ -498,7 +498,7 @@ The steps below are necessary for manually loading images of modules connected f
 1. Run Deckhouse installer version 1.56.0 or higher:
 
   ```shell
-   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.io/deckhouse/ce/install:alpha bash
+   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.io/deckhouse/ce/install:v1.58.4 bash
    ```
 
    Note that the directory from the host file system is mounted in the installer container. It will store module images and the [ModuleSource](cr.html#modulesource) YAML manifest describing the source of modules.

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -419,7 +419,7 @@ This feature is available in Enterprise Edition only.
 1. Run the Deckhouse installer version 1.56.3 or higher.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:v1.56.3 bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.io/deckhouse/ee/install:stable bash
    ```
 
    Note that the directory on the host will be mounted in the installer container. This directory will contain the pulled Deckhouse tarball.
@@ -431,7 +431,8 @@ This feature is available in Enterprise Edition only.
    The command below will pull Deckhouse tarballs for versions that are on the release channels (check [flow.deckhouse.io](https://flow.deckhouse.io) for the current status of the release channels):
 
    ```shell
-   dhctl mirror --license="<DECKHOUSE_LICENSE_KEY>" --images-bundle-path /tmp/d8-images/d8.tar
+    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
+   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > If you interrupt the download before it is finished, calling the command again will check which images have already been downloaded, and the download will continue. This will only happen if no more than 24 hours have passed since the download interruption.
@@ -442,7 +443,8 @@ This feature is available in Enterprise Edition only.
    For example, here is how you can pull all Deckhouse version images starting from version 1.45:
 
    ```shell
-   dhctl mirror --license="<DECKHOUSE_LICENSE_KEY>" --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
+    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
+   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
    ```
 
    > Note that `--min-version` parameter will be ignored if you specify version above current rock-solid channel.
@@ -454,7 +456,9 @@ This feature is available in Enterprise Edition only.
    For example, here is how you can pull images from a third-party registry:
 
    ```shell
-   dhctl mirror --source="corp.company.com/sys/deckhouse" --source-login="user" --source-password="password" --images-bundle-path /tmp/d8-images/d8.tar
+    export DHCTL_CLI_MIRROR_SOURCE_LOGIN="user"
+    export DHCTL_CLI_MIRROR_SOURCE_PASSWORD="password"
+   dhctl mirror --source="corp.company.com/sys/deckhouse" --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > Note: `--license` flag acts as a shortcut for `--source-login` and `--source-password` flags for the Deckhouse registry.
@@ -477,7 +481,9 @@ This feature is available in Enterprise Edition only.
    Example of pushing images from the `/tmp/d8-images/d8.tar` tarball:
 
    ```shell
-   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee" --registry-login="<USERNAME>" --registry-password="<PASSWORD>"
+    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
+    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
+   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee"
    ```
 
    > Please note that the images will be uploaded to the registry along the path specified in the `--registry` parameter (in the example above - /deckhouse/ee).
@@ -498,7 +504,7 @@ The steps below are necessary for manually loading images of modules connected f
 1. Run Deckhouse installer version 1.56.0 or higher:
 
   ```shell
-   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.io/deckhouse/ce/install:v1.56.0 bash
+   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.io/deckhouse/ce/install:stable bash
    ```
 
    Note that the directory from the host file system is mounted in the installer container. It will store module images and the [ModuleSource](cr.html#modulesource) YAML manifest describing the source of modules.
@@ -526,7 +532,9 @@ The steps below are necessary for manually loading images of modules connected f
    Below is an example of a command for pulling images from the `/tmp/d8-modules` directory:
 
    ```shell
-   dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules" --registry-login="<USERNAME>" --registry-password="<PASSWORD>"
+    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
+    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
+   dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules"
    ```
 
    > Please note that the images will be uploaded to the registry along the path specified in the `--registry` parameter (in the example above - /deckhouse-modules).

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -420,7 +420,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. Запустите установщик Deckhouse версии 1.56.3 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.ru/deckhouse/ee/install:stable bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.ru/deckhouse/ee/install:alpha bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы Deckhouse.
@@ -432,8 +432,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Следующая команда скачает образы Deckhouse тех версий, которые находятся на каналах обновлений (о текущем статусе версий на каналах обновлений можно узнать на [flow.deckhouse.io](https://flow.deckhouse.io)):
 
    ```shell
-    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
-   dhctl mirror --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar
+   DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>" dhctl mirror --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > Если загрузка образов будет прервана, повторный вызов команды проверит загруженные образы и продолжит загрузку с момента ее остановки. Продолжение загрузки возможно только если с момента остановки прошло не более суток.
@@ -444,8 +443,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Например, для загрузки всех версий Deckhouse, начиная с версии 1.45, используйте команду:
 
    ```shell
-    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
-   dhctl mirror --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
+   DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>" dhctl mirror --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
    ```
 
    > Обратите внимание, параметр `--min-version` будет проигнорирован если вы укажете версию выше находящейся в канале обновлений rock-solid.
@@ -457,9 +455,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Например, вот как можно загрузить образы из стороннего registry:
 
    ```shell
-    export DHCTL_CLI_MIRROR_SOURCE_LOGIN="user"
-    export DHCTL_CLI_MIRROR_SOURCE_PASSWORD="password"
-   dhctl mirror --source="corp.company.ru/sys/deckhouse" --images-bundle-path /tmp/d8-images/d8.tar
+   DHCTL_CLI_MIRROR_SOURCE_LOGIN="user" DHCTL_CLI_MIRROR_SOURCE_PASSWORD="password" dhctl mirror --source="corp.company.ru/sys/deckhouse" --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > Параметр `--license` действует как сокращение для параметров `--source-login` и `--source-password` и предназначен для использования с официальным registry Deckhouse.
@@ -482,9 +478,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Пример команды для загрузки образов из файла `/tmp/d8-images/d8.tar`:
 
    ```shell
-    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
-    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
-   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee"
+   DHCTL_CLI_MIRROR_USER="<USERNAME>" DHCTL_CLI_MIRROR_PASS="<PASSWORD>" dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee"
    ```
 
    > Обратите внимание, образы будут выгружены в registry по пути, указанному в параметре `--registry` (в примере - /deckhouse/ee).
@@ -505,7 +499,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. Запустите установщик Deckhouse версии 1.56.0 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.ru/deckhouse/ce/install:stable bash
+   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.ru/deckhouse/ce/install:alpha bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы модулей и YAML-манифест [ModuleSource](cr.html#modulesource), описывающий источник модулей.
@@ -534,9 +528,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Пример команды для загрузки образов из директории `/tmp/d8-modules`:
 
    ```shell
-    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
-    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
-   dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules"
+   DHCTL_CLI_MIRROR_USER="<USERNAME>" DHCTL_CLI_MIRROR_PASS="<PASSWORD>" dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules"
    ```
 
    > Обратите внимание, образы будут выгружены в registry по пути, указанному в параметре `--registry` (в примере - /deckhouse-modules).

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -420,7 +420,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. Запустите установщик Deckhouse версии 1.56.3 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.ru/deckhouse/ee/install:v1.56.3 bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.ru/deckhouse/ee/install:stable bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы Deckhouse.
@@ -432,7 +432,8 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Следующая команда скачает образы Deckhouse тех версий, которые находятся на каналах обновлений (о текущем статусе версий на каналах обновлений можно узнать на [flow.deckhouse.io](https://flow.deckhouse.io)):
 
    ```shell
-   dhctl mirror --license="<DECKHOUSE_LICENSE_KEY>" --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar
+    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
+   dhctl mirror --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > Если загрузка образов будет прервана, повторный вызов команды проверит загруженные образы и продолжит загрузку с момента ее остановки. Продолжение загрузки возможно только если с момента остановки прошло не более суток.
@@ -443,7 +444,8 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Например, для загрузки всех версий Deckhouse, начиная с версии 1.45, используйте команду:
 
    ```shell
-   dhctl mirror --license="<DECKHOUSE_LICENSE_KEY>" --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
+    export DHCTL_CLI_MIRROR_LICENSE="<DECKHOUSE_LICENSE_KEY>"
+   dhctl mirror --source="registry.deckhouse.ru/deckhouse/ee" --images-bundle-path /tmp/d8-images/d8.tar --min-version=1.45
    ```
 
    > Обратите внимание, параметр `--min-version` будет проигнорирован если вы укажете версию выше находящейся в канале обновлений rock-solid.
@@ -455,7 +457,9 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Например, вот как можно загрузить образы из стороннего registry:
 
    ```shell
-   dhctl mirror --source="corp.company.ru/sys/deckhouse" --source-login="user" --source-password="password" --images-bundle-path /tmp/d8-images/d8.tar
+    export DHCTL_CLI_MIRROR_SOURCE_LOGIN="user"
+    export DHCTL_CLI_MIRROR_SOURCE_PASSWORD="password"
+   dhctl mirror --source="corp.company.ru/sys/deckhouse" --images-bundle-path /tmp/d8-images/d8.tar
    ```
 
    > Параметр `--license` действует как сокращение для параметров `--source-login` и `--source-password` и предназначен для использования с официальным registry Deckhouse.
@@ -478,7 +482,9 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Пример команды для загрузки образов из файла `/tmp/d8-images/d8.tar`:
 
    ```shell
-   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee" --registry-login="<USERNAME>" --registry-password="<PASSWORD>"
+    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
+    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
+   dhctl mirror --images-bundle-path /tmp/d8-images/d8.tar --registry="your.private.registry.com:5000/deckhouse/ee"
    ```
 
    > Обратите внимание, образы будут выгружены в registry по пути, указанному в параметре `--registry` (в примере - /deckhouse/ee).
@@ -499,7 +505,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. Запустите установщик Deckhouse версии 1.56.0 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.ru/deckhouse/ce/install:v1.56.0 bash
+   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.ru/deckhouse/ce/install:stable bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы модулей и YAML-манифест [ModuleSource](cr.html#modulesource), описывающий источник модулей.
@@ -528,7 +534,9 @@ Deckhouse поддерживает работу только с Bearer token-с�
    Пример команды для загрузки образов из директории `/tmp/d8-modules`:
 
    ```shell
-   dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules" --registry-login="<USERNAME>" --registry-password="<PASSWORD>"
+    export DHCTL_CLI_MIRROR_USER="<USERNAME>"
+    export DHCTL_CLI_MIRROR_PASS="<PASSWORD>"
+   dhctl mirror-modules -d /tmp/d8-modules --registry="your.private.registry.com:5000/deckhouse-modules"
    ```
 
    > Обратите внимание, образы будут выгружены в registry по пути, указанному в параметре `--registry` (в примере - /deckhouse-modules).

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -420,7 +420,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. Запустите установщик Deckhouse версии 1.56.3 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.ru/deckhouse/ee/install:alpha bash
+   docker run -ti --pull=always -v $(pwd)/d8-images:/tmp/d8-images registry.deckhouse.ru/deckhouse/ee/install:v1.58.4 bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы Deckhouse.
@@ -499,7 +499,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
 1. Запустите установщик Deckhouse версии 1.56.0 или выше.
 
    ```shell
-   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.ru/deckhouse/ce/install:alpha bash
+   docker run -ti --pull=always -v $(HOME)/d8-modules:/tmp/d8-modules -v $(HOME)/module_source.yml:/tmp/module_source.yml registry.deckhouse.ru/deckhouse/ce/install:v1.58.4 bash
    ```
 
    Обратите внимание, что в контейнер установщика монтируется директория с файловой системы хоста, в которую будут загружены образы модулей и YAML-манифест [ModuleSource](cr.html#modulesource), описывающий источник модулей.


### PR DESCRIPTION
## Description
Move passwords to env for dhctl mirror examples.

## Why do we need it, and what problem does it solve?
The new variant uses passwords more securely and does not shine them in ps on the system where they are run.

## Why do we need it in the patch release (if we do)?

Optional.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Moved passwords to env for dhctl mirror examples.
impact_level: low
```
