### PR TITLE
Use docker client without auth if dockerCfg is not set

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
@@ -25,13 +25,11 @@ const (
 	SyncedPollPeriod = 100 * time.Millisecond
 )
 
-// GenerateRegistryOptions feteches settings from ModuleSource and generate registry options from them
+// GenerateRegistryOptions fetches settings from ModuleSource and generate registry options from them
 func GenerateRegistryOptions(ms *v1alpha1.ModuleSource) []cr.Option {
 	opts := make([]cr.Option, 0)
 	if ms.Spec.Registry.DockerCFG != "" {
 		opts = append(opts, cr.WithAuth(ms.Spec.Registry.DockerCFG))
-	} else {
-		opts = append(opts, cr.WithDisabledAuth())
 	}
 
 	if ms.Spec.Registry.CA != "" {

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -261,17 +261,14 @@ func WithInsecureSchema(insecure bool) Option {
 	}
 }
 
-// WithDisabledAuth don't use authConfig
-func WithDisabledAuth() Option {
-	return func(options *registryOptions) {
-		options.withoutAuth = true
-	}
-}
-
 // WithAuth use docker config base64 as authConfig
+// if dockerCfg is empty - will use client without auth
 func WithAuth(dockerCfg string) Option {
 	return func(options *registryOptions) {
 		options.dockerCfg = dockerCfg
+		if dockerCfg == "" {
+			options.withoutAuth = true
+		}
 	}
 }
 

--- a/modules/002-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release.go
@@ -577,8 +577,16 @@ func NewDeckhouseReleaseChecker(input *go_hook.HookInput, dc dependency.Containe
 	repo := input.Values.Get("global.modulesImages.registry.base").String() // host/ns/repo
 	dockerCfg := input.Values.Get("global.modulesImages.registry.dockercfg").String()
 	clusterUUID := input.Values.Get("global.discovery.clusterUUID").String()
+
+	opts := []cr.Option{
+		cr.WithCA(getCA(input)),
+		cr.WithInsecureSchema(isHTTP(input)),
+		cr.WithUserAgent(clusterUUID),
+		cr.WithAuth(dockerCfg),
+	}
+
 	// registry.deckhouse.io/deckhouse/ce/release-channel:$release-channel
-	regCli, err := dc.GetRegistryClient(path.Join(repo, "release-channel"), cr.WithAuth(dockerCfg), cr.WithCA(getCA(input)), cr.WithInsecureSchema(isHTTP(input)), cr.WithUserAgent(clusterUUID))
+	regCli, err := dc.GetRegistryClient(path.Join(repo, "release-channel"), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/002-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image.go
@@ -394,7 +394,13 @@ func tagUpdate(input *go_hook.HookInput, dc dependency.Container, deckhousePods 
 
 	dockerCfg := input.Values.Get("global.modulesImages.registry.dockercfg").String()
 
-	regClient, err := dc.GetRegistryClient(repo, cr.WithCA(getCA(input)), cr.WithInsecureSchema(isHTTP(input)), cr.WithAuth(dockerCfg))
+	opts := []cr.Option{
+		cr.WithCA(getCA(input)),
+		cr.WithInsecureSchema(isHTTP(input)),
+		cr.WithAuth(dockerCfg),
+	}
+
+	regClient, err := dc.GetRegistryClient(repo, opts...)
 	if err != nil {
 		input.LogEntry.Errorf("Registry (%s) client init failed: %s", repo, err)
 		return nil

--- a/modules/500-okmeter/hooks/update_agent_image.go
+++ b/modules/500-okmeter/hooks/update_agent_image.go
@@ -46,7 +46,7 @@ func checkRelease(input *go_hook.HookInput, dc dependency.Container) error {
 	if tag == "" {
 		tag = "latest"
 	}
-	regCli, err := dc.GetRegistryClient(repo, cr.WithDisabledAuth())
+	regCli, err := dc.GetRegistryClient(repo, cr.WithAuth(""))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
If dockerCfg for docker registry client is not set (or empty string), we have to use WithoutAuth option

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/5429

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global
type: chore
summary: Use withoutAuth docker registry options if dockerCfg is empty.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
