### PR TITLE
[dhctl] fix(dhctl-for-commander): disable known_hosts file checking for scp

### DIFF
--- a/dhctl/pkg/system/ssh/cmd/scp.go
+++ b/dhctl/pkg/system/ssh/cmd/scp.go
@@ -86,8 +86,9 @@ func (s *SCP) SCP() *SCP {
 		"-C", // compression
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPersist=600s",
-		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "UserKnownHostsFile=.ssh_known_hosts",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "GlobalKnownHostsFile=/dev/null",
 		"-o", "PasswordAuthentication=no",
 	}
 


### PR DESCRIPTION
## Description

This PR disables known_hosts file checking when uploading bundle-related files using scp.

There was related change https://github.com/deckhouse/deckhouse/pull/7360 – which disables strict host checking for ssh client related operations. But seems it lacks just same settings for scp.

## Why do we need it, and what problem does it solve?

We can't connect to the target host anymore from cluster manager worker when target host changes its fingerprint. It may result in following error:

```
2024-03-21T17:57:03Z - [ERROR] - Error happened during task execution: timeout while "Get bundle": last error: detect_bundle.sh: upload: upload file '/tmp/3539489677-detect_bundle.sh': exit status 1

stderr: ssh: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
ssh: @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
ssh: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
ssh: IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
ssh: Someone could be eavesdropping on you right now (man-in-the-middle attack)!
ssh: It is also possible that a host key has just been changed.
ssh: The fingerprint for the ED25519 key sent by the remote host is
SHA256:....
ssh: Please contact your system administrator.
ssh: Add correct host key in .ssh_known_hosts to get rid of this message.
```
