### PR TITLE
[deckhouse] Module components description and automatic CiliumNetworkPolicies generation

### DIFF
--- a/modules/015-admission-policy-engine/components.yaml
+++ b/modules/015-admission-policy-engine/components.yaml
@@ -1,0 +1,34 @@
+components:
+- name: gatekeeper
+  description: The main mutating/validating webhook handler
+  namespace: d8-admission-policy-engine
+  labelSelector:
+    app: gatekeeper
+    control-plane: controller-manager
+  network:
+    listenPorts:
+    - number: 8443
+      description: gatekeeper webhook server
+      name: webhook
+    - number: 10354
+      description: metrics exporter
+      name: metrics
+    output:
+    - type: APIServer
+    input:
+    - type: APIServer
+      ports: [webhook]
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]
+- name: audit
+  description: TODO
+  namespace: d8-admission-policy-engine
+  labelSelector:
+    app: gatekeeper
+    control-plane: audit-controller
+  network:
+    output:
+    - type: APIServer

--- a/modules/021-cni-cilium/components.yaml
+++ b/modules/021-cni-cilium/components.yaml
@@ -1,0 +1,38 @@
+components:
+- name: agent
+  description: TODO
+  namespace: d8-cni-cilium
+  labelSelector:
+    app: agent
+  network:
+    hostNetwork: true
+    listenPorts:
+    - number: 9734
+      description: metrics exporter
+      name: metrics
+    output:
+    - type: APIServer
+    input:
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]
+- name: operator
+  description: TODO
+  namespace: d8-cni-cilium
+  labelSelector:
+    app: operator
+  network:
+    listenPorts:
+    - number: 9735
+      name: metrics
+      description: metrics exporter
+    output:
+    - type: APIServer
+    input:
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]

--- a/modules/031-local-path-provisioner/components.yaml
+++ b/modules/031-local-path-provisioner/components.yaml
@@ -1,0 +1,10 @@
+components:
+- name: local-path-provisioner
+  namespace: d8-local-path-provisioner
+  description: Local path provisioner agent
+  labelSelector:
+    app: local-path-provisioner
+  network:
+    hostNetwork: true
+    output:
+    - type: APIServer

--- a/modules/040-control-plane-manager/components.yaml
+++ b/modules/040-control-plane-manager/components.yaml
@@ -1,0 +1,10 @@
+components:
+- name: control-plane-manager
+  description: The controller to render control-plane manifests with kubeadm.
+  namespace: kube-system
+  labelSelector:
+    app: d8-control-plane-manager
+  network:
+    hostNetwork: true
+    output:
+    - type: APIServer

--- a/modules/042-kube-dns/components.yaml
+++ b/modules/042-kube-dns/components.yaml
@@ -1,0 +1,33 @@
+components:
+- name: kube-dns
+  namespace: kube-system
+  description: The main DNS resolver in cluster (coredns).
+  labelSelector:
+    app: kube-dns
+  network:
+    listenPorts:
+    - number: 5353
+      protocol: TCP
+      description: DNS server (TCP)
+      name: dns-tcp
+    - number: 5353
+      protocol: UDP
+      description: DNS server (UDP)
+      name: dns-udp
+    - number: 9154
+      description: metrics
+      name: https-metrics
+    output:
+    - type: APIServer
+    - type: WorldPorts
+      worldPorts:
+        tcp: [53]
+        udp: [53]
+    input:
+    - type: Cluster
+      ports: [dns-tcp, dns-udp]
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [https-metrics]

--- a/modules/101-cert-manager/components.yaml
+++ b/modules/101-cert-manager/components.yaml
@@ -1,0 +1,45 @@
+components:
+- name: cert-manager
+  description: TODO
+  namespace: d8-cert-manager
+  labelSelector:
+    app: cert-manager
+  network:
+    listenPorts:
+    - number: 9404
+      description: metrics exporter
+      name: metrics
+    output:
+    - type: WorldPorts
+      worldPorts:
+        tcp: [80, 443]
+    - type: APIServer
+    input:
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]
+- name: cainjector
+  description: TODO
+  namespace: d8-cert-manager
+  labelSelector:
+    app: cainjector
+  network:
+    output:
+    - type: APIServer
+- name: webhook
+  description: TODO
+  namespace: d8-cert-manager
+  labelSelector:
+    app: webhook
+  network:
+    listenPorts:
+    - number: 6443
+      description: TODO
+      name: https
+    output:
+    - type: APIServer
+    input:
+    - type: APIServer
+      ports: [https]

--- a/modules/110-istio/components.yaml
+++ b/modules/110-istio/components.yaml
@@ -1,0 +1,30 @@
+components:
+- name: istiod
+  description: The istio control-plane.
+  namespace: d8-istio
+  labelSelector:
+    app: istiod
+  network:
+    listenPorts:
+    - number: 15012
+      description: Discovery port for Istio sidecars.
+      name: xds
+    - number: 15014
+      description: Metrics exporter.
+      name: metrics
+    - number: 15017
+      description: Mutating/validating webhook handler.
+      name: webhook
+    output:
+    - type: APIServer
+    # TODO: multicluster/federation apiserver/metadata???
+    input:
+    - type: APIServer
+      ports: [webhook]
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]
+    - type: Cluster
+      ports: [xds]

--- a/modules/300-prometheus/components.yaml
+++ b/modules/300-prometheus/components.yaml
@@ -1,0 +1,37 @@
+TODO
+
+
+components:
+- name: prometheus-main
+  description: TODO
+  namespace: d8-monitoring
+  labelSelector:
+    app.kubernetes.io/name: prometheus
+    prometheus: main
+  network:
+    listenPorts:
+    - number: 8443
+      description: gatekeeper webhook server
+      name: webhook
+    - number: 10354
+      description: metrics exporter
+      name: metrics
+    output:
+    - type: APIServer
+    input:
+    - type: APIServer
+      ports: [webhook]
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]
+- name: audit
+  description: TODO
+  namespace: d8-admission-policy-engine
+  labelSelector:
+    app: gatekeeper
+    control-plane: audit-controller
+  network:
+    output:
+    - type: APIServer

--- a/modules/402-ingress-nginx/components.yaml
+++ b/modules/402-ingress-nginx/components.yaml
@@ -1,0 +1,47 @@
+components:
+- name: ingress-controller
+  description: The ingress-nginx controller that terminates user HTTP requests.
+  namespace: d8-ingress-nginx
+  labelSelector:
+    app: controller
+  network:
+    listenPorts:
+    - number: 80
+      description: HTTP.
+      name: http
+    - number: 443
+      description: HTTPS.
+      name: https
+    - number: 10354
+      description: Metrics.
+      name: https-metrics
+    output:
+    - type: APIServer
+    - type: ClusterTCP
+    input:
+    - type: World
+      ports: [http, https]
+    - type: D8ModuleComponent
+      d8ModuleComponent:
+        module: prometheus
+        component: prometheus
+      ports: [metrics]
+- name: kruise-controller-manager
+  description: TODO
+  namespace: d8-ingress-nginx
+  labelSelector:
+    app: kruise
+    control-plane: controller-manager
+  network:
+    listenPorts:
+    - number: 10354
+      description: Metrics
+      name: https-metrics
+    - number: 9876
+      description: Webhook.
+      name: webhook-server
+    output:
+    - type: APIServer
+    input:
+    - type: APIServer
+      ports: [https-metrics]


### PR DESCRIPTION
…Policies generation

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
