### PR TITLE
[dhctl] feat(dhctl-for-commander): add import operation skeleton without real implementation, rework on-phase hook

### DIFF
--- a/dhctl/pkg/infrastructure/cluster.go
+++ b/dhctl/pkg/infrastructure/cluster.go
@@ -39,7 +39,7 @@ type ClusterInfra struct {
 	cache            state.Cache
 	terraformContext *terraform.TerraformContext
 
-	*phases.PhasedExecutionContext
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext
 }
 
 func NewClusterInfra(terraState StateLoader, cache state.Cache, terraformContext *terraform.TerraformContext) *ClusterInfra {
@@ -47,7 +47,7 @@ func NewClusterInfra(terraState StateLoader, cache state.Cache, terraformContext
 }
 
 type ClusterInfraOptions struct {
-	PhasedExecutionContext *phases.PhasedExecutionContext
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext
 }
 
 func NewClusterInfraWithOptions(terraState StateLoader, cache state.Cache, terraformContext *terraform.TerraformContext, opts ClusterInfraOptions) *ClusterInfra {
@@ -93,7 +93,7 @@ func (r *ClusterInfra) DestroyCluster(autoApprove bool) error {
 	}
 
 	if r.PhasedExecutionContext != nil {
-		if shouldStop, err := r.PhasedExecutionContext.SwitchPhase(phases.BaseInfraPhase, true, r.cache); err != nil {
+		if shouldStop, err := r.PhasedExecutionContext.SwitchPhase(phases.BaseInfraPhase, true, r.cache, nil); err != nil {
 			return err
 		} else if shouldStop {
 			return nil
@@ -105,7 +105,7 @@ func (r *ClusterInfra) DestroyCluster(autoApprove bool) error {
 	}
 
 	if r.PhasedExecutionContext != nil {
-		return r.PhasedExecutionContext.CompletePhase(r.cache)
+		return r.PhasedExecutionContext.CompletePhase(r.cache, nil)
 	} else {
 		return nil
 	}

--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -62,8 +62,8 @@ var (
 )
 
 type Runner struct {
-	*phases.PhasedExecutionContext
-	terraformContext *terraform.TerraformContext
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext
+	terraformContext       *terraform.TerraformContext
 
 	kubeCl         *client.KubernetesClient
 	changeSettings *terraform.ChangeActionSettings
@@ -102,7 +102,7 @@ func (r *Runner) WithCommanderMode(commanderMode bool) *Runner {
 	return r
 }
 
-func (r *Runner) WithPhasedExecutionContext(pec *phases.PhasedExecutionContext) *Runner {
+func (r *Runner) WithPhasedExecutionContext(pec phases.DefaultPhasedExecutionContext) *Runner {
 	r.PhasedExecutionContext = pec
 	return r
 }
@@ -182,7 +182,7 @@ func (r *Runner) converge() error {
 		}
 
 		if r.PhasedExecutionContext != nil {
-			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache); err != nil {
+			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache, nil); err != nil {
 				return err
 			}
 		}
@@ -263,7 +263,7 @@ func (r *Runner) converge() error {
 		}
 
 		if r.PhasedExecutionContext != nil {
-			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache); err != nil {
+			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache, nil); err != nil {
 				return err
 			}
 		}
@@ -293,7 +293,7 @@ func (r *Runner) converge() error {
 		}
 
 		if r.PhasedExecutionContext != nil {
-			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache); err != nil {
+			if err := r.PhasedExecutionContext.CompletePhase(r.stateCache, nil); err != nil {
 				return err
 			}
 		}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -75,7 +75,7 @@ type Params struct {
 	InitialState               phases.DhctlState
 	ResetInitialState          bool
 	DisableBootstrapClearCache bool
-	OnPhaseFunc                phases.OnPhaseFunc
+	OnPhaseFunc                phases.DefaultOnPhaseFunc
 	CommanderMode              bool
 	TerraformContext           *terraform.TerraformContext
 
@@ -92,9 +92,9 @@ type Params struct {
 
 type ClusterBootstrapper struct {
 	*Params
-	*phases.PhasedExecutionContext
-	initializeNewAgent bool
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext
 
+	initializeNewAgent bool
 	// TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this variable will be unneeded then
 	lastState phases.DhctlState
 }
@@ -102,7 +102,7 @@ type ClusterBootstrapper struct {
 func NewClusterBootstrapper(params *Params) *ClusterBootstrapper {
 	return &ClusterBootstrapper{
 		Params:                 params,
-		PhasedExecutionContext: phases.NewPhasedExecutionContext(params.OnPhaseFunc),
+		PhasedExecutionContext: phases.NewDefaultPhasedExecutionContext(params.OnPhaseFunc),
 		lastState:              params.InitialState,
 	}
 }
@@ -337,7 +337,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		resourcesToCreate = parsedResources
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecuteBashibleBundlePhase, false, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecuteBashibleBundlePhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -350,7 +350,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		return err
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallDeckhousePhase, false, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallDeckhousePhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -365,7 +365,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	}
 
 	if metaConfig.ClusterType == config.CloudClusterType {
-		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallAdditionalMastersAndStaticNodes, true, stateCache); err != nil {
+		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallAdditionalMastersAndStaticNodes, true, stateCache, nil); err != nil {
 			return err
 		} else if shouldStop {
 			return nil
@@ -386,7 +386,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		}
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.CreateResourcesPhase, false, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.CreateResourcesPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -397,7 +397,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		return err
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecPostBootstrapPhase, false, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecPostBootstrapPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -412,7 +412,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		}
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.FinalizationPhase, false, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.FinalizationPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -449,7 +449,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		})
 	}
 
-	return b.PhasedExecutionContext.CompletePhaseAndPipeline(stateCache)
+	return b.PhasedExecutionContext.CompletePhaseAndPipeline(stateCache, nil)
 }
 
 // TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this method will be unneeded then

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -34,7 +34,7 @@ import (
 // TODO(remove-global-app): Support all needed parameters in Params, remove usage of app.*
 type Params struct {
 	SSHClient              *ssh.Client
-	OnPhaseFunc            phases.OnPhaseFunc
+	OnPhaseFunc            phases.DefaultOnPhaseFunc
 	AutoDismissDestructive bool
 	AutoApprove            bool
 
@@ -51,7 +51,7 @@ type Params struct {
 
 type Converger struct {
 	*Params
-	*phases.PhasedExecutionContext
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext
 
 	// TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this variable will be unneeded then
 	lastState phases.DhctlState
@@ -60,7 +60,7 @@ type Converger struct {
 func NewConverger(params *Params) *Converger {
 	return &Converger{
 		Params:                 params,
-		PhasedExecutionContext: phases.NewPhasedExecutionContext(params.OnPhaseFunc),
+		PhasedExecutionContext: phases.NewDefaultPhasedExecutionContext(params.OnPhaseFunc),
 	}
 }
 

--- a/dhctl/pkg/operations/import/import_result.go
+++ b/dhctl/pkg/operations/import/import_result.go
@@ -1,0 +1,23 @@
+package _import
+
+import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/check"
+)
+
+type ImportStatus string
+
+const (
+	ImportStatusScanned  ImportStatus = "Scanned"
+	ImportStatusImported ImportStatus = "Imported"
+)
+
+type ScanResult struct {
+	ClusterConfiguration                 string `json:"cluster_configuration"`
+	ProviderSpecificClusterConfiguration string `json:"provider_specific_cluster_configuration"`
+}
+
+type ImportResult struct {
+	Status      ImportStatus       `json:"status"`
+	ScanResult  *ScanResult        `json:"scan_result"`
+	CheckResult *check.CheckResult `json:"check_result,omitempty"`
+}

--- a/dhctl/pkg/operations/import/importer.go
+++ b/dhctl/pkg/operations/import/importer.go
@@ -1,0 +1,25 @@
+package _import
+
+import (
+	"context"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
+)
+
+type Params struct {
+	CommanderMode    bool
+	TerraformContext *terraform.TerraformContext
+	OnPhaseFunc      OnPhaseFunc
+}
+
+type Importer struct {
+	Params *Params
+}
+
+func NewImporter(params *Params) *Importer {
+	return &Importer{Params: params}
+}
+
+func (i *Importer) Import(ctx context.Context) error {
+	// TODO(cluster-import): implement Scan, Capture and Check phases
+	return nil
+}

--- a/dhctl/pkg/operations/import/phases.go
+++ b/dhctl/pkg/operations/import/phases.go
@@ -1,0 +1,20 @@
+package _import
+
+import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/check"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
+)
+
+type (
+	PhaseData struct {
+		ScanResult  *ScanResult
+		CheckResult *check.CheckResult
+	}
+	OnPhaseFunc phases.OnPhaseFunc[PhaseData]
+)
+
+const (
+	ScanPhase    phases.OperationPhase = "Scan"
+	CapturePhase phases.OperationPhase = "Capture"
+	CheckPhase   phases.OperationPhase = "Check"
+)

--- a/dhctl/pkg/operations/phases/phased_execution_context.go
+++ b/dhctl/pkg/operations/phases/phased_execution_context.go
@@ -1,0 +1,168 @@
+package phases
+
+import (
+	"errors"
+	"fmt"
+	dstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
+)
+
+type (
+	OnPhaseFunc[OperationPhaseDataT any] func(completedPhase OperationPhase, completedPhaseState DhctlState, completedPhaseData OperationPhaseDataT, nextPhase OperationPhase, nextPhaseCritical bool) error
+
+	PhasedExecutionContext[OperationPhaseDataT any] interface {
+		InitPipeline(stateCache dstate.Cache) error
+		Finalize(stateCache dstate.Cache) error
+		StartPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error)
+		CompletePhase(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error
+		CompletePipeline(stateCache dstate.Cache) error
+		SwitchPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) (bool, error)
+		CompletePhaseAndPipeline(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error
+		GetLastState() DhctlState
+	}
+
+	DefaultPhasedExecutionContext PhasedExecutionContext[interface{}]
+	DefaultOnPhaseFunc            OnPhaseFunc[interface{}]
+)
+
+type phasedExecutionContext[OperationPhaseDataT any] struct {
+	onPhaseFunc               OnPhaseFunc[OperationPhaseDataT]
+	lastState                 DhctlState
+	completedPhase            OperationPhase
+	completedPhaseData        OperationPhaseDataT
+	failedPhase               OperationPhase
+	currentPhase              OperationPhase
+	stopOperationCondition    bool
+	pipelineCompletionCounter int
+}
+
+func NewDefaultPhasedExecutionContext(onPhaseFunc DefaultOnPhaseFunc) *phasedExecutionContext[interface{}] {
+	return NewPhasedExecutionContext[interface{}](OnPhaseFunc[interface{}](onPhaseFunc))
+}
+
+func NewPhasedExecutionContext[OperationPhaseDataT any](onPhaseFunc OnPhaseFunc[OperationPhaseDataT]) *phasedExecutionContext[OperationPhaseDataT] {
+	return &phasedExecutionContext[OperationPhaseDataT]{onPhaseFunc: onPhaseFunc}
+}
+
+func (pec *phasedExecutionContext[OperationPhaseDataT]) setLastState(stateCache dstate.Cache) error {
+	state, err := ExtractDhctlState(stateCache)
+	if err != nil {
+		return fmt.Errorf("unable to extract dhctl state: %w", err)
+	}
+	pec.lastState = state
+	return nil
+}
+
+func (pec *phasedExecutionContext[OperationPhaseDataT]) callOnPhase(completedPhase OperationPhase, completedPhaseState DhctlState, completedPhaseData OperationPhaseDataT, nextPhase OperationPhase, nextPhaseIsCritical bool, stateCache dstate.Cache) (bool, error) {
+	if pec.onPhaseFunc == nil {
+		return false, nil
+	}
+
+	onPhaseErr := pec.onPhaseFunc(completedPhase, completedPhaseState, completedPhaseData, nextPhase, nextPhaseIsCritical)
+
+	if onPhaseErr != nil {
+		if err := pec.setLastState(stateCache); err != nil {
+			return false, err
+		}
+
+		pec.stopOperationCondition = true
+
+		if errors.Is(onPhaseErr, StopOperationCondition) {
+			return true, nil
+		} else {
+			return false, onPhaseErr
+		}
+	}
+
+	return false, nil
+}
+
+// InitPipeline initializes phasedExecutionContext before usage.
+// It is not possible to use phasedExecutionContext before InitPipeline called.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) InitPipeline(stateCache dstate.Cache) error {
+	if err := pec.setLastState(stateCache); err != nil {
+		return err
+	}
+	pec.pipelineCompletionCounter++
+	return nil
+}
+
+// Finalize supposed to always be called when errors or no errors have occured (use defer pec.Finalize() for example).
+// Call Finalize in the same scope where InitPipeline has been called.
+//
+// It is not possible to use phasedExecutionContext after Finalize called.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) Finalize(stateCache dstate.Cache) error {
+	if pec.stopOperationCondition {
+		return nil
+	}
+	return pec.setLastState(stateCache)
+}
+
+// StartPhase starts a new phase of some process behind current phasedExecutionContext.
+// StartPhase could be called either after InitPipeline to start first phase or after CompletePhase to start N-th phase.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) StartPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error) {
+	if pec.stopOperationCondition {
+		return true, nil
+	}
+
+	pec.currentPhase = phase
+	return pec.callOnPhase(pec.completedPhase, pec.lastState, pec.completedPhaseData, phase, isCritical, stateCache)
+}
+
+// CompletePhase stops previously started phase and saves current snapshot of state::Cache into the phasedExecutionContext.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePhase(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error {
+	if pec.stopOperationCondition {
+		return nil
+	}
+	pec.completedPhase = pec.currentPhase
+	pec.completedPhaseData = completedPhaseData
+	return pec.setLastState(stateCache)
+}
+
+func (pec *phasedExecutionContext[OperationPhaseDataT]) commitState(stateCache dstate.Cache) error {
+	if pec.stopOperationCondition {
+		return nil
+	}
+	return pec.setLastState(stateCache)
+}
+
+// CompletePipeline stops whole phased process execution pipeline (onPhaseFunc will be called).
+// CompletePipeline or CompletePhaseAndPipeline could be called only once for a given phasedExecutionContext.
+// CompletePipeline or CompletePhaseAndPipeline should be called in the same scope where InitPipeline has been called.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePipeline(stateCache dstate.Cache) error {
+	pec.pipelineCompletionCounter--
+	if pec.stopOperationCondition {
+		return nil
+	}
+	pec.completedPhase = pec.currentPhase
+	if pec.completedPhase == "" {
+		return nil
+	}
+	if pec.pipelineCompletionCounter == 0 {
+		_, err := pec.callOnPhase(pec.completedPhase, pec.lastState, pec.completedPhaseData, "", false, stateCache)
+		return err
+	}
+	return nil
+}
+
+// SwitchPhase is a shortcut to complete current phase & start next phase in one-step.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) SwitchPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) (bool, error) {
+	if err := pec.CompletePhase(stateCache, completedPhaseData); err != nil {
+		return false, err
+	}
+	return pec.StartPhase(phase, isCritical, stateCache)
+}
+
+// CompletePhaseAndPipeline is a shortcut to commit current phase & complete phasedExecutionContext phased process execution pipeline.
+// Complete or CompletePhaseAndPipeline could be called only once for a given phasedExecutionContext.
+// Complete or CompletePhaseAndPipeline should be called in the same scope where InitPipeline has been called.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePhaseAndPipeline(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error {
+	if err := pec.CompletePhase(stateCache, completedPhaseData); err != nil {
+		return err
+	}
+	return pec.CompletePipeline(stateCache)
+}
+
+// GetLastState gets last committed state from phasedExecutionContext.
+func (pec *phasedExecutionContext[OperationPhaseDataT]) GetLastState() DhctlState {
+	return pec.lastState
+}

