### PR TITLE
[log-shipper] add extraLabels validation

### DIFF
--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -661,8 +661,8 @@ spec:
                       array_member: '{{ array[0] }}'
                       symbol_escating_value: '{{ pay\.day }}'
                   x-kubernetes-validations:
-                    - message: parsed_data cannot be used as a key in extraLabels, it's reserved
-                      rule: '!(''parsed_data'' in self)'
+                    - message: using reserved keys in extraLabels
+                      rule: '!([''pod'', ''pod_ip'', ''pod_owner'', ''parsed_data'', ''namespace'', ''image'', ''container'', ''node''].exists(k, k in self))'
                   additionalProperties:
                     type: string
                     anyOf:

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -660,6 +660,9 @@ spec:
                       app_info: '{{ app }}'
                       array_member: '{{ array[0] }}'
                       symbol_escating_value: '{{ pay\.day }}'
+                  x-kubernetes-validations:
+                    - message: parsed_data cannot be used as a key in extraLabels, it's reserved
+                      rule: '!(''parsed_data'' in self)'
                   additionalProperties:
                     type: string
                     anyOf:


### PR DESCRIPTION
## Description
Provides extraLabels validation.

## Why do we need it, and what problem does it solve?
Closes #7740
There is a problem related to the fact that you can use reserved keys for extraLabels, and this causes redefinition and unexpected behavior. Adding validation prevents this.

## What is the expected result?
parsed_data cannot be used as a key in extraLabels.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: log-shipper
type: feature 
summary: Add extraLabels validation.
```
