### PR TITLE
[multitenancy-manager] Fix Project templates rendering

### DIFF
--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -233,6 +233,7 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 
 		if un.GetAPIVersion() != "v1" || un.GetKind() != "Namespace" {
 			data, _ := yaml.Marshal(un.Object)
+			fmt.Println("NON NS\n" + manifest + "\n-=-=-==--==-\n" + string(data))
 			builder.WriteString("\n---\n" + string(data))
 			continue
 		}

--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -8,7 +8,6 @@ package hooks
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -271,8 +270,6 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 	result.WriteString(builder.String())
 
 	ptr.logger.Debugf("Rendered project %q: \n%s", ptr.projectName, result.String())
-
-	fmt.Println("RENDER PROJECT\n" + result.String())
 
 	return result, nil
 }

--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -13,10 +13,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/flant/addon-operator/pkg/utils/logger"
-
 	"github.com/fatih/structs"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/utils/logger"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"helm.sh/helm/v3/pkg/releaseutil"

--- a/ee/modules/160-multitenancy-manager/hooks/project.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project.go
@@ -8,6 +8,7 @@ package hooks
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -258,6 +259,8 @@ func (ptr *projectTemplateHelmRenderer) Run(renderedManifests *bytes.Buffer) (mo
 	}
 
 	result.WriteString(builder.String())
+
+	fmt.Println("RENDER PROJECT\n" + result.String())
 
 	return result, nil
 }

