### PR TITLE
[prometheus] Mention defaultDiskSizeGiB in docs

### DIFF
--- a/modules/300-prometheus/docs/CONFIGURATION.md
+++ b/modules/300-prometheus/docs/CONFIGURATION.md
@@ -36,5 +36,5 @@ kubectl -n d8-monitoring delete secret/basic-auth
     * `10 GiB` — if there is no PVC and if the StorageClass supports resizing;
     * `25 GiB` — if there is no PVC and if the StorageClass does not support resizing;
   * If the `local-storage` is used, and you have to change the `retentionSize`, then you need to manually change the size of the PV and PVC. **Caution!** Note that the value from `.status.capacity.storage` PVC is used for the calculation since it reflects the actual size of the PV in the case of manual resizing.
-* `40 GiB` —  size of PersistentVolumeClaim created by default.
+* `40 GiB` — size of PersistentVolumeClaim created by default.
 * You can change the size of Prometheus disks in the standard Kubernetes way (if the StorageClass permits this) by editing the `.spec.resources.requests.storage` field of the PersistentVolumeClaim resource.

--- a/modules/300-prometheus/docs/CONFIGURATION.md
+++ b/modules/300-prometheus/docs/CONFIGURATION.md
@@ -36,4 +36,5 @@ kubectl -n d8-monitoring delete secret/basic-auth
     * `10 GiB` — if there is no PVC and if the StorageClass supports resizing;
     * `25 GiB` — if there is no PVC and if the StorageClass does not support resizing;
   * If the `local-storage` is used, and you have to change the `retentionSize`, then you need to manually change the size of the PV and PVC. **Caution!** Note that the value from `.status.capacity.storage` PVC is used for the calculation since it reflects the actual size of the PV in the case of manual resizing.
+* `40 GiB` —  size of PersistentVolumeClaim created by default.
 * You can change the size of Prometheus disks in the standard Kubernetes way (if the StorageClass permits this) by editing the `.spec.resources.requests.storage` field of the PersistentVolumeClaim resource.

--- a/modules/300-prometheus/docs/CONFIGURATION_RU.md
+++ b/modules/300-prometheus/docs/CONFIGURATION_RU.md
@@ -36,5 +36,5 @@ kubectl -n d8-monitoring delete secret/basic-auth
     * `10 GiB` — если PVC нет и StorageClass поддерживает ресайз;
     * `25 GiB` — если PVC нет и StorageClass не поддерживает ресайз.
   * Если используется `local-storage` и требуется изменить `retentionSize`, необходимо вручную изменить размер PV и PVC в нужную сторону. **Внимание!** Для расчета берется значение из `.status.capacity.storage` PVC, поскольку оно отражает рельный размер PV в случае ручного ресайза.
-* `40 GiB` — размер создаваемого по-умолчанию PersistentVolumeClaim.
+* `40 GiB` — размер PersistentVolumeClaim создаваемого по умолчанию.
 * Размер дисков Prometheus можно изменить стандартным для Kubernetes способом (если в StorageClass это разрешено), отредактировав в PersistentVolumeClaim поле `.spec.resources.requests.storage`.

--- a/modules/300-prometheus/docs/CONFIGURATION_RU.md
+++ b/modules/300-prometheus/docs/CONFIGURATION_RU.md
@@ -36,5 +36,5 @@ kubectl -n d8-monitoring delete secret/basic-auth
     * `10 GiB` — если PVC нет и StorageClass поддерживает ресайз;
     * `25 GiB` — если PVC нет и StorageClass не поддерживает ресайз.
   * Если используется `local-storage` и требуется изменить `retentionSize`, необходимо вручную изменить размер PV и PVC в нужную сторону. **Внимание!** Для расчета берется значение из `.status.capacity.storage` PVC, поскольку оно отражает рельный размер PV в случае ручного ресайза.
-* `40 GiB` —  размер создаваемого по-умолчанию PersistentVolumeClaim.
+* `40 GiB` — размер создаваемого по-умолчанию PersistentVolumeClaim.
 * Размер дисков Prometheus можно изменить стандартным для Kubernetes способом (если в StorageClass это разрешено), отредактировав в PersistentVolumeClaim поле `.spec.resources.requests.storage`.

--- a/modules/300-prometheus/docs/CONFIGURATION_RU.md
+++ b/modules/300-prometheus/docs/CONFIGURATION_RU.md
@@ -36,4 +36,5 @@ kubectl -n d8-monitoring delete secret/basic-auth
     * `10 GiB` — если PVC нет и StorageClass поддерживает ресайз;
     * `25 GiB` — если PVC нет и StorageClass не поддерживает ресайз.
   * Если используется `local-storage` и требуется изменить `retentionSize`, необходимо вручную изменить размер PV и PVC в нужную сторону. **Внимание!** Для расчета берется значение из `.status.capacity.storage` PVC, поскольку оно отражает рельный размер PV в случае ручного ресайза.
+* `40 GiB` —  размер создаваемого по-умолчанию PersistentVolumeClaim.
 * Размер дисков Prometheus можно изменить стандартным для Kubernetes способом (если в StorageClass это разрешено), отредактировав в PersistentVolumeClaim поле `.spec.resources.requests.storage`.


### PR DESCRIPTION
## Description
Add mention of default prometheus PVC size ([defaultDiskSizeGiB 40GiB](https://github.com/deckhouse/deckhouse/blob/main/modules/300-prometheus/hooks/calculate_storage_capacity.go#L31)) in documentation.

## Why do we need it, and what problem does it solve?
We had multiple questions regarding how default size of prometheus PVC is determined. 

## Why do we need it in the patch release (if we do)?

Not necessary.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Minor documentation addition.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
