### PR TITLE
[istio] Deckhouse release requirements checker fix

### DIFF
--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -56,8 +56,13 @@ func init() {
 	}
 
 	checkIstioAndK8sVersionsCompatibilityFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
-		comingDefaultK8sVersion := requirementValue
+		comingDefaultK8sVersionSemver, err := semver.NewVersion(requirementValue)
+		if err != nil {
+			return false, err
+		}
+		comingDefaultK8sVersion := fmt.Sprintf("%d.%d", comingDefaultK8sVersionSemver.Major(), comingDefaultK8sVersionSemver.Minor())
 
+		comingDefaultK8sVersion := requirementValue
 		currentMinIstioVersionRaw, exists := getter.Get(minVersionValuesKey)
 		if !exists {
 			return false, fmt.Errorf("%s key is not registred", minVersionValuesKey)

--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -62,7 +62,6 @@ func init() {
 		}
 		comingDefaultK8sVersion := fmt.Sprintf("%d.%d", comingDefaultK8sVersionSemver.Major(), comingDefaultK8sVersionSemver.Minor())
 
-		comingDefaultK8sVersion := requirementValue
 		currentMinIstioVersionRaw, exists := getter.Get(minVersionValuesKey)
 		if !exists {
 			return false, fmt.Errorf("%s key is not registred", minVersionValuesKey)

--- a/modules/110-istio/requirements/check_test.go
+++ b/modules/110-istio/requirements/check_test.go
@@ -56,7 +56,7 @@ func TestIstioOperatorVersionRequirement(t *testing.T) {
 		requirements.SaveValue(minVersionValuesKey, "1.13")
 		var mapVersions = map[string][]string{"1.13": {"1.19", "1.20", "1.21"}}
 		requirements.SaveValue(istioToK8sCompatibilityMapKey, mapVersions)
-		ok, err := requirements.CheckRequirement(requirementDefaultK8sKey, "1.20")
+		ok, err := requirements.CheckRequirement(requirementDefaultK8sKey, "1.20.0")
 		assert.True(t, ok)
 		require.NoError(t, err)
 	})
@@ -66,7 +66,7 @@ func TestIstioOperatorVersionRequirement(t *testing.T) {
 		requirements.SaveValue(minVersionValuesKey, "1.13")
 		var mapVersions = map[string][]string{"1.13": {"1.19", "1.20", "1.21"}}
 		requirements.SaveValue(istioToK8sCompatibilityMapKey, mapVersions)
-		ok, err := requirements.CheckRequirement(requirementDefaultK8sKey, "1.22")
+		ok, err := requirements.CheckRequirement(requirementDefaultK8sKey, "1.22.0")
 		assert.False(t, ok)
 		require.Error(t, err)
 	})


### PR DESCRIPTION
## Description

Deckhouse release requirements checker fix.

## Why do we need it, and what problem does it solve?
Deckhouse can't perform upgrade:
```
v1.59.1   Pending      102s             "k8s" requirement for DeckhouseRelease "1.59.1" not met: in coming release the default kubernetes version '1.25.0' will be incompatible with Istio version '1.19'
```

## Why do we need it in the patch release (if we do)?
Deckhouse can't perform upgrade.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Deckhouse release requirements checker fix.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
