### PR TITLE
[deckhouse] relevant behavior of releases with `apply-now` annotation

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -145,7 +145,7 @@ func (du *DeckhouseUpdater) checkReleaseNotification(predictedRelease *Deckhouse
 	}
 
 	du.changeNotifiedFlag(true)
-	if applyTimeChanged {
+	if applyTimeChanged && !predictedRelease.AnnotationFlags.ApplyNow {
 		patch := map[string]interface{}{
 			"spec": map[string]interface{}{
 				"applyAfter": releaseApplyTime,

--- a/modules/002-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image.go
@@ -188,11 +188,6 @@ func updateDeckhouse(input *go_hook.HookInput, dc dependency.Container) error {
 		return nil
 	}
 
-	if deckhouseUpdater.HasAppliedNowRelease() {
-		deckhouseUpdater.ApplyAppliedNowRelease()
-		return nil
-	}
-
 	if deckhouseUpdater.PredictedReleaseIsPatch() {
 		// patch release does not respect update windows or ManualMode
 		deckhouseUpdater.ApplyPredictedRelease(nil)

--- a/modules/002-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image.go
@@ -150,7 +150,11 @@ func updateDeckhouse(input *go_hook.HookInput, dc dependency.Container) error {
 	// initialize deckhouseUpdater
 	approvalMode := input.Values.Get("deckhouse.update.mode").String()
 	// if values key does not exist, then cluster is just bootstrapping
-	clusterBootstrapping := !input.Values.Exists("global.clusterIsBootstrapped")
+	clusterBootstrapping := true
+	clusterBootstrappedV, ok := input.Values.GetOk("global.clusterIsBootstrapped")
+	if ok {
+		clusterBootstrapping = !clusterBootstrappedV.Bool()
+	}
 	deckhouseUpdater, err := updater.NewDeckhouseUpdater(input, approvalMode, releaseData, isDeckhousePodReady(dc.GetHTTPClient()), clusterBootstrapping)
 	if err != nil {
 		return fmt.Errorf("initializing deckhouse updater: %v", err)


### PR DESCRIPTION
## Description
Inherit behavior for releases with the `release.deckhouse.io/apply-now="true"` annotation from the main release logic.

## Why do we need it, and what problem does it solve?
`release.deckhouse.io/apply-now="true"` releases had their own logic and they were incorrect in some cases:
```yaml
v1.58.6   Deployed     7d
v1.58.7   Pending      19m              "k8s" requirement for DeckhouseRelease "1.58.7" not met: istio:minimalVersion key is not registred
```
Patch release should not check the release requirements, but apply-now release had to check it.

We can use standard rules from minor and patch releases but take into account the release annotation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Use the same logic as minor/patch for `apply-now` release, except the time settings.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
