### PR TITLE
[dhctl] fix(dhctl-for-commander): disable local-destroyer lock for commander mode

### DIFF
--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -23,17 +23,24 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 )
 
+type DeckhouseDestroyerOptions struct {
+	CommanderMode bool
+}
+
 type DeckhouseDestroyer struct {
 	convergeUnlocker func(fullUnlock bool)
 	sshClient        *ssh.Client
 	kubeCl           *client.KubernetesClient
 	state            *State
+
+	DeckhouseDestroyerOptions
 }
 
-func NewDeckhouseDestroyer(sshClient *ssh.Client, state *State) *DeckhouseDestroyer {
+func NewDeckhouseDestroyer(sshClient *ssh.Client, state *State, opts DeckhouseDestroyerOptions) *DeckhouseDestroyer {
 	return &DeckhouseDestroyer{
-		sshClient: sshClient,
-		state:     state,
+		sshClient:                 sshClient,
+		state:                     state,
+		DeckhouseDestroyerOptions: opts,
 	}
 }
 
@@ -62,14 +69,15 @@ func (g *DeckhouseDestroyer) GetKubeClient() (*client.KubernetesClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	unlockConverge, err := converge.LockConvergeFromLocal(kubeCl, "local-destroyer")
-	if err != nil {
-		return nil, err
-	}
-
 	g.kubeCl = kubeCl
-	g.convergeUnlocker = unlockConverge
+
+	if !g.CommanderMode {
+		unlockConverge, err := converge.LockConvergeFromLocal(kubeCl, "local-destroyer")
+		if err != nil {
+			return nil, err
+		}
+		g.convergeUnlocker = unlockConverge
+	}
 
 	return kubeCl, err
 }

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -77,7 +77,7 @@ func NewClusterDestroyer(params *Params) (*ClusterDestroyer, error) {
 		pec = phases.NewPhasedExecutionContext(params.OnPhaseFunc)
 	}
 
-	d8Destroyer := NewDeckhouseDestroyer(params.SSHClient, state)
+	d8Destroyer := NewDeckhouseDestroyer(params.SSHClient, state, DeckhouseDestroyerOptions{CommanderMode: params.CommanderMode})
 
 	var terraStateLoader terraform.StateLoader
 	if params.CommanderMode {


### PR DESCRIPTION
## Description

No converge or destroy locks needed in commander mode, so it is safe to disable it.

This PR have the same purpose as:
* https://github.com/deckhouse/deckhouse/pull/7763
* https://github.com/deckhouse/deckhouse/pull/7791

