### PR TITLE
[deckhouse] Multiply function for requirements

### DIFF
--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -56,11 +56,7 @@ func CheckRequirement(key, value string) (bool, error) {
 
 	for _, f := range fs {
 		passed, ferr := f(value, memoryStorage)
-		if ferr != nil {
-			return passed, ferr
-		}
-
-		if !passed {
+		if ferr != nil || !passed {
 			return passed, ferr
 		}
 	}

--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -43,18 +43,29 @@ func RegisterDisruption(key string, f DisruptionFunc) {
 	defaultRegistry.RegisterDisruption(key, f)
 }
 
-// CheckRequirement run check function for `key` requirement. Returns true if check is passed, false otherwise
+// CheckRequirement run check functions for `key` requirement. Returns true if all checks is passed, false otherwise
 func CheckRequirement(key, value string) (bool, error) {
 	if defaultRegistry == nil {
 		return true, nil
 	}
 
-	f, err := defaultRegistry.GetCheckByKey(key)
+	fs, err := defaultRegistry.GetChecksByKey(key)
 	if err != nil {
 		return false, err
 	}
 
-	return f(value, memoryStorage)
+	for _, f := range fs {
+		passed, ferr := f(value, memoryStorage)
+		if ferr != nil {
+			return passed, ferr
+		}
+
+		if !passed {
+			return passed, ferr
+		}
+	}
+
+	return true, nil
 }
 
 // HasDisruption run check function for `key` disruption. Returns true if disruption condition is met, false otherwise. Returns reason for true response.
@@ -99,33 +110,33 @@ type ValueGetter interface {
 
 type requirementsResolver interface {
 	RegisterCheck(key string, f CheckFunc)
-	GetCheckByKey(key string) (CheckFunc, error)
+	GetChecksByKey(key string) ([]CheckFunc, error)
 
 	RegisterDisruption(key string, f DisruptionFunc)
 	GetDisruptionByKey(key string) (DisruptionFunc, error)
 }
 
 type requirementsRegistry struct {
-	checkers    map[string]CheckFunc
+	checkers    map[string][]CheckFunc
 	disruptions map[string]DisruptionFunc
 }
 
 func newRegistry() *requirementsRegistry {
 	return &requirementsRegistry{
-		checkers:    make(map[string]CheckFunc),
+		checkers:    make(map[string][]CheckFunc),
 		disruptions: make(map[string]DisruptionFunc),
 	}
 }
 
 func (r *requirementsRegistry) RegisterCheck(key string, f CheckFunc) {
-	r.checkers[key] = f
+	r.checkers[key] = append(r.checkers[key], f)
 }
 
 func (r *requirementsRegistry) RegisterDisruption(key string, f DisruptionFunc) {
 	r.disruptions[key] = f
 }
 
-func (r *requirementsRegistry) GetCheckByKey(key string) (CheckFunc, error) {
+func (r *requirementsRegistry) GetChecksByKey(key string) ([]CheckFunc, error) {
 	f, ok := r.checkers[key]
 	if !ok {
 		return nil, errors.Wrap(ErrNotRegistered, fmt.Sprintf("requirement with a key: %s", key))


### PR DESCRIPTION
## Description
Close https://github.com/deckhouse/deckhouse/issues/7883

## Why do we need it, and what problem does it solve?
Multiply functions could be used with one requirements key

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix 
summary: Use a few requirement functions for one key
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
