### PR TITLE
[dhctl] fix(dhctl-for-commander): working abandoned nodes converge case with destructive change approval; rework check+converge tf state loading

### DIFF
--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	state_terraform "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 
@@ -71,7 +72,7 @@ func DefineTerraformCheckCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		metaConfig.UUID, err = converge.GetClusterUUID(kubeCl)
+		metaConfig.UUID, err = state_terraform.GetClusterUUID(kubeCl)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -422,7 +422,7 @@ func (m *MetaConfig) CachePath() string {
 }
 
 func (m *MetaConfig) DeepCopy() *MetaConfig {
-	out := MetaConfig{}
+	out := &MetaConfig{}
 
 	if m.ClusterConfig != nil {
 		config := make(map[string]json.RawMessage, len(m.ClusterConfig))
@@ -482,7 +482,7 @@ func (m *MetaConfig) DeepCopy() *MetaConfig {
 		out.UUID = m.UUID
 	}
 
-	return m
+	return out
 }
 
 func (m *MetaConfig) LoadVersionMap(filename string) error {

--- a/dhctl/pkg/infrastructure/cluster.go
+++ b/dhctl/pkg/infrastructure/cluster.go
@@ -16,7 +16,6 @@ package infrastructure
 
 import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
@@ -24,7 +23,7 @@ import (
 
 type StateLoader interface {
 	PopulateMetaConfig() (*config.MetaConfig, error)
-	PopulateClusterState() ([]byte, map[string]converge.NodeGroupTerraformState, error)
+	PopulateClusterState() ([]byte, map[string]state.NodeGroupTerraformState, error)
 }
 
 type NodeGroupController interface {

--- a/dhctl/pkg/kubernetes/actions/converge/commander.go
+++ b/dhctl/pkg/kubernetes/actions/converge/commander.go
@@ -1,0 +1,34 @@
+package converge
+
+import (
+	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	dhctlstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
+	state_terraform "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
+)
+
+func LoadNodesStateForCommanderMode(stateCache dhctlstate.Cache, metaConfig *config.MetaConfig, kubeCl *client.KubernetesClient) (map[string]dhctlstate.NodeGroupTerraformState, error) {
+	stateLoader := state_terraform.NewFileTerraStateLoader(stateCache, metaConfig)
+	_, nodesState, err := stateLoader.PopulateClusterState()
+	if err != nil {
+		return nil, fmt.Errorf("state loader from cache failed: %w", err)
+	}
+
+	// NOTE(dhctl-for-commander): This Settings initialization needed for compatibility.
+	// NOTE(dhctl-for-commander): If nodesState from local cache does not contain previous node-group-settings, then use settings from the cluster.
+	// NOTE(dhctl-for-commander): In future versions nodesState loading from target kubernetes cluster for commander mode will be removed.
+	inClusterNodesState, err := state_terraform.GetNodesStateFromCluster(kubeCl)
+	if err != nil {
+		return nil, fmt.Errorf("state loader from kubernetes failed: %w", err)
+	}
+	for nodeName, state := range nodesState {
+		if state.Settings == nil {
+			newState := state
+			newState.Settings = inClusterNodesState[nodeName].Settings
+			nodesState[nodeName] = newState
+		}
+	}
+
+	return nodesState, nil
+}

--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -21,19 +21,20 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/hook/controlplane"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	dstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
+	state_terraform "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
@@ -198,13 +199,22 @@ func (r *Runner) converge() error {
 			}
 		}
 
-		var nodesState map[string]NodeGroupTerraformState
-
+		var nodesState map[string]state.NodeGroupTerraformState
 		err = log.Process("converge", "Gather Nodes Terraform state", func() error {
-			nodesState, err = GetNodesStateFromCluster(r.kubeCl)
-			if err != nil {
-				return fmt.Errorf("terraform nodes state in Kubernetes cluster not found: %w", err)
+			// NOTE: Nodes state loaded from target kubernetes cluster in default dhctl-converge.
+			// NOTE: In the commander mode nodes state should exist in the local state cache.
+			if r.commanderMode {
+				nodesState, err = LoadNodesStateForCommanderMode(r.stateCache, metaConfig, r.kubeCl)
+				if err != nil {
+					return fmt.Errorf("unable to load nodes state: %w", err)
+				}
+			} else {
+				nodesState, err = state_terraform.GetNodesStateFromCluster(r.kubeCl)
+				if err != nil {
+					return fmt.Errorf("terraform nodes state in Kubernetes cluster not found: %w", err)
+				}
 			}
+
 			return nil
 		})
 		if err != nil {
@@ -294,19 +304,25 @@ func (r *Runner) converge() error {
 
 func (r *Runner) updateClusterState(metaConfig *config.MetaConfig) error {
 	return log.Process("converge", "Update Cluster Terraform state", func() error {
-		clusterState, err := GetClusterStateFromCluster(r.kubeCl)
-		if err != nil {
-			return fmt.Errorf("terraform cluster state in Kubernetes cluster not found: %w", err)
+		var clusterState []byte
+		var err error
+		// NOTE: Cluster state loaded from target kubernetes cluster in default dhctl-converge.
+		// NOTE: In the commander mode cluster state should exist in the local state cache.
+		if !r.commanderMode {
+			clusterState, err = state_terraform.GetClusterStateFromCluster(r.kubeCl)
+			if err != nil {
+				return fmt.Errorf("terraform cluster state in Kubernetes cluster not found: %w", err)
+			}
+			if clusterState == nil {
+				return fmt.Errorf("kubernetes cluster has no state")
+			}
 		}
 
-		if clusterState == nil {
-			return fmt.Errorf("kubernetes cluster has no state")
-		}
-
-		baseRunner := r.terraformContext.GetConvergeBaseInfraRunner(metaConfig, r.stateCache, terraform.ConvergeBaseInfraRunnerOptions{
+		baseRunner := r.terraformContext.GetConvergeBaseInfraRunner(metaConfig, terraform.BaseInfraRunnerOptions{
 			AutoDismissDestructive:           r.changeSettings.AutoDismissDestructive,
 			AutoApprove:                      r.changeSettings.AutoApprove,
 			CommanderMode:                    r.commanderMode,
+			StateCache:                       r.stateCache,
 			ClusterState:                     clusterState,
 			AdditionalStateSaverDestinations: []terraform.SaverDestination{NewClusterStateSaver(r.kubeCl)},
 		})
@@ -358,7 +374,7 @@ type NodeGroupController struct {
 
 	nodeToHost map[string]string
 	name       string
-	state      NodeGroupTerraformState
+	state      state.NodeGroupTerraformState
 
 	commanderMode    bool
 	terraformContext *terraform.TerraformContext
@@ -376,7 +392,7 @@ func (n *NodeGroupGroupOptions) CurReplicas() int {
 	return len(n.State)
 }
 
-func NewConvergeController(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, name string, state NodeGroupTerraformState, stateCache dstate.Cache, terraformContext *terraform.TerraformContext) *NodeGroupController {
+func NewConvergeController(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, name string, state state.NodeGroupTerraformState, stateCache dstate.Cache, terraformContext *terraform.TerraformContext) *NodeGroupController {
 	return &NodeGroupController{
 		client:           kubeCl,
 		config:           metaConfig,
@@ -561,7 +577,12 @@ func (c *NodeGroupController) updateNode(nodeGroup *NodeGroupGroupOptions, nodeN
 		return nil
 	}
 
-	state := nodeGroup.State[nodeName]
+	// NOTE: In the commander mode nodes state should exist in the local state cache, no need to pass state explicitly.
+	var nodeState []byte
+	if !c.commanderMode {
+		nodeState = nodeGroup.State[nodeName]
+	}
+
 	nodeIndex, err := config.GetIndexFromNodeName(nodeName)
 	if err != nil {
 		log.ErrorF("can't extract index from terraform state secret (%v), skip %s\n", err, nodeName)
@@ -583,16 +604,17 @@ func (c *NodeGroupController) updateNode(nodeGroup *NodeGroupGroupOptions, nodeN
 		nodeGroupSettingsFromConfig = c.config.FindTerraNodeGroup(nodeGroup.Name)
 	}
 
-	nodeRunner := c.terraformContext.GetConvergeNodeRunner(c.config, c.stateCache, terraform.ConvergeNodeRunnerOptions{
+	nodeRunner := c.terraformContext.GetConvergeNodeRunner(c.config, terraform.NodeRunnerOptions{
 		AutoDismissDestructive: c.changeSettings.AutoDismissDestructive,
 		AutoApprove:            c.changeSettings.AutoApprove,
 		NodeName:               nodeName,
-		NodeGroupName:          nodeGroup.Name, // FIXME(dhctl-for-commander): nodeGroupName != nodeGroup.Name, which of these should be used?
+		NodeGroupName:          nodeGroup.Name,
 		NodeGroupStep:          nodeGroup.Step,
 		NodeIndex:              nodeIndex,
-		NodeState:              state,
+		NodeState:              nodeState,
 		NodeCloudConfig:        nodeGroup.CloudConfig,
 		CommanderMode:          c.commanderMode,
+		StateCache:             c.stateCache,
 		AdditionalStateSaverDestinations: []terraform.SaverDestination{
 			NewNodeStateSaver(c.client, nodeName, nodeGroupName, nodeGroupSettingsFromConfig),
 		},
@@ -656,16 +678,23 @@ func (c *NodeGroupController) deleteRedundantNodes(nodeGroup *NodeGroupGroupOpti
 			return nil
 		}
 
-		nodeRunner := c.terraformContext.GetConvergeNodeDeleteRunner(c.config, c.stateCache, terraform.ConvergeNodeDeleteRunnerOptions{
+		// NOTE: In the commander mode nodes state should exist in the local state cache, no need to pass state explicitly.
+		var nodeState []byte
+		if !c.commanderMode {
+			nodeState = state
+		}
+
+		nodeRunner := c.terraformContext.GetConvergeNodeDeleteRunner(cfg, terraform.NodeDeleteRunnerOptions{
 			AutoDismissDestructive: c.changeSettings.AutoDismissDestructive,
 			AutoApprove:            c.changeSettings.AutoApprove,
 			NodeName:               name,
 			NodeGroupName:          nodeGroup.Name,
 			NodeGroupStep:          nodeGroup.Step,
 			NodeIndex:              nodeIndex,
-			NodeState:              state,
+			NodeState:              nodeState,
 			NodeCloudConfig:        nodeGroup.CloudConfig,
 			CommanderMode:          c.commanderMode,
+			StateCache:             c.stateCache,
 			AdditionalStateSaverDestinations: []terraform.SaverDestination{
 				NewNodeStateSaver(c.client, name, nodeGroup.Name, nil),
 			},
@@ -683,6 +712,11 @@ func (c *NodeGroupController) deleteRedundantNodes(nodeGroup *NodeGroupGroupOpti
 
 		if err := DeleteNode(c.client, name); err != nil {
 			allErrs = multierror.Append(allErrs, fmt.Errorf("%s: %w", name, err))
+			continue
+		}
+
+		if err := state_terraform.DeleteNodeTerraformStateFromCache(name, c.stateCache); err != nil {
+			allErrs = multierror.Append(allErrs, fmt.Errorf("unable to delete node %s terraform state from cache: %w", name, err))
 			continue
 		}
 
@@ -864,7 +898,7 @@ func GetMetaConfig(kubeCl *client.KubernetesClient) (*config.MetaConfig, error) 
 		return nil, err
 	}
 
-	metaConfig.UUID, err = GetClusterUUID(kubeCl)
+	metaConfig.UUID, err = state_terraform.GetClusterUUID(kubeCl)
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/kubernetes/actions/converge/nodegroup.go
+++ b/dhctl/pkg/kubernetes/actions/converge/nodegroup.go
@@ -14,7 +14,10 @@
 
 package converge
 
-import "github.com/deckhouse/deckhouse/dhctl/pkg/config"
+import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+)
 
 func getReplicasByNodeGroupName(metaConfig *config.MetaConfig, nodeGroupName string) int {
 	replicas := 0
@@ -39,7 +42,7 @@ func getStepByNodeGroupName(nodeGroupName string) string {
 	return step
 }
 
-func sortNodeGroupsStateKeys(state map[string]NodeGroupTerraformState, sortedNodeGroupsFromConfig []string) []string {
+func sortNodeGroupsStateKeys(state map[string]state.NodeGroupTerraformState, sortedNodeGroupsFromConfig []string) []string {
 	nodeGroupsFromConfigSet := make(map[string]struct{}, len(sortedNodeGroupsFromConfig))
 	for _, key := range sortedNodeGroupsFromConfig {
 		nodeGroupsFromConfigSet[key] = struct{}{}

--- a/dhctl/pkg/operations/commander/meta_config.go
+++ b/dhctl/pkg/operations/commander/meta_config.go
@@ -16,7 +16,6 @@ package commander
 
 import (
 	"fmt"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 )

--- a/dhctl/pkg/operations/exporter.go
+++ b/dhctl/pkg/operations/exporter.go
@@ -15,6 +15,7 @@
 package operations
 
 import (
+	state_terraform "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"net/http"
 	"os"
@@ -222,7 +223,7 @@ func (c *ConvergeExporter) getStatistic() *converge.Statistics {
 		return nil
 	}
 
-	metaConfig.UUID, err = converge.GetClusterUUID(c.kubeCl)
+	metaConfig.UUID, err = state_terraform.GetClusterUUID(c.kubeCl)
 	if err != nil {
 		log.ErrorLn(err)
 		c.CounterMetrics["errors"].WithLabelValues().Inc()

--- a/dhctl/pkg/state/state.go
+++ b/dhctl/pkg/state/state.go
@@ -1,0 +1,6 @@
+package state
+
+type NodeGroupTerraformState struct {
+	State    map[string][]byte
+	Settings []byte
+}

--- a/dhctl/pkg/state/terraform/cluster_cached.go
+++ b/dhctl/pkg/state/terraform/cluster_cached.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
@@ -70,7 +69,7 @@ func (s *KubeTerraStateLoader) PopulateMetaConfig() (*config.MetaConfig, error) 
 		return nil, err
 	}
 
-	metaConfig.UUID, err = converge.GetClusterUUID(kubeCl)
+	metaConfig.UUID, err = GetClusterUUID(kubeCl)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +81,7 @@ func (s *KubeTerraStateLoader) PopulateMetaConfig() (*config.MetaConfig, error) 
 	return metaConfig, nil
 }
 
-func (s *KubeTerraStateLoader) PopulateClusterState() ([]byte, map[string]converge.NodeGroupTerraformState, error) {
+func (s *KubeTerraStateLoader) PopulateClusterState() ([]byte, map[string]state.NodeGroupTerraformState, error) {
 	clusterState, err := s.getClusterState()
 	if err != nil {
 		return nil, nil, err
@@ -96,10 +95,10 @@ func (s *KubeTerraStateLoader) PopulateClusterState() ([]byte, map[string]conver
 	return clusterState, nodesState, nil
 }
 
-func (s *KubeTerraStateLoader) getNodesState() (map[string]converge.NodeGroupTerraformState, error) {
+func (s *KubeTerraStateLoader) getNodesState() (map[string]state.NodeGroupTerraformState, error) {
 	var err error
 	var kubeCl *client.KubernetesClient
-	var nodesState map[string]converge.NodeGroupTerraformState
+	var nodesState map[string]state.NodeGroupTerraformState
 
 	confirmation := input.NewConfirmation().
 		WithMessage("Do you want to continue with Nodes state from local cache?").
@@ -118,7 +117,7 @@ func (s *KubeTerraStateLoader) getNodesState() (map[string]converge.NodeGroupTer
 		if kubeCl, err = s.kubeGetter.GetKubeClient(); err != nil {
 			return nil, err
 		}
-		nodesState, err = converge.GetNodesStateFromCluster(kubeCl)
+		nodesState, err = GetNodesStateFromCluster(kubeCl)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +153,7 @@ func (s *KubeTerraStateLoader) getClusterState() ([]byte, error) {
 		if kubeCl, err = s.kubeGetter.GetKubeClient(); err != nil {
 			return nil, err
 		}
-		clusterState, err = converge.GetClusterStateFromCluster(kubeCl)
+		clusterState, err = GetClusterStateFromCluster(kubeCl)
 		if err != nil {
 			return nil, err
 		}

--- a/dhctl/pkg/state/terraform/lazy.go
+++ b/dhctl/pkg/state/terraform/lazy.go
@@ -15,15 +15,15 @@
 package terraform
 
 import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"sync"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
 )
 
 type StateLoader interface {
 	PopulateMetaConfig() (*config.MetaConfig, error)
-	PopulateClusterState() ([]byte, map[string]converge.NodeGroupTerraformState, error)
+	PopulateClusterState() ([]byte, map[string]state.NodeGroupTerraformState, error)
 }
 
 type LazyTerraStateLoader struct {
@@ -31,7 +31,7 @@ type LazyTerraStateLoader struct {
 
 	lock            sync.Mutex
 	clusterState    []byte
-	nodesTerraState map[string]converge.NodeGroupTerraformState
+	nodesTerraState map[string]state.NodeGroupTerraformState
 	metaConfig      *config.MetaConfig
 }
 
@@ -57,7 +57,7 @@ func (l *LazyTerraStateLoader) PopulateMetaConfig() (*config.MetaConfig, error) 
 	return l.metaConfig, nil
 }
 
-func (l *LazyTerraStateLoader) PopulateClusterState() ([]byte, map[string]converge.NodeGroupTerraformState, error) {
+func (l *LazyTerraStateLoader) PopulateClusterState() ([]byte, map[string]state.NodeGroupTerraformState, error) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 

--- a/dhctl/pkg/state/terraform/state.go
+++ b/dhctl/pkg/state/terraform/state.go
@@ -1,0 +1,84 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+	"time"
+
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+)
+
+func GetClusterStateFromCluster(kubeCl *client.KubernetesClient) ([]byte, error) {
+	var state []byte
+	err := retry.NewLoop("Get Cluster Terraform state from Kubernetes cluster", 5, 5*time.Second).Run(func() error {
+		clusterStateSecret, err := kubeCl.CoreV1().Secrets("d8-system").Get(context.TODO(), "d8-cluster-terraform-state", metav1.GetOptions{})
+		if err != nil {
+			if k8errors.IsNotFound(err) {
+				// Return empty state, if there is no state in cluster. Need to skip cluster state apply in converge.
+				return nil
+			}
+			return err
+		}
+
+		state = clusterStateSecret.Data["cluster-tf-state.json"]
+		return nil
+	})
+	return state, err
+}
+
+func GetClusterUUID(kubeCl *client.KubernetesClient) (string, error) {
+	var clusterUUID string
+	err := retry.NewLoop("Get Cluster UUID from the Kubernetes cluster", 5, 5*time.Second).Run(func() error {
+		uuidConfigMap, err := kubeCl.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "d8-cluster-uuid", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		clusterUUID = uuidConfigMap.Data["cluster-uuid"]
+		return nil
+	})
+	return clusterUUID, err
+}
+
+func GetNodesStateFromCluster(kubeCl *client.KubernetesClient) (map[string]state.NodeGroupTerraformState, error) {
+	extractedState := make(map[string]state.NodeGroupTerraformState)
+
+	err := retry.NewLoop("Get Nodes Terraform state from Kubernetes cluster", 5, 5*time.Second).Run(func() error {
+		nodeStateSecrets, err := kubeCl.CoreV1().Secrets("d8-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "node.deckhouse.io/terraform-state"})
+		if err != nil {
+			return err
+		}
+
+		for _, nodeState := range nodeStateSecrets.Items {
+			name := nodeState.Labels["node.deckhouse.io/node-name"]
+			if name == "" {
+				return fmt.Errorf("can't determine Node name for %q secret", nodeState.Name)
+			}
+
+			nodeGroup := nodeState.Labels["node.deckhouse.io/node-group"]
+			if nodeGroup == "" {
+				return fmt.Errorf("can't determine NodeGroup for %q secret", nodeState.Name)
+			}
+
+			if _, ok := extractedState[nodeGroup]; !ok {
+				extractedState[nodeGroup] = state.NodeGroupTerraformState{State: make(map[string][]byte)}
+			}
+
+			// TODO: validate, that all secrets from node group have same node-group-settings.json
+			nodeGroupTerraformState := extractedState[nodeGroup]
+			nodeGroupTerraformState.Settings = nodeState.Data["node-group-settings.json"]
+
+			state := nodeState.Data["node-tf-state.json"]
+			nodeGroupTerraformState.State[name] = state
+
+			extractedState[nodeGroup] = nodeGroupTerraformState
+		}
+		return nil
+	})
+	return extractedState, err
+}

--- a/dhctl/pkg/terraform/pipeline.go
+++ b/dhctl/pkg/terraform/pipeline.go
@@ -57,7 +57,7 @@ func ApplyPipeline(r RunnerInterface, name string, extractFn func(r RunnerInterf
 			return err
 		}
 
-		err = r.Plan()
+		err = r.Plan(PlanOptions{})
 		if err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func ApplyPipeline(r RunnerInterface, name string, extractFn func(r RunnerInterf
 	return extractedData, err
 }
 
-func CheckPipeline(r RunnerInterface, name string) (int, TerraformPlan, *PlanDestructiveChanges, error) {
+func CheckPipeline(r RunnerInterface, name string, opts PlanOptions) (int, TerraformPlan, *PlanDestructiveChanges, error) {
 	isChange := PlanHasNoChanges
 	var destructiveChanges *PlanDestructiveChanges
 	var terraformPlan map[string]any
@@ -88,7 +88,7 @@ func CheckPipeline(r RunnerInterface, name string) (int, TerraformPlan, *PlanDes
 			return err
 		}
 
-		err = r.Plan()
+		err = r.Plan(opts)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func CheckBaseInfrastructurePipeline(r RunnerInterface, name string) (int, Terra
 			return err
 		}
 
-		err = r.Plan()
+		err = r.Plan(PlanOptions{})
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/terraform/runner.go
+++ b/dhctl/pkg/terraform/runner.go
@@ -423,7 +423,7 @@ func (r *Runner) Apply() error {
 	})
 }
 
-func (r *Runner) Plan() error {
+func (r *Runner) Plan(opts PlanOptions) error {
 	if r.stopped {
 		return ErrRunnerStopped
 	}
@@ -444,6 +444,9 @@ func (r *Runner) Plan() error {
 			fmt.Sprintf("-out=%s", tmpFile.Name()),
 		}
 
+		if opts.Destroy {
+			args = append(args, "-destroy")
+		}
 		args = append(args, r.workingDir)
 
 		exitCode, err := r.execTerraform(args...)

--- a/dhctl/pkg/terraform/runner_interface.go
+++ b/dhctl/pkg/terraform/runner_interface.go
@@ -14,10 +14,14 @@
 
 package terraform
 
+type PlanOptions struct {
+	Destroy bool
+}
+
 type RunnerInterface interface {
 	Init() error
 	Apply() error
-	Plan() error
+	Plan(opts PlanOptions) error
 	Destroy() error
 	Stop()
 

--- a/dhctl/pkg/terraform/single_shot_runner.go
+++ b/dhctl/pkg/terraform/single_shot_runner.go
@@ -42,9 +42,9 @@ func (r *SingleShotRunner) Apply() (err error) {
 	return
 }
 
-func (r *SingleShotRunner) Plan() (err error) {
+func (r *SingleShotRunner) Plan(opts PlanOptions) (err error) {
 	r.plan.Do(func() {
-		err = r.Runner.Plan()
+		err = r.Runner.Plan(opts)
 	})
 	return
 }


### PR DESCRIPTION
## Description

* generate abandoned node terraform plan correctlly for check & converge;
* load state for check and converge using dhctl state given from parameters in commander mode, instead of using in-cluster state;
* fix panic due to typo in the Config::DeepCopy method.

