### PR TITLE
[ci] remove deprecated cri labels

### DIFF
--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -1196,8 +1196,8 @@ Put \`/e2e/use\` options below \`/e2e/run\` command to set specific CRI and Kube
 
 \`\`\`
 /e2e/run/aws main
-/e2e/use/k8s/1.20
-/e2e/use/k8s/1.23
+/e2e/use/k8s/1.27
+/e2e/use/k8s/1.29
 
 This comment will run 2 e2e jobs on AWS with containerd
 and with Kubernetes version 1.20 and 1.23 using image built from main branch.
@@ -1205,7 +1205,7 @@ and with Kubernetes version 1.20 and 1.23 using image built from main branch.
 
 \`\`\`
 /e2e/run/aws release-1.35 release-1.36
-/e2e/use/k8s/1.23
+/e2e/use/k8s/1.27
 
 This comment will create cluster in AWS using Deckhouse built from release-1.35 branch
 and then switch to images built from release-1.36 branch.

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -488,7 +488,7 @@ const setCRIAndVersionsFromLabels = ({ core, labels }) => {
   }
   if (cri.length === 0) {
     const defaultCRI = e2eDefaults.criName.toLowerCase();
-    core.info(`No 'e2e/use/cri' labels found. Will run e2e with default cri=${defaultCRI}.`);
+    core.info(`Will run e2e with default cri=${defaultCRI}.`);
     cri = [defaultCRI];
   }
   core.endGroup();
@@ -639,8 +639,6 @@ const parseCommandArgumentAsRef = (cmdArg) => {
  *   /build release-1.30
  *   /e2e/run/aws v1.31.0-alpha.0
  *   /e2e/use/k8s/1.22
- *   /e2e/use/cri/docker
- *   /e2e/use/cri/containerd
  *   /deploy/web/stage v1.3.2
  *   /deploy/alpha - to deploy all editions
  *   /deploy/alpha/ce,ee,fe
@@ -1186,8 +1184,6 @@ You can trigger release related actions by commenting on this issue:
   - \`provider\` is one of \`${availableProviders}\`
   - \`git_ref_1\` is a release-* or main branch
   - \`git_ref_2\` is a release-* or main branch
-- \`/e2e/use/cri/<cri_name>\` specifies which CRI to use for e2e test.
-  - \`cri_name\` is one of \`${availableCRI}\`
 - \`/e2e/use/k8s/<version>\` specifies which Kubernetes version to use for e2e test.
   - \`version\` is one of \`${availableKubernetesVersions}\`
 - \`/build git_ref\` will run build for release related refs.
@@ -1200,18 +1196,15 @@ Put \`/e2e/use\` options below \`/e2e/run\` command to set specific CRI and Kube
 
 \`\`\`
 /e2e/run/aws main
-/e2e/use/cri/docker
-/e2e/use/cri/containerd
 /e2e/use/k8s/1.20
 /e2e/use/k8s/1.23
 
-This comment will run 4 e2e jobs on AWS with Docker and containerd
+This comment will run 2 e2e jobs on AWS with containerd
 and with Kubernetes version 1.20 and 1.23 using image built from main branch.
 \`\`\`
 
 \`\`\`
 /e2e/run/aws release-1.35 release-1.36
-/e2e/use/cri/containerd
 /e2e/use/k8s/1.23
 
 This comment will create cluster in AWS using Deckhouse built from release-1.35 branch

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -36,10 +36,6 @@ const labels = {
   'e2e/run/yandex-cloud': { type: 'e2e-run', provider: 'yandex-cloud' },
   'e2e/run/static': { type: 'e2e-run', provider: 'static' },
 
-  // E2E: use CRI
-  'e2e/use/cri/docker': { type: 'e2e-use', cri: 'Docker' },
-  'e2e/use/cri/containerd': { type: 'e2e-use', cri: 'Containerd' },
-
   // E2E: use Kubernetes version
   'e2e/use/k8s/1.25': { type: 'e2e-use', ver: '1.25' },
   'e2e/use/k8s/1.26': { type: 'e2e-use', ver: '1.26' },

--- a/.github/scripts/js/specs/constants.test.js
+++ b/.github/scripts/js/specs/constants.test.js
@@ -23,7 +23,6 @@ test('knownProviders', () => {
 
 test('knownCRINames', () => {
   expect(knownCRINames).toContain('Containerd')
-  expect(knownCRINames).toContain('Docker')
 })
 
 test('knownKubernetesVersions', () => {


### PR DESCRIPTION
## Description

Remove deprecated `e2e/use/cri/*` labels for CI.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Currently we only use cri containerd, which is used by default. There are changes to remove deprecated labels:
```
/e2e/use/cri/docker
/e2e/use/cri/containerd
```
## What is the expected result?

https://github.com/deckhouse/deckhouse-test-1/actions/runs/8523761744/job/23346768733

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Remove deprecated labels in ci
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
