### PR TITLE
Fix antiAffinity and GF_SERVER_ROOT_URL env for grafana-v10

### DIFF
--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -69,7 +69,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "grafana")) | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "grafana-v10")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       serviceAccountName: grafana
       imagePullSecrets:
@@ -81,7 +81,7 @@ spec:
         env:
         {{- if .Values.global.modules.publicDomainTemplate }}
         - name: GF_SERVER_ROOT_URL
-          value: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}
+          value: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
         {{- end }}
         - name: GF_AUTH_BASIC_ENABLED
           value: "false"


### PR DESCRIPTION
## Description
This PR fixes antiAffinity labels and GF_SERVER_ROOT_URL for Grafana v10.

## Why do we need it, and what problem does it solve?
Currently, old and new Grafana share the same label selectors in podAntiAffinity. This results in pod scheduling issues in clusters with HA mode enabled. Also GF_SERVER_ROOT_URL environment variable in Grafana v10 pods has an invalid value.

## Why do we need it in the patch release (if we do)?
This patch will prevent Grafana pods from getting stuck in a pending state due to unresolved antiAffinity conditions.

## What is the expected result?
Proper scheduling of the old version and new version of Grafana pods.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix grafana-v10 podAntiAffinity and environment variables.
impact: grafana-v10 deployment rolling restart.
impact_level: low
```
