### PR TITLE
[docs] usage bb-*-install in cuda install

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -638,9 +638,11 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-    curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    if [ ! -f "/etc/apt/sources.list.d/nvidia-container-toolkit.list" ]; then
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+      curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
+      curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    fi
     bb-apt-install nvidia-container-toolkit nvidia-driver-535-server
   nodeGroups:
   - gpu
@@ -672,8 +674,10 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+    if [ ! -f "/etc/yum.repos.d/nvidia-container-toolkit.repo" ]; then
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+      curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+    fi
     bb-yum-install nvidia-container-toolkit nvidia-driver
   nodeGroups:
   - gpu

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -645,9 +645,11 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-    curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    if [ ! -f "/etc/apt/sources.list.d/nvidia-container-toolkit.list" ]; then
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+      curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
+      curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    fi
     bb-apt-install nvidia-container-toolkit nvidia-driver-535-server
   nodeGroups:
   - gpu
@@ -679,8 +681,10 @@ spec:
     # See the License for the specific language governing permissions and
     # limitations under the License.
 
-    distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+    if [ ! -f "/etc/yum.repos.d/nvidia-container-toolkit.repo" ]; then
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+      curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+    fi
     bb-yum-install nvidia-container-toolkit nvidia-driver
   nodeGroups:
   - gpu


### PR DESCRIPTION
## Description
Driver installation scripts are improved by checking the existence of files and packages
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
For static nodes it is not always acceptable to update packages during operation. The old version leads to attempts to update packages once every 4h
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Usage bb-*-install in CUDA install on `node-manager`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
