### PR TITLE
[dhctl] feat(cliuster-import): Improve import logs

### DIFF
--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -140,6 +140,7 @@ func NewPrettyLogger(opts LoggerOptions) *PrettyLogger {
 			"converge":  {"🛸 ~ Converge: %s", ConvergeOptions},
 			"bootstrap": {"⛵ ~ Bootstrap: %s", BootstrapOptions},
 			"mirror":    {"🪞 ~ Mirror: %s", MirrorOptions},
+			"import":    {"📦 ~ Import: %s", ImportOptions},
 			"default":   {"%s", BoldOptions},
 		},
 		isDebug: opts.IsDebug,

--- a/dhctl/pkg/log/options.go
+++ b/dhctl/pkg/log/options.go
@@ -22,8 +22,13 @@ import (
 func BootstrapOptions(opts types.LogProcessOptionsInterface) {
 	opts.Style(color.New(color.FgYellow, color.Bold))
 }
+
 func MirrorOptions(opts types.LogProcessOptionsInterface) {
 	opts.Style(color.New(color.FgGreen, color.Bold))
+}
+
+func ImportOptions(opts types.LogProcessOptionsInterface) {
+	opts.Style(color.New(color.FgLightCyan, color.Bold))
 }
 
 func CommonOptions(opts types.LogProcessOptionsInterface) {


### PR DESCRIPTION
- improve import operation logs, add new process to logger
- reuse single k8s client in sequential import and check operations

<img width="532" alt="Screenshot 2024-04-14 at 17 13 23" src="https://github.com/deckhouse/deckhouse/assets/37873799/b692b557-b7b0-4d57-954f-8a8a0c737b70">
<img width="572" alt="Screenshot 2024-04-14 at 17 13 15" src="https://github.com/deckhouse/deckhouse/assets/37873799/d387a1ed-28db-47f5-8d98-1ae2c7042751">
<img width="1421" alt="Screenshot 2024-04-14 at 20 48 32" src="https://github.com/deckhouse/deckhouse/assets/37873799/278cadd7-9575-4a7c-b596-924d17b4a6cb">
<img width="1161" alt="Screenshot 2024-04-14 at 17 13 39" src="https://github.com/deckhouse/deckhouse/assets/37873799/2f16b339-9504-4209-93b3-286c2b46cc96">
