### PR TITLE
[dhctl][kube-dns][deckhouse] add extra publicdomaintemplate check

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -17,12 +17,13 @@ package app
 import "gopkg.in/alecthomas/kingpin.v2"
 
 var (
-	PreflightSkipAll                   = false
-	PreflightSkipSSHForword            = false
-	PreflightSkipAvailabilityPorts     = false
-	PreflightSkipResolvingLocalhost    = false
-	PreflightSkipDeckhouseVersionCheck = false
-	PreflightSkipRegistryThroughProxy  = false
+	PreflightSkipAll                       = false
+	PreflightSkipSSHForword                = false
+	PreflightSkipAvailabilityPorts         = false
+	PreflightSkipResolvingLocalhost        = false
+	PreflightSkipDeckhouseVersionCheck     = false
+	PreflightSkipRegistryThroughProxy      = false
+	PreflightSkipPublicDomainTemplateCheck = false
 )
 
 const (
@@ -31,6 +32,7 @@ const (
 	ResolvingLocalhostArgName        = "preflight-skip-resolving-localhost-check"
 	DeckhouseVersionCheckArgName     = "preflight-skip-deckhouse-version-check"
 	RegistryThroughProxyCheckArgName = "preflight-skip-registry-through-proxy"
+	PublicDomainTemplateCheckArgName = "preflight-skip-public-domain-template-check"
 )
 
 func DefinePreflight(cmd *kingpin.CmdClause) {
@@ -52,4 +54,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(RegistryThroughProxyCheckArgName, "Skip verifying deckhouse version").
 		Envar(configEnvName("PREFLIGHT_SKIP_REGISTRY_THROUGH_PROXY")).
 		BoolVar(&PreflightSkipRegistryThroughProxy)
+	cmd.Flag(PublicDomainTemplateCheckArgName, "Skip verifying PublicDomainTemplate check").
+		Envar(configEnvName("PREFLIGHT_SKIP_PUBLIC_DOMAIN_TEMPLATE")).
+		BoolVar(&PreflightSkipPublicDomainTemplateCheck)
 }

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -79,7 +79,13 @@ func (pc *Checker) Cloud() error {
 }
 
 func (pc *Checker) Global() error {
-	return nil
+	return pc.do("Global preflight checks", []checkStep{
+		{
+			fun:            pc.CheckPublicDomainTemplate,
+			successMessage: "PublicDomainTemplate is correctly",
+			skipFlag:       app.PublicDomainTemplateCheckArgName,
+		},
+	})
 }
 
 func (pc *Checker) do(title string, checks []checkStep) error {

--- a/modules/002-deckhouse/webhooks/validating/public-domain-template
+++ b/modules/002-deckhouse/webhooks/validating/public-domain-template
@@ -57,12 +57,14 @@ function __main__() {
     dnsDomains=$(echo $kubeDNSConf | grep -oP  'kubernetes .*? ip6.arpa')
     publicDomainTemplate=$(context::jq -r '.review.request.object.spec.settings.modules.publicDomainTemplate' | sed s/%s.//)
 
-    if [[ $dnsDomains =~ $publicDomainTemplate  ]]; then
-      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+    for domain in $dnsDomains; do
+      if [[ $publicDomainTemplate == $domain ]]; then
+        cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"The publicDomainTemplate \"%s.$publicDomainTemplate\" MUST NOT match the one specified in the clusterDomain/clusterDomainAliases parameters of the resource: [\"$dnsDomains\"]." }
 EOF
-    return 0
-    fi
+      return 0
+      fi
+    done
   fi
 cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true}

--- a/modules/002-deckhouse/webhooks/validating/public-domain-template
+++ b/modules/002-deckhouse/webhooks/validating/public-domain-template
@@ -38,6 +38,9 @@ kubernetes:
       }
 kubernetesValidating:
 - name: publicdomaintemplate-policy.deckhouse.io
+	nameSelector:
+		matchNames:
+		- global
   group: main
   includeSnapshotsFrom: ["d8-kube-dns-cm-wh"]
   rules:

--- a/modules/002-deckhouse/webhooks/validating/public-domain-template
+++ b/modules/002-deckhouse/webhooks/validating/public-domain-template
@@ -38,9 +38,9 @@ kubernetes:
       }
 kubernetesValidating:
 - name: publicdomaintemplate-policy.deckhouse.io
-	nameSelector:
-		matchNames:
-		- global
+  nameSelector:
+    matchNames:
+    - global
   group: main
   includeSnapshotsFrom: ["d8-kube-dns-cm-wh"]
   rules:

