### PR TITLE
[deckhouse] fix annotantions on ns d8-cloud-intance-manager to move to the another module

### DIFF
--- a/modules/002-deckhouse/hooks/migrate/adopt_node_manager_resources.go
+++ b/modules/002-deckhouse/hooks/migrate/adopt_node_manager_resources.go
@@ -36,7 +36,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion:                   "v1",
 			Kind:                         "Namespace",
 			NameSelector:                 &types.NameSelector{MatchNames: []string{"d8-cloud-instance-manager"}},
-			ExecuteHookOnSynchronization: pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(true),
 			ExecuteHookOnEvents:          pointer.Bool(false),
 			FilterFunc:                   filterResource,
 		},
@@ -50,7 +50,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 				},
 			},
 			NameSelector:                 &types.NameSelector{MatchNames: []string{"kube-rbac-proxy-ca.crt"}},
-			ExecuteHookOnSynchronization: pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(true),
 			ExecuteHookOnEvents:          pointer.Bool(false),
 			FilterFunc:                   filterResource,
 		},
@@ -69,6 +69,7 @@ func adoptResources(input *go_hook.HookInput) error {
 		"metadata": map[string]interface{}{
 			"annotations": map[string]string{
 				"meta.helm.sh/release-name": "deckhouse",
+				"helm.sh/resource-policy":   "keep",
 			},
 		},
 	}

--- a/modules/002-deckhouse/hooks/migrate/adopt_node_manager_resources.go
+++ b/modules/002-deckhouse/hooks/migrate/adopt_node_manager_resources.go
@@ -65,7 +65,7 @@ func filterResource(unstructured *unstructured.Unstructured) (go_hook.FilterResu
 }
 
 func adoptResources(input *go_hook.HookInput) error {
-	patch := map[string]interface{}{
+	nsPatch := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]string{
 				"meta.helm.sh/release-name": "deckhouse",
@@ -74,11 +74,19 @@ func adoptResources(input *go_hook.HookInput) error {
 		},
 	}
 
+	cmPatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				"meta.helm.sh/release-name": "deckhouse",
+			},
+		},
+	}
+
 	snap := input.Snapshots["ns"]
 	if len(snap) == 1 {
 		if snap[0] != nil {
 			name := snap[0].(string)
-			input.PatchCollector.MergePatch(patch, "v1", "Namespace", "", name)
+			input.PatchCollector.MergePatch(nsPatch, "v1", "Namespace", "", name)
 		}
 	}
 
@@ -86,7 +94,7 @@ func adoptResources(input *go_hook.HookInput) error {
 	if len(snap) == 1 {
 		if snap[0] != nil {
 			name := snap[0].(string)
-			input.PatchCollector.MergePatch(patch, "v1", "ConfigMap", "d8-cloud-instance-manager", name)
+			input.PatchCollector.MergePatch(cmPatch, "v1", "ConfigMap", "d8-cloud-instance-manager", name)
 		}
 	}
 	return nil

--- a/modules/002-deckhouse/hooks/migrate/adopt_node_manager_resources_test.go
+++ b/modules/002-deckhouse/hooks/migrate/adopt_node_manager_resources_test.go
@@ -46,6 +46,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     meta.helm.sh/release-name: deckhouse
     meta.helm.sh/release-namespace: d8-system
   labels:
@@ -69,6 +70,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     meta.helm.sh/release-name: deckhouse
     meta.helm.sh/release-namespace: d8-system
   labels:
@@ -114,6 +116,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     meta.helm.sh/release-name: deckhouse
     meta.helm.sh/release-namespace: d8-system
   labels:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix annotantions on ns d8-cloud-intance-manager to move to the another module.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When moving ns to another module and helm release we need to set up helm `keep` annotation to prevent namespace deletion.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: fix annotantions on ns d8-cloud-intance-manager to move to the another module
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
