### PR TITLE
[log-shipper] Improve alert D8LogShipperAgentNotScheduledInCluster

### DIFF
--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -46,8 +46,16 @@
       description: |
         A number of log-shipper-agents are not scheduled.
 
-        Consider checking state of the d8-log-shipper/log-shipper-agent DaemonSet.
-        `kubectl -n d8-log-shipper get daemonset,pod --selector=app=log-shipper-agent`
+        Consider checking state of the d8-log-shipper/log-shipper-agent DaemonSet:
+        `kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper`
+
+        Consider checking state of the d8-log-shipper/log-shipper-agent Pods:
+        `kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent`
+
+        This command might help figuring out problematic nodes given you are aware where the DaemonSet should be scheduled in the first place:
+        ```
+        kubectl -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        ```
 
   - alert: D8LogShipperDestinationErrors
     for: 10m

--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -51,7 +51,7 @@
         kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper
         ```
 
-        To check the state of the d8-log-shipper/log-shipper-agent Pods:
+        To check the state of the `d8-log-shipper/log-shipper-agent` Pods:
         ```shell
         kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent
         ```

--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -46,13 +46,17 @@
       description: |
         A number of log-shipper-agents are not scheduled.
 
-        Consider checking state of the d8-log-shipper/log-shipper-agent DaemonSet:
-        `kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper`
+        To check the state of the `d8-log-shipper/log-shipper-agent` DaemonSet:
+        ```shell
+        kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper
+        ```
 
-        Consider checking state of the d8-log-shipper/log-shipper-agent Pods:
-        `kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent`
+        To check the state of the d8-log-shipper/log-shipper-agent Pods:
+        ```shell
+        kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent
+        ```
 
-        This command might help figuring out problematic nodes given you are aware where the DaemonSet should be scheduled in the first place:
+        The following command might help figuring out problematic nodes given you are aware where the DaemonSet should be scheduled in the first place:
         ```
         kubectl -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```


### PR DESCRIPTION
## Description
Improve alert `D8LogShipperAgentNotScheduledInCluster`.

## Why do we need it, and what problem does it solve?
Command in alert is not give us full information (daemonset have different name)
```
kubectl -n d8-log-shipper get daemonset,pod --selector=app=log-shipper-agent
NAME                          READY   STATUS             RESTARTS          AGE
pod/log-shipper-agent-2g62s   3/3     Running            0                 9d
pod/log-shipper-agent-2rwp7   3/3     Running            0                 9d
pod/log-shipper-agent-65qcx   3/3     Running            0                 11h
pod/log-shipper-agent-6zhrm   3/3     Running            0                 9d
pod/log-shipper-agent-7vjjh   3/3     Running            0                 5d10h
pod/log-shipper-agent-965xs   3/3     Running            131 (3h34m ago)   8d
pod/log-shipper-agent-98fd4   3/3     Running            0                 9d
pod/log-shipper-agent-b5954   3/3     Running            0                 9d
pod/log-shipper-agent-bkpw2   3/3     Running            0                 6h22m
pod/log-shipper-agent-dg9br   3/3     Running            0                 16h
pod/log-shipper-agent-dj5nw   3/3     Running            0                 9d
pod/log-shipper-agent-fksqs   2/3     CrashLoopBackOff   3566 (12s ago)    9d
pod/log-shipper-agent-grhnv   3/3     Running            1 (8d ago)        9d
pod/log-shipper-agent-jwt4b   3/3     Running            1754 (12m ago)    9d
pod/log-shipper-agent-k5jtv   3/3     Running            0                 11h
pod/log-shipper-agent-kpzs9   3/3     Running            0                 6d10h
pod/log-shipper-agent-l66dt   3/3     Running            0                 9d
pod/log-shipper-agent-lsk2d   3/3     Running            33 (15m ago)      9d
pod/log-shipper-agent-lstbh   3/3     Running            210 (3m12s ago)   9d
pod/log-shipper-agent-lxtjc   3/3     Running            0                 9d
pod/log-shipper-agent-nzcss   3/3     Running            238 (27m ago)     9d
pod/log-shipper-agent-p7v47   3/3     Running            0                 9d
pod/log-shipper-agent-pzsq7   3/3     Running            0                 9d
pod/log-shipper-agent-r4qhf   3/3     Running            109 (8d ago)      9d
pod/log-shipper-agent-rgc4z   3/3     Running            0                 9h
pod/log-shipper-agent-rzdt5   3/3     Running            0                 9d
pod/log-shipper-agent-swtmm   3/3     Running            2 (29h ago)       9d
pod/log-shipper-agent-t2n2v   3/3     Running            0                 9d
pod/log-shipper-agent-v75pv   3/3     Running            9 (3h59m ago)     18h
pod/log-shipper-agent-vqlp8   3/3     Running            23 (17m ago)      9d
pod/log-shipper-agent-xbhng   3/3     Running            12 (46h ago)      9d
```

Sets of new commands give us more needed information
```
~ $ kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper
NAME                DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
log-shipper-agent   30        30        29      30           29          <none>          688d
~ $ kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent
NAME                      READY   STATUS             RESTARTS           AGE
log-shipper-agent-2g62s   3/3     Running            0                  9d
log-shipper-agent-2rwp7   3/3     Running            0                  9d
log-shipper-agent-6zhrm   3/3     Running            0                  9d
log-shipper-agent-7vjjh   3/3     Running            0                  5d11h
log-shipper-agent-965xs   3/3     Running            131 (3h39m ago)    8d
log-shipper-agent-98fd4   3/3     Running            0                  9d
log-shipper-agent-b5954   3/3     Running            0                  9d
log-shipper-agent-bkpw2   3/3     Running            0                  6h26m
log-shipper-agent-dg9br   3/3     Running            0                  16h
log-shipper-agent-dj5nw   3/3     Running            0                  9d
log-shipper-agent-fksqs   1/3     CrashLoopBackOff   3567 (113s ago)    9d
log-shipper-agent-grhnv   3/3     Running            1 (8d ago)         9d
log-shipper-agent-jwt4b   3/3     Running            1757 (2m12s ago)   9d
log-shipper-agent-k5jtv   3/3     Running            0                  11h
log-shipper-agent-kpzs9   3/3     Running            0                  6d10h
log-shipper-agent-l66dt   3/3     Running            0                  9d
log-shipper-agent-lsk2d   3/3     Running            33 (19m ago)       9d
log-shipper-agent-lstbh   3/3     Running            210 (7m22s ago)    9d
log-shipper-agent-lxtjc   3/3     Running            0                  9d
log-shipper-agent-nzcss   3/3     Running            238 (31m ago)      9d
log-shipper-agent-p7v47   3/3     Running            0                  9d
log-shipper-agent-pzsq7   3/3     Running            0                  9d
log-shipper-agent-r4qhf   3/3     Running            109 (8d ago)       9d
log-shipper-agent-rgc4z   3/3     Running            0                  10h
log-shipper-agent-rzdt5   3/3     Running            0                  9d
log-shipper-agent-swtmm   3/3     Running            2 (29h ago)        9d
log-shipper-agent-t2n2v   3/3     Running            0                  9d
log-shipper-agent-v75pv   3/3     Running            9 (4h4m ago)       18h
log-shipper-agent-vqlp8   3/3     Running            23 (21m ago)       9d
log-shipper-agent-xbhng   3/3     Running            12 (46h ago)       9d
~ $ kubectl -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
main-aws-worker-t3a-2xlarge-od-a62f8145-66d45-qpc6r
~ $
```


## Why do we need it in the patch release (if we do)?

Not necessarily

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Improve alert `D8LogShipperAgentNotScheduledInCluster`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
