### PR TITLE
[monitoring] Migrate from statusmap and status-history to state-timeline plugin

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
@@ -1583,7 +1583,7 @@
           "text": "default",
           "value": "default"
         },
-        "hide": 0,
+        "hide": 1,
         "includeAll": false,
         "label": "Prometheus",
         "multi": false,

--- a/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
@@ -1583,7 +1583,7 @@
           "text": "default",
           "value": "default"
         },
-        "hide": 1,
+        "hide": 2,
         "includeAll": false,
         "label": "Prometheus",
         "multi": false,

--- a/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
@@ -1576,7 +1576,27 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-3h",

--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -1583,7 +1583,7 @@
           "text": "default",
           "value": "default"
         },
-        "hide": 0,
+        "hide": 1,
         "includeAll": false,
         "label": "Prometheus",
         "multi": false,

--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -1583,7 +1583,7 @@
           "text": "default",
           "value": "default"
         },
-        "hide": 1,
+        "hide": 2,
         "includeAll": false,
         "label": "Prometheus",
         "multi": false,

--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -1576,7 +1576,27 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-3h",

--- a/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
+++ b/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
@@ -80,13 +80,14 @@
       "links": [],
       "maxDataPoints": 150,
       "options": {
-        "colWidth": 0.9,
+	"alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
+	"mergeValues": false,
         "rowHeight": 0.9,
-        "showValue": "auto",
+        "showValue": "never",
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -103,7 +104,7 @@
         }
       ],
       "title": "Heartbeat",
-      "type": "status-history"
+      "type": "state-timeline"
     },
     {
       "datasource": {

--- a/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
+++ b/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
@@ -80,12 +80,12 @@
       "links": [],
       "maxDataPoints": 150,
       "options": {
-	"alignValue": "left",
+        "alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
-	"mergeValues": false,
+        "mergeValues": false,
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {

--- a/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
+++ b/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
@@ -3,88 +3,67 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": false,
-  "gnetId": null,
   "graphTooltip": 1,
   "iteration": 1628520681205,
   "links": [],
   "panels": [
     {
-      "cacheTimeout": null,
-      "cards": {
-        "cardHSpacing": 2,
-        "cardMinWidth": 5,
-        "cardRound": null,
-        "cardVSpacing": 2
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
       },
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateGnYlRd",
-        "defaultColor": "#757575",
-        "exponent": 0.5,
-        "max": 7,
-        "min": 4,
-        "mode": "discrete",
-        "thresholds": [
-          {
-            "color": "#FFCB7D",
-            "tooltip": "Heartbeat missing",
-            "value": "0"
-          },
-          {
-            "color": "#73BF69",
-            "tooltip": "Ok",
-            "value": "1"
-          }
-        ]
-      },
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
           "mappings": [
             {
-              "from": "",
-              "id": 0,
-              "operator": "",
-              "text": "Ok",
-              "to": "",
-              "type": 1,
-              "value": "6"
-            },
-            {
-              "from": "",
-              "id": 1,
-              "operator": "",
-              "text": "Error",
-              "to": "",
-              "type": 1,
-              "value": "0"
+              "options": {
+                "0": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "heartbeat is missing"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "OK"
+                }
+              },
+              "type": "value"
             }
           ],
-          "max": 6,
-          "min": 0,
-          "noValue": "Error",
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 6
+                "value": null
               }
             ]
           }
@@ -97,20 +76,23 @@
         "x": 0,
         "y": 0
       },
-      "highlightCards": true,
       "id": 44,
-      "interval": null,
-      "legend": {
-        "show": true
-      },
       "links": [],
