### PR TITLE
[candi] Change containerd restart flow to avoid unwanted restarts

### DIFF
--- a/candi/bashible/bashbooster/20_event.sh
+++ b/candi/bashible/bashbooster/20_event.sh
@@ -62,7 +62,7 @@ bb-event-fire() {
     fi
     if [[ -f "$BB_EVENT_DIR/$EVENT.handlers" ]]
     then
-        bb-log-debug "Run handlers for event '$EVENT'"
+        bb-log-info "Run handlers for event '$EVENT'"
         while read -r HANDLER
         do
             eval "$HANDLER $@"

--- a/candi/bashible/bashbooster/30_flag.sh
+++ b/candi/bashible/bashbooster/30_flag.sh
@@ -33,6 +33,7 @@ bb-flag-set() {
         bb-log-debug "Creating flag directory at '$BB_FLAG_DIR'"
         mkdir "$BB_FLAG_DIR"
     fi
+    bb-log-info "Creating flag '$FLAG' at '$BB_FLAG_DIR'"
     touch "$BB_FLAG_DIR/$FLAG"
 }
 

--- a/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2023 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,18 @@
 {{- if eq .cri "Containerd" }}
 
 bb-event-on 'bb-package-installed' 'post-install'
+
+# This handler triggered by 'bb-event-fire "bb-package-installed" "${PACKAGE}"'
+# from bb-rp-install() function (defined in 50_deckhouse_registrypackages.sh).
+# All arguments (except the event name, i.e. 'bb-package-installed')
+# passed to the bb-event-fire() function are passed to the post-install() function.
+# This means that the post-install() function is called with an argument
+# containing the name of the installed package, which is used in the logic below.
+#
+# For example:
+# - 'post-install containerd'
+# - 'post-install crictl'
+
 post-install() {
   local PACKAGE="$1"
 

--- a/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/031_install_containerd.sh.tpl
@@ -16,11 +16,15 @@
 
 bb-event-on 'bb-package-installed' 'post-install'
 post-install() {
-  systemctl daemon-reload
-  systemctl enable containerd-deckhouse.service
-{{ if ne .runType "ImageBuilding" -}}
-  bb-flag-set containerd-need-restart
-{{- end }}
+  local PACKAGE="$1"
+
+  if [[ "${PACKAGE}" == "containerd" ]]; then
+    systemctl daemon-reload
+    systemctl enable containerd-deckhouse.service
+    {{- if ne .runType "ImageBuilding" }}
+    bb-flag-set containerd-need-restart
+    {{- end }}
+  fi
 }
 
 bb-rp-install "containerd:{{- index $.images.registrypackages "containerd1713" }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}" "toml-merge:{{ .images.registrypackages.tomlMerge01 }}"

--- a/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
@@ -14,9 +14,8 @@
 
 {{- if eq .cri "Containerd" }}
 _on_containerd_config_changed() {
-  {{ if ne .runType "ImageBuilding" -}}
+  {{- if ne .runType "ImageBuilding" }}
   bb-flag-set containerd-need-restart
-  bb-flag-set kubelet-need-restart
   {{- end }}
 }
 
@@ -196,13 +195,4 @@ timeout: 2
 debug: false
 pull-image-on-create: false
 EOF
-
-if bb-flag? containerd-need-restart; then
-  bb-log-warning "'containerd-need-restart' flag was set. Containerd should be restarted!"
-  {{ if ne .runType "ImageBuilding" -}}
-  systemctl restart containerd-deckhouse.service
-  {{- end }}
-  bb-flag-unset containerd-need-restart
-fi
-
 {{- end }}

--- a/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
@@ -1,0 +1,24 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .cri "Containerd" }}
+if bb-flag? containerd-need-restart; then
+  bb-log-warning "'containerd-need-restart' flag was set, restarting containerd."
+  {{- if ne .runType "ImageBuilding" }}
+  systemctl restart containerd-deckhouse.service
+  {{- end }}
+  bb-flag-set kubelet-need-restart
+  bb-flag-unset containerd-need-restart
+fi
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change containerd restart flow to avoid unwanted restarts. Add some logging to make future debugging easier.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Handlers declared via `bb-event-on` are executed after the step is completed. Thus `_on_containerd_config_changed` is called after the `containerd-need-restart` flag is checked and unset at the end of step 032, and sets this flag again, resulting in an unwanted restart of containerd on the next bashible run.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Double containerd restarts  can have unwanted consequences.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Change containerd restart flow to avoid unwanted restarts.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
