### PR TITLE
[node-manager] Add permission for cluster api resources for cluster autoscaler and support scale from zero for vcd

### DIFF
--- a/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
+++ b/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
@@ -201,6 +201,22 @@ func (aic *openStackInstanceClass) ExtractCapacity(catalog *InstanceTypesCatalog
 	return catalog.Get(aic)
 }
 
+type vcdInstanceClass struct {
+	SizingPolicy string `json:"sizingPolicy,omitempty"`
+}
+
+func (aic *vcdInstanceClass) GetCapacity() *Capacity {
+	return nil
+}
+
+func (aic *vcdInstanceClass) GetType() string {
+	return aic.SizingPolicy
+}
+
+func (aic *vcdInstanceClass) ExtractCapacity(catalog *InstanceTypesCatalog) (*v1alpha1.InstanceType, error) {
+	return catalog.Get(aic)
+}
+
 type testInstanceClass struct {
 	Capacity *Capacity `json:"capacity,omitempty"`
 	Type     string    `json:"type,omitempty"`
@@ -255,6 +271,10 @@ func CalculateNodeTemplateCapacity(instanceClassName string, instanceClassSpec i
 
 	case "OpenStackInstanceClass":
 		var spec openStackInstanceClass
+		extractor = &spec
+
+	case "VCDInstanceClass":
+		var spec vcdInstanceClass
 		extractor = &spec
 
 	case "D8TestInstanceClass":

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -134,7 +134,7 @@ metadata:
   name: d8:node-manager:cluster-autoscaler
   {{- include "helm_lib_module_labels" (list . (dict "app" "cluster-autoscaler")) | nindent 2 }}
 rules:
-# accessing & modifyd8-cloud-instance-managering cluster state (nodes & pods)
+# accessing & modifying cluster state (nodes & pods)
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch", "update", "patch"]

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -79,14 +79,6 @@ rules:
   - update
 # cluster api
 - apiGroups:
-    - infrastructure.cluster.x-k8s.io
-  verbs:
-    - get
-    - list
-    - watch
-  resources:
-    - vcdmachinetemplates
-- apiGroups:
   - cluster.x-k8s.io
   resources:
   - machinedeployments
@@ -142,7 +134,7 @@ metadata:
   name: d8:node-manager:cluster-autoscaler
   {{- include "helm_lib_module_labels" (list . (dict "app" "cluster-autoscaler")) | nindent 2 }}
 rules:
-# accessing & modifying cluster state (nodes & pods)
+# accessing & modifyd8-cloud-instance-managering cluster state (nodes & pods)
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch", "update", "patch"]
@@ -176,6 +168,14 @@ rules:
   resources: ["events"]
   verbs: ["create", "update", "patch"]
 # cluster api
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  verbs:
+  - get
+  - list
+  - watch
+  resources:
+  - vcdmachinetemplates
 - apiGroups: ["cluster.x-k8s.io"]
   resources:
   - machinedeployments

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -79,6 +79,14 @@ rules:
   - update
 # cluster api
 - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+  verbs:
+    - get
+    - list
+    - watch
+  resources:
+    - vcdmachinetemplates
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - machinedeployments

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -34,6 +34,14 @@ rules:
   - watch
 # cluster api
 - apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  verbs:
+  - get
+  - list
+  - watch
+  resources:
+  - vcdmachinetemplates
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - machinedeployments

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -40,6 +40,7 @@ rules:
   - machines
   - machinesets
   - machinedeployments/scale
+  - machinepools
   verbs:
   - get
   - list
@@ -165,6 +166,7 @@ rules:
   - machines
   - machinesets
   - machinedeployments/scale
+  - machinepools
   verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description
Add permission for machinepoll clusterapi resource
Add support for scale from zero for vcd. But it works partially (see pr https://github.com/kubernetes/autoscaler/pull/4840)

## Why do we need it, and what problem does it solve?
Cluster autoscaller for clusterapi does not work with k8s 1.27+

## Why do we need it in the patch release (if we do)?
Cluster autoscaller for clusterapi does not work with k8s 1.27+
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/deckhouse/deckhouse/assets/30695496/16ec55f2-38c2-4a96-9b14-736c6b2fc809)
![image](https://github.com/deckhouse/deckhouse/assets/30695496/b6fcaac3-e225-4ee2-b114-18a6744a45d2)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Add permission for cluster api resources for cluster
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
