### PR TITLE
[monitoring-applications] Update rabbitmq alerts severity

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/applications/rabbitmq/prometheus-rules/rabbitmq.yaml
+++ b/ee/fe/modules/340-monitoring-applications/applications/rabbitmq/prometheus-rules/rabbitmq.yaml
@@ -25,7 +25,7 @@
     expr: ((rabbitmq_node_mem_used{job="rabbitmq"} / rabbitmq_node_mem_limit{job="rabbitmq"}) or (rabbitmq_process_resident_memory_bytes{job="rabbitmq"} / rabbitmq_resident_memory_limit_bytes{job="rabbitmq"})) * 100 > 95
     for: 1m
     labels:
-      severity_level: "3"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown
@@ -45,7 +45,7 @@
     expr: predict_linear(rabbitmq_disk_space_available_bytes{job="rabbitmq"}[15m], 1 * 60 * 60) < rabbitmq_node_disk_free_limit
     for: 5m
     labels:
-      severity_level: "3"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown
@@ -60,7 +60,7 @@
     expr: (rabbitmq_process_open_fds{job="rabbitmq"} / rabbitmq_process_max_fds{job="rabbitmq"}) * 100 > 90
     for: 1m
     labels:
-      severity_level: "3"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown
@@ -74,7 +74,7 @@
     expr: (rabbitmq_process_open_tcp_sockets{job="rabbitmq"} / rabbitmq_process_max_tcp_sockets{job="rabbitmq"}) * 100 > 90
     for: 1m
     labels:
-      severity_level: "3"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown
@@ -88,7 +88,7 @@
     expr: kube_statefulset_status_replicas{statefulset=~"(rabbitmq|rmq).*"} - kube_statefulset_status_replicas_ready{statefulset=~"(rabbitmq|rmq).*"} >= 1
     for: 5m
     labels:
-      severity_level: "3"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown


### PR DESCRIPTION
## Description
Change severity of RabbitMQ alerts from 3 to 4.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-applications
type: chore
summary: Change severity of RabbitMQ alerts from 3 to 4.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
