### PR TITLE
[prometheus] add imagePullSecrets to memcached

### DIFF
--- a/modules/300-prometheus/templates/memcached/sts.yaml
+++ b/modules/300-prometheus/templates/memcached/sts.yaml
@@ -39,7 +39,7 @@ spec:
         app: memcached
     spec:
       imagePullSecrets:
-        - name: deckhouse-registry
+      - name: deckhouse-registry
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}

--- a/modules/300-prometheus/templates/memcached/sts.yaml
+++ b/modules/300-prometheus/templates/memcached/sts.yaml
@@ -29,8 +29,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "memcached")) | nindent 2 }}
 spec:
   serviceName: memcached
-  imagePullSecrets:
-  - name: deckhouse-registry
   selector:
     matchLabels:
       app: memcached
@@ -40,6 +38,8 @@ spec:
       labels:
         app: memcached
     spec:
+      imagePullSecrets:
+        - name: deckhouse-registry
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Memcached doesn't use `imagePullSecrets` because of incorrect Statefulset. And if registry needs auth, image can't be pulled.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
`imagePullSecrets` appear in Statefulset `-o yaml`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.