### PR TITLE
[deckhouse] Validate that registry address is always present

### DIFF
--- a/modules/002-deckhouse/templates/registry-secret.yaml
+++ b/modules/002-deckhouse/templates/registry-secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/resource-policy: keep
 {{- /* Helm checks changes only in .dockerconfigjson field, so if other field changes, helm don't change secret. Checksum resolve this. */}}
     checksum: {{ printf $.Values.global.modulesImages.registry.dockercfg $.Values.global.modulesImages.registry.address $.Values.global.modulesImages.registry.path $.Values.global.modulesImages.registry.scheme $.Values.global.modulesImages.registry.CA | sha256sum }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "registry")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "registry" "name" "deckhouse-registry")) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ $.Values.global.modulesImages.registry.dockercfg }}

--- a/modules/002-deckhouse/webhooks/validating/registry-secret-address
+++ b/modules/002-deckhouse/webhooks/validating/registry-secret-address
@@ -22,6 +22,9 @@ configVersion: v1
 kubernetesValidating:
 - name: registry-secret-address.deckhouse.io
   group: main
+  labelSelector:
+    matchLabels:
+      name: deckhouse-registry
   rules:
   - apiGroups:   [""]
     apiVersions: ["v1"]
@@ -32,8 +35,8 @@ EOF
 }
 
 function __main__() {
-  secretName = $(context::jq -r '.review.request.object.metadata.name')
-  secretNs = $(context::jq -r '.review.request.object.metadata.namespace')
+  secretName=$(context::jq -r '.review.request.object.metadata.name')
+  secretNs=$(context::jq -r '.review.request.object.metadata.namespace')
   if [[ "$secretName" == "deckhouse-registry" ]]; then
     if [[ "$secretNs" == "d8-system" ]]; then
       addr=$(context::jq -r '.review.request.object.data.address')

--- a/modules/002-deckhouse/webhooks/validating/registry-secret-address
+++ b/modules/002-deckhouse/webhooks/validating/registry-secret-address
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetesValidating:
+- name: registry-secret-address.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["secrets"]
+    scope:       "Namespaced"
+EOF
+}
+
+function __main__() {
+  secretName = $(context::jq -r '.review.request.object.metadata.name')
+  secretNs = $(context::jq -r '.review.request.object.metadata.namespace')
+  if [[ "$secretName" == "deckhouse-registry" ]]; then
+    if [[ "$secretNs" == "d8-system" ]]; then
+      addr=$(context::jq -r '.review.request.object.data.address')
+      if [[ -z "$addr" ]]; then
+        cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"Registry address is required." }
+EOF
+        return 0
+      fi
+    fi
+  fi
+
+  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+}
+
+hook::run "$@"

--- a/modules/002-deckhouse/webhooks/validating/registry-secret-address
+++ b/modules/002-deckhouse/webhooks/validating/registry-secret-address
@@ -40,7 +40,7 @@ function __main__() {
   if [[ "$secretName" == "deckhouse-registry" ]]; then
     if [[ "$secretNs" == "d8-system" ]]; then
       addr=$(context::jq -r '.review.request.object.data.address')
-      if [[ -z "$addr" ]]; then
+      if [[ -z "$addr" ]] || [[ "$addr" == "null" ]]; then
         cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"Registry address is required." }
 EOF

--- a/modules/002-deckhouse/webhooks/validating/registry-secret-address
+++ b/modules/002-deckhouse/webhooks/validating/registry-secret-address
@@ -22,6 +22,10 @@ configVersion: v1
 kubernetesValidating:
 - name: registry-secret-address.deckhouse.io
   group: main
+  namespace:
+    labelSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: d8-system
   labelSelector:
     matchLabels:
       name: deckhouse-registry


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a webhook to validate that registry address in `deckhouse-registry` secret is always present

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Closes https://github.com/deckhouse/deckhouse/issues/7173

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Validate that registry address is always present in deckhouse configuration.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
