### PR TITLE
[ingress-nginx] Fix misleading summary in alert NginxIngressDeprecatedVersion

### DIFF
--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -182,7 +182,7 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |-
-        Ingress version 1.1 will be disabled in Deckhouse release 1.57
+        Ingress version 1.1 will be disabled in upcoming Deckhouse releases
       description: |-
         There is at least one ingress nginx controller with deprecated version 1.1. Ingress nginx version 1.1 will be disabled in upcoming Deckhouse releases. Consider upgrading to a newer version of Ingress nginx controller (all the pods of the affected Ingress Nginx controllers will be consequently recreated during upgrade).
         Use the following command to list the affected Ingress nginx controllers:


### PR DESCRIPTION
## Description
Fix misleading summary in alert `NginxIngressDeprecatedVersion`

## Why do we need it, and what problem does it solve?
Just fix misleading summary in alert
Closes #7921

## Why do we need it in the patch release (if we do)?
We need it for both actual `1.58` and `1.57` deckhouse releases to fix misleading summary in alert


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Fix misleading summary in alert `NginxIngressDeprecatedVersion`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
