### PR TITLE
[prometheus] Switch Alertmanager configuration selector from alertmanagerConfiguration to alertmanagerConfigSelector

### DIFF
--- a/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
@@ -8,8 +8,9 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list $ (dict "app" "alertmanager")) | nindent 2 }}
 spec:
-  alertmanagerConfiguration:
-    name: {{ .name }}
+  alertmanagerConfigSelector:
+    matchLabels:
+      alertmanagerConfig: {{ .name }}
   replicas: {{ include "helm_lib_is_ha_to_value" (list $ 2 1) }}
   image: {{ include "helm_lib_module_image" (list $ "alertmanager") }}
   imagePullSecrets:


### PR DESCRIPTION
## Description
Switch Alertmanager configuration selector from alertmanagerConfiguration to alertmanagerConfigSelector

## Why do we need it, and what problem does it solve?
When we using alertmanagerConfiguration prometheus-operator does not add TLS certificate to special secret which mount to alertmanager. Switch  to alertmanagerConfigSelector resolve this problem 

## Why do we need it in the patch release (if we do)?
Needs for clients.

## What is the expected result?
TLS secret before 
![image](https://github.com/deckhouse/deckhouse/assets/30695496/9f1f24a1-1c60-41a0-8c44-ee7275186784)
TLS secret after
![image](https://github.com/deckhouse/deckhouse/assets/30695496/72630723-099c-4ed3-9df6-6994e98d1202)

Container contains pem 
![image](https://github.com/deckhouse/deckhouse/assets/30695496/571122d5-7eeb-4a01-8b67-c5b485631e70)

Switching from old method to new working without problem
![image](https://github.com/deckhouse/deckhouse/assets/30695496/5a83cc13-7b5c-4d64-bd75-8e9fa2b0c392)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Switch Alertmanager configuration selector from alertmanagerConfiguration to alertmanagerConfigSelector
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
