### PR TITLE
[admission-policy-engine] add new columns to grafana

### DIFF
--- a/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
+++ b/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
@@ -397,7 +397,27 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "PSS": {
+                  "text": "PodSecurityStandard",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "regex",
+              "options": {
+                "pattern": "^d8-pod-security-([a-zA-Z]+)-.*",
+                "result": {
+                  "text": "$1",
+                  "index": 1
+                }
+              }
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -617,7 +637,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 233
+                "value": 140
               }
             ]
           },
@@ -677,7 +697,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 99
+                "value": 140
               }
             ]
           },
@@ -689,7 +709,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 99
+                "value": 170
               }
             ]
           }

--- a/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
+++ b/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
@@ -397,27 +397,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "PSS": {
-                  "text": "PodSecurityStandard",
-                  "index": 0
-                }
-              }
-            },
-            {
-              "type": "regex",
-              "options": {
-                "pattern": "^d8-pod-security-([a-zA-Z]+)-.*",
-                "result": {
-                  "text": "$1",
-                  "index": 1
-                }
-              }
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -565,7 +545,27 @@
             "filterable": false,
             "inspect": false
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "PSS": {
+                  "text": "PodSecurityStandard",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "regex",
+              "options": {
+                "pattern": "^d8-pod-security-([a-zA-Z]+)-.*",
+                "result": {
+                  "text": "$1",
+                  "index": 1
+                }
+              }
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
+++ b/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
@@ -660,7 +660,19 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Source Type"
+              "options": "Name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 205
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Policy Name"
             },
             "properties": [
               {
@@ -672,12 +684,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Name"
+              "options": "Policy Type"
             },
             "properties": [
               {
                 "id": "custom.width",
-                "value": 205
+                "value": 99
               }
             ]
           }
@@ -706,7 +718,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "group(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}) by (violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg, source_type)",
+          "expr": "group(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}) by (violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg, source_type, name)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -730,7 +742,8 @@
                 "violation_enforcement",
                 "violation_msg",
                 "violating_namespace",
-                "source_type"
+                "source_type",
+                "name"
               ]
             }
           }
@@ -743,13 +756,14 @@
             },
             "indexByName": {
               "Time": 0,
-              "kind": 1,
-              "violating_kind": 3,
-              "violating_name": 4,
-              "violating_namespace": 2,
-              "violation_enforcement": 5,
-              "violation_msg": 6,
-              "source_type": 7
+              "source_type": 1,
+              "name": 2,
+              "kind": 3,
+              "violating_kind": 5,
+              "violating_name": 6,
+              "violating_namespace": 4,
+              "violation_enforcement": 7,
+              "violation_msg": 8
             },
             "renameByName": {
               "Time": "",
@@ -759,7 +773,8 @@
               "violating_namespace": "Namespace",
               "violation_enforcement": "Enforcement",
               "violation_msg": "Message",
-              "source_type": "Source Type"
+              "source_type": "Policy Type",
+              "name": "Policy Name"
             }
           }
         }

--- a/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
+++ b/modules/015-admission-policy-engine/monitoring/grafana-dashboards/security/admission-policy-engine.json
@@ -660,6 +660,18 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "Source Type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "Name"
             },
             "properties": [
@@ -694,7 +706,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "group(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}) by (violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg)",
+          "expr": "group(d8_gatekeeper_exporter_constraint_violations{violating_namespace=~\".*\"}) by (violating_kind, violating_namespace, violating_name, kind, violation_enforcement, violation_msg, source_type)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -717,7 +729,8 @@
                 "violating_name",
                 "violation_enforcement",
                 "violation_msg",
-                "violating_namespace"
+                "violating_namespace",
+                "source_type"
               ]
             }
           }
@@ -735,7 +748,8 @@
               "violating_name": 4,
               "violating_namespace": 2,
               "violation_enforcement": 5,
-              "violation_msg": 6
+              "violation_msg": 6,
+              "source_type": 7
             },
             "renameByName": {
               "Time": "",
@@ -744,7 +758,8 @@
               "violating_name": "Name",
               "violating_namespace": "Namespace",
               "violation_enforcement": "Enforcement",
-              "violation_msg": "Message"
+              "violation_msg": "Message",
+              "source_type": "Source Type"
             }
           }
         }


### PR DESCRIPTION
## Description
Provides new columns to grafana representing policy name and policy type to grafana

## Why do we need it, and what problem does it solve?
Closes #7351

## What is the expected result?
Grafana contains new columns marking if an event is triggered by OP or SP.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: feature
summary: add new columns to grafana representing policy name and policy type
```

