### PR TITLE
[control-plane-manager] fix checksum loop

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
@@ -35,7 +35,7 @@ import (
 const (
 	waitingApprovalAnnotation = `control-plane-manager.deckhouse.io/waiting-for-approval`
 	approvedAnnotation        = `control-plane-manager.deckhouse.io/approved`
-	maxRetries                = 42
+	maxRetries                = 120
 	namespace                 = `kube-system`
 	kubernetesConfigPath      = `/etc/kubernetes`
 	manifestsPath             = kubernetesConfigPath + `/manifests`

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
@@ -35,7 +35,7 @@ import (
 const (
 	waitingApprovalAnnotation = `control-plane-manager.deckhouse.io/waiting-for-approval`
 	approvedAnnotation        = `control-plane-manager.deckhouse.io/approved`
-	maxRetries                = 120
+	maxRetries                = 180
 	namespace                 = `kube-system`
 	kubernetesConfigPath      = `/etc/kubernetes`
 	manifestsPath             = kubernetesConfigPath + `/manifests`

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
@@ -35,7 +35,7 @@ import (
 const (
 	waitingApprovalAnnotation = `control-plane-manager.deckhouse.io/waiting-for-approval`
 	approvedAnnotation        = `control-plane-manager.deckhouse.io/approved`
-	maxRetries                = 180
+	maxRetries                = 120
 	namespace                 = `kube-system`
 	kubernetesConfigPath      = `/etc/kubernetes`
 	manifestsPath             = kubernetesConfigPath + `/manifests`

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -246,7 +246,7 @@ func waitPodIsReady(componentName string, checksum string) error {
 			return fmt.Errorf("timeout waiting for pod %s to become ready with expected checksum %s", podName, checksum)
 		}
 
-		attemptReReadManifest := maxRetries - 20
+		attemptReReadManifest := maxRetries - 60
 
 		if tries == attemptReReadManifest {
 			err := triggerKubeletRereadManifest(componentName)

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -288,7 +288,6 @@ func triggerKubeletRereadManifest(componentName string) error {
 	if err := copy.Copy(srcPath, dstPath); err != nil {
 		return err
 	}
-
 	if err := os.Remove(srcPath); err != nil {
 		return err
 	}
@@ -296,6 +295,9 @@ func triggerKubeletRereadManifest(componentName string) error {
 	time.Sleep(2 * time.Second)
 
 	if err := copy.Copy(dstPath, srcPath); err != nil {
+		return err
+	}
+	if err := os.Remove(dstPath); err != nil {
 		return err
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -240,6 +241,17 @@ func waitPodIsReady(componentName string, checksum string) error {
 		if err != nil {
 			log.Warn(err)
 		}
+
+		if tries > maxRetries {
+			log.Warnf("timeout waiting for pod %s to become ready with expected checksum %s", podName, checksum)
+			err := triggerKubeletRestart(componentName)
+			// https://github.com/kubernetes/kubernetes/issues/109596
+			if err != nil {
+				return fmt.Errorf("fail to trigger restart kubelet for %s: %s", componentName, err)
+			}
+			return fmt.Errorf("trying to trigger kubelet to re-read manifest")
+		}
+
 		if podChecksum := pod.Annotations["control-plane-manager.deckhouse.io/checksum"]; podChecksum != checksum {
 			log.Warnf("kubernetes pod %s checksum %s does not match expected checksum %s", podName, podChecksum, checksum)
 			time.Sleep(1 * time.Second)
@@ -258,11 +270,37 @@ func waitPodIsReady(componentName string, checksum string) error {
 			continue
 		}
 
-		if tries > 240 {
-			return fmt.Errorf("timeout waiting for pod %s to become ready with expected checksum %s", podName, checksum)
-		}
-
 		log.Infof("kubernetes pod %s has matching checksum %s and is ready", podName, checksum)
 		return nil
 	}
+}
+
+func triggerKubeletRestart(componentName string) error {
+
+	srcPath := filepath.Join(manifestsPath, componentName+".yaml")
+	dstPath := filepath.Join(config.TmpPath, srcPath)
+
+	if err := os.RemoveAll(config.TmpPath); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Join(config.TmpPath, manifestsPath), 0755); err != nil {
+		return err
+	}
+
+	if err := copy.Copy(srcPath, dstPath); err != nil {
+		return err
+	}
+
+	if err := os.Remove(srcPath); err != nil {
+		return err
+	}
+
+	time.Sleep(2 * time.Second)
+
+	if err := copy.Copy(dstPath, srcPath); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -244,10 +244,10 @@ func waitPodIsReady(componentName string, checksum string) error {
 
 		if tries > maxRetries {
 			log.Warnf("timeout waiting for pod %s to become ready with expected checksum %s", podName, checksum)
-			err := triggerKubeletRestart(componentName)
+			err := triggerKubeletRereadManifest(componentName)
 			// https://github.com/kubernetes/kubernetes/issues/109596
 			if err != nil {
-				return fmt.Errorf("fail to trigger restart kubelet for %s: %s", componentName, err)
+				return fmt.Errorf("fail to trigger re-read manifest for %s: %s", componentName, err)
 			}
 			return fmt.Errorf("trying to trigger kubelet to re-read manifest")
 		}
@@ -275,7 +275,7 @@ func waitPodIsReady(componentName string, checksum string) error {
 	}
 }
 
-func triggerKubeletRestart(componentName string) error {
+func triggerKubeletRereadManifest(componentName string) error {
 
 	srcPath := filepath.Join(manifestsPath, componentName+".yaml")
 	dstPath := filepath.Join(config.TmpPath, srcPath)

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/node.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/node.go
@@ -56,7 +56,7 @@ func waitNodeApproval() error {
 		if _, ok := node.Annotations[approvedAnnotation]; ok {
 			return nil
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 	return fmt.Errorf("can't get annotation %s from our node %s", approvedAnnotation, config.NodeName)
 }


### PR DESCRIPTION
## Description

Fix infinite loop of checksum verification.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Closes #7134

In cases where the static manifest get changes while the kube-apiserver  is unavaliable, we may are stuck in an infinite loop. This behavior looks like a issue:
https://github.com/kubernetes/kubernetes/issues/109596#issuecomment-1219172244

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

After 120 tries/seconds, we try to recreate static pod:

```
{"level":"warning","msg":"kubernetes pod kube-apiserver-dev-master-0 checksum  does not match expected checksum 079bac0150a77fbe9e1f1937fff87c941b91e2d469fd8c74a3d684fc506ebdbf","time":"2024-04-09T13:48:05Z"}
{"level":"warning","msg":"kubernetes pod kube-apiserver-dev-master-0 checksum  does not match expected checksum 079bac0150a77fbe9e1f1937fff87c941b91e2d469fd8c74a3d684fc506ebdbf","time":"2024-04-09T13:48:06Z"}
{"level":"warning","msg":"kubernetes pod kube-apiserver-dev-master-0 checksum  does not match expected checksum 079bac0150a77fbe9e1f1937fff87c941b91e2d469fd8c74a3d684fc506ebdbf","time":"2024-04-09T13:48:07Z"}
{"level":"warning","msg":"kubernetes pod kube-apiserver-dev-master-0 checksum  does not match expected checksum 079bac0150a77fbe9e1f1937fff87c941b91e2d469fd8c74a3d684fc506ebdbf","time":"2024-04-09T13:48:08Z"}
{"level":"warning","msg":"kubernetes pod kube-apiserver-dev-master-0 checksum  does not match expected checksum 079bac0150a77fbe9e1f1937fff87c941b91e2d469fd8c74a3d684fc506ebdbf","time":"2024-04-09T13:48:09Z"}
{"level":"warning","msg":"timeout waiting for pod kube-apiserver-dev-master-0 to become ready with expected checksum 079bac0150a77fbe9e1f1937fff87c941b91e2d469fd8c74a3d684fc506ebdbf","time":"2024-04-09T13:48:10Z"}
{"level":"error","msg":"trying to trigger kubelet to re-read manifest","time":"2024-04-09T13:48:12Z"}
{"level":"info","msg":"remove backups older than 5","time":"2024-04-09T13:48:12Z"}
```

```
Apr 09 13:48:10 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:10.360952 1057915 kubelet.go:2399] "SyncLoop REMOVE" source="file" pods=["kube-system/kube-apiserver-dev-master-0"]
Apr 09 13:48:10 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:10.361207 1057915 kuberuntime_container.go:745] "Killing container with a grace period" pod="kube-system/kube-apiserver-dev-master-0" podUID="afaa2e4b4613eaf5b2f692b321b8fe70" containerName="kube-apiserver" containerID="containerd://b273184bd90cf5a61f033cd4c5b960a1f38597c190bae2861b3913e479aa3b42" gracePeriod=30
Apr 09 13:48:10 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:10.361281 1057915 kuberuntime_container.go:745] "Killing container with a grace period" pod="kube-system/kube-apiserver-dev-master-0" podUID="afaa2e4b4613eaf5b2f692b321b8fe70" containerName="healthcheck" containerID="containerd://52eacc53741f467ec4cfbd5646556f1f358c4084280370229bdca6cfafe166c1" gracePeriod=30
Apr 09 13:48:11 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:11.092493 1057915 generic.go:334] "Generic (PLEG): container finished" podID="afaa2e4b4613eaf5b2f692b321b8fe70" containerID="52eacc53741f467ec4cfbd5646556f1f358c4084280370229bdca6cfafe166c1" exitCode=2
Apr 09 13:48:12 dev-master-0 d8-kubelet-forker[1057915]: E0409 13:48:12.361108 1057915 file.go:108] "Unable to process watch event" err="can't process config file \"/etc/kubernetes/manifests/kube-apiserver.yaml\": /etc/kubernetes/manifests/kube-apiserver.yaml: couldn't parse as pod(Object 'Kind' is missing in 'null'), please check config file"
Apr 09 13:48:12 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:12.369141 1057915 kubelet.go:2389] "SyncLoop ADD" source="file" pods=["kube-system/kube-apiserver-dev-master-0"]
Apr 09 13:48:43 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:43.330377 1057915 kubelet.go:2421] "SyncLoop (PLEG): event for pod" pod="kube-system/kube-apiserver-dev-master-0" event={"ID":"afaa2e4b4613eaf5b2f692b321b8fe70","Type":"ContainerStarted","Data":"b092d7a29298f625accfb8719f595393ae3cb0e1f0a1971678b75ea5322c80d0"}
Apr 09 13:48:43 dev-master-0 d8-kubelet-forker[1057915]: I0409 13:48:43.807910 1057915 kubelet_getters.go:187] "Pod status updated" pod="kube-system/kube-apiserver-dev-master-0" status="Running"
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix infinite loop of checksum verification in control-plane-manager.
impact: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
