### PR TITLE
[candi] Fix httpProxy regex pattern 

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -146,7 +146,7 @@ apiVersions:
           httpProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: ^https?://([0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$
             description: |
               Proxy URL for HTTP requests.
 
@@ -157,7 +157,7 @@ apiVersions:
           httpsProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: ^https?://([0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$
             description: |
               Proxy URL for HTTPS requests.
 

--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -146,7 +146,7 @@ apiVersions:
           httpProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!%0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTP requests.
 
@@ -157,7 +157,7 @@ apiVersions:
           httpsProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!%0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTPS requests.
 

--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -146,7 +146,7 @@ apiVersions:
           httpProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!%0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTP requests.
 
@@ -157,7 +157,7 @@ apiVersions:
           httpsProxy:
             type: string
             x-doc-d8Revision: ee
-            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
+            pattern: '^https?://([0-9a-zA-Z\.\-\_]+(\:[!%0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$'
             description: |
               Proxy URL for HTTPS requests.
 


### PR DESCRIPTION
## Description
Allow [reserved](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) characters in http[s]Proxy

## Why do we need it in the patch release (if we do)?

Not very important.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: candi
type: fix
summary: Fix regex pattern for `httpProxy` to allow using reserved characters.
```
