### PR TITLE
Fix taking a crd that is not yet installed

### DIFF
--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix-on-startup-webhook-handler-fail-2"}}
+{{- $shellOperatorVersion := "fix-on-startup-webhook-handler"}}
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix-on-startup-webhook-handler-fail"}}
+{{- $shellOperatorVersion := "fix-on-startup-webhook-handler-fail-2"}}
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "v1.4.5"}}
+{{- $shellOperatorVersion := "fix-on-startup-webhook-handler-fail"}}
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}
@@ -50,7 +50,7 @@ shell:
     - make install-libLTLIBRARIES install-includeHEADERS
     - cp -f modules/oniguruma/src/.libs/libonig.* /libjq/lib
     - cd /
-    - git clone --branch {{ $shellOperatorVersion }} --depth 1 {{ .SOURCE_REPO }}/flant/shell-operator.git
+    - git clone --branch {{ $shellOperatorVersion }} --depth 1 https://github.com/flant/shell-operator.git
     - cd /shell-operator
     - go mod tidy
     - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '{{ .SOURCE_REPO }}/flant/shell-operator/pkg/app.Version=latest'" -tags use_libjq -o shell-operator ./cmd/shell-operator

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix-on-startup-webhook-handler"}}
+{{- $shellOperatorVersion := "v1.4.6"}}
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}
@@ -50,7 +50,7 @@ shell:
     - make install-libLTLIBRARIES install-includeHEADERS
     - cp -f modules/oniguruma/src/.libs/libonig.* /libjq/lib
     - cd /
-    - git clone --branch {{ $shellOperatorVersion }} --depth 1 https://github.com/flant/shell-operator.git
+    - git clone --branch {{ $shellOperatorVersion }} --depth 1 {{ .SOURCE_REPO }}/flant/shell-operator.git
     - cd /shell-operator
     - go mod tidy
     - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '{{ .SOURCE_REPO }}/flant/shell-operator/pkg/app.Version=latest'" -tags use_libjq -o shell-operator ./cmd/shell-operator

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -1,5 +1,5 @@
 ---
-title: "The deckhouse module: FAQqw"
+title: "The deckhouse module: FAQ"
 ---
 
 ## How to run kube-bench in my cluster?

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -1,5 +1,5 @@
 ---
-title: "The deckhouse module: FAQ"
+title: "The deckhouse module: FAQqw"
 ---
 
 ## How to run kube-bench in my cluster?


### PR DESCRIPTION
## Description

Added repeated queries to get crd and apply conversation strategies.

![screen](https://github.com/deckhouse/deckhouse/assets/52157046/0de94dee-fb9a-4c15-9b43-3e1de60c48c4)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

The processing of conversation strategies occurs at the start of deckhouse and when a particular module is enabled.
In this case, processing may be started before crd is installed. This situation leads to an error.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

The problem described above occurs in the 1.58 update and users may encounter it.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

A good example to check is the multitenancy module.
It is necessary to turn off the module. Then remove the crd of this module such as (projects.deckhouse.io, projecttemplates.deckhouse.io) and enable the module again. The first attempt to apply conversation strategies will fail, but after a few attempts it will succeed.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: shell-operator
type: fix
summary: Repeat queries to get CRD and apply conversation strategies.
impact: Prevents a critical error from occurring in the cluster when starting or turning on modules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
