### PR TITLE
promxy: drop externalLabels if configured through the ModuleConfig

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
@@ -53,8 +53,10 @@ data:
             - targets:
                 - prometheus-longterm.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:9090
           metrics_relabel_configs:
+          {{- range append (keys .Values.prometheus.externalLabels) "prometheus" | uniq }}
             - action: labeldrop
-              source_label: prometheus
+              source_label: {{ . }}
+          {{- end }}
           ignore_error: true
           anti_affinity: 300s
           timeout: 5s


### PR DESCRIPTION
## Description
Deckhouse Prometheus module provides configuration option `externalLabels` which is directly passed to the eponymous field in `Prometheus` CR spec. This allows users to add custom labels to metrics and is used primarily for the remote write, thus allowing them to distinguish metrics from different sources and clusters.

The long-term Prometheus in the Deckhouse Platform employs federation to collect metrics from the main Prometheus. When exporting metrics for the federation purpose, Prometheus adds all the labels listed in `externalLabels` to the metrics. This makes label sets in main and long-term Prometheus differ and this is where the problem in conjunction with promxy emerges.

Promxy aggregates metrics from both main and longterm prometheus. This allows the user to query any time range that main or long-term Prometheus may satisfy without switching the data source, acting as a universal one.
This, however, imposes an obligation: label sets in both data sources have to be equal, otherwise unsolicited series will appear in a query result which in turn may lead to the "many-to-many matching not allowed" errors.

## Why do we need it, and what problem does it solve?
Promxy allows us to filter out arbitrary labels from the data source, so we can use this feature to remove labels listed `externalLabels` from the long-term Prometheus response. But this will partially solve the described problem, as promxy will only operate with the current label drop list. If the `externalLabels`  list changes it may lead to issues querying older series before the change.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
