### PR TITLE
[deckhouse] Requirements with module state

### DIFF
--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -48,7 +48,7 @@ func RegisterDisruption(key string, f DisruptionFunc) {
 	defaultRegistry.RegisterDisruption(key, f)
 }
 
-var mreg = regexp.MustCompile(`/modules/[0-9]+-(\S+)/requirements`)
+var mreg = regexp.MustCompile(`/modules/([0-9]+-)?(\S+)/requirements`)
 
 // CheckRequirement run check functions for `key` requirement. Returns true if all checks is passed, false otherwise
 // enabledModules is optional and will filter check-functions if module is disabled
@@ -72,7 +72,7 @@ func CheckRequirement(key, value string, enabledModules ...set.Set) (bool, error
 			match := mreg.FindStringSubmatch(fn.Name())
 			var moduleName string
 			if len(match) > 0 {
-				moduleName = match[1] // name of a module
+				moduleName = match[2] // name of a module
 			}
 
 			if moduleName != "" && !modulesSet.Has(moduleName) {

--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -58,7 +58,7 @@ func RegisterDisruption(key string, f DisruptionFunc) {
 	defaultRegistry.RegisterDisruption(key, f)
 }
 
-var mreg = regexp.MustCompile(`/modules/[0-9]+-(\\S+)/requirements`)
+var mreg = regexp.MustCompile(`/modules/[0-9]+-(\S+)/requirements`)
 
 // CheckRequirement run check functions for `key` requirement. Returns true if all checks is passed, false otherwise
 func CheckRequirement(key, value string, modulesSetParams ...set.Set) (bool, error) {
@@ -78,13 +78,14 @@ func CheckRequirement(key, value string, modulesSetParams ...set.Set) (bool, err
 			fn := runtime.FuncForPC(pc)
 			fmt.Println("##! RUN CHECK FUNCTION", fn.Name())
 			rr := mreg.FindStringSubmatch(fn.Name())
+			fmt.Println("##! SUMB", rr)
 			var moduleName string
 			if len(rr) > 0 {
 				moduleName = rr[1]
 			}
 			fmt.Println("##! CHECKING MODULE NAME", moduleName)
 
-			if !modulesSet.Has(moduleName) {
+			if moduleName != "" && !modulesSet.Has(moduleName) {
 				// module is disabled, we don't have to run its checks
 				fmt.Println("##! SKIPPING DISABLED MODULE", moduleName)
 				continue

--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -40,16 +40,6 @@ func init() {
 
 // RegisterCheck add CheckFunc for some component
 func RegisterCheck(key string, f CheckFunc) {
-	fmt.Println("CALLER")
-	pc, file, no, ok := runtime.Caller(1)
-	if ok {
-		fmt.Printf("called from %s#%d\n", file, no)
-	}
-
-	details := runtime.FuncForPC(pc)
-	if ok && details != nil {
-		fmt.Printf("called from2 %s - %d\n", details.Name(), details.Entry())
-	}
 	defaultRegistry.RegisterCheck(key, f)
 }
 
@@ -61,7 +51,8 @@ func RegisterDisruption(key string, f DisruptionFunc) {
 var mreg = regexp.MustCompile(`/modules/[0-9]+-(\S+)/requirements`)
 
 // CheckRequirement run check functions for `key` requirement. Returns true if all checks is passed, false otherwise
-func CheckRequirement(key, value string, modulesSetParams ...set.Set) (bool, error) {
+// enabledModules is optional and will filter check-functions if module is disabled
+func CheckRequirement(key, value string, enabledModules ...set.Set) (bool, error) {
 	if defaultRegistry == nil {
 		return true, nil
 	}
@@ -72,22 +63,20 @@ func CheckRequirement(key, value string, modulesSetParams ...set.Set) (bool, err
 	}
 
 	for _, f := range fs {
-		if len(modulesSetParams) > 0 {
-			modulesSet := modulesSetParams[0]
+		if len(enabledModules) > 0 {
+			modulesSet := enabledModules[0]
 			pc := reflect.ValueOf(f).Pointer()
 			fn := runtime.FuncForPC(pc)
-			fmt.Println("##! RUN CHECK FUNCTION", fn.Name())
-			rr := mreg.FindStringSubmatch(fn.Name())
-			fmt.Println("##! SUMB", rr)
+			// return the caller of the function like: github.com/deckhouse/deckhouse/modules/402-ingress-nginx/requirements.init.0.func1
+
+			match := mreg.FindStringSubmatch(fn.Name())
 			var moduleName string
-			if len(rr) > 0 {
-				moduleName = rr[1]
+			if len(match) > 0 {
+				moduleName = match[1] // name of a module
 			}
-			fmt.Println("##! CHECKING MODULE NAME", moduleName)
 
 			if moduleName != "" && !modulesSet.Has(moduleName) {
 				// module is disabled, we don't have to run its checks
-				fmt.Println("##! SKIPPING DISABLED MODULE", moduleName)
 				continue
 			}
 		}

--- a/go_lib/dependency/requirements/requirements_test.go
+++ b/go_lib/dependency/requirements/requirements_test.go
@@ -1,13 +1,59 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package requirements
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
 func TestModuleRegexp(t *testing.T) {
 	funcName := "github.com/deckhouse/deckhouse/modules/402-ingress-nginx/requirements.init.0.func1"
 	rr := mreg.FindStringSubmatch(funcName)
 	assert.Equal(t, "ingress-nginx", rr[1])
+}
+
+func TestCheckRequirements(t *testing.T) {
+	f := func(requirementValue string, getter ValueGetter) (bool, error) {
+		return false, errors.New("mock error")
+	}
+
+	// overwrite the regexp
+	mreg = regexp.MustCompile(`/go_lib/(\S+)/requirements`)
+
+	RegisterCheck("test-me", f)
+
+	t.Run("module is enabled", func(t *testing.T) {
+		s := set.New("dependency")
+		pass, err := CheckRequirement("test-me", "test", s)
+		assert.False(t, pass)
+		assert.ErrorContains(t, err, "mock error")
+	})
+
+	t.Run("module is disabled", func(t *testing.T) {
+		s := set.New("not-found")
+		pass, err := CheckRequirement("test-me", "test", s)
+		// should not run the check
+		assert.True(t, pass)
+		assert.NoError(t, err)
+	})
 }

--- a/go_lib/dependency/requirements/requirements_test.go
+++ b/go_lib/dependency/requirements/requirements_test.go
@@ -1,0 +1,13 @@
+package requirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModuleRegexp(t *testing.T) {
+	funcName := "github.com/deckhouse/deckhouse/modules/402-ingress-nginx/requirements.init.0.func1"
+	rr := mreg.FindStringSubmatch(funcName)
+	assert.Equal(t, "ingress-nginx", rr[1])
+}

--- a/go_lib/dependency/requirements/requirements_test.go
+++ b/go_lib/dependency/requirements/requirements_test.go
@@ -29,7 +29,7 @@ import (
 func TestModuleRegexp(t *testing.T) {
 	funcName := "github.com/deckhouse/deckhouse/modules/402-ingress-nginx/requirements.init.0.func1"
 	rr := mreg.FindStringSubmatch(funcName)
-	assert.Equal(t, "ingress-nginx", rr[1])
+	assert.Equal(t, "ingress-nginx", rr[2])
 }
 
 func TestCheckRequirements(t *testing.T) {


### PR DESCRIPTION
## Description
Run release requirements checks only for enabled modules
Closes #7923

## Why do we need it, and what problem does it solve?
If module is disabled it's weird to run the requirements check. Requirement values are empty because hook has not been run.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
```bash
# kubectl get modules istio
NAME    WEIGHT   STATE      SOURCE     STAGE   STATUS
istio   110      Disabled   Embedded           Info: disabled by Default bundle
```

Before:
```bash
# kubectl get deckhousereleases.deckhouse.io
NAME      PHASE     TRANSITIONTIME   MESSAGE
v1.58.6   Pending   60m              "k8s" requirement for DeckhouseRelease "1.58.6" not met: istio:minimalVersion key is not registred
```

After:
```bash
# kubectl get deckhousereleases.deckhouse.io
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.58.6   Deployed   27s
```

Enabled modules work:
```bash
# kubectl get deckhouserelease v1.58.6
NAME      PHASE     TRANSITIONTIME   MESSAGE
v1.58.6   Pending   5m54s            "k8s" requirement for DeckhouseRelease "1.58.6" not met: current kubernetes version is lower than required
```


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Run DeckhouseRelease requirements checks only for enabled modules.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
