### PR TITLE
[dhctl] Support Deckhouse controller high availability mode during bootstrap

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/node.go
+++ b/dhctl/pkg/kubernetes/actions/converge/node.go
@@ -58,7 +58,9 @@ func GetCloudConfig(kubeCl *client.KubernetesClient, nodeGroupName string, showD
 					case <-ctx.Done():
 						return
 					default:
-						_, _ = deckhouse.NewLogPrinter(kubeCl).Print(ctx)
+						_, _ = deckhouse.NewLogPrinter(kubeCl).
+							WithLeaderElectionAwarenessMode(types.NamespacedName{Namespace: "d8-system", Name: "deckhouse-leader-election"}).
+							Print(ctx)
 					}
 				}
 			}()

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -523,12 +523,14 @@ func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode stri
 	return log.Process("default", "Waiting for Deckhouse to become Ready", func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), app.DeckhouseTimeout)
 		defer cancel()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return ErrTimedOut
 			default:
 				ok, err := NewLogPrinter(kubeCl).
+					WithLeaderElectionAwarenessMode(types.NamespacedName{Namespace: "d8-system", Name: "deckhouse-leader-election"}).
 					WaitPodBecomeReady().
 					WithExcludeNode(excludeNode).
 					Print(ctx)

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -238,22 +238,6 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 					},
 				},
 			},
-			Affinity: &apiv1.Affinity{
-				NodeAffinity: &apiv1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
-						NodeSelectorTerms: []apiv1.NodeSelectorTerm{
-							{
-								MatchExpressions: []apiv1.NodeSelectorRequirement{
-									{
-										Key:      ConvergeLabel,
-										Operator: apiv1.NodeSelectorOpDoesNotExist,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -68,14 +68,8 @@ spec:
       annotations:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: dhctl.deckhouse.io/node-for-converge
-                    operator: DoesNotExist
 {{- if (include "helm_lib_ha_enabled" .) }}
+      affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Dhctl will now corretcly handle multiple deckhouse pods in HA mode during bootstrap and detect which one to check via `d8-system/deckhouse-leader-election` lease object.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This is required as a HA mode for deckhouse deployment is the new default now

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Support Deckhouse controller high availability mode during bootstrap.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
