### PR TITLE
[deckhouse-controller] replace insecure flag with scheme flag

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
@@ -331,7 +331,6 @@ func Test_checkBearerSupport(t *testing.T) {
 		{
 			name:         "check non existed registry",
 			registryHost: "registry.example.com",
-			scheme:       "http",
 			args: args{
 				ctx: context.Background(),
 			},
@@ -345,7 +344,7 @@ func Test_checkBearerSupport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := checkBearerSupport(tt.args.ctx, reg, http.DefaultTransport, tt.scheme); (err != nil) != tt.wantErr {
+			if err := checkBearerSupport(tt.args.ctx, reg, http.DefaultTransport); (err != nil) != tt.wantErr {
 				t.Errorf("checkBearerSupport() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -38,18 +38,18 @@ func DefineHelperCommands(kpApp *kingpin.Application) {
 
 	{
 		changeRegistryCommand := helpersCommand.Command("change-registry", "Change registry for deckhouse images.")
-		newRegistry := changeRegistryCommand.Arg("new-registry", "Registry that will be used for deckhouse images (example: registry.deckhouse.io/deckhouse/ce). By default, https will be used, if you need http - provide '--insecure' flag").Required().String()
+		newRegistry := changeRegistryCommand.Arg("new-registry", "Registry that will be used for deckhouse images (example: registry.deckhouse.io/deckhouse/ce). By default, https will be used, if you need http - provide '--scheme' flag with http value").Required().String()
 
 		user := changeRegistryCommand.Flag("user", "User with pull access to registry.").String()
 		password := changeRegistryCommand.Flag("password", "Password/token for registry user.").String()
 		caFile := changeRegistryCommand.Flag("ca-file", "Path to registry CA.").ExistingFile()
 
-		insecure := changeRegistryCommand.Flag("insecure", "Use HTTP while connecting to new registry.").Bool()
+		scheme := changeRegistryCommand.Flag("scheme", "Used scheme while connecting to registry, http or https.").String()
 		dryRun := changeRegistryCommand.Flag("dry-run", "Don't change deckhouse resources, only print them.").Default("false").Bool()
 
 		newImageTag := changeRegistryCommand.Flag("new-deckhouse-tag", "New tag that will be used for deckhouse deployment image (by default current tag from deckhouse deployment will be used).").String()
 		changeRegistryCommand.Action(func(c *kingpin.ParseContext) error {
-			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *insecure, *dryRun)
+			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *scheme, *dryRun)
 		})
 	}
 


### PR DESCRIPTION
## Description
Provides replacement of insecure flag with scheme flag.

## Why do we need it, and what problem does it solve?
Closes #8026

## What is the expected result?
The schema can be defined explicitly, rather than being calculated by path.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature 
summary: replace insecure flag with scheme flag
```