--- a/modules/002-deckhouse/webhooks/validating/public-domain-template
+++ b/modules/002-deckhouse/webhooks/validating/public-domain-template
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetes:
+  - name: d8-kube-dns-cm-wh
+    apiVersion: v1
+    kind: ConfigMap
+    executeHookOnEvent: []
+    executeHookOnSynchronization: false
+    keepFullObjectsInMemory: false
+    nameSelector:
+      matchNames:
+      - d8-kube-dns
+    namespace:
+      nameSelector:
+        matchNames: ["kube-system"]
+    jqFilter: |
+      {
+        "kube-dns-conf": .data.Corefile,
+      }
+kubernetesValidating:
+- name: publicdomaintemplate-policy.deckhouse.io
+  group: main
+  includeSnapshotsFrom: ["d8-kube-dns-cm-wh"]
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["moduleconfigs"]
+    scope:       "Cluster"
+EOF
+}
+
+
+function __main__() {
+  mcName=$(context::jq -r '.review.request.object.metadata.name')
+  if [[ "$mcName" == "global" ]]; then
+    kubeDNSConf=$(context::jq -r '.snapshots.["d8-kube-dns-cm-wh"][].filterResult.["kube-dns-conf"]')
+    dnsDomains=$(echo $kubeDNSConf | grep -oP  'kubernetes .*? ip6.arpa')
+    publicDomainTemplate=$(context::jq -r '.review.request.object.spec.settings.modules.publicDomainTemplate' | sed s/%s.//)
+
+    if [[ $dnsDomains =~ $publicDomainTemplate  ]]; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"The publicDomainTemplate \"%s.$publicDomainTemplate\" MUST NOT match the one specified in the clusterDomain/clusterDomainAliases parameters of the resource: [\"$dnsDomains\"]." }
+EOF
+    return 0
+    fi
+  fi
+cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+}
+
+hook::run "$@"

--- a/modules/002-deckhouse/webhooks/validating/public-domain-template
+++ b/modules/002-deckhouse/webhooks/validating/public-domain-template
@@ -38,9 +38,6 @@ kubernetes:
       }
 kubernetesValidating:
 - name: publicdomaintemplate-policy.deckhouse.io
-  nameSelector:
-    matchNames:
-    - global
   group: main
   includeSnapshotsFrom: ["d8-kube-dns-cm-wh"]
   rules:

--- a/modules/042-kube-dns/webhooks/validating/cluster-domain-alias
+++ b/modules/042-kube-dns/webhooks/validating/cluster-domain-alias
@@ -49,7 +49,7 @@ EOF
 function __main__() {
   mcName=$(context::jq -r '.review.request.object.metadata.name')
   if [[ "$mcName" == "kube-dns" ]]; then
-    publicDomainTemplate=$(context::jq -r '.snapshots.["global-module-config"][].filterResult["publicDomainTemplate"] | sed s/%s.//')
+    publicDomainTemplate=$(context::jq -r '.snapshots.["global-module-config"][].filterResult["publicDomainTemplate"]' | sed s/%s.//)
     clusterDomainAliases=$(context::jq -r '.review.request.object.spec.settings.clusterDomainAliases[]')
 
     for alias in $clusterDomainAliases; do

--- a/modules/042-kube-dns/webhooks/validating/cluster-domain-alias
+++ b/modules/042-kube-dns/webhooks/validating/cluster-domain-alias
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetes:
+  - name: global-module-config
+    apiVersion: deckhouse.io/v1alpha1
+    kind: ModuleConfig
+    executeHookOnEvent: []
+    executeHookOnSynchronization: false
+    keepFullObjectsInMemory: false
+    nameSelector:
+      matchNames:
+      - global
+    jqFilter: |
+      {
+        "publicDomainTemplate": .spec.settings.modules.publicDomainTemplate,
+      }
+kubernetesValidating:
+- name: clusterdomainaliases-policy.deckhouse.io
+  group: main
+  includeSnapshotsFrom: ["global-module-config"]
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["moduleconfigs"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+  mcName=$(context::jq -r '.review.request.object.metadata.name')
+  if [[ "$mcName" == "kube-dns" ]]; then
+    publicDomainTemplate=$(context::jq -r '.snapshots.["global-module-config"][].filterResult["publicDomainTemplate"] | sed s/%s.//')
+    clusterDomainAliases=$(context::jq -r '.review.request.object.spec.settings.clusterDomainAliases[]')
+
+    for alias in $clusterDomainAliases; do
+      if [[ $publicDomainTemplate == $alias ]]; then
+        cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"The clusterDomainAliases \"$alias\" MUST NOT match the one specified in the publicDomainTemplate parameter of the resource: \"%s.$publicDomainTemplate\"." }
+EOF
+      return 0
+      fi
+    done
+  fi
+cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+}
+
+hook::run "$@"


### PR DESCRIPTION
## Description

Add extra `publicDomainTemplate` and `clusterDomainAliases` checks.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Closes #7796

It is changes that add preflight check for dhctl and validation webhook that forbid using same domain in `clusterDomain` and `publicDomainTemplate`.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

<img width="1330" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/4b1bfe24-4975-4322-9d38-d5e837b2f33d">

<img width="1379" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/30a1753d-2f55-409b-abfa-1fd965e10b20">

<img width="1387" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/1282f8c4-5531-45eb-bb30-d64e393ce665">



<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add preflight check for `publicDomainTemplate`.
impact_level: low
```
```changes
section: deckhouse
type: feature
summary: Add validation webhook for `publicDomainTemplate`.
impact_level: default
```
```changes
section: kube-dns
type: feature
summary: Add validation webhook for `clusterDomainAliases`.
impact_level: default
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
