### PR TITLE
[ingress-nginx] digital ocean k8s upgrade, update timeoutSeconds

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/admission.yaml
+++ b/modules/402-ingress-nginx/templates/controller/admission.yaml
@@ -34,7 +34,7 @@ webhooks:
         scope: Namespaced
     failurePolicy: Fail
     sideEffects: None
-    timeoutSeconds: 30
+    timeoutSeconds: 28
     admissionReviewVersions:
     - v1
     clientConfig:

--- a/modules/402-ingress-nginx/templates/kruise/webhook.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/webhook.yaml
@@ -38,7 +38,7 @@ webhooks:
     admissionReviewVersions:
       - v1
     sideEffects: None
-    timeoutSeconds: 30
+    timeoutSeconds: 28
     name: mpod.kb.io
     namespaceSelector:
       matchExpressions:
@@ -72,7 +72,7 @@ webhooks:
     admissionReviewVersions:
       - v1
     sideEffects: None
-    timeoutSeconds: 30
+    timeoutSeconds: 28
     name: vdaemonset.kb.io
     rules:
       - apiGroups:


### PR DESCRIPTION
## Description

Reduce timeoutSeconds parameter to 28 seconds in 402-ingress-nginx/templates/controller/admission.yaml and 402-ingress-nginx/templates/kruise/webhook.yaml

## Why do we need it, and what problem does it solve?

Can't update k8s in digital ocean. Error:

```
Errors preventing us from upgrading this cluster safely
Validating webhook with a TimeoutSeconds value smaller than 1 second or greater than 29 seconds will block upgrades.
Validating webhook with a TimeoutSeconds value smaller than 1 second or greater than 29 seconds will block upgrades.
Mutating webhook with a TimeoutSeconds value smaller than 1 second or greater than 29 seconds will block upgrades.
Validating webhook is configured in such a way that it may be problematic during upgrades.
```

## Why do we need it in the patch release (if we do)?

Need to update before the end of the month
![image](https://github.com/deckhouse/deckhouse/assets/113165676/0e22eb81-7531-44cf-a9ee-07aff300a02d)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix 
summary: Digital ocean Kubernetes upgrade, update `timeoutSeconds`.
```
