### PR TITLE
[admission-policy-engine] fix storage class fake alert

### DIFF
--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -45,6 +45,10 @@ type Args struct {
 	ObjectName                    string `json:"objectName"`
 	InternalValuesSubPath         string `json:"internalValuesSubPath,omitempty"`
 	D8ConfigStorageClassParamName string `json:"d8ConfigStorageClassParamName,omitempty"`
+
+	// if return value is false - hook will stop its execution
+	// if return value is true - hook will continue
+	BeforeHookCheck func(input *go_hook.HookInput) bool
 }
 
 func RegisterHook(args Args) bool {
@@ -224,17 +228,15 @@ func calculateEffectiveStorageClass(input *go_hook.HookInput, args Args, current
 		input.Values.Set(internalValuesPath, effectiveStorageClass)
 	}
 
-	if len(input.Snapshots["pvcs"]) != 0 {
-		input.MetricsCollector.Set(
-			"d8_emptydir_usage",
-			emptydirUsageMetricValue,
-			map[string]string{
-				"namespace":   args.Namespace,
-				"module_name": args.ModuleName,
-			},
-			metrics.WithGroup("storage_class_change"),
-		)
-	}
+	input.MetricsCollector.Set(
+		"d8_emptydir_usage",
+		emptydirUsageMetricValue,
+		map[string]string{
+			"namespace":   args.Namespace,
+			"module_name": args.ModuleName,
+		},
+		metrics.WithGroup("storage_class_change"),
+	)
 
 	return effectiveStorageClass
 }
