### PR TITLE
[docs] Reflect module behaviour when changing default SC

### DIFF
--- a/ee/modules/450-network-gateway/openapi/config-values.yaml
+++ b/ee/modules/450-network-gateway/openapi/config-values.yaml
@@ -74,4 +74,6 @@ properties:
 
       If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
+      `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
+
       Dnsmasq (underlies our DHCP server) has its own mechanisms for protecting against the duplication of IP addresses if the lease database is lost (but it is better not to lose it).

--- a/ee/modules/450-network-gateway/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/450-network-gateway/openapi/doc-ru-config-values.yaml
@@ -33,4 +33,6 @@ properties:
 
       Если не указано, используется StorageClass существующей PVC, а если PVC пока нет, используется или глобальный [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет, данные сохраняются в emptyDir.
 
+      `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
+
       Dnsmasq, на котором основан наш DHCP-сервер, имеет свои механизмы защиты от дублирования IP-адресов в случае утери базы с lease'ами, но лучше ее не терять.

--- a/ee/se/modules/502-delivery/openapi/config-values.yaml
+++ b/ee/se/modules/502-delivery/openapi/config-values.yaml
@@ -29,7 +29,9 @@ properties:
 
       If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
-      **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in disk reprovisioning and data loss.
+      `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
+
+      **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in disk re-provisioning and data loss.
 
       Setting it to `false` forces the use of an emptyDir volume.
   https:

--- a/ee/se/modules/502-delivery/openapi/doc-ru-config-values.yaml
+++ b/ee/se/modules/502-delivery/openapi/doc-ru-config-values.yaml
@@ -21,6 +21,8 @@ properties:
 
       Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
 
+      `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
+
       **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск будет перезаказан, а все данные удалены.
 
       Если указать `false` — будет форсироваться использование emptyDir'а.

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -13,9 +13,11 @@ properties:
 
       If omitted, the StorageClass of the existing Prometheus PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
+      `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
+
       `storageClass: false` — forces the `emptyDir` usage. You will need to delete the old PVC and restart the Pod manually.
 
-      **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in Prometheus volume reprovisioning and data loss.
+      **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in Prometheus volume re-provisioning and data loss.
   longtermStorageClass:
     type: string
     x-examples: ["ceph-ssd"]

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -26,6 +26,8 @@ properties:
 
       If omitted, the StorageClass of the existing Longterm Prometheus PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data;
 
+      `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
+
       **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in Longterm Prometheus volume reprovisioning and data loss.
   longtermRetentionDays:
     type: integer

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -16,6 +16,8 @@ properties:
 
       Если не указано, используется StorageClass существующей PVC Longterm Prometheus, а если PVC пока нет, используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет, данные сохраняются в `emptyDir`.
 
+      `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
+
       **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск Longterm Prometheus будет перезаказан, а все данные удалены.
   longtermRetentionDays:
     description: |

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -7,6 +7,8 @@ properties:
 
       Если не указано, используется StorageClass существующей PVC Prometheus, а если PVC пока нет, используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет, данные сохраняются в `emptyDir`.
 
+      `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
+
       `false` — принудительное использование `emptyDir`. Удалить старый PVC и рестартануть под придется вручную.
 
       **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск Prometheus будет перезаказан, а все данные удалены.

--- a/modules/462-loki/openapi/config-values.yaml
+++ b/modules/462-loki/openapi/config-values.yaml
@@ -12,17 +12,13 @@ properties:
     description: >
       The name of the StorageClass to use.
 
-      If omitted, the StorageClass of the existing Loki PVC is used. If there is
-      no PVC yet, either the [global
-      StorageClass](../../deckhouse-configure-global.html#parameters-storageclass)
-      or `global.discovery.defaultStorageClass` is used, and if those are
-      undefined, the emptyDir volume is used to store the data.
+      If omitted, the StorageClass of the existing Loki PVC is used. If there is no PVC yet, either the [global StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
-      `storageClass: false` — forces the `emptyDir` usage. You will need to
-      delete the old PVC and restart the Pod manually.
+      `storageClass: false` — forces the `emptyDir` usage. You will need to delete the old PVC and restart the Pod manually.
 
-      **CAUTION!** Setting a value other than the current one (in the existing
-      PVC) will cause the Loki volume to be re-provisioned and the data to be
+      `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
+
+      **CAUTION!** Setting a value other than the current one (in the existing PVC) will cause the Loki volume to be re-provisioned and the data to be
       lost.
   diskSizeGigabytes:
     type: integer

--- a/modules/462-loki/openapi/config-values.yaml
+++ b/modules/462-loki/openapi/config-values.yaml
@@ -9,7 +9,7 @@ properties:
     x-examples:
       - false
       - default
-    description: >
+    description: |
       The name of the StorageClass to use.
 
       If omitted, the StorageClass of the existing Loki PVC is used. If there is no PVC yet, either the [global StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.

--- a/modules/462-loki/openapi/doc-ru-config-values.yaml
+++ b/modules/462-loki/openapi/doc-ru-config-values.yaml
@@ -5,6 +5,8 @@ properties:
 
       Если не указано, используется StorageClass существующей PVC Loki, а если PVC пока нет, используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет, данные сохраняются в `emptyDir`.
 
+      `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
+
       `false` — принудительное использование `emptyDir`. Удалить старый PVC и рестартануть под придется вручную.
 
       **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск Loki будет перезаказан, а все данные удалены.

--- a/modules/500-upmeter/openapi/config-values.yaml
+++ b/modules/500-upmeter/openapi/config-values.yaml
@@ -12,7 +12,9 @@ properties:
     description: |
       The name of the StorageClass to use. If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
-      **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in disk reprovisioning and data loss.
+      `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
+
+      **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in disk re-provisioning and data loss.
 
       Setting it to `false` forces the use of an emptyDir volume.
   auth:
@@ -165,6 +167,8 @@ properties:
           A StorageClass to use when checking the health of disks.
 
           If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
+
+          `global.discovery.defaultStorageClass` is applied during module activation, changing default StorageClass in cluster won't result in disk re-provisioning.
 
           Setting it to `false` forces the use of an emptyDir volume.
       ingressClass:

--- a/modules/500-upmeter/openapi/doc-ru-config-values.yaml
+++ b/modules/500-upmeter/openapi/doc-ru-config-values.yaml
@@ -4,6 +4,7 @@ properties:
       Имя storageClass'а, который будет использоваться.
 
       * Если не указано, используется StorageClass существующей PVC, а если PVC пока нет, используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет, данные сохраняются в emptyDir.
+      * `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
       * **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск будет перезаказан, а все данные удалены.
       * Если указать `false`, будет форсироваться использование emptyDir'а.
   auth:
@@ -95,6 +96,7 @@ properties:
           StorageClass для использования при проверке работоспособности дисков.
 
           * Если не указано, используется StorageClass существующей PVC, а если PVC пока нет, используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет, данные сохраняются в emptyDir.
+          * `global.discovery.defaultStorageClass` применяется только при включении модуля, смена StorageClass по умолчанию в кластере не приведет к перезаказу диска.
           * Если указать `false`, будет форсироваться использование emptyDir'а.
       ingressClass:
         description: |


### PR DESCRIPTION
## Description

Added notes in modules' configuration docs that reflect that changing default storageclass in cluster won't affect current volumes until re-enabling a module.

## Why do we need it, and what problem does it solve?

We should reflect in the docs how modules behave when the cluster default storageClass is changed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Minor documentation update.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
