### PR TITLE
[deckhouse] Set default k8s version to '1.27'

### DIFF
--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -36,8 +36,8 @@ const (
 	candiDir          = "/deckhouse/candi"
 	modulesDir        = "/deckhouse/modules"
 	globalHooksModule = "/deckhouse/global-hooks"
-	// don't forget to update the version in release requirements (release.yaml)
-	DefaultKubernetesVersion = "1.25"
+	// don't forget to update the version in release requirements (release.yaml) 'autoK8sVersion' key
+	DefaultKubernetesVersion = "1.27"
 )
 
 const (

--- a/global-hooks/discovery/cluster_configuration_test.go
+++ b/global-hooks/discovery/cluster_configuration_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -197,7 +198,7 @@ data:
 			Expect(f.ValuesGet("global.clusterConfiguration.podSubnetCIDR").String()).To(Equal("10.122.0.0/16"))
 			Expect(f.ValuesGet("global.clusterConfiguration.podSubnetNodeCIDRPrefix").String()).To(Equal("26"))
 			Expect(f.ValuesGet("global.clusterConfiguration.serviceSubnetCIDR").String()).To(Equal("10.213.0.0/16"))
-			Expect(f.ValuesGet("global.clusterConfiguration.kubernetesVersion").String()).To(Equal("1.25"))
+			Expect(f.ValuesGet("global.clusterConfiguration.kubernetesVersion").String()).To(Equal(config.DefaultKubernetesVersion))
 
 			Expect(f.ValuesGet("global.discovery.podSubnet").String()).To(Equal("10.122.0.0/16"))
 			Expect(f.ValuesGet("global.discovery.serviceSubnet").String()).To(Equal("10.213.0.0/16"))

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -36,7 +36,7 @@
 
   - alert: D8KubernetesVersionIsDeprecated
     for: 10m
-    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.24"}) == 1
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.25"}) == 1
     labels:
       severity_level: "7"
       tier: cluster
@@ -47,7 +47,7 @@
       description: |-
         Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed within 6 months
 
-        Please migrate to the next kubernetes version (at least 1.25)
+        Please migrate to the next kubernetes version (at least 1.26)
 
         Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
 

--- a/release.yaml
+++ b/release.yaml
@@ -24,6 +24,9 @@
 # release requirements, don't forget to register check function in a file requirements.go
 requirements:
   "k8s": "1.25.0" # modules/040-control-plane-manager/requirements/check.go
+  # autoK8sVersion must be equal to 'DefaultKubernetesVersion' in the 'dhctl/pkg/config/base.go'
+  # it's used to block release with deprecated APIs when changing default kubernetes version
+  "autoK8sVersion": "1.27" #modules/340-monitoring-kubernetes/requirements/check.go
   "ingressNginx": "1.6" # modules/402-ingress-nginx/requirements/check.go
   "nodesMinimalOSVersionUbuntu": "18.04" # modules/040-node-manager/requirements/check.go
   "nodesMinimalOSVersionDebian": "10" # modules/040-node-manager/requirements/check.go


### PR DESCRIPTION
## Description
Set the Default K8s version to '1.27'  (when using `Automatic` in the [kubernetesVersion](https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration-kubernetesversion) parameter).

## Why do we need it, and what problem does it solve?
Deckhouse Life Cycle.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Change the default Kubernetes version to '1.27'.
impact: Cluster will upgrade if the [kubernetesVersion](https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration-kubernetesversion) parameter is set to `Automatic`) .
impact_level: high
```
