### PR TITLE
[monitoring] Fix aggregation with longterm prometheus

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
@@ -52,6 +52,9 @@ data:
         - static_configs:
             - targets:
                 - prometheus-longterm.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:9090
+          metrics_relabel_configs:
+            - action: labeldrop
+              source_label: prometheus
           ignore_error: true
           anti_affinity: 300s
           timeout: 5s


### PR DESCRIPTION
## Description
Currently, when using a `promxy-backed` data source, both main and long-term Prometheus are queried.
Long-term Prometheus metrics may have extra labels, e.g. `prometheus="deckhouse"` thus, when combining the response some unsolicited series emerge and break most of the queries in Grafana dashboards.

This PR strips the only currently known label from the long-term Prometheus responses.

## Changelog entries
```changes
section: prometheus
type: fix 
summary: Fix aggregation with longterm Prometheus
```