@@ -326,6 +328,9 @@ func isEmptyOrFalseStr(sc string) bool {
 
 func storageClassChange(args Args) func(input *go_hook.HookInput, dc dependency.Container) error {
 	return func(input *go_hook.HookInput, dc dependency.Container) error {
+		if args.BeforeHookCheck != nil && !args.BeforeHookCheck(input) {
+			return nil
+		}
 		err := storageClassChangeWithArgs(input, dc, args)
 		if err != nil {
 			return err

--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -210,30 +210,6 @@ func calculateEffectiveStorageClass(input *go_hook.HookInput, args Args, current
 		effectiveStorageClass = input.ConfigValues.Get(configValuesPath).String()
 	}
 
-	var internalValuesPath = fmt.Sprintf("%s.internal.effectiveStorageClass", strcase.ToLowerCamel(args.ModuleName))
-
-	if args.InternalValuesSubPath != "" {
-		internalValuesPath = fmt.Sprintf("%s.internal.%s.effectiveStorageClass", strcase.ToLowerCamel(args.ModuleName), args.InternalValuesSubPath)
-	}
-
-	emptydirUsageMetricValue := 0.0
-	if len(effectiveStorageClass) == 0 || effectiveStorageClass == "false" {
-		input.Values.Set(internalValuesPath, false)
-		emptydirUsageMetricValue = 1.0
-	} else {
-		input.Values.Set(internalValuesPath, effectiveStorageClass)
-	}
-
-	input.MetricsCollector.Set(
-		"d8_emptydir_usage",
-		emptydirUsageMetricValue,
-		map[string]string{
-			"namespace":   args.Namespace,
-			"module_name": args.ModuleName,
-		},
-		metrics.WithGroup("storage_class_change"),
-	)
-
 	return effectiveStorageClass
 }
 
@@ -304,6 +280,32 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 		if err != nil && !errors.IsNotFound(err) {
 			input.LogEntry.Errorf("%v", err)
 		}
+	}
+
+	if len(pvcs) != 0 {
+		var internalValuesPath = fmt.Sprintf("%s.internal.effectiveStorageClass", strcase.ToLowerCamel(args.ModuleName))
+
+		if args.InternalValuesSubPath != "" {
+			internalValuesPath = fmt.Sprintf("%s.internal.%s.effectiveStorageClass", strcase.ToLowerCamel(args.ModuleName), args.InternalValuesSubPath)
+		}
+
+		emptydirUsageMetricValue := 0.0
+		if len(effectiveStorageClass) == 0 || effectiveStorageClass == "false" {
+			input.Values.Set(internalValuesPath, false)
+			emptydirUsageMetricValue = 1.0
+		} else {
+			input.Values.Set(internalValuesPath, effectiveStorageClass)
+		}
+
+		input.MetricsCollector.Set(
+			"d8_emptydir_usage",
+			emptydirUsageMetricValue,
+			map[string]string{
+				"namespace":   args.Namespace,
+				"module_name": args.ModuleName,
+			},
+			metrics.WithGroup("storage_class_change"),
+		)
 	}
 	return nil
 }

--- a/modules/015-admission-policy-engine/hooks/storage_class_change.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change.go
@@ -31,7 +31,6 @@ var _ = storage_class_change.RegisterHook(storage_class_change.Args{
 	ObjectName:                    "trivy-provider",
 	D8ConfigStorageClassParamName: "denyVulnerableImages.storageClass",
 	BeforeHookCheck: func(input *go_hook.HookInput) bool {
-		return input.Values.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool() ||
-			input.ConfigValues.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool()
+		return input.Values.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool()
 	},
 })

--- a/modules/015-admission-policy-engine/hooks/storage_class_change.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change.go
@@ -22,12 +22,13 @@ import (
 )
 
 var _ = storage_class_change.RegisterHook(storage_class_change.Args{
-	ModuleName:         "admission-policy-engine",
-	Namespace:          "d8-admission-policy-engine",
-	LabelSelectorKey:   "app",
-	LabelSelectorValue: "trivy-provider",
-	ObjectKind:         "StatefulSet",
-	ObjectName:         "trivy-provider",
+	ModuleName:                    "admission-policy-engine",
+	Namespace:                     "d8-admission-policy-engine",
+	LabelSelectorKey:              "app",
+	LabelSelectorValue:            "trivy-provider",
+	ObjectKind:                    "StatefulSet",
+	ObjectName:                    "trivy-provider",
+	D8ConfigStorageClassParamName: "denyVulnerableImages.storageClass",
 	BeforeHookCheck: func(input *go_hook.HookInput) bool {
 		return input.Values.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool()
 	},

--- a/modules/015-admission-policy-engine/hooks/storage_class_change.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package hooks
 
-import "github.com/deckhouse/deckhouse/go_lib/hooks/storage_class_change"
+import (
+	"github.com/deckhouse/deckhouse/go_lib/hooks/storage_class_change"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+)
 
 var _ = storage_class_change.RegisterHook(storage_class_change.Args{
 	ModuleName:         "admission-policy-engine",
@@ -25,4 +28,7 @@ var _ = storage_class_change.RegisterHook(storage_class_change.Args{
 	LabelSelectorValue: "trivy-provider",
 	ObjectKind:         "StatefulSet",
 	ObjectName:         "trivy-provider",
+	BeforeHookCheck: func(input *go_hook.HookInput) bool {
+		return input.Values.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool()
+	},
 })

--- a/modules/015-admission-policy-engine/hooks/storage_class_change.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change.go
@@ -17,12 +17,13 @@ limitations under the License.
 package hooks
 
 import (
-	"github.com/deckhouse/deckhouse/go_lib/hooks/storage_class_change"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+
+	"github.com/deckhouse/deckhouse/go_lib/hooks/storage_class_change"
 )
 
 var _ = storage_class_change.RegisterHook(storage_class_change.Args{
-	ModuleName:                    "admission-policy-engine",
+	ModuleName:                    "admissionPolicyEngine",
 	Namespace:                     "d8-admission-policy-engine",
 	LabelSelectorKey:              "app",
 	LabelSelectorValue:            "trivy-provider",
@@ -30,6 +31,7 @@ var _ = storage_class_change.RegisterHook(storage_class_change.Args{
 	ObjectName:                    "trivy-provider",
 	D8ConfigStorageClassParamName: "denyVulnerableImages.storageClass",
 	BeforeHookCheck: func(input *go_hook.HookInput) bool {
-		return input.Values.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool()
+		return input.Values.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool() ||
+			input.ConfigValues.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool()
 	},
 })

--- a/modules/015-admission-policy-engine/hooks/storage_class_change_test.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: storage_class_c
 	Context("Storage class is not set", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(""))
-			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", "true")
+			f.ValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", true)
 			f.RunHook()
 		})
 		It("Should set effectiveClass to false", func() {
@@ -52,7 +52,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: storage_class_c
 	Context("Global storage class is set", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(""))
-			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", "true")
+			f.ValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", true)
 			f.ConfigValuesSet("global.storageClass", "test")
 			f.RunHook()
 		})
@@ -65,7 +65,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: storage_class_c
 	Context("Storage class is set", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(""))
-			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", "true")
+			f.ValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", true)
 			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.storageClass", "test1")
 			f.RunHook()
 		})

--- a/modules/015-admission-policy-engine/hooks/storage_class_change_test.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: storage_class_c
 	Context("Global storage class is set but denyVulnerableImages is disabled", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ConfigValuesSet("global.storageClass", "test")
 			f.RunHook()
 		})
 		It("Should not set effectiveClass", func() {
@@ -66,6 +67,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: storage_class_c
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(""))
 			f.ValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", true)
+			f.ConfigValuesSet("global.storageClass", "global")
 			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.storageClass", "test1")
 			f.RunHook()
 		})

--- a/modules/015-admission-policy-engine/hooks/storage_class_change_test.go
+++ b/modules/015-admission-policy-engine/hooks/storage_class_change_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: admission-policy-engine :: hooks :: storage_class_change ::", func() {
+	f := HookExecutionConfigInit(`{"admissionPolicyEngine":{"internal":{"denyVulnerableImages": {}}}}`, "")
+
+	Context("Storage class is not set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", "true")
+			f.RunHook()
+		})
+		It("Should set effectiveClass to false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.effectiveStorageClass").String()).To(Equal("false"))
+		})
+	})
+
+	Context("Global storage class is set but denyVulnerableImages is disabled", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+		It("Should not set effectiveClass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.effectiveStorageClass").String()).To(Equal(""))
+		})
+	})
+
+	Context("Global storage class is set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", "true")
+			f.ConfigValuesSet("global.storageClass", "test")
+			f.RunHook()
+		})
+		It("Should set effectiveClass to test", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.effectiveStorageClass").String()).To(Equal("test"))
+		})
+	})
+
+	Context("Storage class is set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.enabled", "true")
+			f.ConfigValuesSet("admissionPolicyEngine.denyVulnerableImages.storageClass", "test1")
+			f.RunHook()
+		})
+		It("Should set effectiveClass to test1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.effectiveStorageClass").String()).To(Equal("test1"))
+		})
+	})
+})