-      "nullPointMode": "as zero",
-      "pageSize": 15,
-      "pluginVersion": "7.0.6",
-      "seriesFilterIndex": -1,
-      "statusmap": {
-        "ConfigVersion": "v1"
+      "maxDataPoints": 150,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
+      "pluginVersion": "7.0.6",
       "targets": [
         {
           "expr": "ceil(max by (job) (increase(deckhouse_live_ticks[1m]) > 5))^0",
@@ -120,33 +102,16 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Heartbeat",
-      "tooltip": {
-        "freezeOnClick": true,
-        "items": [],
-        "show": true,
-        "showItems": false
-      },
-      "type": "flant-statusmap-panel",
-      "useMax": true,
-      "usingPagination": false,
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "maxWidth": -1,
-        "minWidth": -1,
-        "show": true
-      },
-      "yAxisSort": "metrics"
+      "type": "status-history"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -190,7 +155,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "7.0.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "expr": "deckhouse_tasks_queue_length{queue=\"main\"}",
@@ -200,16 +165,16 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Main queue length",
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "max": 700,
           "min": 0,
@@ -253,7 +218,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "7.0.6",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "expr": "deckhouse_convergence_seconds{activation=\"OperatorStartup\"}",
@@ -263,14 +228,15 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Last startup converge duration",
       "type": "gauge"
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -280,11 +246,13 @@
       "id": 40,
       "panels": [
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {
-                "align": null,
                 "displayMode": "color-text"
               },
               "mappings": [],
@@ -294,8 +262,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "#EAB839",
@@ -363,8 +330,6 @@
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "Queue length",
           "transformations": [
             {
@@ -397,7 +362,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {},
@@ -406,8 +374,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -463,9 +430,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Queue rate",
           "tooltip": {
             "shared": true,
@@ -474,9 +439,7 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -484,25 +447,18 @@
             {
               "$$hashKey": "object:1373",
               "format": "ops",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "$$hashKey": "object:1374",
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         }
       ],
@@ -511,7 +467,10 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -521,12 +480,13 @@
       "id": 36,
       "panels": [
         {
-          "cacheTimeout": null,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {
-                "align": null,
                 "displayMode": "color-text"
               },
               "mappings": [],
@@ -536,8 +496,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "#EAB839",
@@ -584,7 +543,6 @@
             "y": 18
           },
           "id": 32,
-          "interval": null,
           "links": [],
           "maxDataPoints": 100,
           "options": {
@@ -607,8 +565,6 @@
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "Snapshots objects",
           "transformations": [
             {
@@ -643,11 +599,13 @@
           "type": "table"
         },
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {
-                "align": null,
                 "displayMode": "color-text"
               },
               "mappings": [],
@@ -657,8 +615,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "#EAB839",
@@ -726,8 +683,6 @@
               "refId": "A"
             }
           ],
-          "timeFrom": null,
-          "timeShift": null,
           "title": "Snapshots size",
           "transformations": [
             {
@@ -767,7 +722,10 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -781,7 +739,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -841,9 +802,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Total CPU time",
           "tooltip": {
             "msResolution": false,
@@ -853,9 +812,7 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -864,22 +821,16 @@
               "format": "short",
               "label": "seconds",
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -887,7 +838,10 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -952,9 +906,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Total Memory",
           "tooltip": {
             "msResolution": false,
@@ -964,33 +916,24 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "format": "bytes",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -998,7 +941,10 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -1073,9 +1019,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Process Memory",
           "tooltip": {
             "msResolution": false,
@@ -1085,33 +1029,24 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "format": "bytes",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1119,7 +1054,10 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -1178,9 +1116,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Goroutines",
           "tooltip": {
             "msResolution": false,
@@ -1190,33 +1126,24 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1224,7 +1151,10 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -1283,9 +1213,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Opened file descriptors",
           "tooltip": {
             "msResolution": false,
@@ -1295,9 +1223,7 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -1305,24 +1231,17 @@
             {
               "decimals": 0,
               "format": "none",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": false
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1330,7 +1249,10 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -1395,9 +1317,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Object allocations rate",
           "tooltip": {
             "msResolution": false,
@@ -1407,33 +1327,24 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "format": "cps",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1441,7 +1352,10 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "main",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -1501,9 +1415,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "GC duration",
           "tooltip": {
             "msResolution": false,
@@ -1513,33 +1425,24 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "format": "ns",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         }
       ],
@@ -1548,7 +1451,10 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1562,7 +1468,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1615,9 +1524,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Events frequency by Kind",
           "tooltip": {
             "shared": true,
@@ -1626,9 +1533,7 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -1637,25 +1542,18 @@
               "$$hashKey": "object:1929",
               "decimals": 0,
               "format": "ops",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "$$hashKey": "object:1930",
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": false
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1663,7 +1561,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1722,9 +1623,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Hook run frequency",
           "tooltip": {
             "shared": true,
@@ -1733,36 +1632,26 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "$$hashKey": "object:1929",
-              "decimals": null,
               "format": "ops",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "$$hashKey": "object:1930",
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": false
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1770,7 +1659,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1823,9 +1715,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "JQ Filter frequency",
           "tooltip": {
             "shared": true,
@@ -1834,9 +1724,7 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
@@ -1845,25 +1733,18 @@
               "$$hashKey": "object:437",
               "decimals": 0,
               "format": "ops",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "$$hashKey": "object:438",
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": false
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1871,7 +1752,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1926,9 +1810,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Helm run frequency",
           "tooltip": {
             "shared": false,
@@ -1937,37 +1819,27 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "$$hashKey": "object:592",
-              "decimals": null,
               "format": "ops",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "$$hashKey": "object:593",
               "decimals": 0,
               "format": "ops",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": false
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         },
         {
@@ -1975,7 +1847,10 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -2028,9 +1903,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "Kubernetes client requests frequency",
           "tooltip": {
             "shared": true,
@@ -2039,33 +1912,24 @@
           },
           "type": "graph",
           "xaxis": {
-            "buckets": null,
             "mode": "time",
-            "name": null,
             "show": true,
             "values": []
           },
           "yaxes": [
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             },
             {
               "format": "short",
-              "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
               "show": true
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+            "align": false
           }
         }
       ],
@@ -2074,7 +1938,10 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2084,7 +1951,10 @@
       "id": 52,
       "panels": [
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "description": "5 top global hooks that have lognest duration on startup",
           "fieldConfig": {
             "defaults": {
@@ -2100,8 +1970,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2155,7 +2024,10 @@
           "type": "table"
         },
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "description": "5 top module hooks that have lognest duration on startup",
           "fieldConfig": {
             "defaults": {
@@ -2171,8 +2043,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2226,7 +2097,10 @@
           "type": "table"
         },
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "description": "5 top global hooks that have longest helm render duration on startup",
           "fieldConfig": {
             "defaults": {
@@ -2242,8 +2116,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2295,7 +2168,10 @@
           "type": "table"
         },
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "description": "5 top global hooks that have the longest helm check duration on startup",
           "fieldConfig": {
             "defaults": {
@@ -2311,8 +2187,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2364,7 +2239,10 @@
           "type": "table"
         },
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "description": "5 top global hooks that have the longest helm upgrade duration on startup",
           "fieldConfig": {
             "defaults": {
@@ -2380,8 +2258,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2433,7 +2310,10 @@
           "type": "table"
         },
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -2449,8 +2329,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2507,7 +2386,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 27,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
+++ b/modules/340-monitoring-deckhouse/monitoring/grafana-dashboards/main/deckhouse.json
@@ -37,8 +37,8 @@
             "mode": "thresholds"
           },
           "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
+            "fillOpacity": 70,
+            "lineWidth": 0
           },
           "mappings": [
             {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
@@ -908,13 +908,14 @@
       "id": 53,
       "links": [],
       "options": {
-        "colWidth": 0.9,
+	"alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
+	"mergeValues": false,
         "rowHeight": 0.9,
-        "showValue": "auto",
+        "showValue": "never",
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -935,7 +936,7 @@
         }
       ],
       "title": "Status",
-      "type": "status-history"
+      "type": "state-timeline"
     },
     {
       "datasource": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
@@ -848,7 +848,7 @@
           },
           "custom": {
             "fillOpacity": 70,
-            "lineWidth": 1
+            "lineWidth": 0
           },
           "mappings": [
             {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
@@ -908,12 +908,12 @@
       "id": 53,
       "links": [],
       "options": {
-	"alignValue": "left",
+        "alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
-	"mergeValues": false,
+        "mergeValues": false,
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
@@ -855,8 +855,8 @@
             "mode": "thresholds"
           },
           "custom": {
-            "fillOpacity": 100,
-            "lineWidth": 1
+            "fillOpacity": 70,
+            "lineWidth": 0
           },
           "decimals": 0,
           "displayName": "availability",

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
@@ -901,11 +901,12 @@
       "id": 223,
       "links": [],
       "options": {
-        "colWidth": 1,
+	"alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
+	"mergeValues": false,
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {
@@ -952,7 +953,7 @@
           }
         }
       ],
-      "type": "status-history"
+      "type": "state-timeline"
     },
     {
       "datasource": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
@@ -901,12 +901,12 @@
       "id": 223,
       "links": [],
       "options": {
-	"alignValue": "left",
+        "alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
-	"mergeValues": false,
+        "mergeValues": false,
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
@@ -964,13 +964,14 @@
       "id": 47,
       "links": [],
       "options": {
-        "colWidth": 0.9,
+	"alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
+	"mergeValues": false,
         "rowHeight": 0.9,
-        "showValue": "auto",
+        "showValue": "never",
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -991,7 +992,7 @@
         }
       ],
       "title": "Status",
-      "type": "status-history"
+      "type": "state-timeline"
     },
     {
       "datasource": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
@@ -964,12 +964,12 @@
       "id": 47,
       "links": [],
       "options": {
-	"alignValue": "left",
+        "alignValue": "left",
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
         },
-	"mergeValues": false,
+        "mergeValues": false,
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
@@ -879,7 +879,7 @@
           },
           "custom": {
             "fillOpacity": 70,
-            "lineWidth": 1
+            "lineWidth": 0
           },
           "mappings": [
             {


### PR DESCRIPTION
## Description
Switch from `statusmap` plugin to `statushistory`.

## Changelog entries
```changes
section: prometheus
type: fix 
summary: Switch from `statusmap` plugin to `statushistory`.
```
