### PR TITLE
[deckhouse-controller] use fqdn k8s pod name for the lease leader

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -91,7 +91,7 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator) {
 	}
 
 	clusterDomain := os.Getenv("KUBERNETES_CLUSTER_DOMAIN")
-	if len(podIP) == 0 {
+	if len(clusterDomain) == 0 {
 		log.Info("KUBERNETES_CLUSTER_DOMAIN env not set or empty")
 		os.Exit(1)
 	}

--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -92,8 +92,7 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator) {
 
 	clusterDomain := os.Getenv("KUBERNETES_CLUSTER_DOMAIN")
 	if len(clusterDomain) == 0 {
-		log.Info("KUBERNETES_CLUSTER_DOMAIN env not set or empty")
-		os.Exit(1)
+		log.Fatal("KUBERNETES_CLUSTER_DOMAIN env not set or empty")
 	}
 
 	podNs := os.Getenv("ADDON_OPERATOR_NAMESPACE")

--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -90,11 +90,17 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator) {
 		os.Exit(1)
 	}
 
+	clusterDomain := os.Getenv("KUBERNETES_CLUSTER_DOMAIN")
+	if len(podIP) == 0 {
+		log.Info("KUBERNETES_CLUSTER_DOMAIN env not set or empty")
+		os.Exit(1)
+	}
+
 	podNs := os.Getenv("ADDON_OPERATOR_NAMESPACE")
 	if len(podNs) == 0 {
 		podNs = defaultNamespace
 	}
-	identity := fmt.Sprintf("%s.%s.%s.pod", podName, strings.ReplaceAll(podIP, ".", "-"), podNs)
+	identity := fmt.Sprintf("%s.%s.%s.pod.%s", podName, strings.ReplaceAll(podIP, ".", "-"), podNs, clusterDomain)
 
 	err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
 		// Create a leaderElectionConfig for leader election

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -137,6 +137,8 @@ spec:
             - name: DECKHOUSE_HA
 {{- if (include "helm_lib_ha_enabled" .) }}
               value: "true"
+            - name: KUBERNETES_CLUSTER_DOMAIN
+              value: {{ .Values.global.clusterConfiguration.clusterDomain | quote }}
 {{- else }}
               value: "false"
 {{- end }}


### PR DESCRIPTION
## Description
FQDN k8s pod name is used as the holder identity for the deckhouse-leader-election lease.
It should help in case there is an http proxy implemented in the cluster and NO_PROXY already has `cluster.local` entry or similiar.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It should solve a communication problem between deckhouse pods if there is an http proxy enforced in the cluster.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
We have a couple of affected clients with HA mode enabled.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
All deckhouse pods should be in ready 2/2 state as soon as the leader starts reporting converged state.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Use fqdn k8s pod name for the lease leader.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
