### PR TITLE
[cloud-provider-openstack] Allow to install clusters with http proxy

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/deployment.yaml
@@ -92,6 +92,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
           ports:
           - name: https
             containerPort: 10471

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
@@ -129,6 +129,7 @@ spec:
               name: cloud-data-discoverer
         - name: CLUSTER_UUID
           value: {{ .Values.global.discovery.clusterUUID | quote }}
+        {{- include "helm_lib_envs_for_proxy" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/ee/modules/030-cloud-provider-openstack/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/csi/controller.yaml
@@ -10,6 +10,7 @@
   valueFrom:
     fieldRef:
       fieldPath: spec.nodeName
+{{- include "helm_lib_envs_for_proxy" . }}
 {{- end }}
 
 {{- define "csi_controller_volumes" }}
@@ -35,6 +36,7 @@
   valueFrom:
     fieldRef:
       fieldPath: spec.nodeName
+{{- include "helm_lib_envs_for_proxy" . }}
 {{- end }}
 
 {{- define "csi_node_volumes" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Add helm_lib_envs_for_proxy to cloud-controller-manager, cloud-data-discoverer and csi components
- Set custom HTTPClient for discoverer if env `OS_CACERT` is provided

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We support setups when components use http proxy to access public networks and internet.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Nothing will change for existing clusters.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: feature
summary: Allow to install clusters with http proxy in OpenStack
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
