### PR TITLE
aggregating-proxy: don't query longterm prometheus

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
@@ -48,22 +48,3 @@ data:
             bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
             tls_config:
               insecure_skip_verify: true
-          {{- if ne (int .Values.prometheus.longtermRetentionDays) 0 }}
-        - static_configs:
-            - targets:
-                - prometheus-longterm.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:9090
-          metrics_relabel_configs:
-            - action: labeldrop
-              source_label: prometheus
-          ignore_error: true
-          anti_affinity: 300s
-          timeout: 5s
-          remote_read: false
-          prefer_max: true
-          scheme: https
-          http_client:
-            dial_timeout: 1s
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            tls_config:
-              insecure_skip_verify: true
-          {{- end }}


### PR DESCRIPTION
## Description
Long-term Prometheus uses a federation endpoint to scrape metrics from the main Prometheus. This results in the label set discrepancy in the main and long-term series. Thus, it is not always possible for promxy to return unique series while querying these data sources. This can break queries in Grafana dashboards in certain cases, making them unusable.

## Why do we need it, and what problem does it solve?
This PR drops long-term Prometheus querying in aggregating-proxy. This approach turns out to be unreliable.

## Why do we need it in the patch release (if we do)?
Multiple known configurations exist when querying long-term in aggregating-proxy breaks queries in Grafana dashboards.
Such as using `externalLabels` configuration option in the Prometheus `ModuleConfig`

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Don't query longterm Prometheus in the aggregating-proxy.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
