### PR TITLE
[l2-load-balancer] Updater for L2 Load Balancers Status

### DIFF
--- a/ee/modules/381-l2-load-balancer/crds/l2-load-balncer.yaml
+++ b/ee/modules/381-l2-load-balancer/crds/l2-load-balncer.yaml
@@ -16,6 +16,8 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema: &schema
       openAPIV3Schema:
         type: object

--- a/ee/modules/381-l2-load-balancer/crds/l2-load-balncer.yaml
+++ b/ee/modules/381-l2-load-balancer/crds/l2-load-balncer.yaml
@@ -89,4 +89,11 @@ spec:
                         targetPort:
                           type: integer
                           description: Number of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535.
+          status:
+            type: object
+            properties:
+              publicAddresses:
+                type: array
+                items:
+                  type: string
 

--- a/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
+++ b/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
@@ -91,7 +91,7 @@ func patchLoadBalancerStatus(pc *object_patch.PatchCollector, name, namespace st
 		},
 	}
 
-	pc.MergePatch(patch, "deckhouse.io/v1alpha1", "L2LoadBalancer", namespace, name, object_patch.WithSubresource("/status"), object_patch.IgnoreMissingObject())
+	pc.MergePatch(patch, "deckhouse.io/v1alpha1", "L2LoadBalancer", namespace, name, object_patch.WithSubresource("/status"))
 }
 
 func loadFromServicesInfo(servicesInfo []go_hook.FilterResult) (result map[string][]string) {

--- a/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
+++ b/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/l2-load-balancer/status",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "l2loadbalancers",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "L2LoadBalancer",
+			FilterFunc: applyLoadBalancerStatusFilter,
+		},
+		{
+			Name:       "services",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyServiceFilter,
+			// ignore d8 services, we don't use misconfigured external services
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "l2-load-balancer",
+				},
+			},
+		},
+	},
+}, handleLoadBalancerStatus)
+
+func applyServiceFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var service corev1.Service
+
+	err := sdk.FromUnstructured(obj, &service)
+	if err != nil {
+		return nil, err
+	}
+
+	externalIP := service.Status.LoadBalancer.Ingress[0].IP
+	loadBalancerName := service.Labels["instance"]
+
+	return ServiceInfo{
+		ExternalIP:       externalIP,
+		LoadBalancerName: loadBalancerName,
+	}, nil
+}
+
+func applyLoadBalancerStatusFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var lb L2LoadBalancer
+	err := sdk.FromUnstructured(obj, &lb)
+	if err != nil {
+		return nil, err
+	}
+
+	return L2LoadBalancerInfo{
+		Name:      lb.Name,
+		Namespace: lb.Namespace,
+	}, nil
+}
+
+func handleLoadBalancerStatus(input *go_hook.HookInput) error {
+	l2LBsSnapshot := input.Snapshots["l2loadbalancers"]
+	serviceToLoadBalancerMap := loadFromServicesInfo(input.Snapshots["services"])
+
+	for _, lb := range l2LBsSnapshot {
+		loadBalancer := lb.(L2LoadBalancerInfo)
+		if externalIPs, ok := serviceToLoadBalancerMap[loadBalancer.Name]; ok {
+			patchLoadBalancerStatus(input.PatchCollector, loadBalancer.Name, loadBalancer.Namespace, externalIPs)
+		}
+	}
+	return nil
+}
+
+func patchLoadBalancerStatus(pc *object_patch.PatchCollector, name, namespace string, ips []string) {
+	patch := map[string]interface{}{
+		"status": map[string]interface{}{
+			"publicAddresses": ips,
+		},
+	}
+
+	pc.MergePatch(patch, "deckhouse.io/v1alpha1", "L2LoadBalancer", namespace, name, object_patch.WithSubresource("/status"))
+}
+
+func loadFromServicesInfo(servicesInfo []go_hook.FilterResult) (result map[string][]string) {
+	result = make(map[string][]string)
+	for _, si := range servicesInfo {
+		serviceInfo := si.(ServiceInfo)
+		result[serviceInfo.LoadBalancerName] = append(result[serviceInfo.LoadBalancerName], serviceInfo.ExternalIP)
+	}
+	return
+}
+
+type ServiceInfo struct {
+	ExternalIP       string
+	LoadBalancerName string
+}

