### PR TITLE
[istio] Fixing istio-to-k8s requirement

### DIFF
--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -113,7 +113,7 @@ func operatorRevisionsToInstallDiscovery(input *go_hook.HookInput) error {
 	if minVersion == nil {
 		requirements.RemoveValue(minVersionValuesKey)
 	} else {
-		requirements.SaveValue(minVersionValuesKey, minVersion.String())
+		requirements.SaveValue(minVersionValuesKey, fmt.Sprintf("%s.%s", minVersion.Major(), minVersion.Minor()))
 	}
 
 	return nil

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -113,7 +113,7 @@ func operatorRevisionsToInstallDiscovery(input *go_hook.HookInput) error {
 	if minVersion == nil {
 		requirements.RemoveValue(minVersionValuesKey)
 	} else {
-		requirements.SaveValue(minVersionValuesKey, fmt.Sprintf("%s.%s", minVersion.Major(), minVersion.Minor()))
+		requirements.SaveValue(minVersionValuesKey, fmt.Sprintf("%d.%d", minVersion.Major(), minVersion.Minor()))
 	}
 
 	return nil

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
@@ -53,7 +53,7 @@ internal:
 
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.1.0"))
+			Expect(value).To(BeEquivalentTo("1.1"))
 		})
 	})
 
@@ -102,7 +102,7 @@ spec:
 
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.2.0"))
+			Expect(value).To(BeEquivalentTo("1.2"))
 		})
 	})
 
@@ -160,7 +160,7 @@ spec:
 
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.2.0"))
+			Expect(value).To(BeEquivalentTo("1.2"))
 		})
 	})
 })

--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -18,8 +18,6 @@ package requirements
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
@@ -64,10 +62,6 @@ func init() {
 			return false, fmt.Errorf("%s key is not registred", minVersionValuesKey)
 		}
 		currentMinIstioVersionStr := currentMinIstioVersionRaw.(string)
-		verParts := strings.Split(currentMinIstioVersionStr, ".")
-		if len(verParts) > 2 {
-			currentMinIstioVersionStr = verParts[0] + "." + verParts[1]
-		}
 
 		isAtomaticK8sVerRaw, exists := getter.Get(isK8sVersionAutomaticKey)
 		if !exists {

--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -18,6 +18,7 @@ package requirements
 
 import (
 	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"

--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -18,6 +18,7 @@ package requirements
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -63,6 +64,10 @@ func init() {
 			return false, fmt.Errorf("%s key is not registred", minVersionValuesKey)
 		}
 		currentMinIstioVersionStr := currentMinIstioVersionRaw.(string)
+		verParts := strings.Split(currentMinIstioVersionStr, ".")
+		if len(verParts) > 2 {
+			currentMinIstioVersionStr = verParts[0] + "." + verParts[1]
+		}
 
 		isAtomaticK8sVerRaw, exists := getter.Get(isK8sVersionAutomaticKey)
 		if !exists {


### PR DESCRIPTION
## Description
Fixing istio-to-k8s requirement.

## Why do we need it, and what problem does it solve?
Fix bug with release version check.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fix `istio-to-k8s` requirement checker.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
