### PR TITLE
Watch crd to set webhook

### DIFF
--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "v1.4.6"}}
+{{- $shellOperatorVersion := "v1.4.7"}}
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}

--- a/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
@@ -17,7 +17,7 @@ rules:
   verbs: ["create", "list", "update"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
-  verbs: ["list", "update"]
+  verbs: ["get", "list", "update"]
 - apiGroups: ["deckhouse.io"]
   resources: ["*"]
   verbs: ["get","list","watch"]


### PR DESCRIPTION
## Description

Add repeated queries to get CRD and apply conversion strategies.

![Image-1](https://github.com/deckhouse/deckhouse/assets/52157046/8e22bcc5-551c-4198-bc62-262e4f2c2abb)

![Image-2](https://github.com/deckhouse/deckhouse/assets/52157046/e2218ced-8aac-4596-881e-b080aa8cd77f)

## Why do we need it, and what problem does it solve?

The processing of conversion strategies occurs at the deckhouse start and when a particular module enables.
In this case, processing may be started before CRD is installed. This situation leads to an error.

## Why do we need it in the patch release (if we do)?

The problem described above occurs in Deckhouse v1.58, and users may encounter it.

## What is the expected result?

A good example to check is the multitenancy module.
It is necessary to turn off the module. Then remove the CRD of this module (such as projects.deckhouse.io, projecttemplates.deckhouse.io) and enable the module again. The first attempt to apply conversion strategies will fail, but after a few attempts, it will succeed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Repeated queries with a limited number of attempts to get CRDs and apply conversion strategies.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
