### PR TITLE
[cloud-provider-yandex] disable orphan disks discovery

### DIFF
--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
@@ -18,11 +18,11 @@ package main
 
 import (
 	"context"
-	"fmt"
+	// "fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
+	// "github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
 	ycsdk "github.com/yandex-cloud/go-sdk"
 	"github.com/yandex-cloud/go-sdk/iamkey"
 

--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
@@ -81,7 +81,7 @@ func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryDa
 	return nil, nil
 }
 
-// TemporaryDisable, until CSI starts placing cluster labels that solve the problem discovery disks different cluster in one folder.
+// TemporaryDisable, until CSI starts placing cluster labels that solve the problem of discovery orphan disks from different clusters in one folder.
 func (d *Discoverer) DisksMeta(ctx context.Context) ([]v1alpha1.DiskMeta, error) {
 	return []v1alpha1.DiskMeta{}, nil
 }

--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
@@ -81,41 +81,46 @@ func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryDa
 	return nil, nil
 }
 
+// TemporaryDisable, until CSI starts placing cluster labels that solve the problem discovery disks different cluster in one folder.
 func (d *Discoverer) DisksMeta(ctx context.Context) ([]v1alpha1.DiskMeta, error) {
-	disks, err := d.getDisksCreatedByCSIDriver(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get disks: %v", err)
-	}
-
-	disksMeta := make([]v1alpha1.DiskMeta, 0, len(disks))
-
-	for _, disk := range disks {
-		disksMeta = append(disksMeta, v1alpha1.DiskMeta{ID: disk.Id, Name: disk.Name})
-	}
-
-	return disksMeta, nil
+	return []v1alpha1.DiskMeta{}, nil
 }
 
-func (d *Discoverer) getDisksCreatedByCSIDriver(ctx context.Context) ([]*compute.Disk, error) {
-	diskList, err := d.sdk.Compute().Disk().List(ctx, &compute.ListDisksRequest{
-		FolderId: d.folderID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list disks: %v", err)
-	}
+// func (d *Discoverer) DisksMeta(ctx context.Context) ([]v1alpha1.DiskMeta, error) {
+// 	disks, err := d.getDisksCreatedByCSIDriver(ctx)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to get disks: %v", err)
+// 	}
 
-	disks := diskList.GetDisks()
-	disksCreatedByCSIDriver := make([]*compute.Disk, 0, len(disks))
+// 	disksMeta := make([]v1alpha1.DiskMeta, 0, len(disks))
 
-	for _, disk := range disks {
-		if disk.Description == "Created by Yandex CSI driver" {
-			disksCreatedByCSIDriver = append(disksCreatedByCSIDriver, disk)
-		}
-	}
+// 	for _, disk := range disks {
+// 		disksMeta = append(disksMeta, v1alpha1.DiskMeta{ID: disk.Id, Name: disk.Name})
+// 	}
 
-	if len(disksCreatedByCSIDriver) == 0 {
-		d.logger.Warnln("Unexpected behavior: no disks created by the CSI driver were found in the cloud. Should be checked manually")
-	}
+// 	return disksMeta, nil
+// }
 
-	return disksCreatedByCSIDriver, nil
-}
+// func (d *Discoverer) getDisksCreatedByCSIDriver(ctx context.Context) ([]*compute.Disk, error) {
+// 	diskList, err := d.sdk.Compute().Disk().List(ctx, &compute.ListDisksRequest{
+// 		FolderId: d.folderID,
+// 	})
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to list disks: %v", err)
+// 	}
+
+// 	disks := diskList.GetDisks()
+// 	disksCreatedByCSIDriver := make([]*compute.Disk, 0, len(disks))
+
+// 	for _, disk := range disks {
+// 		if disk.Description == "Created by Yandex CSI driver" {
+// 			disksCreatedByCSIDriver = append(disksCreatedByCSIDriver, disk)
+// 		}
+// 	}
+
+// 	if len(disksCreatedByCSIDriver) == 0 {
+// 		d.logger.Warnln("Unexpected behavior: no disks created by the CSI driver were found in the cloud. Should be checked manually")
+// 	}
+
+// 	return disksCreatedByCSIDriver, nil
+// }


### PR DESCRIPTION
## Description

Temporarily disable discovery orphan disks in yandex cloud, until CSI starts placing cluster labels that solve the problem of discovery from different clusters in one folder.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Currently alert `ClusterHasOrphanedDisks` gives incorrect information for different clusters in the same yandex folder.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Temporary disable orphan disks discovery for yandex cloud.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Temporary disable orphan disks discovery for yandex cloud.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