--- a/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
+++ b/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
@@ -73,11 +73,11 @@ func applyLoadBalancerStatusFilter(obj *unstructured.Unstructured) (go_hook.Filt
 
 func handleLoadBalancerStatus(input *go_hook.HookInput) error {
 	l2LBsSnapshot := input.Snapshots["l2loadbalancers"]
-	serviceToLoadBalancerMap := loadFromServicesInfo(input.Snapshots["services"])
+	servicesGroupedByLoadBalancerName := loadFromServicesInfo(input.Snapshots["services"])
 
 	for _, lb := range l2LBsSnapshot {
 		loadBalancer := lb.(L2LoadBalancerInfo)
-		if externalIPs, ok := serviceToLoadBalancerMap[loadBalancer.Name]; ok {
+		if externalIPs, ok := servicesGroupedByLoadBalancerName[loadBalancer.Name]; ok {
 			patchLoadBalancerStatus(input.PatchCollector, loadBalancer.Name, loadBalancer.Namespace, externalIPs)
 		}
 	}

--- a/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
+++ b/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update.go
@@ -28,7 +28,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion: "v1",
 			Kind:       "Service",
 			FilterFunc: applyServiceFilter,
-			// ignore d8 services, we don't use misconfigured external services
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"heritage": "deckhouse",

--- a/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update_test.go
+++ b/ee/modules/381-l2-load-balancer/hooks/load_balancers_status_update_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("l2-load-balancer :: hooks :: update_load_balancers_status ::", func() {
+	f := HookExecutionConfigInit(`{"l2LoadBalancer":{"internal": {}}}`, "")
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "L2LoadBalancer", true)
+
+	Context("Update L2 LBs status", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+		It("Should run", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+		})
+
+		Context("After adding load balancer", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: L2LoadBalancer
+metadata:
+  name: test
+  namespace: test
+spec:
+  addressPool: mypool
+  nodeSelector:
+    role: worker
+  service:
+    sourceRanges:
+    - 10.0.0.0/24
+    labelSelector:
+      app: test
+    ports:
+    - name: http
+      protocol: TCP
+      port: 8081
+      targetPort: 80
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: L2LoadBalancer
+metadata:
+  name: test2
+  namespace: test2
+spec:
+  addressPool: mypool
+  nodeSelector:
+    role: worker
+  service:
+    sourceRanges:
+    - 10.0.0.0/24
+    labelSelector:
+      app: test2
+    ports:
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: l2-load-balancer
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    instance: test
+    module: l2-load-balancer
+  name: d8-l2-load-balancer-test-0
+  namespace: test
+spec: {}
+status:
+  loadBalancer:
+    ingress:
+    - ip: 192.168.122.100
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: l2-load-balancer
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    instance: test
+    module: l2-load-balancer
+  name: d8-l2-load-balancer-test-1
+  namespace: test
+spec: {}
+status:
+  loadBalancer:
+    ingress:
+    - ip: 192.168.122.101
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: l2-load-balancer
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    instance: test2
+    module: l2-load-balancer
+  name: d8-l2-load-balancer-test2-0
+  namespace: test2
+spec: {}
+status:
+  loadBalancer:
+    ingress:
+    - ip: 192.168.122.102
+`))
+				f.RunHook()
+			})
+
+			It("Should store load balancer crds to values", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+				Expect(f.KubernetesResource("L2LoadBalancer", "test", "test").Field("status.publicAddresses").Array()).To(HaveLen(2))
+				Expect(f.KubernetesResource("L2LoadBalancer", "test2", "test2").Field("status.publicAddresses").Array()).To(HaveLen(1))
+
+				Expect(f.KubernetesResource("L2LoadBalancer", "test2", "test2").Field("status").String()).To(MatchJSON(`{
+"publicAddresses": ["192.168.122.102"]
+}`))
+			})
+		})
+	})
+})

--- a/ee/modules/381-l2-load-balancer/templates/rbac-to-us.yaml
+++ b/ee/modules/381-l2-load-balancer/templates/rbac-to-us.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
 - apiGroups: ["apps"]
   resources: ["daemonsets/prometheus-metrics", "deployments/prometheus-metrics"]
-  resourceNames: ["metallb", "speaker"]
+  resourceNames: ["controller", "speaker"]
   verbs: ["get"]
 
 {{- if (.Values.global.enabledModules | has "prometheus") }}

--- a/ee/modules/381-l2-load-balancer/templates/user-services/service.yaml
+++ b/ee/modules/381-l2-load-balancer/templates/user-services/service.yaml
@@ -7,7 +7,7 @@ kind: Service
 metadata:
   name: d8-l2-load-balancer-{{ $loadBalancer.name }}-{{ $index }}
   namespace: {{ $loadBalancer.namespace }}
-  {{- include "helm_lib_module_labels" (list $ (dict "app"  "l2-load-balancer" "instance" $loadBalancer.name)) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "l2-load-balancer" "instance" $loadBalancer.name)) | nindent 2 }}
   annotations:
     metallb.universe.tf/preferredL2SpeakerNode: {{ $node.name }}
     metallb.universe.tf/address-pool: {{ $loadBalancer.addressPool }}


### PR DESCRIPTION
## Description
Updater for L2 Load Balancers Status.

## Why do we need it, and what problem does it solve?
We can see External IP from Services in L2LoadBalancer Status field. It is convenient.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: l2-load-balancer
type: feature
summary:  Show public IP in the status of a CustomResource.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