--- a/dhctl/pkg/operations/phases/phases.go
+++ b/dhctl/pkg/operations/phases/phases.go
@@ -16,14 +16,14 @@ package phases
 
 import (
 	"errors"
-	"fmt"
-	dstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
 )
 
-type OnPhaseFunc func(completedPhase OperationPhase, completedPhaseState DhctlState, nextPhase OperationPhase, nextPhaseCritical bool) error
+type (
+	OperationPhase string
+)
 
-type OperationPhase string
-
+// Define common operations phases for such operations as bootstrap, converge and destroy.
+// Notice that each operation could define own phases (like import operation do).
 const (
 	BaseInfraPhase                         OperationPhase = "BaseInfra"
 	ExecuteBashibleBundlePhase             OperationPhase = "ExecuteBashibleBundle"
@@ -39,140 +39,3 @@ const (
 var (
 	StopOperationCondition = errors.New("StopOperationCondition")
 )
-
-type PhasedExecutionContext struct {
-	onPhaseFunc               OnPhaseFunc
-	lastState                 DhctlState
-	completedPhase            OperationPhase
-	failedPhase               OperationPhase
-	currentPhase              OperationPhase
-	stopOperationCondition    bool
-	pipelineCompletionCounter int
-}
-
-func NewPhasedExecutionContext(onPhaseFunc OnPhaseFunc) *PhasedExecutionContext {
-	return &PhasedExecutionContext{onPhaseFunc: onPhaseFunc}
-}
-
-func (pec *PhasedExecutionContext) setLastState(stateCache dstate.Cache) error {
-	state, err := ExtractDhctlState(stateCache)
-	if err != nil {
-		return fmt.Errorf("unable to extract dhctl state: %w", err)
-	}
-	pec.lastState = state
-	return nil
-}
-
-func (pec *PhasedExecutionContext) callOnPhase(completedPhase OperationPhase, completedPhaseState DhctlState, nextPhase OperationPhase, nextPhaseIsCritical bool, stateCache dstate.Cache) (bool, error) {
-	if pec.onPhaseFunc == nil {
-		return false, nil
-	}
-
-	onPhaseErr := pec.onPhaseFunc(completedPhase, completedPhaseState, nextPhase, nextPhaseIsCritical)
-
-	if onPhaseErr != nil {
-		if err := pec.setLastState(stateCache); err != nil {
-			return false, err
-		}
-
-		pec.stopOperationCondition = true
-
-		if errors.Is(onPhaseErr, StopOperationCondition) {
-			return true, nil
-		} else {
-			return false, onPhaseErr
-		}
-	}
-
-	return false, nil
-}
-
-// InitPipeline initializes PhasedExecutionContext before usage.
-// It is not possible to use PhasedExecutionContext before InitPipeline called.
-func (pec *PhasedExecutionContext) InitPipeline(stateCache dstate.Cache) error {
-	if err := pec.setLastState(stateCache); err != nil {
-		return err
-	}
-	pec.pipelineCompletionCounter++
-	return nil
-}
-
-// Finalize supposed to always be called when errors or no errors have occured (use defer pec.Finalize() for example).
-// Call Finalize in the same scope where InitPipeline has been called.
-//
-// It is not possible to use PhasedExecutionContext after Finalize called.
-func (pec *PhasedExecutionContext) Finalize(stateCache dstate.Cache) error {
-	if pec.stopOperationCondition {
-		return nil
-	}
-	return pec.setLastState(stateCache)
-}
-
-// StartPhase starts a new phase of some process behind current PhasedExecutionContext.
-// StartPhase could be called either after InitPipeline to start first phase or after CompletePhase to start N-th phase.
-func (pec *PhasedExecutionContext) StartPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error) {
-	if pec.stopOperationCondition {
-		return true, nil
-	}
-
-	pec.currentPhase = phase
-	return pec.callOnPhase(pec.completedPhase, pec.lastState, phase, isCritical, stateCache)
-}
-
-// CompletePhase stops previously started phase and saves current snapshot of state::Cache into the PhasedExecutionContext.
-func (pec *PhasedExecutionContext) CompletePhase(stateCache dstate.Cache) error {
-	if pec.stopOperationCondition {
-		return nil
-	}
-	pec.completedPhase = pec.currentPhase
-	return pec.setLastState(stateCache)
-}
-
-func (pec *PhasedExecutionContext) commitState(stateCache dstate.Cache) error {
-	if pec.stopOperationCondition {
-		return nil
-	}
-	return pec.setLastState(stateCache)
-}
-
-// CompletePipeline stops whole phased process execution pipeline (onPhaseFunc will be called).
-// CompletePipeline or CompletePhaseAndPipeline could be called only once for a given PhasedExecutionContext.
-// CompletePipeline or CompletePhaseAndPipeline should be called in the same scope where InitPipeline has been called.
-func (pec *PhasedExecutionContext) CompletePipeline(stateCache dstate.Cache) error {
-	pec.pipelineCompletionCounter--
-	if pec.stopOperationCondition {
-		return nil
-	}
-	pec.completedPhase = pec.currentPhase
-	if pec.completedPhase == "" {
-		return nil
-	}
-	if pec.pipelineCompletionCounter == 0 {
-		_, err := pec.callOnPhase(pec.completedPhase, pec.lastState, "", false, stateCache)
-		return err
-	}
-	return nil
-}
-
-// SwitchPhase is a shortcut to complete current phase & start next phase in one-step.
-func (pec *PhasedExecutionContext) SwitchPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error) {
-	if err := pec.CompletePhase(stateCache); err != nil {
-		return false, err
-	}
-	return pec.StartPhase(phase, isCritical, stateCache)
-}
-
-// CompletePhaseAndPipeline is a shortcut to commit current phase & complete PhasedExecutionContext phased process execution pipeline.
-// Complete or CompletePhaseAndPipeline could be called only once for a given PhasedExecutionContext.
-// Complete or CompletePhaseAndPipeline should be called in the same scope where InitPipeline has been called.
-func (pec *PhasedExecutionContext) CompletePhaseAndPipeline(stateCache dstate.Cache) error {
-	if err := pec.CompletePhase(stateCache); err != nil {
-		return err
-	}
-	return pec.CompletePipeline(stateCache)
-}
-
-// GetLastState gets last committed state from PhasedExecutionContext.
-func (pec *PhasedExecutionContext) GetLastState() DhctlState {
-	return pec.lastState
-}


### PR DESCRIPTION
## Description

New import operation which works only in commander-mode. Import task allows any deckhouse cluster become commander's cluster. This implies running commander-agent, disabling auto-converger and other possible in-cluster changes.

## Why do we need it, and what problem does it solve?

This operation needed only for commander mode to implement user-story where user puts already existing deckhouse cluster into control of commander.