### PR TITLE
[dhctl] fix(dhct-for-commander): improve validation error messages

### DIFF
--- a/dhctl/pkg/config/validation_rules.go
+++ b/dhctl/pkg/config/validation_rules.go
@@ -61,12 +61,12 @@ func UpdateReplicasRule(oldRaw, newRaw json.RawMessage) error {
 	}
 
 	if newValue == 0 {
-		return fmt.Errorf("%w: got unacceptable masterNodeGroup.replicas zero value", ErrValidationRuleFailed)
+		return fmt.Errorf("%w: got unacceptable .masterNodeGroup.replicas zero value", ErrValidationRuleFailed)
 	}
 
 	if newValue < oldValue && newValue < 2 {
 		return fmt.Errorf(
-			"%w: the new masterNodeGroup.replicas value (%d) cannot be less that than 2 (%d)",
+			"%w: the new .masterNodeGroup.replicas value (%d) cannot be less that than 2 (%d)",
 			ErrValidationRuleFailed, newValue, oldValue,
 		)
 	}
@@ -104,7 +104,7 @@ func DeleteZonesRule(oldRaw, newRaw json.RawMessage) error {
 	}
 
 	return fmt.Errorf(
-		"%w: can't delete zone if masterNodeGroup.replicas < 3 (%d)",
+		"%w: can't delete zone if .masterNodeGroup.replicas < 3 (%d)",
 		ErrValidationRuleFailed,
 		newConfig.MasterNodeGroup.Replicas,
 	)
@@ -154,7 +154,7 @@ func UpdateMasterImageRule(oldRaw, newRaw json.RawMessage) error {
 	} {
 		if images.new != "" && images.old != images.new {
 			return fmt.Errorf(
-				"%w: can't update masterNodeGroup.%s if masterNodeGroup.replicas == 1",
+				"%w: can't update .masterNodeGroup.%s if .masterNodeGroup.replicas == 1",
 				ErrValidationRuleFailed,
 				images.field,
 			)

--- a/dhctl/pkg/config/validation_rules_test.go
+++ b/dhctl/pkg/config/validation_rules_test.go
@@ -116,7 +116,7 @@ clusterType: Cloud
 masterNodeGroup:
   replicas: 1`,
 			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: "clusterType": unsafe field has been changed`,
+			errContains: `ChangesValidationFailed: unsafe field has been changed: .clusterType`,
 		},
 		"unsafe object changed": {
 			phase: phases.FinalizationPhase,
@@ -137,7 +137,7 @@ unsafeObject:
   fieldB: dd
 `,
 			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: "unsafeObject": unsafe field has been changed`,
+			errContains: `ChangesValidationFailed: unsafe field has been changed: .unsafeObject`,
 		},
 		"unsafe rule, ok: updateReplicas": {
 			phase: phases.FinalizationPhase,
@@ -170,7 +170,7 @@ clusterType: Static
 masterNodeGroup:
   replicas: 1`,
 			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: "masterNodeGroup": "replicas": validation rule failed: the new masterNodeGroup.replicas value (1) cannot be less that than 2 (3)`,
+			errContains: `ChangesValidationFailed: validation rule failed: the new .masterNodeGroup.replicas value (1) cannot be less that than 2 (3)`,
 		},
 		"unsafe rule, ok: deleteZones": {
 			phase: phases.FinalizationPhase,
@@ -207,7 +207,7 @@ zones: [ru-central1]
 masterNodeGroup:
   replicas: 1`,
 			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: validation rule failed: can't delete zone if masterNodeGroup.replicas < 3 (1)`,
+			errContains: `ChangesValidationFailed: validation rule failed: can't delete zone if .masterNodeGroup.replicas < 3 (1)`,
 		},
 		"unsafe rule, ok: updateMasterImage": {
 			phase: phases.FinalizationPhase,
@@ -248,7 +248,7 @@ masterNodeGroup:
   instanceClass:
     imageID: bar`,
 			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: "masterNodeGroup": validation rule failed: can't update masterNodeGroup.imageID if masterNodeGroup.replicas == 1`,
+			errContains: `ChangesValidationFailed: validation rule failed: can't update .masterNodeGroup.imageID if .masterNodeGroup.replicas == 1`,
 		},
 		"change number of docs": {
 			phase: phases.FinalizationPhase,


### PR DESCRIPTION
## Description
Add more config valdiations:
* return clusterConfig from ValidateClusterConfiguration even if there are validation errors 
* hide errors with empty string kind from ValidateClusterConfiguration
* make errors from ValidateClusterSettingsChanges more readable
* add tests