### PR TITLE
[dhctl] mirror: fix producing bundles with unexpected components versions

### DIFF
--- a/dhctl/pkg/operations/mirror/layouts.go
+++ b/dhctl/pkg/operations/mirror/layouts.go
@@ -44,6 +44,8 @@ type ImageLayouts struct {
 	SecurityImages map[string]struct{}
 
 	Modules map[string]ModuleImageLayout
+
+	TagsResolver *TagsResolver
 }
 
 type ModuleImageLayout struct {
@@ -59,7 +61,10 @@ func CreateOCIImageLayoutsForDeckhouse(
 	modules []Module,
 ) (*ImageLayouts, error) {
 	var err error
-	layouts := &ImageLayouts{Modules: map[string]ModuleImageLayout{}}
+	layouts := &ImageLayouts{
+		TagsResolver: NewTagsResolver(),
+		Modules:      map[string]ModuleImageLayout{},
+	}
 
 	fsPaths := map[*layout.Path]string{
 		&layouts.Deckhouse:      rootFolder,
@@ -188,7 +193,7 @@ func FillLayoutsImages(
 	layouts.ReleaseChannelImages[mirrorCtx.DeckhouseRegistryRepo+"/release-channel:rock-solid"] = struct{}{}
 }
 
-var digestRegex = regexp.MustCompile(`sha256:([a-f0-9]{64})`)
+var digestRegex = regexp.MustCompile(`@sha256:([a-f0-9]{64})`)
 
 func FindDeckhouseModulesImages(mirrorCtx *Context, layouts *ImageLayouts) error {
 	modulesNames := maputil.Keys(layouts.Modules)

--- a/dhctl/pkg/operations/mirror/pull.go
+++ b/dhctl/pkg/operations/mirror/pull.go
@@ -35,6 +35,7 @@ func PullInstallers(mirrorCtx *Context, layouts *ImageLayouts) error {
 		mirrorCtx.RegistryAuth,
 		layouts.Install,
 		layouts.InstallImages,
+		layouts.TagsResolver.GetTagDigest,
 		mirrorCtx.Insecure,
 		mirrorCtx.SkipTLSVerification,
 		false,
@@ -51,6 +52,7 @@ func PullDeckhouseReleaseChannels(mirrorCtx *Context, layouts *ImageLayouts) err
 		mirrorCtx.RegistryAuth,
 		layouts.ReleaseChannel,
 		layouts.ReleaseChannelImages,
+		layouts.TagsResolver.GetTagDigest,
 		mirrorCtx.Insecure,
 		mirrorCtx.SkipTLSVerification,
 		mirrorCtx.SpecificVersion != nil,
@@ -67,6 +69,7 @@ func PullDeckhouseImages(mirrorCtx *Context, layouts *ImageLayouts) error {
 		mirrorCtx.RegistryAuth,
 		layouts.Deckhouse,
 		layouts.DeckhouseImages,
+		layouts.TagsResolver.GetTagDigest,
 		mirrorCtx.Insecure,
 		mirrorCtx.SkipTLSVerification,
 		false,
@@ -77,23 +80,37 @@ func PullDeckhouseImages(mirrorCtx *Context, layouts *ImageLayouts) error {
 	return nil
 }
 
+type TagToDigestMappingFunc func(imageRef string) *v1.Hash
+
 func PullImageSet(
 	authProvider authn.Authenticator,
 	targetLayout layout.Path,
 	imageSet map[string]struct{},
+	tagToDigestMappingFunc TagToDigestMappingFunc,
 	insecure, skipVerifyTLS, allowMissingTags bool,
 ) error {
+	pullOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
+
 	pullCount := 1
 	totalCount := len(imageSet)
-	for imageTag := range imageSet {
-		pullOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipVerifyTLS)
-		ref, err := name.ParseReference(imageTag, pullOpts...)
+	for imageReferenceString := range imageSet {
+		imageRepo := imageReferenceString[:strings.LastIndex(imageReferenceString, ":")]
+		imageTag := imageReferenceString[strings.LastIndex(imageReferenceString, ":")+1:]
+
+		// If we already know the digest of the tagged image, we should pull it by this digest instead of pulling by tag
+		// to avoid race-conditions between mirror and releases
+		pullReference := imageReferenceString
+		if mapping := tagToDigestMappingFunc(imageReferenceString); mapping != nil {
+			pullReference = imageRepo + "@" + mapping.String()
+		}
+
+		ref, err := name.ParseReference(pullReference, pullOpts...)
 		if err != nil {
-			return fmt.Errorf("parse image reference %q: %w", imageTag, err)
+			return fmt.Errorf("parse image reference %q: %w", pullReference, err)
 		}
 
 		err = retry.NewLoop(
-			fmt.Sprintf("[%d / %d] Pulling %s...", pullCount, totalCount, imageTag),
+			fmt.Sprintf("[%d / %d] Pulling %s...", pullCount, totalCount, imageReferenceString),
 			6,
 			10*time.Second,
 		).Run(func() error {
@@ -110,8 +127,8 @@ func PullImageSet(
 			err = targetLayout.AppendImage(img,
 				layout.WithPlatform(v1.Platform{Architecture: "amd64", OS: "linux"}),
 				layout.WithAnnotations(map[string]string{
-					"org.opencontainers.image.ref.name": imageTag,
-					"io.deckhouse.image.short_tag":      imageTag[strings.LastIndex(imageTag, ":")+1:],
+					"org.opencontainers.image.ref.name": imageReferenceString,
+					"io.deckhouse.image.short_tag":      imageTag,
 				}),
 			)
 			if err != nil {
@@ -121,7 +138,7 @@ func PullImageSet(
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("pull image %q: %w", imageTag, err)
+			return fmt.Errorf("pull image %q: %w", imageReferenceString, err)
 		}
 		pullCount++
 	}
@@ -131,10 +148,26 @@ func PullImageSet(
 func PullModules(mirrorCtx *Context, layouts *ImageLayouts) error {
 	log.InfoLn("Beginning to pull Deckhouse modules")
 	for moduleName, moduleData := range layouts.Modules {
-		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ModuleLayout, moduleData.ModuleImages, mirrorCtx.Insecure, mirrorCtx.SkipTLSVerification, false); err != nil {
+		if err := PullImageSet(
+			mirrorCtx.RegistryAuth,
+			moduleData.ModuleLayout,
+			moduleData.ModuleImages,
+			layouts.TagsResolver.GetTagDigest,
+			mirrorCtx.Insecure,
+			mirrorCtx.SkipTLSVerification,
+			false,
+		); err != nil {
 			return fmt.Errorf("pull %q module: %w", moduleName, err)
 		}
-		if err := PullImageSet(mirrorCtx.RegistryAuth, moduleData.ReleasesLayout, moduleData.ReleaseImages, mirrorCtx.Insecure, mirrorCtx.SkipTLSVerification, true); err != nil {
+		if err := PullImageSet(
+			mirrorCtx.RegistryAuth,
+			moduleData.ReleasesLayout,
+			moduleData.ReleaseImages,
+			layouts.TagsResolver.GetTagDigest,
+			mirrorCtx.Insecure,
+			mirrorCtx.SkipTLSVerification,
+			true,
+		); err != nil {
 			return fmt.Errorf("pull %q module release information: %w", moduleName, err)
 		}
 	}

--- a/dhctl/pkg/operations/mirror/tag_resolver.go
+++ b/dhctl/pkg/operations/mirror/tag_resolver.go
@@ -1,0 +1,100 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+type TagsResolver struct {
+	tagsDigestsMapping map[string]v1.Hash
+}
+
+func NewTagsResolver() *TagsResolver {
+	return &TagsResolver{tagsDigestsMapping: make(map[string]v1.Hash)}
+}
+
+func NopTagToDigestMappingFunc(_ string) *v1.Hash {
+	return nil
+}
+
+func (r *TagsResolver) ResolveTagsDigestsForImageLayouts(mirrorCtx *Context, layouts *ImageLayouts) error {
+	imageSets := []map[string]struct{}{
+		layouts.DeckhouseImages,
+		layouts.ReleaseChannelImages,
+		layouts.InstallImages,
+	}
+
+	for _, moduleImageLayout := range layouts.Modules {
+		imageSets = append(imageSets, moduleImageLayout.ModuleImages)
+		imageSets = append(imageSets, moduleImageLayout.ReleaseImages)
+	}
+
+	for _, imageSet := range imageSets {
+		if err := r.ResolveTagsDigestsFromImageSet(
+			imageSet,
+			mirrorCtx.RegistryAuth,
+			mirrorCtx.Insecure,
+			mirrorCtx.SkipTLSVerification,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *TagsResolver) ResolveTagsDigestsFromImageSet(
+	imageSet map[string]struct{},
+	authProvider authn.Authenticator,
+	insecure, skipTLSVerification bool,
+) error {
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(authProvider, insecure, skipTLSVerification)
+	for imageRef := range imageSet {
+		if digestRegex.MatchString(imageRef) {
+			continue
+		}
+
+		ref, err := name.ParseReference(imageRef, nameOpts...)
+		if err != nil {
+			return fmt.Errorf("parse %q image reference: %w", imageRef, err)
+		}
+		desc, err := remote.Head(ref, remoteOpts...)
+		if err != nil {
+			if isImageNotFoundError(err) {
+				continue
+			}
+
+			return fmt.Errorf("get image descriptor for %q: %w", imageRef, err)
+		}
+
+		r.tagsDigestsMapping[imageRef] = desc.Digest
+	}
+
+	return nil
+}
+
+func (r *TagsResolver) GetTagDigest(imageRef string) *v1.Hash {
+	digest, found := r.tagsDigestsMapping[imageRef]
+	if !found {
+		return nil
+	}
+	return &digest
+}

--- a/dhctl/pkg/operations/mirror/tag_resolver_test.go
+++ b/dhctl/pkg/operations/mirror/tag_resolver_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"io"
+	"log"
+	"maps"
+	"math/rand"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagsResolver_GetTagDigest_HappyPath(t *testing.T) {
+	const imageReference = "registry.deckhouse.io/deckhouse/ee/install:stable"
+
+	want := v1.Hash{
+		Algorithm: "sha256",
+		Hex:       "77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182",
+	}
+	resolver := &TagsResolver{tagsDigestsMapping: map[string]v1.Hash{
+		imageReference: want,
+	}}
+
+	got := resolver.GetTagDigest(imageReference)
+	require.Equal(t, want, *got)
+}
+
+func TestTagsResolver_GetTagDigest_UnknownTag(t *testing.T) {
+	const imageReference = "registry.deckhouse.io/deckhouse/ee/install:stable"
+	resolver := &TagsResolver{tagsDigestsMapping: map[string]v1.Hash{}}
+
+	got := resolver.GetTagDigest(imageReference)
+	require.Nil(t, got)
+}
+
+func TestTagsResolver_ResolveTagsDigestsFromImageSet(t *testing.T) {
+	registryHost, registryRepoPath := setupEmptyRegistryRepo(false)
+
+	taggedImages := map[string]struct{}{
+		registryHost + registryRepoPath + ":alpha": {},
+		registryHost + registryRepoPath + ":beta":  {},
+	}
+
+	untaggedImages := map[string]struct{}{
+		registryHost + registryRepoPath + "@sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182": {},
+		registryHost + registryRepoPath + "@sha256:09ea463141cd441da365200b2933cf9863141cd441da365200b2933cf98b2f1f": {},
+	}
+
+	digests := map[string]string{}
+	imageSet := map[string]struct{}{}
+	maps.Copy(imageSet, taggedImages)
+	maps.Copy(imageSet, untaggedImages)
+
+	for imageRef := range imageSet {
+		digests[imageRef] = createRandomImageInRegistry(t, imageRef)
+	}
+
+	r := NewTagsResolver()
+	err := r.ResolveTagsDigestsFromImageSet(imageSet, nil, true, false)
+	require.NoError(t, err)
+
+	for imageRef := range taggedImages {
+		digest := r.GetTagDigest(imageRef)
+		require.NotNil(t, digest)
+		require.Equal(t, digests[imageRef], digest.String())
+	}
+}
+
+func setupEmptyRegistryRepo(useTLS bool) (host, repoPath string) {
+	bh := registry.NewInMemoryBlobHandler()
+	registryHandler := registry.New(registry.WithBlobHandler(bh), registry.Logger(log.New(io.Discard, "", 0)))
+
+	server := httptest.NewUnstartedServer(registryHandler)
+	if useTLS {
+		server.StartTLS()
+	} else {
+		server.Start()
+	}
+
+	host = strings.TrimPrefix(server.URL, "http://")
+	repoPath = "/deckhouse/ee"
+	if useTLS {
+		host = strings.TrimPrefix(server.URL, "https://")
+	}
+
+	return host, repoPath
+}
+
+func createRandomImageInRegistry(t *testing.T, imageRef string) (digest string) {
+	t.Helper()
+
+	img, err := random.Image(int64(rand.Intn(1024)+1), int64(rand.Intn(5)+1))
+	require.NoError(t, err)
+
+	nameOpts, remoteOpts := MakeRemoteRegistryRequestOptions(nil, true, false)
+	ref, err := name.ParseReference(imageRef, nameOpts...)
+	require.NoError(t, err)
+
+	err = remote.Write(ref, img, remoteOpts...)
+	require.NoError(t, err)
+
+	digestHash, err := img.Digest()
+	require.NoError(t, err)
+
+	return digestHash.String()
+}

--- a/dhctl/pkg/operations/mirror/trivy-db.go
+++ b/dhctl/pkg/operations/mirror/trivy-db.go
@@ -38,7 +38,15 @@ func PullTrivyVulnerabilityDatabaseImageToLayout(
 	}
 
 	images := map[string]struct{}{ref.String(): {}}
-	if err = PullImageSet(authProvider, targetLayout, images, insecure, skipVerifyTLS, false); err != nil {
+	if err = PullImageSet(
+		authProvider,
+		targetLayout,
+		images,
+		NopTagToDigestMappingFunc,
+		insecure,
+		skipVerifyTLS,
+		false,
+	); err != nil {
 		return fmt.Errorf("pull vulnerability database: %w", err)
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`dhctl mirror` will now resolve all tagged image references to their digests and pull images by that digests instead of tags. This reduces the probability of races between mirror pull and images tags being updated during release processes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes a bug where the mirror was creating an inconsistent package with component versions that didn't match what it was supposed to contain and what was reported at an execution time.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

```changes
section: dhctl
type: fix
summary: fix `dhctl mirror` producing bundles with unexpected components versions
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