--- a/ee/modules/160-multitenancy-manager/hooks/project_test.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project_test.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/flant/addon-operator/sdk"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -458,7 +460,7 @@ spec:
 `
 
 func TestPostRenderer(t *testing.T) {
-	pr := new(projectTemplateHelmRenderer)
+	pr := &projectTemplateHelmRenderer{logger: logrus.New()}
 	pr.SetProject("test-project-1")
 	buf := bytes.NewBuffer(nil)
 

--- a/ee/modules/160-multitenancy-manager/hooks/project_test.go
+++ b/ee/modules/160-multitenancy-manager/hooks/project_test.go
@@ -9,11 +9,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/flant/addon-operator/sdk"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
@@ -147,10 +147,10 @@ spec:
         {{ with .parameters.resourceQuota.requests.storage }}requests.storage: {{ . }}{{ end }}
         {{ with .parameters.resourceQuota.limits.cpu }}limits.cpu: {{ . }}{{ end }}
         {{ with .parameters.resourceQuota.limits.memory }}limits.memory: {{ . }}{{ end }}
+    {{- if eq .parameters.networkPolicy "Isolated" }}
     ---
     # Deny all network traffic by default except namespaced traffic and dns.
     # Refer to https://kubernetes.io/docs/concepts/services-networking/network-policies/
-    {{- if eq .parameters.networkPolicy "Isolated" }}
     kind: NetworkPolicy
     apiVersion: networking.k8s.io/v1
     metadata:
@@ -196,9 +196,9 @@ spec:
             - protocol: UDP
               port: 53
     {{- end }}
+    {{- with .parameters.clusterLogDestinationName }}
     ---
     # Refer to https://deckhouse.io/documentation/v1/modules/460-log-shipper/
-    {{- with .parameters.clusterLogDestinationName }}
     apiVersion: deckhouse.io/v1alpha1
     kind: PodLoggingConfig
     metadata:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
@@ -184,10 +184,10 @@ spec:
         {{ with .parameters.resourceQuota.requests.storage }}requests.storage: {{ . }}{{ end }}
         {{ with .parameters.resourceQuota.limits.cpu }}limits.cpu: {{ . }}{{ end }}
         {{ with .parameters.resourceQuota.limits.memory }}limits.memory: {{ . }}{{ end }}
+    {{- if eq .parameters.networkPolicy "Isolated" }}
     ---
     # Deny all network traffic by default except namespaced traffic and dns.
     # Refer to https://kubernetes.io/docs/concepts/services-networking/network-policies/
-    {{- if eq .parameters.networkPolicy "Isolated" }}
     kind: NetworkPolicy
     apiVersion: networking.k8s.io/v1
     metadata:
@@ -233,9 +233,9 @@ spec:
             - protocol: UDP
               port: 53
     {{- end }}
+    {{- with .parameters.clusterLogDestinationName }}
     ---
     # Refer to https://deckhouse.io/documentation/v1/modules/460-log-shipper/
-    {{- with .parameters.clusterLogDestinationName }}
     apiVersion: deckhouse.io/v1alpha1
     kind: PodLoggingConfig
     metadata:
@@ -261,12 +261,12 @@ spec:
           labelSelector:
             matchLabels:
               kubernetes.io/metadata.name: "{{ .projectName }}"
+    {{- if .parameters.runtimeAuditEnabled }}
+    {{- if or .parameters.allowedUIDs .parameters.allowedGIDs }}
     ---
     # Enable audit rules (create a falco audit rule to record some malicious activities of the pods in a given namespace).
     # As example send notifications when a shell is run in a container.
     # Refer to https://deckhouse.io/documentation/v1/modules/650-runtime-audit-engine/examples.html
-    {{- if .parameters.runtimeAuditEnabled }}
-    {{- if or .parameters.allowedUIDs .parameters.allowedGIDs }}
     apiVersion: deckhouse.io/v1alpha1
     kind: FalcoAuditRules
     metadata:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
@@ -278,10 +278,10 @@ spec:
         {{ with .parameters.resourceQuota.requests.storage }}requests.storage: {{ . }}{{ end }}
         {{ with .parameters.resourceQuota.limits.cpu }}limits.cpu: {{ . }}{{ end }}
         {{ with .parameters.resourceQuota.limits.memory }}limits.memory: {{ . }}{{ end }}
+    {{- if eq .parameters.networkPolicy "Isolated" }}
     ---
     # Deny all network traffic by default except namespaced traffic and dns.
     # Refer to https://kubernetes.io/docs/concepts/services-networking/network-policies/
-    {{- if eq .parameters.networkPolicy "Isolated" }}
     kind: NetworkPolicy
     apiVersion: networking.k8s.io/v1
     metadata:
@@ -327,9 +327,9 @@ spec:
             - protocol: UDP
               port: 53
     {{- end }}
+    {{- with .parameters.clusterLogDestinationName }}
     ---
     # Refer to https://deckhouse.io/documentation/v1/modules/460-log-shipper/
-    {{- with .parameters.clusterLogDestinationName }}
     apiVersion: deckhouse.io/v1alpha1
     kind: PodLoggingConfig
     metadata:
@@ -355,12 +355,12 @@ spec:
           labelSelector:
             matchLabels:
               kubernetes.io/metadata.name: "{{ .projectName }}"
+    {{- if .parameters.runtimeAuditEnabled }}
+    {{- if or .parameters.allowedUIDs .parameters.allowedGIDs }}
     ---
     # Enable audit rules (create a falco audit rule to record some malicious activities of the pods in a given namespace).
     # As example send notifications when a shell is run in a container.
     # Refer to https://deckhouse.io/documentation/v1/modules/650-runtime-audit-engine/examples.html
-    {{- if .parameters.runtimeAuditEnabled }}
-    {{- if or .parameters.allowedUIDs .parameters.allowedGIDs }}
     apiVersion: deckhouse.io/v1alpha1
     kind: FalcoAuditRules
     metadata:


### PR DESCRIPTION
## Description
A few fixes:
- remove empty manifests generation for embedded templates
- add empty manifests handler for PostRenderer (skip garbage generation)
- add logger for PostRenderer

## Why do we need it, and what problem does it solve?
In some cases embedded templates can generate empty manifests which would create invalid resources in the post renderer. We can avoid this behavior.
Also, add a logger to print generated manifests in the Debug deckhouse mode

## Why do we need it in the patch release (if we do)?
We can't create some projects without this fix

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: fix 
summary: Fix Project rendering in some cases for embedded templates.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
