### PR TITLE
[log-shipper] Add key_field in destination kafka

### DIFF
--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -135,7 +135,7 @@ type KafkaSpec struct {
 	BootstrapServers []string `json:"bootstrapServers,omitempty"`
 
 	Topic    string        `json:"topic,omitempty"`
-	KeyField string        `json:"key_field,omitempty"`
+	KeyField string        `json:"keyField,omitempty"`
 	TLS      CommonTLSSpec `json:"tls,omitempty"`
 
 	SASL KafkaSASL `json:"sasl,omitempty"`

--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -134,9 +134,9 @@ type LokiSpec struct {
 type KafkaSpec struct {
 	BootstrapServers []string `json:"bootstrapServers,omitempty"`
 
-	Topic string `json:"topic,omitempty"`
-
-	TLS CommonTLSSpec `json:"tls,omitempty"`
+	Topic    string        `json:"topic,omitempty"`
+	KeyField string        `json:"key_field,omitempty"`
+	TLS      CommonTLSSpec `json:"tls,omitempty"`
 
 	SASL KafkaSASL `json:"sasl,omitempty"`
 

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -387,7 +387,7 @@ spec:
                           type: string
                           enum: ["JSON", "CEF"]
                           default: "JSON"
-                    key_field:
+                    keyField:
                       type: string
                       description: |
                         The log [field name](https://vector.dev/docs/reference/configuration/sinks/kafka/#key_field) or tag key to use for the topic key.

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -390,9 +390,7 @@ spec:
                     keyField:
                       type: string
                       description: |
-                        The log [field name](https://vector.dev/docs/reference/configuration/sinks/kafka/#key_field) or tag key to use for the topic key.
-                        If the field does not exist in the log or in the tags, a blank value is used. If unspecified, the key is not sent.
-                        Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key.
+                        Allows to set the [key_field](https://vector.dev/docs/reference/configuration/sinks/kafka/#key_field).
                       x-doc-examples: ["host", "node", "namespace","parsed_data.app_info"]
                     sasl:
                       type: object

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -387,6 +387,13 @@ spec:
                           type: string
                           enum: ["JSON", "CEF"]
                           default: "JSON"
+                    key_field:
+                      type: string
+                      description: |
+                        The log [field name](https://vector.dev/docs/reference/configuration/sinks/kafka/#key_field) or tag key to use for the topic key.
+                        If the field does not exist in the log or in the tags, a blank value is used. If unspecified, the key is not sent.
+                        Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key.
+                      x-doc-examples: ["host", "node", "namespace","parsed_data.app_info"]
                     sasl:
                       type: object
                       description: Configuration for SASL authentication when interacting with Kafka.

--- a/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
@@ -161,6 +161,9 @@ spec:
                     encoding:
                       description: |
                         В каком формате закодировать сообщение.
+                    keyField:
+                      description: |
+                        Позволяет задать поле [key_field](https://vector.dev/docs/reference/configuration/sinks/kafka/#key_field).
                     sasl:
                       description: Конфигурация аутентификации SASL для взаимодействия с Kafka.
                       properties:

--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -30,8 +30,8 @@ type Kafka struct {
 
 	Encoding Encoding `json:"encoding,omitempty"`
 
-	Topic string `json:"topic"`
-
+	Topic       string `json:"topic"`
+	KeyField    string `json:"key_field,omitempty"`
 	Compression string `json:"compression,omitempty"`
 
 	TLS CommonTLS `json:"tls"`
@@ -118,6 +118,7 @@ func NewKafka(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Kafka {
 		Topic:            spec.Topic,
 		Encoding:         encoding,
 		SASL:             sasl,
+		KeyField:         spec.KeyField,
 		Compression:      "gzip",
 		BootstrapServers: strings.Join(spec.BootstrapServers, ","),
 	}

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/manifests.yaml
@@ -20,6 +20,7 @@ spec:
     bootstrapServers:
     - "192.168.1.1:9200"
     topic: "logs"
+    keyField: host
     sasl:
       mechanism: PLAIN
       username: test

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
@@ -40,6 +40,7 @@
         "timestamp_format": "rfc3339"
       },
       "topic": "logs",
+      "key_field": "host",
       "compression": "gzip",
       "tls": {
         "verify_hostname": true,


### PR DESCRIPTION
## Description
Added the ability to set key_field for kafka
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/8115
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

Not important.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: feature
summary: Add the ability to set key_field for Kafka.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
