### PR TITLE
[istio] Wiping istioVer requirement from release.yaml

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -32,7 +32,8 @@ requirements:
   # "istioMinimalVersion": "1.16" # modules/110-istio/requirements/check.go
 
   # TODO: Delete in D8 1.60, migrating to istioMinimalVersion
-  "istioVer": "1.16" # modules/110-istio/requirements/check.go
+  # Had to comment out for 1.58 release due to upgrade locks :(.
+  # "istioVer": "1.16" # modules/110-istio/requirements/check.go
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:


### PR DESCRIPTION
## Description
Wiping istioVer requirement from release.yaml

## Why do we need it, and what problem does it solve?
We [solved](https://github.com/deckhouse/deckhouse/pull/7815) upgrading issue from 1.57 to 1.58 by wiping istioMinimalVersion. But now we cant update 1.58.4 -> 1.58.5.

## Why do we need it in the patch release (if we do)?

There are patch update locks.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Wiped `istioVer` requirement from `release.yaml`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
