### PR TITLE
[operator-trivy] fix incorrect reports links

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -21,12 +21,14 @@ COPY patches/002-skip-some-checks.patch /src
 COPY patches/003-aws-ecr.patch /src
 COPY patches/004-scan-job-registry-ca.patch /src
 COPY patches/005-cis-benchmark-on-startup.patch /src
+COPY patches/006-new-metrics.patch /src
 
 RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
     patch -p1 < 002-skip-some-checks.patch && \
     patch -p1 < 003-aws-ecr.patch && \
     patch -p1 < 004-scan-job-registry-ca.patch && \
-    patch -p1 < 005-cis-benchmark-on-startup.patch
+    patch -p1 < 005-cis-benchmark-on-startup.patch && \
+    patch -p1 < 006-new-metrics.patch
 
 RUN go get golang.org/x/net@v0.17.0 && go mod tidy && go mod vendor
 RUN go build -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go

--- a/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/metrics/collector.go b/pkg/metrics/collector.go
-index 117c27c1..3b4d80cf 100644
+index 117c27c1..e181b40f 100644
 --- a/pkg/metrics/collector.go
 +++ b/pkg/metrics/collector.go
 @@ -3,6 +3,7 @@ package metrics
@@ -35,23 +35,14 @@ index 117c27c1..3b4d80cf 100644
  				}
  				var vulnList = make(map[string]bool)
  				for _, vuln := range r.Report.Vulnerabilities {
-@@ -590,6 +593,23 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
+@@ -590,6 +593,14 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
  					if vuln.Score != nil {
  						vulnLabelValues[20] = strconv.FormatFloat(*vuln.Score, 'f', -1, 64)
  					}
-+					if strings.Contains(vuln.VulnerabilityID, "BDU") {
-+						if strings.Contains(vuln.VulnerabilityID, "BDU-") {
-+							splits := strings.Split(vuln.VulnerabilityID, "BDU-")
-+							if len(splits) == 2 {
-+								vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + splits[1]
-+							}
-+						}
++					if strings.Contains(vuln.VulnerabilityID, "BDU") && len(vuln.VulnerabilityID) > 4 {
++						vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + vuln.VulnerabilityID[4:]
 +						if strings.Contains(vuln.VulnerabilityID, "BDU:") {
-+						  vulnLabelValues[19] = vuln.VulnerabilityID
-+							splits := strings.Split(vuln.VulnerabilityID, "BDU:")
-+							if len(splits) == 2 {
-+								vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + splits[1]
-+							}
++							vulnLabelValues[19] = vuln.VulnerabilityID
 +						}
 +					} else {
 +						vulnLabelValues[21] = vuln.PrimaryLink

--- a/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/metrics/collector.go b/pkg/metrics/collector.go
-index 117c27c1..e181b40f 100644
+index 117c27c1..6c8396f6 100644
 --- a/pkg/metrics/collector.go
 +++ b/pkg/metrics/collector.go
 @@ -3,6 +3,7 @@ package metrics
@@ -35,15 +35,13 @@ index 117c27c1..e181b40f 100644
  				}
  				var vulnList = make(map[string]bool)
  				for _, vuln := range r.Report.Vulnerabilities {
-@@ -590,6 +593,14 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
+@@ -590,6 +593,12 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
  					if vuln.Score != nil {
  						vulnLabelValues[20] = strconv.FormatFloat(*vuln.Score, 'f', -1, 64)
  					}
-+					if strings.Contains(vuln.VulnerabilityID, "BDU") && len(vuln.VulnerabilityID) > 4 {
++					if strings.HasPrefix(vuln.VulnerabilityID, "BDU") && len(vuln.VulnerabilityID) > 4 {
 +						vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + vuln.VulnerabilityID[4:]
-+						if strings.Contains(vuln.VulnerabilityID, "BDU:") {
-+							vulnLabelValues[19] = vuln.VulnerabilityID
-+						}
++						vulnLabelValues[19] = vuln.VulnerabilityID
 +					} else {
 +						vulnLabelValues[21] = vuln.PrimaryLink
 +					}

--- a/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
@@ -1,0 +1,38 @@
+diff --git a/pkg/metrics/collector.go b/pkg/metrics/collector.go
+index 117c27c1..5a16d61d 100644
+--- a/pkg/metrics/collector.go
++++ b/pkg/metrics/collector.go
+@@ -39,6 +39,7 @@ const (
+ 	severity           = "severity"
+ 	vuln_id            = "vuln_id"
+ 	vuln_title         = "vuln_title"
++	vuln_url           = "vuln_url"
+ 	vuln_score         = "vuln_score"
+ 	//compliance
+ 	title       = "title"
+@@ -264,6 +265,7 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
+ 		vuln_id,
+ 		vuln_title,
+ 		vuln_score,
++		vuln_url,
+ 	}
+ 	vulnIdLabels = append(vulnIdLabels, dynamicLabels...)
+ 	exposedSecretLabels := []string{
+@@ -567,7 +569,7 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
+ 				vulnLabelValues[7] = r.Report.Artifact.Tag
+ 				vulnLabelValues[8] = r.Report.Artifact.Digest
+ 				for i, label := range c.GetReportResourceLabels() {
+-					vulnLabelValues[i+21] = r.Labels[label]
++					vulnLabelValues[i+22] = r.Labels[label]
+ 				}
+ 				var vulnList = make(map[string]bool)
+ 				for _, vuln := range r.Report.Vulnerabilities {
+@@ -590,6 +592,7 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
+ 					if vuln.Score != nil {
+ 						vulnLabelValues[20] = strconv.FormatFloat(*vuln.Score, 'f', -1, 64)
+ 					}
++					vulnLabelValues[21] = vuln.PrimaryLink
+ 					metrics <- prometheus.MustNewConstMetric(c.vulnIdDesc, prometheus.GaugeValue, float64(1), vulnLabelValues...)
+ 				}
+ 			}
+

--- a/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
@@ -1,8 +1,16 @@
 diff --git a/pkg/metrics/collector.go b/pkg/metrics/collector.go
-index 117c27c1..5a16d61d 100644
+index 117c27c1..3b4d80cf 100644
 --- a/pkg/metrics/collector.go
 +++ b/pkg/metrics/collector.go
-@@ -39,6 +39,7 @@ const (
+@@ -3,6 +3,7 @@ package metrics
+ import (
+ 	"context"
+ 	"strconv"
++	"strings"
+
+ 	"github.com/aquasecurity/trivy-operator/pkg/kube"
+ 	"github.com/aquasecurity/trivy-operator/pkg/trivyoperator"
+@@ -39,6 +40,7 @@ const (
  	severity           = "severity"
  	vuln_id            = "vuln_id"
  	vuln_title         = "vuln_title"
@@ -10,7 +18,7 @@ index 117c27c1..5a16d61d 100644
  	vuln_score         = "vuln_score"
  	//compliance
  	title       = "title"
-@@ -264,6 +265,7 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
+@@ -264,6 +266,7 @@ func buildMetricDescriptors(config trivyoperator.ConfigData) metricDescriptors {
  		vuln_id,
  		vuln_title,
  		vuln_score,
@@ -18,7 +26,7 @@ index 117c27c1..5a16d61d 100644
  	}
  	vulnIdLabels = append(vulnIdLabels, dynamicLabels...)
  	exposedSecretLabels := []string{
-@@ -567,7 +569,7 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
+@@ -567,7 +570,7 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
  				vulnLabelValues[7] = r.Report.Artifact.Tag
  				vulnLabelValues[8] = r.Report.Artifact.Digest
  				for i, label := range c.GetReportResourceLabels() {
@@ -27,11 +35,27 @@ index 117c27c1..5a16d61d 100644
  				}
  				var vulnList = make(map[string]bool)
  				for _, vuln := range r.Report.Vulnerabilities {
-@@ -590,6 +592,7 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
+@@ -590,6 +593,23 @@ func (c ResourcesMetricsCollector) collectVulnerabilityIdReports(ctx context.Con
  					if vuln.Score != nil {
  						vulnLabelValues[20] = strconv.FormatFloat(*vuln.Score, 'f', -1, 64)
  					}
-+					vulnLabelValues[21] = vuln.PrimaryLink
++					if strings.Contains(vuln.VulnerabilityID, "BDU") {
++						vulnLabelValues[19] = vuln.VulnerabilityID
++						if strings.Contains(vuln.VulnerabilityID, "BDU-") {
++							splits := strings.Split(vuln.VulnerabilityID, "BDU-")
++							if len(splits) == 2 {
++								vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + splits[1]
++							}
++						}
++						if strings.Contains(vuln.VulnerabilityID, "BDU:") {
++							splits := strings.Split(vuln.VulnerabilityID, "BDU:")
++							if len(splits) == 2 {
++								vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + splits[1]
++							}
++						}
++					} else {
++						vulnLabelValues[21] = vuln.PrimaryLink
++					}
  					metrics <- prometheus.MustNewConstMetric(c.vulnIdDesc, prometheus.GaugeValue, float64(1), vulnLabelValues...)
  				}
  			}

--- a/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/006-new-metrics.patch
@@ -40,7 +40,6 @@ index 117c27c1..3b4d80cf 100644
  						vulnLabelValues[20] = strconv.FormatFloat(*vuln.Score, 'f', -1, 64)
  					}
 +					if strings.Contains(vuln.VulnerabilityID, "BDU") {
-+						vulnLabelValues[19] = vuln.VulnerabilityID
 +						if strings.Contains(vuln.VulnerabilityID, "BDU-") {
 +							splits := strings.Split(vuln.VulnerabilityID, "BDU-")
 +							if len(splits) == 2 {
@@ -48,6 +47,7 @@ index 117c27c1..3b4d80cf 100644
 +							}
 +						}
 +						if strings.Contains(vuln.VulnerabilityID, "BDU:") {
++						  vulnLabelValues[19] = vuln.VulnerabilityID
 +							splits := strings.Split(vuln.VulnerabilityID, "BDU:")
 +							if len(splits) == 2 {
 +								vulnLabelValues[21] = "https://bdu.fstec.ru/vul/" + splits[1]

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -1,16 +1,16 @@
 # Patches
 
-## 001-add-registry-secret-as-dockerconfigjson.patch
+### 001-add-registry-secret-as-dockerconfigjson.patch
 
 This patch adds docker auth config via kubernetes volume/volumeMount to scanjobs in Standalone mode so that trivy init container can download trivy-db from a private registry. ClientServer mode doesn't have to download trivy-db on its own.
 This [issue](https://github.com/aquasecurity/trivy-operator/issues/695) covers both trivy and trivy-operator. We've decided not to pursue patch upstreaming for now.
 
-## 002-skip-some-checks.patch
+### 002-skip-some-checks.patch
 
 Skip some defseq checks for proper reports result for deckhouse installation.
 
 
-## 003-aws-ecr.patch
+### 003-aws-ecr.patch
 
 In ClientServer mode scan pods can't retrive images from Amazon Elastic Container Registry, because `AWS_REGION` environment variable is absent.
 This patch is fixing this behaviour.
@@ -27,6 +27,10 @@ This patch adds the ability to specify CA for scan jobs via environment variable
 
 ### 005-cis-benchmark-on-startup.patch
 
-The first check begins instantly when the operator starts
+The first check begins instantly when the operator starts.
 
 [Issue](https://github.com/deckhouse/deckhouse/issues/5174)
+
+### 006-new-metrics.patch
+
+This patch adds new prometheus metrics for reports.

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -33,4 +33,4 @@ The first check begins instantly when the operator starts.
 
 ### 006-new-metrics.patch
 
-This patch adds new prometheus metrics for reports.
+This patch adds primaryLink metric for reports.

--- a/ee/modules/500-operator-trivy/monitoring/grafana-dashboards/security/trivy.json
+++ b/ee/modules/500-operator-trivy/monitoring/grafana-dashboards/security/trivy.json
@@ -246,7 +246,7 @@
             {
               "targetBlank": true,
               "title": "More details",
-              "url": "${__data.fields.vuln_id_url}"
+              "url": "${__data.fields.vuln_url}"
             }
           ],
           "mappings": [
@@ -305,37 +305,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vuln_id_url"
+              "options": "vuln_url"
             },
             "properties": [
               {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "pattern": "BDU-(.+)",
-                      "result": {
-                        "index": 0,
-                        "text": "https://bdu.fstec.ru/vul/$1"
-                      }
-                    },
-                    "type": "regex"
-                  },
-                  {
-                    "options": {
-                      "pattern": "(CVE.+)",
-                      "result": {
-                        "index": 1,
-                        "text": "https://nvd.nist.gov/vuln/detail/$1"
-                      }
-                    },
-                    "type": "regex"
-                  }
-                ]
-              },
-              {
-                "id": "custom.width",
-                "value": 1
+                "id": "custom.hidden",
+                "value": true
               }
             ]
           },
@@ -387,7 +362,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{namespace=~\"$namespace\",severity=~\"$severity\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"}) by (image_repository,image_tag,severity, vuln_id, namespace, resource_kind, resource, resource_name,vuln_title)",
+          "expr": "sum(trivy_vulnerability_id{namespace=~\"$namespace\",severity=~\"$severity\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"}) by (image_repository,image_tag,severity, vuln_id, namespace, resource_kind, resource, resource_name,vuln_title,vuln_url)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -397,20 +372,6 @@
       ],
       "title": "Vulnerability by Vulnerability Id",
       "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "vuln_id_url",
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "vuln_id"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
         {
           "id": "organize",
           "options": {


### PR DESCRIPTION
## Description
Provides fix for incorrect links in trivy-operator grafana dashboad.

## Why do we need it, and what problem does it solve?
When the vuln does not match our mapping there are incorrect links. To fix this, we have added primaryLink metric for collector and are now using a more "native" way to get these links.

## What is the expected result?
Correct links for vulns in grafana.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: operator-trivy
summary: fix incorrect reports links
```
