### PR TITLE
[deckhouse-controller] add documentation updater

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_pull_override.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_pull_override.go
@@ -87,3 +87,18 @@ func (f *ModulePullOverrideKind) SetGroupVersionKind(_ schema.GroupVersionKind) 
 func (f *ModulePullOverrideKind) GroupVersionKind() schema.GroupVersionKind {
 	return ModulePullOverrideGVK
 }
+
+// GetModuleSource returns module source for module pull override
+func (mo *ModulePullOverride) GetModuleSource() string {
+	return mo.Spec.Source
+}
+
+// GetModuleName returns the module's name of the module pull override
+func (mo *ModulePullOverride) GetModuleName() string {
+	return mo.Name
+}
+
+// GetReleaseVersion returns the version of the module pull override ("dev")
+func (mo *ModulePullOverride) GetReleaseVersion() string {
+	return mo.Spec.ImageTag
+}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_pull_override.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_pull_override.go
@@ -88,7 +88,7 @@ func (f *ModulePullOverrideKind) GroupVersionKind() schema.GroupVersionKind {
 	return ModulePullOverrideGVK
 }
 
-// GetModuleSource returns module source for module pull override
+// GetModuleSource returns the module source of the related module
 func (mo *ModulePullOverride) GetModuleSource() string {
 	return mo.Spec.Source
 }
@@ -98,12 +98,12 @@ func (mo *ModulePullOverride) GetModuleName() string {
 	return mo.Name
 }
 
-// GetReleaseVersion returns the version of the module pull override ("dev")
+// GetReleaseVersion returns the version of the related module
 func (mo *ModulePullOverride) GetReleaseVersion() string {
 	return mo.Spec.ImageTag
 }
 
