### PR TITLE
[admission-policy-engine] Fix allowedClusterRoles field in SecurityPolicy CRD

### DIFF
--- a/modules/015-admission-policy-engine/crds/doc-ru-security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-security-policy.yaml
@@ -171,6 +171,8 @@ spec:
                             description: Значения для SELinux type-меток.
                           user:
                             description: Значения для SELinux user-меток.
+                    allowedClusterRoles:
+                      description: "Список разрешенных ролей кластера для связывания с пользователями."
                     allowedVolumes:
                       description: Список разрешенных volume-плагинов.
                 match:

--- a/modules/015-admission-policy-engine/crds/security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/security-policy.yaml
@@ -344,6 +344,11 @@ spec:
                     automountServiceAccountToken:
                       type: boolean
                       description: Allows pods to run with `automountServiceAccountToken` enabled.
+                    allowedClusterRoles:
+                      type: array
+                      description: "A list of allowed cluster roles to bind to users."
+                      items:
+                        type: string
                     seccompProfiles:
                       type: object
                       description: Specifies the list of allowed profiles that can be set for the Pod or container's seccomp annotations.


### PR DESCRIPTION
## Description
Fix allowedClusterRoles field in SecurityPolicy CRD (was accidentally deleted in #7643).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: admission-policy-engine
type: chore
summary: Fix allowedClusterRoles field in SecurityPolicy CRD.
impact_level: low
```
