### PR TITLE
[deckhouse-controller] add a fallback if KUBERNETES_CLUSTER_DOMAIN isn't set

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -78,6 +78,7 @@ func start(_ *kingpin.ParseContext) error {
 }
 
 func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator) {
+	var identity string
 	podName := os.Getenv("DECKHOUSE_POD")
 	if len(podName) == 0 {
 		log.Info("DECKHOUSE_POD env not set or empty")
@@ -90,16 +91,18 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator) {
 		os.Exit(1)
 	}
 
-	clusterDomain := os.Getenv("KUBERNETES_CLUSTER_DOMAIN")
-	if len(clusterDomain) == 0 {
-		log.Fatal("KUBERNETES_CLUSTER_DOMAIN env not set or empty")
-	}
-
 	podNs := os.Getenv("ADDON_OPERATOR_NAMESPACE")
 	if len(podNs) == 0 {
 		podNs = defaultNamespace
 	}
-	identity := fmt.Sprintf("%s.%s.%s.pod.%s", podName, strings.ReplaceAll(podIP, ".", "-"), podNs, clusterDomain)
+
+	clusterDomain := os.Getenv("KUBERNETES_CLUSTER_DOMAIN")
+	if len(clusterDomain) == 0 {
+		log.Warn("KUBERNETES_CLUSTER_DOMAIN env not set or empty - it's value won't be used for the leader election")
+		identity = fmt.Sprintf("%s.%s.%s.pod", podName, strings.ReplaceAll(podIP, ".", "-"), podNs)
+	} else {
+		identity = fmt.Sprintf("%s.%s.%s.pod.%s", podName, strings.ReplaceAll(podIP, ".", "-"), podNs, clusterDomain)
+	}
 
 	err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
 		// Create a leaderElectionConfig for leader election


### PR DESCRIPTION
## Description
Add a fallback if deckhouse is in HA mode and KUBERNETES_CLUSTER_DOMAIN env isn't set (it happens if deckhouse had already been in HA mode when 1.59.5 version was applied). In that case, the identity value for the leader election ignores KUBERNETES_CLUSTER_DOMAIN value.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
If the deckhouse deployment is in HA mode and version 1.59.5 is applied, deckhouse won't start as the KUBERNETES_CLUSTER_DOMAIN isn't set, but it is mandatory to have it set.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It fixes a nasty bug in HA mode.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
If the KUBERNETES_CLUSTER_DOMAIN env isn't set, the identity value for the leader election is successfully set without the env.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Drop cluster-domain part of the leader identity if KUBERNETES_CLUSTER_DOMAIN isn't set.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
