### PR TITLE
[ingress-nginx] fix maxmind db download for controller 1.9

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -214,6 +214,7 @@ COPY --from=controller-builder /src/rootfs/bin/amd64/dbg /
 COPY --from=controller-builder /src/rootfs/bin/amd64/nginx-ingress-controller  /
 COPY --from=controller-builder /src/rootfs/bin/amd64/wait-shutdown /
 COPY --chown=www-data:www-data nginx-chroot-wrapper.sh /usr/bin/nginx
+COPY --chown=www-data:www-data curl-chroot-wrapper.sh /usr/bin/curl
 
 COPY --from=dumb-init-builder /dumb-init/dumb-init /usr/bin/dumb-init
 

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -206,8 +206,9 @@ RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
     -s /sbin/nologin -c www-data www-data
 
 COPY --from=chroot /chroot /chroot
-COPY --from=chroot /usr/share/pki/ca-trust-source/ca-bundle.trust.p11-kit /usr/share/pki/ca-trust-source/ca-bundle.trust.p11-kit
+COPY --from=chroot /etc/pki /etc/pki
 COPY --from=chroot /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=chroot /usr/bin/curl /usr/bin/curl
 
 COPY --from=controller-builder /src/rootfs/bin/amd64/dbg /
 COPY --from=controller-builder /src/rootfs/bin/amd64/nginx-ingress-controller  /

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -229,6 +229,8 @@ RUN  chmod 1777 /tmp \
   && setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx \
   && setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init \
   && setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init \
+  && ln -sf /chroot/etc/pki /etc/pki \
+  && ln -sf /chroot/usr/share/ca-certificates /usr/share/ca-certificates \
   && ln -sf /chroot/etc/nginx /etc/nginx \
   && ln -sf /chroot/tmp/nginx /tmp/nginx \
   && ln -sf /chroot/etc/ingress-controller /etc/ingress-controller \

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -125,6 +125,8 @@ RUN bash -eu -c ' \
   writeDirs=( \
     /chroot/etc/nginx \
     /chroot/usr/local/nginx \
+    /chroot/usr/share \
+    /chroot/usr/bin \
     /chroot/etc/ingress-controller \
     /chroot/etc/ingress-controller/ssl \
     /chroot/etc/ingress-controller/auth \
@@ -152,6 +154,9 @@ RUN bash -eu -c ' \
   && touch /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml \
   && chown -R www-data.www-data /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml \
   && mkdir -p /chroot/etc/nginx/geoip \
+  && cp -a /etc/pki /chroot/etc/pki \
+  && cp -a /usr/share/ca-certificates /chroot/usr/share/ca-certificates \
+  && cp -a /usr/bin/curl /chroot/usr/bin/curl \
   && cp -a /lib64/* /chroot/lib64/ \
   && cp -a /usr/lib64/libGeoIP* /chroot/usr/lib64/ \
   && cp -a /usr/lib64/libcurl* /chroot/usr/lib64/ \
@@ -206,9 +211,6 @@ RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
     -s /sbin/nologin -c www-data www-data
 
 COPY --from=chroot /chroot /chroot
-COPY --from=chroot /etc/pki /etc/pki
-COPY --from=chroot /usr/share/ca-certificates /usr/share/ca-certificates
-COPY --from=chroot /usr/bin/curl /chroot/usr/bin/curl
 
 COPY --from=controller-builder /src/rootfs/bin/amd64/dbg /
 COPY --from=controller-builder /src/rootfs/bin/amd64/nginx-ingress-controller  /

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -208,7 +208,7 @@ RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
 COPY --from=chroot /chroot /chroot
 COPY --from=chroot /etc/pki /etc/pki
 COPY --from=chroot /usr/share/ca-certificates /usr/share/ca-certificates
-COPY --from=chroot /usr/bin/curl /usr/bin/curl
+COPY --from=chroot /usr/bin/curl /chroot/usr/bin/curl
 
 COPY --from=controller-builder /src/rootfs/bin/amd64/dbg /
 COPY --from=controller-builder /src/rootfs/bin/amd64/nginx-ingress-controller  /

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -229,6 +229,7 @@ RUN  chmod 1777 /tmp \
   && setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx \
   && setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init \
   && setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init \
+  && rm -rf /etc/pki \
   && ln -sf /chroot/etc/pki /etc/pki \
   && ln -sf /chroot/usr/share/ca-certificates /usr/share/ca-certificates \
   && ln -sf /chroot/etc/nginx /etc/nginx \

--- a/modules/402-ingress-nginx/images/controller-1-9/curl-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-9/curl-chroot-wrapper.sh
@@ -14,5 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cat /etc/resolv.conf > /chroot/etc/resolv.conf
 unshare  -S 101 -R /chroot /usr/bin/curl "$@"

--- a/modules/402-ingress-nginx/images/controller-1-9/curl-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-9/curl-chroot-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat /etc/resolv.conf > /chroot/etc/resolv.conf
+unshare  -S 101 -R /chroot /usr/bin/curl "$@"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix maxmind db download for controller 1.9.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Now if we set maxmind db parameters to ingressNginxController resource, nothing is download.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: fix maxmind db download for controller 1.9
impact: ingress-nginx 1.9 controller should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
