### PR TITLE
[ceph-csi] Update FAQ

### DIFF
--- a/modules/031-ceph-csi/docs/FAQ.md
+++ b/modules/031-ceph-csi/docs/FAQ.md
@@ -5,6 +5,6 @@ title: "The ceph-csi module: FAQ"
 ## How to get a list of RBD volumes separated by nodes?
 
 ```shell
-kubectl -n d8-ceph-csi get po -l app=csi-node-rbd --no-headers -owide \
-  | awk '{print "echo "$7"; kubectl -n d8-ceph-csi exec  "$1" -c node -- rbd showmapped"}' | bash
+kubectl -n d8-ceph-csi get po -l app=csi-node-rbd -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName --no-headers \
+  | awk '{print "echo "$2"; kubectl -n d8-ceph-csi exec  "$1" -c node -- rbd showmapped"}' | bash
 ```

--- a/modules/031-ceph-csi/docs/FAQ_RU.md
+++ b/modules/031-ceph-csi/docs/FAQ_RU.md
@@ -5,5 +5,6 @@ title: "Модуль ceph-csi: FAQ"
 ## Как получить список томов RBD, разделенный по узлам?
 
 ```shell
-kubectl -n d8-ceph-csi get po -l app=csi-node-rbd --no-headers -owide | awk '{print "echo "$7"; kubectl -n d8-ceph-csi exec  "$1" -c node -- rbd showmapped"}' | bash
+kubectl -n d8-ceph-csi get po -l app=csi-node-rbd -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName --no-headers \
+  | awk '{print "echo "$2"; kubectl -n d8-ceph-csi exec  "$1" -c node -- rbd showmapped"}' | bash
 ```


### PR DESCRIPTION
## Description
Changed the command to display a list of RBD volumes divided by nodes.

## Why do we need it, and what problem does it solve?
The current command sometimes displays incorrect information due to the display of the time of the last restart of the pod.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ceph-csi
type: chore
summary: Update FAQ.
impact_level: low
```
