### PR TITLE
[node-manager] Drain advanced daemonset pods on a node update/delete

### DIFF
--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -20,7 +20,7 @@ shell:
   - apk add git
   setup:
   - mkdir /src && cd /src
-  - git clone --depth 1 --branch v0.36.0-flant.14 {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
+  - git clone --depth 1 --branch v0.36.0-flant.15 {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
   - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o machine-controller-manager cmd/machine-controller-manager/controller_manager.go
   - chown 64535:64535 machine-controller-manager
   - chmod 0700 machine-controller-manager


### PR DESCRIPTION
## Description
Update MCM version to `v0.36.0-flant.15` which supports draining of advanced DaemonSet pods.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
With this MCM version, we can gradually drain frontend nodes before deleting them from the cluster, letting a load balancer know that it should withdraw traffic from the nodes.

## What is the expected result?
When deleting a frontend node, MCM drains advanced daemonset pods instead of ignoring them.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: node-manager
type: feature
summary: Drain advanced DaemonSet pods when a node is deleted or updated.
impact_level: default
```
