### PR TITLE
[e2e] update redos ver for e2e

### DIFF
--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -49,6 +49,6 @@ masterNodeGroup:
   instanceClass:
     rootDiskSize: 20
     flavorName: m1.large
-    imageName: "debian-11-genericcloud-amd64-20220911-1135"
+    imageName: "redos-STD-MINIMAL-7.3.4"
   volumeTypeMap:
     ru-3a: "fast.ru-3a"

--- a/testing/cloud_layouts/OpenStack/Standard/resources.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/resources.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   rootDiskSize: 20
   flavorName: m1.large
-  imageName: "debian-11-genericcloud-amd64-20220911-1135"
+  imageName: "redos-STD-MINIMAL-7.3.4"
 ---
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController

--- a/testing/cloud_layouts/OpenStack/Standard/resources.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/resources.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   rootDiskSize: 20
   flavorName: m1.large
-  imageName: "redos-STD-MINIMAL-7.3.4"
+  imageName: "debian-11-genericcloud-amd64-20220911-1135"
 ---
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -123,7 +123,7 @@ data "openstack_images_image_v2" "alt_image" {
 data "openstack_images_image_v2" "redos_image" {
   most_recent = true
   visibility  = "shared"
-  name        = "redos-MUROM-7.3.2-20221027.0"
+  name        = "redos-STD-MINIMAL-7.3.4"
 }
 
 resource "openstack_blockstorage_volume_v3" "master" {

--- a/testing/cloud_layouts/Static/redos-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/redos-instance-bootstrap.sh
@@ -17,6 +17,6 @@
 cat > /usr/local/bin/is-instance-bootstrapped << EOF
 #!/bin/bash
 set -Eeo pipefail
-cat /etc/redos-release | grep -q "MUROM (7.3.2)"
+cat /etc/redos-release | grep -q "MUROM (7.3.4)"
 EOF
 chmod +x /usr/local/bin/is-instance-bootstrapped

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -28,7 +28,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: 'fd8q0kjl4l1iovds9f29'
+    imageID: 'fd8rfb93hae3rsv7a5a1' #RED OS MUROM (7.3.4)
     diskSizeGB: 50
     externalIPAddresses:
     - Auto

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -272,7 +272,7 @@ function prepare_environment() {
         envsubst '${DECKHOUSE_DOCKERCFG} ${PREFIX} ${DEV_BRANCH} ${KUBERNETES_VERSION} ${CRI} ${CLOUD_ID} ${FOLDER_ID} ${SERVICE_ACCOUNT_JSON}' \
         <"$cwd/configuration.tpl.yaml" >"$cwd/configuration.yaml"
 
-    ssh_user="cloud-user"
+    ssh_user="redos"
     ;;
 
   "GCP")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Redos image update in e2e.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

For using actual redos version in e2e.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
e2e with redos 7.3.4 was passed:
openstack:
<img width="1009" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/4b6a8e2f-57fc-482a-91a3-0d6f96c54d42">
https://github.com/deckhouse/deckhouse/actions/runs/8392076004

static:
<img width="1749" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/07108e43-0fdb-4dfd-b81b-626e3744219a">
https://github.com/deckhouse/deckhouse/actions/runs/8417452675

yandex-cloud:
<img width="1859" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/c4238bf5-b14d-40e1-989c-bc9ba020e327">
https://github.com/deckhouse/deckhouse/actions/runs/8418482812

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: redos version image update in e2e.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
