### PR TITLE
[admission-policy-engine] add a separate queue and throttling for bootstrap hook

### DIFF
--- a/modules/015-admission-policy-engine/hooks/bootstrap_handler.go
+++ b/modules/015-admission-policy-engine/hooks/bootstrap_handler.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
@@ -45,6 +46,11 @@ type cTemplate struct {
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/admission-policy-engine/bootstrap",
+	Settings: &go_hook.HookConfigSettings{
+		ExecutionMinInterval: 3 * time.Second,
+		ExecutionBurst:       1,
+	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "gatekeeper_templates",


### PR DESCRIPTION
## Description
Provides adding a separate queue and throttling for bootstrap hook.

## Why do we need it, and what problem does it solve?
Closes #6591

## What is the expected result?
Bootstrap hook works in separate queue.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: admission-policy-engine
type: feature
summary: add a separate queue and throttling for bootstrap hook
```

