### PR TITLE
[monitoring-custom] Set scrapeInterval via pod/service annotation

### DIFF
--- a/modules/340-monitoring-custom/docs/README.md
+++ b/modules/340-monitoring-custom/docs/README.md
@@ -62,6 +62,7 @@ metadata:
     prometheus.deckhouse.io/query-param-format: "prometheus"  # '' by default
     prometheus.deckhouse.io/allow-unready-pod: "true"         # by default, NON-ready Pods are ignored
     prometheus.deckhouse.io/sample-limit: "5000"              # by default, the sample is limited to 5000 metrics for a single Pod
+    prometheus.deckhouse.io/scrape-interval: "60s"            # by default scrapeInterval from monitoring module config
 spec:
   ports:
   - name: my-app
@@ -92,7 +93,8 @@ spec:
         app: my-app
         prometheus.deckhouse.io/custom-target: my-app
       annotations:
-        prometheus.deckhouse.io/sample-limit: "5000"  # by default, the sample is limited to 5000 metrics for a single Pod
+        prometheus.deckhouse.io/sample-limit: "5000"   # by default, the sample is limited to 5000 metrics for a single Pod
+        prometheus.deckhouse.io/scrape-interval: "60s" # by default scrapeInterval from monitoring module config
     spec:
       containers:
       - name: my-app

--- a/modules/340-monitoring-custom/docs/README_RU.md
+++ b/modules/340-monitoring-custom/docs/README_RU.md
@@ -63,6 +63,7 @@ metadata:
     prometheus.deckhouse.io/query-param-format: "prometheus"  # По умолчанию ''.
     prometheus.deckhouse.io/allow-unready-pod: "true"         # По умолчанию поды НЕ в Ready игнорируются.
     prometheus.deckhouse.io/sample-limit: "5000"              # По умолчанию принимается не больше 5000 метрик от одного пода.
+    prometheus.deckhouse.io/scrape-interval: "60s"            # По умолчанию значение scrapeInterval модуля monitoring.
 spec:
   ports:
   - name: my-app
@@ -93,7 +94,8 @@ spec:
         app: my-app
         prometheus.deckhouse.io/custom-target: my-app
       annotations:
-        prometheus.deckhouse.io/sample-limit: "5000"  # По умолчанию принимается не больше 5000 метрик от одного пода.
+        prometheus.deckhouse.io/sample-limit: "5000"   # По умолчанию принимается не больше 5000 метрик от одного пода.
+        prometheus.deckhouse.io/scrape-interval: "60s" # По умолчанию значение scrapeInterval модуля monitoring.
     spec:
       containers:
       - name: my-app

--- a/modules/340-monitoring-custom/templates/_helpers.tpl
+++ b/modules/340-monitoring-custom/templates/_helpers.tpl
@@ -26,7 +26,7 @@
   action: labeldrop
 
 # We do not differentiate containers on the discovery. The only thing matters is a combination of the pod id / port.
-# This is a fix for a bag with the duplicated endpoints for pod monitors.
+# This is a fix for a bug with the duplicated endpoints for pod monitors.
 - regex: container
   action: labeldrop
 
@@ -42,6 +42,11 @@
 - sourceLabels: [__meta_kubernetes_{{ $scrapeType }}_annotation_prometheus_deckhouse_io_sample_limit]
   regex: (.+)
   targetLabel: __sample_limit__
+
+# Set scrape interval from the annotation
+- sourceLabels: [__meta_kubernetes_{{ $scrapeType }}_annotation_prometheus_deckhouse_io_scrape_interval]
+  regex: (.+)
+  targetLabel: __scrape_interval__
 {{- end }}
 
 {{- define "endpoint_by_container_port_name" }}


### PR DESCRIPTION
## Description

Currently, when using the `monitoring-custom` module, it is not possible to change the `scrapeInterval` for monitoring a Pod/Service. A common value specified in the `monitoring` module settings is used.

The change presented in this PR will allow modifying this value via the annotation `prometheus.deckhouse.io/scrape-interval`.

## Why do we need it, and what problem does it solve?

This feature will allow for additional customization of the scrape process within application monitoring.

## Why do we need it in the patch release (if we do)?

We don't.

## What is the expected result?

In the PodMonitor `custom-pod` and ServiceMonitor `custom-service` in the `d8-monitoring` namespace, an additional relabelings will be added that modifies the `__scrape_interval__` label, substituting it with the value specified in the  `prometheus.deckhouse.io/scrape-interval` annotation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-custom
type: feature
summary: Set `scrapeInterval` for user application monitoring via pod/service annotation.
impact_level: default
```