### PR TITLE
[global-hooks] Fix k8s upgrade migration

### DIFF
--- a/global-hooks/migrate/migrate_k8s_upgrade.go
+++ b/global-hooks/migrate/migrate_k8s_upgrade.go
@@ -81,7 +81,11 @@ func k8sPostUpgrade(input *go_hook.HookInput, dc dependency.Container) error {
 	if config.KubernetesVersion != "Automatic" {
 		kubernetesVersion = config.KubernetesVersion
 	} else {
-		kubernetesVersion = string(secret.Data["deckhouseDefaultKubernetesVersion"])
+		defaultKubernetesVersion, ok := secret.Data["deckhouseDefaultKubernetesVersion"]
+		if !ok {
+			return nil
+		}
+		kubernetesVersion = string(defaultKubernetesVersion)
 	}
 
 	input.LogEntry.Printf("kubernetesVersion: %s", kubernetesVersion)
@@ -92,7 +96,7 @@ func k8sPostUpgrade(input *go_hook.HookInput, dc dependency.Container) error {
 	}
 	v, err := semver.NewVersion(kubernetesVersion)
 	if err != nil {
-		return fmt.Errorf("version not being parsable: %s", err.Error())
+		return fmt.Errorf("version \"%s\" not being parsable: %s", kubernetesVersion, err.Error())
 	}
 	// if kubernetesVersion < v1.29.0
 	if c.Check(v) {


### PR DESCRIPTION
## Description
Skip migration if `kubernetesVersion` is set to `Automatic` and the `deckhouseDefaultKubernetesVersion` field is not present in the `d8-cluster-configuration` secret.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This is necessary because The `deckhouseDefaultKubernetesVersion` field also appeared in this release and we rely on it if the `Automatic` version is set.

## Why do we need it in the patch release (if we do)?

Important. Fixes a bug.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix
summary: Fix K8s upgrade migration.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
