### PR TITLE
Fix error on empty cluster-configuration.yaml config

### DIFF
--- a/modules/340-monitoring-kubernetes/hooks/auto_k8s_version.go
+++ b/modules/340-monitoring-kubernetes/hooks/auto_k8s_version.go
@@ -19,7 +19,6 @@ package hooks
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -95,11 +94,7 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 
 func clusterConfiguration(input *go_hook.HookInput, dc dependency.Container) error {
 	kubernetesVersion, ok := input.Snapshots["kubernetesVersion"]
-	if !ok || len(kubernetesVersion) == 0 {
-		return errors.New("cluster configuration kubernetesVersion is empty or invalid")
-	}
-
-	if kubernetesVersion[0].(string) == "Automatic" {
+	if ok && len(kubernetesVersion) > 0 && kubernetesVersion[0].(string) == "Automatic" {
 		var (
 			unsupportVersion k8sUnsupportedVersion
 			wg               sync.WaitGroup

--- a/modules/340-monitoring-kubernetes/hooks/auto_k8s_version_test.go
+++ b/modules/340-monitoring-kubernetes/hooks/auto_k8s_version_test.go
@@ -145,30 +145,11 @@ data:
 		Context("check for empty \"ClusterConfiguration\"", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.KubeStateSet(""))
-				var sec corev1.Secret
-				_ = yaml.Unmarshal([]byte(helm3ReleaseWithDeprecated), &sec)
-
-				_, err := dependency.TestDC.MustGetK8sClient().
-					CoreV1().
-					Secrets("appns").
-					Create(context.TODO(), &sec, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
 				f.RunGoHook()
 			})
 
-			It("must return error", func() {
-				Expect(f.GoHookError).To(MatchError("cluster configuration kubernetesVersion is empty or invalid"))
-
-				var k8sVersion string
-				if val, exists := requirements.GetValue(AutoK8sVersion); exists {
-					k8sVersion = fmt.Sprintf("%v", val)
-				}
-				var reasons []string
-				if val, exists := requirements.GetValue(AutoK8sReason); exists {
-					reasons = strings.Split(fmt.Sprintf("%v", val), ", ")
-				}
-				Expect(k8sVersion).To(BeEmpty())
-				Expect(reasons).To(BeEmpty())
+			It("must execute successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
 			})
 		})
 	})


### PR DESCRIPTION
## Description

Skip error when "d8-cluster-configuration" secret is missing.
In the case of a managed cluster, this is a perfectly acceptable situation.
```
[error][monitoring-kubernetes] - Module hook failed, requeue task to retry after delay. Failed count is 71. Error: module hook '340-monitoring-kubernetes/hooks/auto_k8s_version.go' failed: cluster configuration kubernetesVersion is empty or invalid
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix error when `d8-cluster-configuration` secret is missing.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
