### PR TITLE
[multitenancy-manager] mark system project templates

### DIFF
--- a/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
@@ -3,6 +3,8 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ProjectTemplate
 metadata:
   name: default
+  labels:
+    heritage: deckhouse
 spec:
   parametersSchema:
     openAPIV3Schema:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
@@ -3,6 +3,8 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ProjectTemplate
 metadata:
   name: secure
+  labels:
+    heritage: deckhouse
 spec:
   parametersSchema:
     openAPIV3Schema:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
@@ -3,6 +3,8 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ProjectTemplate
 metadata:
   name: secure-with-dedicated-nodes
+  labels:
+    heritage: deckhouse
 spec:
   parametersSchema:
     openAPIV3Schema:

--- a/ee/modules/160-multitenancy-manager/webhooks/validating/projectTemplate
+++ b/ee/modules/160-multitenancy-manager/webhooks/validating/projectTemplate
@@ -35,12 +35,10 @@ EOF
 }
 
 function __main__() {
-projectTemplateName=$(context::jq -r '.review.request.oldObject.metadata.name')
 operation=$(context::jq -r '.review.request.operation')
 
-echo "<====== OPERATION: $operation ======>"
-
 if [ "$operation" = "DELETE" ]; then
+  projectTemplateName=$(context::jq -r '.review.request.oldObject.metadata.name')
   if usedInProjectName="$(context::jq -er --arg templateName "$projectTemplateName" '[.snapshots.projects[].filterResult | select(.projectTemplateName == $templateName) | .projectName] | first' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"ProjectTemplate \"$projectTemplateName\" cannot be deleted. It is used in the Project \"$usedInProjectName\"" }
@@ -50,11 +48,16 @@ EOF
 fi
 
 if [ "$operation" = "CREATE" ] || [ "$operation" = "UPDATE" ]; then
+  projectTemplateName=$(context::jq -r '.review.request.object.metadata.name')
   user=$(context::jq -r '.review.request.userInfo.username')
-  groups=$(context::jq -r '.review.request.userInfo.groups')
-  labels=$(context::jq -r '.review.request.oldObject.metadata.labels')
+  labelExists=$(context::jq -r '.review.request.object.metadata.labels | select(.heritage != null) | .heritage=="deckhouse"')
 
-  echo "<====== USER: $user GROUPS: $groups LABELS: $labels  ======>"
+  if $labelExists && [ "$user" != "system:serviceaccount:d8-system:deckhouse" ]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"ProjectTemplate \"$projectTemplateName\" has label \"heritage\" with forbidden value: \"deckhouse\"" }
+EOF
+    return 0
+  fi
 fi
 
   cat <<EOF > "$VALIDATING_RESPONSE_PATH"

--- a/ee/modules/160-multitenancy-manager/webhooks/validating/projectTemplate
+++ b/ee/modules/160-multitenancy-manager/webhooks/validating/projectTemplate
@@ -28,7 +28,7 @@ kubernetesValidating:
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["*"]
-    operations:  ["DELETE"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
     resources:   ["projecttemplates"]
     scope:       "Cluster"
 EOF
@@ -36,12 +36,25 @@ EOF
 
 function __main__() {
 projectTemplateName=$(context::jq -r '.review.request.oldObject.metadata.name')
-                                                              
-if usedInProjectName="$(context::jq -er --arg templateName "$projectTemplateName" '[.snapshots.projects[].filterResult | select(.projectTemplateName == $templateName) | .projectName] | first' 2>&1)"; then
+operation=$(context::jq -r '.review.request.operation')
+
+echo "<====== OPERATION: $operation ======>"
+
+if [ "$operation" = "DELETE" ]; then
+  if usedInProjectName="$(context::jq -er --arg templateName "$projectTemplateName" '[.snapshots.projects[].filterResult | select(.projectTemplateName == $templateName) | .projectName] | first' 2>&1)"; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"ProjectTemplate \"$projectTemplateName\" cannot be deleted. It is used in the Project \"$usedInProjectName\"" }
 EOF
-  return 0
+    return 0
+  fi
+fi
+
+if [ "$operation" = "CREATE" ] || [ "$operation" = "UPDATE" ]; then
+  user=$(context::jq -r '.review.request.userInfo.username')
+  groups=$(context::jq -r '.review.request.userInfo.groups')
+  labels=$(context::jq -r '.review.request.oldObject.metadata.labels')
+
+  echo "<====== USER: $user GROUPS: $groups LABELS: $labels  ======>"
 fi
 
   cat <<EOF > "$VALIDATING_RESPONSE_PATH"

--- a/ee/modules/160-multitenancy-manager/webhooks/validating/projectTemplate
+++ b/ee/modules/160-multitenancy-manager/webhooks/validating/projectTemplate
@@ -50,7 +50,7 @@ fi
 if [ "$operation" = "CREATE" ] || [ "$operation" = "UPDATE" ]; then
   projectTemplateName=$(context::jq -r '.review.request.object.metadata.name')
   user=$(context::jq -r '.review.request.userInfo.username')
-  labelExists=$(context::jq -r '.review.request.object.metadata.labels | select(.heritage != null) | .heritage=="deckhouse"')
+  labelExists=$(context::jq -r '.review.request.object.metadata.labels | .heritage == "deckhouse"')
 
   if $labelExists && [ "$user" != "system:serviceaccount:d8-system:deckhouse" ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"


### PR DESCRIPTION
## Description
Provides an additional label for system project templates to identify that these are our templates.

## Why do we need it, and what problem does it solve?
Closes #8066

## What is the expected result?
System project templates are marked with the label  `heritage:deckhouse`, and users cannot create project templates with this label.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: feature 
summary: Set `heritage: deckhouse` label to embedded ProjectTemplates. Deny ProjectTemplates copying with this label.
```
