### PR TITLE
[dhctl] fix(dhctl): meta config deep copy method does not return copy

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -422,7 +422,7 @@ func (m *MetaConfig) CachePath() string {
 }
 
 func (m *MetaConfig) DeepCopy() *MetaConfig {
-	out := MetaConfig{}
+	out := &MetaConfig{}
 
 	if m.ClusterConfig != nil {
 		config := make(map[string]json.RawMessage, len(m.ClusterConfig))
@@ -482,7 +482,7 @@ func (m *MetaConfig) DeepCopy() *MetaConfig {
 		out.UUID = m.UUID
 	}
 
-	return m
+	return out
 }
 
 func (m *MetaConfig) LoadVersionMap(filename string) error {


### PR DESCRIPTION
## Description

This PR fixes MetaConfig::DeepCopy method, which should create a copy object and return it.
There is a typo: deep copy never creates a copy, it returns old object itself.

## Why do we need it, and what problem does it solve?

As a side effect of non-copy behavior we've experienced a panic in the converge op when scaling down some node-group, panic occured after abandoned nodes deletion.