-// GetWeight returns the weight of the related module
+// GetWeight always returns 0
 func (mo *ModulePullOverride) GetWeight() uint32 {
 	return 0
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_pull_override.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_pull_override.go
@@ -102,3 +102,8 @@ func (mo *ModulePullOverride) GetModuleName() string {
 func (mo *ModulePullOverride) GetReleaseVersion() string {
 	return mo.Spec.ImageTag
 }
+
+// GetWeight returns the weight of the related module
+func (mo *ModulePullOverride) GetWeight() uint32 {
+	return 0
+}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
@@ -86,6 +86,11 @@ func (mr *ModuleRelease) GetReleaseVersion() string {
 	return "v" + mr.Spec.Version.String()
 }
 
+// GetWeight returns the weight of the related module
+func (mr *ModuleRelease) GetWeight() uint32 {
+	return mr.Spec.Weight
+}
+
 type Changelog map[string]any
 
 func (c Changelog) DeepCopy() Changelog {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
@@ -76,6 +76,16 @@ func (mr *ModuleRelease) GetModuleSource() string {
 	return mr.Labels["source"]
 }
 
+// GetModuleName returns the module's name of the release
+func (mr *ModuleRelease) GetModuleName() string {
+	return mr.Spec.ModuleName
+}
+
+// GetReleaseVersion returns the version of the release in the form of "vx.y.z"
+func (mr *ModuleRelease) GetReleaseVersion() string {
+	return "v" + mr.Spec.Version.String()
+}
+
 type Changelog map[string]any
 
 func (c Changelog) DeepCopy() Changelog {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -41,9 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	coordinationv1 "k8s.io/client-go/listers/coordination/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -56,9 +54,8 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/models"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/docs"
 	deckhouseconfig "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
-	d8http "github.com/deckhouse/deckhouse/go_lib/dependency/http"
-	docs_builder "github.com/deckhouse/deckhouse/go_lib/module/docs-builder"
 )
 
 // Controller is the controller implementation for ModuleRelease resources
@@ -69,8 +66,6 @@ type Controller struct {
 	// d8ClientSet is a clientset for our own API group
 	d8ClientSet versioned.Interface
 
-	docsBuilder *docs_builder.Client
-
 	moduleReleasesLister       d8listers.ModuleReleaseLister
 	moduleReleasesSynced       cache.InformerSynced
 	moduleSourcesLister        d8listers.ModuleSourceLister
@@ -79,8 +74,6 @@ type Controller struct {
 	moduleUpdatePoliciesSynced cache.InformerSynced
 	modulePullOverridesLister  d8listers.ModulePullOverrideLister
 	modulePullOverridesSynced  cache.InformerSynced
-	leaseLister                coordinationv1.LeaseLister
-	leaseInformer              cache.SharedIndexInformer
 	metricStorage              *metric_storage.MetricStorage
 
 	// workqueue is a rate limited work queue. This is used to queue work to be
@@ -88,8 +81,7 @@ type Controller struct {
 	// means we can ensure we only process a fixed amount of resources at a
 	// time, and makes it easy to ensure we are never processing the same item
 	// simultaneously in two different workers.
-	workqueue      workqueue.RateLimitingInterface
-	leaseWorkqueue workqueue.RateLimitingInterface
+	workqueue workqueue.RateLimitingInterface
 
 	logger logger.Logger
 
@@ -105,7 +97,8 @@ type Controller struct {
 	m             sync.Mutex
 	delayTimer    *time.Timer
 	restartReason string
-	httpClient    d8http.Client
+
+	documentationUpdater *docs.Updater
 }
 
 const (
@@ -118,8 +111,6 @@ const (
 	manualApprovalRequired = `Waiting for manual approval (annotation modules.deckhouse.io/approved="true" required)`
 	disabledByIgnorePolicy = `Update disabled by 'Ignore' update policy`
 	waitingForWindow       = "Release is waiting for the update window: %s"
-	docsLeaseLabel         = "deckhouse.io/documentation-builder-sync"
-	namespace              = "d8-system"
 )
 
 // NewController returns a new sample controller
@@ -130,9 +121,9 @@ func NewController(ks kubernetes.Interface,
 	moduleUpdatePolicyInformer d8informers.ModuleUpdatePolicyInformer,
 	modulePullOverridesInformer d8informers.ModulePullOverrideInformer,
 	mv moduleValidator,
-	httpClient d8http.Client,
 	metricStorage *metric_storage.MetricStorage,
 	embeddedPolicy *v1alpha1.ModuleUpdatePolicySpec,
+	documentationUpdater *docs.Updater,
 ) *Controller {
 	ratelimiter := workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 1000*time.Second),
@@ -141,22 +132,9 @@ func NewController(ks kubernetes.Interface,
 
 	lg := log.WithField("component", "ModuleReleaseController")
 
-	factory := informers.NewSharedInformerFactoryWithOptions(
-		ks,
-		15*time.Minute,
-		informers.WithNamespace(namespace),
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = docsLeaseLabel
-		}),
-	)
-	leaseInformerFactory := factory.Coordination().V1().Leases()
-	leaseLister := leaseInformerFactory.Lister()
-	leaseInformer := leaseInformerFactory.Informer()
-
 	controller := &Controller{
 		kubeclientset:              ks,
 		d8ClientSet:                d8ClientSet,
-		docsBuilder:                docs_builder.NewClient(httpClient),
 		moduleReleasesLister:       moduleReleaseInformer.Lister(),
 		moduleReleasesSynced:       moduleReleaseInformer.Informer().HasSynced,
 		moduleSourcesLister:        moduleSourceInformer.Lister(),
@@ -165,11 +143,8 @@ func NewController(ks kubernetes.Interface,
 		moduleUpdatePoliciesSynced: moduleUpdatePolicyInformer.Informer().HasSynced,
 		modulePullOverridesLister:  modulePullOverridesInformer.Lister(),
 		modulePullOverridesSynced:  modulePullOverridesInformer.Informer().HasSynced,
-		leaseLister:                leaseLister,
-		leaseInformer:              leaseInformer,
 		metricStorage:              metricStorage,
 		workqueue:                  workqueue.NewRateLimitingQueue(ratelimiter),
-		leaseWorkqueue:             workqueue.NewRateLimitingQueue(ratelimiter),
 		logger:                     lg,
 
 		sourceModules: make(map[string]string),
@@ -180,6 +155,8 @@ func NewController(ks kubernetes.Interface,
 		deckhouseEmbeddedPolicy: embeddedPolicy,
 
 		delayTimer: time.NewTimer(3 * time.Second),
+
+		documentationUpdater: documentationUpdater,
 	}
 
 	// Set up an event handler for when ModuleRelease resources change
@@ -202,13 +179,6 @@ func NewController(ks kubernetes.Interface,
 		log.Fatalf("add event handler failed: %s", err)
 	}
 
-	_, err = leaseInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controller.enqueueLease,
-	})
-	if err != nil {
-		log.Fatalf("add event handler failed: %s", err)
-	}
-
 	return controller
 }
 
@@ -221,17 +191,6 @@ func (c *Controller) enqueueModuleRelease(obj interface{}) {
 	}
 	c.logger.Debugf("enqueue ModuleRelease: %s", key)
 	c.workqueue.Add(key)
-}
-
-func (c *Controller) enqueueLease(obj interface{}) {
-	var key cache.ObjectName
-	var err error
-	if key, err = cache.ObjectToName(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	c.logger.Debugf("enqueue Lease: %s", key)
-	c.leaseWorkqueue.Add(key)
 }
 
 func (c *Controller) emitRestart(msg string) {
@@ -272,7 +231,6 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	defer utilruntime.HandleCrash()
 	defer c.workqueue.ShutDown()
-	defer c.leaseWorkqueue.ShutDown()
 
 	// Check if controller's dependencies have been initialized
 	_ = wait.PollUntilContextCancel(ctx, utils.SyncedPollPeriod, false,
@@ -289,9 +247,8 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	go c.restartLoop(ctx)
 
-	go c.leaseInformer.Run(ctx.Done())
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.moduleReleasesSynced, c.moduleSourcesSynced,
-		c.moduleUpdatePoliciesSynced, c.modulePullOverridesSynced, c.leaseInformer.HasSynced); !ok {
+		c.moduleUpdatePoliciesSynced, c.modulePullOverridesSynced); !ok {
 		c.logger.Fatal("failed to wait for caches to sync")
 	}
 
@@ -303,7 +260,6 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	c.logger.Infof("Starting workers count: %d", workers)
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-		go wait.UntilWithContext(ctx, c.runLeaseWorker, time.Second)
 	}
 
 	<-ctx.Done()
@@ -312,11 +268,6 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 func (c *Controller) runWorker(ctx context.Context) {
 	for c.processNextWorkItem(ctx) {
-	}
-}
-
-func (c *Controller) runLeaseWorker(ctx context.Context) {
-	for c.processNextLease(ctx) {
 	}
 }
 
@@ -433,7 +384,7 @@ func (c *Controller) createOrUpdateReconcile(ctx context.Context, roMR *v1alpha1
 		return ctrl.Result{}, nil
 
 	case v1alpha1.PhaseDeployed:
-		err := c.sendDocumentation(ctx, mr)
+		err := c.documentationUpdater.SendDocumentation(ctx, mr)
 		if err != nil {
 			return ctrl.Result{Requeue: true}, fmt.Errorf("send documentation: %w", err)
 		}
@@ -687,64 +638,6 @@ func (c *Controller) reconcilePendingRelease(ctx context.Context, mr *v1alpha1.M
 	return ctrl.Result{}, nil
 }
 
-func (c *Controller) processNextLease(ctx context.Context) bool {
-	obj, shutdown := c.leaseWorkqueue.Get()
-	if shutdown {
-		return false
-	}
-
-	err := func(obj interface{}) error {
-		defer c.leaseWorkqueue.Done(obj)
-		var key cache.ObjectName
-		var ok bool
-		var req ctrl.Request
-
-		if key, ok = obj.(cache.ObjectName); !ok {
-			c.leaseWorkqueue.Forget(obj)
-			c.logger.Errorf("expected cache.ObjectName in workqueue but got %#v", obj)
-			return nil
-		}
-
-		req.Namespace, req.Name = key.Parts()
-		result, err := c.leaseCreateReconcile(ctx, req)
-		switch {
-		case result.RequeueAfter != 0:
-			c.leaseWorkqueue.AddAfter(key, result.RequeueAfter)
-
-		case result.Requeue:
-			c.leaseWorkqueue.AddRateLimited(key)
-
-		default:
-			c.leaseWorkqueue.Forget(key)
-		}
-
-		return err
-	}(obj)
-	if err != nil {
-		c.logger.Errorf("Lease reconcile error: %s", err.Error())
-		return true
-	}
-
-	return true
-}
-
-func (c *Controller) leaseCreateReconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	releases, err := c.moduleReleasesLister.List(labels.Everything())
-	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("fetch ModuleReleases failed: %w", err)
-	}
-
-	for _, release := range releases {
-		if release.Status.Phase != v1alpha1.PhaseDeployed {
-			continue
-		}
-
-		c.enqueueModuleRelease(release)
-	}
-
-	return ctrl.Result{}, nil
-}
-
 func (c *Controller) Reconcile(ctx context.Context, releaseName string) (ctrl.Result, error) {
 	// Get the ModuleRelease resource with this name
 	mr, err := c.moduleReleasesLister.Get(releaseName)
@@ -900,6 +793,7 @@ func (c *Controller) RunPreflightCheck(ctx context.Context) error {
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.moduleReleasesSynced, c.moduleSourcesSynced, c.moduleUpdatePoliciesSynced, c.modulePullOverridesSynced); !ok {
 		c.logger.Fatal("failed to wait for caches to sync")
 	}
+	c.logger.Info("Release controller's object cache synced")
 
 	err := c.restoreAbsentSourceModules()
 	if err != nil {
@@ -1189,69 +1083,6 @@ type moduleValidator interface {
 	GetValuesValidator() *validation.ValuesValidator
 	DisableModuleHooks(moduleName string)
 	GetModule(moduleName string) *addonmodules.BasicModule
-}
-
-func (c *Controller) sendDocumentation(ctx context.Context, mr *v1alpha1.ModuleRelease) error {
-	addrs, err := c.getDocsBuilderAddresses(ctx)
-	if err != nil {
-		return fmt.Errorf("get docs builder addresses: %w", err)
-	}
-
-	if len(addrs) == 0 {
-		return nil
-	}
-
-	ms, err := c.moduleSourcesLister.Get(mr.GetModuleSource())
-	if err != nil {
-		return fmt.Errorf("get module source: %w", err)
-	}
-
-	md := downloader.NewModuleDownloader(c.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
-	for _, addr := range addrs {
-		err := c.buildDocumentation(addr, md, mr.Spec.ModuleName, "v"+mr.Spec.Version.String())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *Controller) getDocsBuilderAddresses(ctx context.Context) (addresses []string, err error) {
-	list, err := c.kubeclientset.CoordinationV1().Leases("d8-system").List(ctx, metav1.ListOptions{LabelSelector: docsLeaseLabel})
-	if err != nil {
-		return nil, fmt.Errorf("list leases: %w", err)
-	}
-
-	for _, lease := range list.Items {
-		if lease.Spec.HolderIdentity == nil {
-			continue
-		}
-
-		addresses = append(addresses, "http://"+*lease.Spec.HolderIdentity)
-	}
-
-	return
-}
-
-func (c *Controller) buildDocumentation(baseAddr string, md *downloader.ModuleDownloader, moduleName, moduleVersion string) error {
-	docsArchive, err := md.GetDocumentationArchive(moduleName, moduleVersion)
-	if err != nil {
-		return fmt.Errorf("get documentation archive: %w", err)
-	}
-	defer docsArchive.Close()
-
-	err = c.docsBuilder.SendDocumentation(baseAddr, moduleName, moduleVersion, docsArchive)
-	if err != nil {
-		return fmt.Errorf("send documentation: %w", err)
-	}
-
-	err = c.docsBuilder.BuildDocumentation(baseAddr)
-	if err != nil {
-		return fmt.Errorf("build documentation: %w", err)
-	}
-
-	return nil
 }
 
 func (c *Controller) updateModuleReleaseDownloadStatistic(ctx context.Context, release *v1alpha1.ModuleRelease,

--- a/deckhouse-controller/pkg/docs/updater.go
+++ b/deckhouse-controller/pkg/docs/updater.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coordination_informers_v1 "k8s.io/client-go/informers/coordination/v1"
+	coordination_listers_v1 "k8s.io/client-go/listers/coordination/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	d8informers "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/client/informers/externalversions/deckhouse.io/v1alpha1"
+	d8listers "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/client/listers/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	d8http "github.com/deckhouse/deckhouse/go_lib/dependency/http"
+	docs_builder "github.com/deckhouse/deckhouse/go_lib/module/docs-builder"
+	"github.com/flant/addon-operator/pkg/utils/logger"
+	log "github.com/sirupsen/logrus"
+)
+
+type moduleReleaseGetter interface {
+	GetModuleName() string
+	GetReleaseVersion() string
+	GetModuleSource() string
+}
+
+type Updater struct {
+	leasesInformer cache.SharedIndexInformer
+	leasesLister   coordination_listers_v1.LeaseLister
+	leasesSynced   cache.InformerSynced
+
+	moduleReleasesLister      d8listers.ModuleReleaseLister
+	moduleReleasesSynced      cache.InformerSynced
+	moduleSourcesLister       d8listers.ModuleSourceLister
+	moduleSourcesSynced       cache.InformerSynced
+	modulePullOverridesLister d8listers.ModulePullOverrideLister
+	modulePullOverridesSynced cache.InformerSynced
+
+	leaseWorkqueue workqueue.RateLimitingInterface
+
+	externalModulesDir string
+
+	docsBuilder *docs_builder.Client
+	httpClient  d8http.Client
+
+	logger logger.Logger
+}
+
+func NewUpdater(
+	leasesInformer coordination_informers_v1.LeaseInformer,
+	moduleReleasesInformer d8informers.ModuleReleaseInformer,
+	moduleSourcesInformer d8informers.ModuleSourceInformer,
+	modulePullOverridesInformer d8informers.ModulePullOverrideInformer,
+	httpClient d8http.Client,
+) *Updater {
+	ratelimiter := workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 1000*time.Second),
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
+	)
+
+	lg := log.WithField("component", "ModuleDocumentationUpdater")
+
+	updater := &Updater{
+		leasesInformer:            leasesInformer.Informer(),
+		leasesLister:              leasesInformer.Lister(),
+		leasesSynced:              leasesInformer.Informer().HasSynced,
+		moduleSourcesLister:       moduleSourcesInformer.Lister(),
+		moduleSourcesSynced:       moduleSourcesInformer.Informer().HasSynced,
+		moduleReleasesLister:      moduleReleasesInformer.Lister(),
+		moduleReleasesSynced:      moduleReleasesInformer.Informer().HasSynced,
+		modulePullOverridesLister: modulePullOverridesInformer.Lister(),
+		modulePullOverridesSynced: modulePullOverridesInformer.Informer().HasSynced,
+
+		leaseWorkqueue: workqueue.NewRateLimitingQueue(ratelimiter),
+
+		logger:             lg,
+		externalModulesDir: os.Getenv("EXTERNAL_MODULES_DIR"),
+
+		docsBuilder: docs_builder.NewClient(httpClient),
+	}
+
+	_, err := updater.leasesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: updater.enqueueLease,
+	})
+	if err != nil {
+		updater.logger.Fatalf("add event handler failed: %s", err)
+	}
+
+	return updater
+}
+
+func (d *Updater) RunLeaseInformer(stopCh <-chan struct{}) {
+	go d.leasesInformer.Run(stopCh)
+}
+
+func (d *Updater) Run(ctx context.Context) {
+	defer d.leaseWorkqueue.ShutDown()
+
+	go wait.UntilWithContext(ctx, d.runLeaseWorker, time.Second)
+
+	<-ctx.Done()
+}
+
+func (d *Updater) RunPreflightCheck(ctx context.Context) error {
+	if d.externalModulesDir == "" {
+		return nil
+	}
+
+	if ok := cache.WaitForCacheSync(ctx.Done(), d.leasesSynced, d.moduleSourcesSynced, d.moduleReleasesSynced, d.modulePullOverridesSynced); !ok {
+		d.logger.Fatal("failed to wait for caches to sync")
+	}
+	d.logger.Info("Documentation builder's object cache synced")
+
+	return nil
+}
+
+func (d *Updater) SendDocumentation(ctx context.Context, m moduleReleaseGetter) error {
+	addrs, err := d.getDocsBuilderAddresses(ctx)
+	if err != nil {
+		return fmt.Errorf("get docs builder addresses: %w", err)
+	}
+
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	ms, err := d.moduleSourcesLister.Get(m.GetModuleSource())
+	if err != nil {
+		return fmt.Errorf("get module source: %w", err)
+	}
+
+	md := downloader.NewModuleDownloader(d.externalModulesDir, ms, utils.GenerateRegistryOptions(ms))
+	for _, addr := range addrs {
+		err := d.buildDocumentation(addr, md, m.GetModuleName(), m.GetReleaseVersion())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Updater) getDocsBuilderAddresses(_ context.Context) (addresses []string, err error) {
+	list, err := d.leasesLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("list leases: %w", err)
+	}
+
+	for _, lease := range list {
+		if lease.Spec.HolderIdentity == nil {
+			continue
+		}
+
+		addresses = append(addresses, "http://"+*lease.Spec.HolderIdentity)
+	}
+
+	return
+}
+
+func (d *Updater) buildDocumentation(baseAddr string, md *downloader.ModuleDownloader, moduleName, moduleVersion string) error {
+	docsArchive, err := md.GetDocumentationArchive(moduleName, moduleVersion)
+	if err != nil {
+		return fmt.Errorf("get documentation archive: %w", err)
+	}
+	defer docsArchive.Close()
+
+	err = d.docsBuilder.SendDocumentation(baseAddr, moduleName, moduleVersion, docsArchive)
+	if err != nil {
+		return fmt.Errorf("send documentation: %w", err)
+	}
+
+	err = d.docsBuilder.BuildDocumentation(baseAddr)
+	if err != nil {
+		return fmt.Errorf("build documentation: %w", err)
+	}
+
+	return nil
+}
+
+func (d *Updater) enqueueLease(obj interface{}) {
+	var key cache.ObjectName
+	var err error
+	if key, err = cache.ObjectToName(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	d.logger.Debugf("enqueue Lease: %s", key)
+	d.leaseWorkqueue.Add(key)
+}
+
+func (d *Updater) runLeaseWorker(ctx context.Context) {
+	for d.processNextLease(ctx) {
+	}
+}
+
+func (d *Updater) processNextLease(ctx context.Context) bool {
+	obj, shutdown := d.leaseWorkqueue.Get()
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer d.leaseWorkqueue.Done(obj)
+		var key cache.ObjectName
+		var ok bool
+		var req ctrl.Request
+
+		if key, ok = obj.(cache.ObjectName); !ok {
+			d.leaseWorkqueue.Forget(obj)
+			d.logger.Errorf("expected cache.ObjectName in workqueue but got %#v", obj)
+			return nil
+		}
+
+		req.Namespace, req.Name = key.Parts()
+		result, err := d.leaseCreateReconcile(ctx, req)
+		switch {
+		case result.RequeueAfter != 0:
+			d.leaseWorkqueue.AddAfter(key, result.RequeueAfter)
+
+		case result.Requeue:
+			d.leaseWorkqueue.AddRateLimited(key)
+
+		default:
+			d.leaseWorkqueue.Forget(key)
+		}
+
+		return err
+	}(obj)
+	if err != nil {
+		d.logger.Errorf("Lease reconcile error: %s", err.Error())
+		return true
+	}
+
+	return true
+}
+
+func (d *Updater) leaseCreateReconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	releases, err := d.moduleReleasesLister.List(labels.Everything())
+	if err != nil {
+		return ctrl.Result{Requeue: true}, fmt.Errorf("fetch ModuleReleases failed: %w", err)
+	}
+
+	for _, release := range releases {
+		// check if ModulePullOverride exists
+		mpo, err := d.modulePullOverridesLister.List(labels.SelectorFromValidatedSet(map[string]string{"source": release.GetModuleSource(), "module": release.Spec.ModuleName}))
+		if err != nil {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("fetch ModulePullOverride for %s failed: %w", release.Spec.ModuleName, err)
+		}
+
+		if len(mpo) > 0 {
+			continue
+		}
+
+		if release.Status.Phase != v1alpha1.PhaseDeployed {
+			continue
+		}
+
+		err = d.SendDocumentation(ctx, release)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+	}
+
+	mpos, err := d.modulePullOverridesLister.List(labels.Everything())
+	if err != nil {
+		return ctrl.Result{Requeue: true}, fmt.Errorf("fetch ModulePullOverrides failed: %w", err)
+	}
+
+	for _, mpo := range mpos {
+		d.SendDocumentation(ctx, mpo)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/go_lib/module/docs.go
+++ b/go_lib/module/docs.go
@@ -52,7 +52,7 @@ func extractDocumentation(rc io.ReadCloser, output io.Writer) error {
 			return fmt.Errorf("tar reader next: %w", err)
 		}
 
-		if !isDocsPath(filepath.Clean(hdr.Name)) {
+		if !IsDocsPath(filepath.Clean(hdr.Name)) {
 			continue
 		}
 
@@ -74,7 +74,7 @@ func extractDocumentation(rc io.ReadCloser, output io.Writer) error {
 	return nil
 }
 
-func isDocsPath(path string) bool {
+func IsDocsPath(path string) bool {
 	return strings.HasPrefix(path, "docs") ||
 		strings.HasPrefix(path, "crds") ||
 		strings.HasPrefix(path, "openapi")


### PR DESCRIPTION
## Description
This pr introduces the following changes:
- Deckhouse documentation-related lease informer is moved from release controller to a dedicated structure of the main controller where it is available both for release and override controllers (and whatsoever in the future);
- MPO-enabled modules have their documentation published and updated the same way it works for module releases;
- In case of rebuilding a modules' documentation, the documentation archive is formed from the files in the local module's directory. If the directory is unavailable for some reason, the documentation is pulled from the image in the repository.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Modules releases and MPO follow the same way of updating their documentation and most of the time the documentation is built from local files instead of pulling from the registry.
Closes #7969 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Modules' documentation is build for modules with deployed releases and for MPO-enabled modules.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Provide documentation for modules deployed by ModulePullOverride.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