--- a/modules/015-admission-policy-engine/openapi/config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/config-values.yaml
@@ -60,6 +60,13 @@ properties:
     description: |
       Trivy provider will deny creation of the `Pod`/`Deployment`/`StatefulSet`/`DaemonSet` with vulnerable images in namespaces with `security.deckhouse.io/trivy-provider: ""` label.
     properties:
+      storageClass:
+        type: string
+        x-examples: ["ceph-ssd", "false"]
+        description: |
+          The name of the trivy-provider StorageClass to use.
+
+          `storageClass: false` — forces the `emptyDir` usage. You will need to delete the old PVC and restart the Pod manually.
       enabled:
         type: boolean
         default: false

--- a/modules/015-admission-policy-engine/openapi/config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/config-values.yaml
@@ -64,9 +64,9 @@ properties:
         type: string
         x-examples: ["ceph-ssd", "false"]
         description: |
-          The name of the trivy-provider StorageClass to use.
+          The name of the StorageClass to use for `trivy-provider`.
 
-          `storageClass: false` — forces the `emptyDir` usage. You will need to delete the old PVC and restart the Pod manually.
+          `false` — forces the `emptyDir` usage. Manually delete the old PVC and restart Pod, after setting the parameter.
       enabled:
         type: boolean
         default: false

--- a/modules/015-admission-policy-engine/openapi/doc-ru-config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/doc-ru-config-values.yaml
@@ -34,6 +34,11 @@ properties:
 
       Trivy-провайдер запрещает создание `Pod`/`Deployment`/`StatefulSet`/`DaemonSet` с образами, которые имеют уязвимости в пространствах имен с лейблом `security.deckhouse.io/trivy-provider: ""`.
     properties:
+      storageClass:
+        description: |
+          Имя StorageClass'а, который предполагается использовать для trivy-provider.
+
+          `false` — принудительное использование `emptyDir`. Удалить старый PVC и рестартануть под придется вручную.
       enabled:
         description: "Включить trivy-провайдер."
       registrySecrets:

--- a/modules/015-admission-policy-engine/openapi/doc-ru-config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/doc-ru-config-values.yaml
@@ -36,9 +36,9 @@ properties:
     properties:
       storageClass:
         description: |
-          Имя StorageClass'а, который предполагается использовать для trivy-provider.
+          Имя StorageClass для использования `trivy_provider`.
 
-          `false` — принудительное использование `emptyDir`. Удалить старый PVC и рестартануть под придется вручную.
+          `false` — принудительное использование `emptyDir`. После установки необходимо вручную удалить старый PVC и перезапустить под.
       enabled:
         description: "Включить trivy-провайдер."
       registrySecrets:


### PR DESCRIPTION
## Description
Provides storageClass field for admission-policy-engine and fix storage class fake alert. 

## Why do we need it, and what problem does it solve?
Add storageClass field to admission-policy-engine and Closes #7671

## What is the expected result?
You can choose a storage class for trivy-provider and no `DeckhouseModuleUseEmptyDir` alert as the module's StatefulSet trivy-provider that uses storage is not deployed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Fix storageFlass fake alert.
```

