### PR TITLE
Fix grafana-v10 plugin installation command in entrypoint

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/entrypoint/main.go
+++ b/modules/300-prometheus/images/grafana-v10/entrypoint/main.go
@@ -164,7 +164,8 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 		if strings.Contains(plugin, ";") {
 			part := strings.Split(plugin, ";")
 			cmd := exec.Command(
-				"grafana-cli",
+				"grafana",
+				"cli",
 				"--pluginUrl",
 				part[0],
 				"--pluginsDir",
@@ -180,7 +181,8 @@ func installPlugins(gfInstallPlugins, gfPathsPlugins string) error {
 			continue
 		}
 		cmd := exec.Command(
-			"grafana-cli",
+			"grafana",
+			"cli",
 			"--pluginsDir",
 			gfPathsPlugins,
 			"plugins",


### PR DESCRIPTION
Grafana v10 lacks `grafana-cli` binary. `grafana cli` should be used instead.

Missed in the original PR, grafana-v10 pods fail to start if additional plugin installation requested.