### PR TITLE
[ci] fix e2e temp directories owner

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -539,6 +539,17 @@ check_e2e_labels:
         else
           echo Not a directory.
         fi
+        if [ -n $USER_RUNNER_ID ]; then
+          echo "Fix temp directories owner..."
+          chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+          chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+          chown -R $USER_RUNNER_ID /tmp || true
+        else
+          echo "Fix temp directories permissions..."
+          chmod -f -R 777 "$(pwd)/testing" || true
+          chmod -f -R 777 "/deckhouse/testing" || true
+          chmod -f -R 777 /tmp || true
+        fi
 
 {!{- if coll.Has $ctx "manualRun" }!}
 {!{    tmpl.Exec "update_comment_on_finish" (slice "job,separate" $ctx.jobName) | strings.Indent 4 }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -681,12 +681,12 @@ check_e2e_labels:
           echo Not a directory.
         fi
         if [ -n $USER_RUNNER_ID ]; then
-          echo "Fix temp directories owner before cleanup ..."
+          echo "Fix temp directories owner..."
           chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
           chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
           chown -R $USER_RUNNER_ID /tmp || true
         else
-          echo "Fix temp directories permissions before cleanup ..."
+          echo "Fix temp directories permissions..."
           chmod -f -R 777 "$(pwd)/testing" || true
           chmod -f -R 777 "/deckhouse/testing" || true
           chmod -f -R 777 /tmp || true

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -680,6 +680,17 @@ check_e2e_labels:
         else
           echo Not a directory.
         fi
+        if [ -n $USER_RUNNER_ID ]; then
+          echo "Fix temp directories owner before cleanup ..."
+          chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+          chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+          chown -R $USER_RUNNER_ID /tmp || true
+        else
+          echo "Fix temp directories permissions before cleanup ..."
+          chmod -f -R 777 "$(pwd)/testing" || true
+          chmod -f -R 777 "/deckhouse/testing" || true
+          chmod -f -R 777 /tmp || true
+        fi
 
 {!{    tmpl.Exec "update_comment_on_finish" (slice "job,separate" $ctx.jobName) | strings.Indent 4 }!}
 # </template: e2e_run_job_template>

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -305,12 +305,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -582,12 +582,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -859,12 +859,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1136,12 +1136,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1413,12 +1413,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -304,6 +304,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -569,6 +580,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -836,6 +858,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1102,6 +1135,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1367,6 +1411,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -309,12 +309,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -590,12 +590,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -871,12 +871,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1152,12 +1152,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1433,12 +1433,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -308,6 +308,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -577,6 +588,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -848,6 +870,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1118,6 +1151,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1387,6 +1431,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -308,12 +308,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -588,12 +588,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -868,12 +868,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1148,12 +1148,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1428,12 +1428,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -307,6 +307,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -575,6 +586,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -845,6 +867,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1114,6 +1147,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1382,6 +1426,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -303,12 +303,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -578,12 +578,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -853,12 +853,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1128,12 +1128,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1403,12 +1403,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -302,6 +302,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -565,6 +576,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -830,6 +852,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1094,6 +1127,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1357,6 +1401,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -303,12 +303,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -578,12 +578,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -853,12 +853,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1128,12 +1128,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1403,12 +1403,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -302,6 +302,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -565,6 +576,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -830,6 +852,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1094,6 +1127,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1357,6 +1401,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -303,12 +303,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -578,12 +578,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -853,12 +853,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1128,12 +1128,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1403,12 +1403,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -302,6 +302,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -565,6 +576,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -830,6 +852,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1094,6 +1127,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1357,6 +1401,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -305,12 +305,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -582,12 +582,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -859,12 +859,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1136,12 +1136,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1413,12 +1413,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -304,6 +304,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -569,6 +580,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -836,6 +858,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1102,6 +1135,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1367,6 +1411,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -306,6 +306,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -573,6 +584,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>
@@ -842,6 +864,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1110,6 +1143,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1377,6 +1421,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner before cleanup ..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions before cleanup ..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
       # <template: update_comment_on_finish>

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -307,12 +307,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -586,12 +586,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -865,12 +865,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1144,12 +1144,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
@@ -1423,12 +1423,12 @@ jobs:
             echo Not a directory.
           fi
           if [ -n $USER_RUNNER_ID ]; then
-            echo "Fix temp directories owner before cleanup ..."
+            echo "Fix temp directories owner..."
             chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
             chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
             chown -R $USER_RUNNER_ID /tmp || true
           else
-            echo "Fix temp directories permissions before cleanup ..."
+            echo "Fix temp directories permissions..."
             chmod -f -R 777 "$(pwd)/testing" || true
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -609,6 +609,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1059,6 +1070,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1511,6 +1533,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1962,6 +1995,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2412,6 +2456,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -617,6 +617,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1075,6 +1086,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1535,6 +1557,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1994,6 +2027,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2452,6 +2496,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -496,6 +496,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
 
       # <template: send_alert_template>
@@ -928,6 +939,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
 
       # <template: send_alert_template>
@@ -1347,6 +1369,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
 
@@ -1776,6 +1809,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
 
       # <template: send_alert_template>
@@ -2195,6 +2239,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
 
@@ -2620,6 +2675,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
 
 
       # <template: send_alert_template>
@@ -3039,6 +3105,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
 
 

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -650,6 +650,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1141,6 +1152,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1634,6 +1656,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2126,6 +2159,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2617,6 +2661,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -605,6 +605,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1051,6 +1062,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1499,6 +1521,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1946,6 +1979,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2392,6 +2436,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -605,6 +605,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1051,6 +1062,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1499,6 +1521,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1946,6 +1979,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2392,6 +2436,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -605,6 +605,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1051,6 +1062,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1499,6 +1521,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1946,6 +1979,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2392,6 +2436,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -609,6 +609,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1059,6 +1070,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1511,6 +1533,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1962,6 +1995,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2412,6 +2456,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -613,6 +613,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1067,6 +1078,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1523,6 +1545,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -1978,6 +2011,17 @@ jobs:
           else
             echo Not a directory.
           fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
+          fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish
         id: update_comment_on_finish
@@ -2432,6 +2476,17 @@ jobs:
             rm -rf "${TMPPATH}"
           else
             echo Not a directory.
+          fi
+          if [ -n $USER_RUNNER_ID ]; then
+            echo "Fix temp directories owner..."
+            chown -R $USER_RUNNER_ID "$(pwd)/testing" || true
+            chown -R $USER_RUNNER_ID "/deckhouse/testing" || true
+            chown -R $USER_RUNNER_ID /tmp || true
+          else
+            echo "Fix temp directories permissions..."
+            chmod -f -R 777 "$(pwd)/testing" || true
+            chmod -f -R 777 "/deckhouse/testing" || true
+            chmod -f -R 777 /tmp || true
           fi
       # <template: update_comment_on_finish>
       - name: Update comment on finish


### PR DESCRIPTION
## Description

Add chown temp directories owner in `Cleanup temp directory` job.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

If e2e was stuck:
https://github.com/deckhouse/deckhouse/actions/runs/8626464723/job/23644672318
we get orphaned tmp directories with root owner, which will break the next e2e test:
https://github.com/deckhouse/deckhouse/actions/runs/8627080527/job/23649875067

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Success start e2e test.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix 
summary: Add chown temp directories owner in Cleanup temp directory job.
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
