### PR TITLE
[cloud-provider-yandex] Simplify creation of internal LB

### DIFF
--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -6,8 +6,8 @@ title: "Cloud provider — Yandex Cloud: FAQ"
 
 Attach one of the following annotations to the service:
 
-- `yandex.cpi.flant.com/listener-subnet-id: SubnetID` - the annotation links the LoadBalancer with the appropriate subnet.
-- `yandex.cpi.flant.com/loadbalancer-internal: ""` - LoadBalancer will listen to the first available subnet.
+- `yandex.cpi.flant.com/listener-subnet-id: SubnetID` — the annotation links the LoadBalancer with the appropriate subnet.
+- `yandex.cpi.flant.com/loadbalancer-internal: ""` — LoadBalancer will listen to the first available subnet.
 
 ## How to reserve a public IP address?
 

--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -10,12 +10,12 @@ Attach one of the following annotations to the service:
    ```yaml
    yandex.cpi.flant.com/listener-subnet-id: SubnetID
    ```
-   
+
    The annotation links the LoadBalancer with the appropriate Subnet.
 
-2. 
+2.
    ```yaml
-   yandex.cloud/load-balancer-type: Internal
+   yandex.cpi.flant.com/loadbalancer-internal: ""
    ```
 
    LoadBalancer will listen to the first available subnet.

--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -6,19 +6,8 @@ title: "Cloud provider — Yandex Cloud: FAQ"
 
 Attach one of the following annotations to the service:
 
-1.
-   ```yaml
-   yandex.cpi.flant.com/listener-subnet-id: SubnetID
-   ```
-
-   The annotation links the LoadBalancer with the appropriate Subnet.
-
-2.
-   ```yaml
-   yandex.cpi.flant.com/loadbalancer-internal: ""
-   ```
-
-   LoadBalancer will listen to the first available subnet.
+- `yandex.cpi.flant.com/listener-subnet-id: SubnetID` - the annotation links the LoadBalancer with the appropriate subnet.
+- `yandex.cpi.flant.com/loadbalancer-internal: ""` - LoadBalancer will listen to the first available subnet.
 
 ## How to reserve a public IP address?
 

--- a/modules/030-cloud-provider-yandex/docs/FAQ.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ.md
@@ -4,13 +4,21 @@ title: "Cloud provider — Yandex Cloud: FAQ"
 
 ## How do I set up the INTERNAL LoadBalancer?
 
-Attach the following annotation to the service:
+Attach one of the following annotations to the service:
 
-```yaml
-yandex.cpi.flant.com/listener-subnet-id: SubnetID
-```
+1.
+   ```yaml
+   yandex.cpi.flant.com/listener-subnet-id: SubnetID
+   ```
+   
+   The annotation links the LoadBalancer with the appropriate Subnet.
 
-The annotation links the LoadBalancer with the appropriate Subnet.
+2. 
+   ```yaml
+   yandex.cloud/load-balancer-type: Internal
+   ```
+
+   LoadBalancer will listen to the first available subnet.
 
 ## How to reserve a public IP address?
 

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -4,11 +4,19 @@ title: "Cloud provider — Yandex Cloud: FAQ"
 
 ## Как настроить INTERNAL LoadBalancer?
 
-Для настройки INTERNAL LoadBalancer'а установите аннотацию для сервиса:
+Для настройки INTERNAL LoadBalancer'а установите одну из следующих аннотаций для сервиса:
 
-```yaml
-yandex.cpi.flant.com/listener-subnet-id: SubnetID
-```
+1.
+   ```yaml
+   yandex.cpi.flant.com/listener-subnet-id: SubnetID
+   ```
+   Аннотация указывает, какой subnet будет слушать LoadBalancer.
+2.
+   ```yaml
+   yandex.cloud/load-balancer-type: Internal
+   ```
+   
+   LoadBalancer будет слушать первую из доступных subnet.
 
 Аннотация указывает, какой subnet будет слушать LoadBalancer.
 

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -6,19 +6,8 @@ title: "Cloud provider — Yandex Cloud: FAQ"
 
 Для настройки INTERNAL LoadBalancer'а установите одну из следующих аннотаций для сервиса:
 
-1.
-   ```yaml
-   yandex.cpi.flant.com/listener-subnet-id: SubnetID
-   ```
-
-   Аннотация указывает, какой subnet будет слушать LoadBalancer.
-   
-2.
-   ```yaml
-   yandex.cpi.flant.com/loadbalancer-internal: ""
-   ```
-
-   LoadBalancer будет слушать первую из доступных subnet.
+- `yandex.cpi.flant.com/listener-subnet-id: SubnetID` - аннотация указывает, какой subnet будет слушать LoadBalancer.
+- `yandex.cpi.flant.com/loadbalancer-internal: ""` - LoadBalancer будет слушать первую из доступных subnet.
 
 Аннотация указывает, какой subnet будет слушать LoadBalancer.
 

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -6,8 +6,8 @@ title: "Cloud provider — Yandex Cloud: FAQ"
 
 Для настройки INTERNAL LoadBalancer'а установите одну из следующих аннотаций для сервиса:
 
-- `yandex.cpi.flant.com/listener-subnet-id: SubnetID` - аннотация указывает, какой subnet будет слушать LoadBalancer.
-- `yandex.cpi.flant.com/loadbalancer-internal: ""` - LoadBalancer будет слушать первую из доступных subnet.
+- `yandex.cpi.flant.com/listener-subnet-id: SubnetID` — аннотация указывает, какой subnet будет слушать LoadBalancer.
+- `yandex.cpi.flant.com/loadbalancer-internal: ""` — LoadBalancer будет слушать первую из доступных subnet.
 
 Аннотация указывает, какой subnet будет слушать LoadBalancer.
 

--- a/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/FAQ_RU.md
@@ -10,12 +10,14 @@ title: "Cloud provider — Yandex Cloud: FAQ"
    ```yaml
    yandex.cpi.flant.com/listener-subnet-id: SubnetID
    ```
+
    Аннотация указывает, какой subnet будет слушать LoadBalancer.
+   
 2.
    ```yaml
-   yandex.cloud/load-balancer-type: Internal
+   yandex.cpi.flant.com/loadbalancer-internal: ""
    ```
-   
+
    LoadBalancer будет слушать первую из доступных subnet.
 
 Аннотация указывает, какой subnet будет слушать LoadBalancer.

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/004-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/004-internal-lb.patch
@@ -1,0 +1,80 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f18e85c 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/README.md
@@ -17,3 +17,9 @@ Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 004-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/004-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/004-internal-lb.patch
@@ -1,0 +1,80 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f18e85c 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/README.md
@@ -17,3 +17,9 @@ Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 004-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/003-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/003-internal-lb.patch
@@ -1,0 +1,80 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f18e85c 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.25/README.md
@@ -11,3 +11,9 @@ Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 003-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.26/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.26/002-internal-lb.patch
@@ -1,0 +1,80 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f18e85c 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.26/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.26/README.md
@@ -5,3 +5,9 @@
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 002-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.27/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.27/002-internal-lb.patch
@@ -1,0 +1,80 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f18e85c 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.27/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.27/README.md
@@ -5,3 +5,9 @@
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 002-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.28/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.28/002-internal-lb.patch
@@ -1,0 +1,80 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f18e85c 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.28/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.28/README.md
@@ -5,3 +5,9 @@
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 002-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
@@ -1,0 +1,29 @@
+diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
+index 7b09147..f110610 100644
+--- a/pkg/cloudprovider/yandex/load_balancer.go
++++ b/pkg/cloudprovider/yandex/load_balancer.go
+@@ -19,6 +19,7 @@ const (
+ 	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
+ 	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
+ 	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
++	loadBalancerTypeAnnotation            = "yandex.cloud/load-balancer-type"
+ 
+ 	nodesHealthCheckPath = "/healthz"
+ 	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
+@@ -217,8 +218,14 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.listenerSubnetID = value
+ 	} else if len(yc.config.lbListenerSubnetID) != 0 {
+ 		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
+-		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+-		lbParams.internal = !isExternal
++
++		if lbType, hasAnnotation := svc.ObjectMeta.Annotations[loadBalancerTypeAnnotation]; hasAnnotation && lbType == "Internal" {
++			lbParams.internal = true
++		}
++
++		if _, hasAnnotation := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]; hasAnnotation {
++			lbParams.internal = false
++		}
+ 	}
+ 
+ 	if value, ok := svc.ObjectMeta.Annotations[targetGroupNetworkIdAnnotation]; ok {

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
-index 7b09147..16ccb70 100644
+index 7b09147..d6e7b7b 100644
 --- a/pkg/cloudprovider/yandex/load_balancer.go
 +++ b/pkg/cloudprovider/yandex/load_balancer.go
 @@ -19,6 +19,7 @@ const (
@@ -10,21 +10,19 @@ index 7b09147..16ccb70 100644
  
  	nodesHealthCheckPath = "/healthz"
  	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
-@@ -216,9 +217,16 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
- 		lbParams.internal = true
+@@ -217,8 +218,14 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
  		lbParams.listenerSubnetID = value
  	} else if len(yc.config.lbListenerSubnetID) != 0 {
-+		lbParams.internal = true
  		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
 -		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
 -		lbParams.internal = !isExternal
 +
-+		if _, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]; isExternal {
-+			lbParams.internal = false
-+		}
-+
 +		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
 +			lbParams.internal = true
++		}
++
++		if _, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]; isExternal {
++			lbParams.internal = false
 +		}
  	}
  

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
@@ -1,28 +1,30 @@
 diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
-index 7b09147..f110610 100644
+index 7b09147..16ccb70 100644
 --- a/pkg/cloudprovider/yandex/load_balancer.go
 +++ b/pkg/cloudprovider/yandex/load_balancer.go
 @@ -19,6 +19,7 @@ const (
  	externalLoadBalancerAnnotation        = "yandex.cpi.flant.com/loadbalancer-external"
  	listenerSubnetIdAnnotation            = "yandex.cpi.flant.com/listener-subnet-id"
  	listenerAddressIPv4                   = "yandex.cpi.flant.com/listener-address-ipv4"
-+	loadBalancerTypeAnnotation            = "yandex.cloud/load-balancer-type"
++	loadBalancerInternal                  = "yandex.cpi.flant.com/loadbalancer-internal"
  
  	nodesHealthCheckPath = "/healthz"
  	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
-@@ -217,8 +218,14 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+@@ -216,9 +217,16 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
+ 		lbParams.internal = true
  		lbParams.listenerSubnetID = value
  	} else if len(yc.config.lbListenerSubnetID) != 0 {
++		lbParams.internal = true
  		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
 -		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
 -		lbParams.internal = !isExternal
 +
-+		if lbType, hasAnnotation := svc.ObjectMeta.Annotations[loadBalancerTypeAnnotation]; hasAnnotation && lbType == "Internal" {
-+			lbParams.internal = true
++		if _, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]; isExternal {
++			lbParams.internal = false
 +		}
 +
-+		if _, hasAnnotation := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]; hasAnnotation {
-+			lbParams.internal = false
++		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
++			lbParams.internal = true
 +		}
  	}
  

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/002-internal-lb.patch
@@ -1,5 +1,61 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..8fffc4a 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -29,26 +29,28 @@ import (
+ const (
+ 	providerName = "yandex"
+ 
+-	envClusterName        = "YANDEX_CLUSTER_NAME"
+-	envRouteTableID       = "YANDEX_CLOUD_ROUTE_TABLE_ID"
+-	envServiceAccountJSON = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
+-	envFolderID           = "YANDEX_CLOUD_FOLDER_ID"
+-	envLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
+-	envLbTgNetworkID      = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
+-	envInternalNetworkIDs = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
+-	envExternalNetworkIDs = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
++	envClusterName                = "YANDEX_CLUSTER_NAME"
++	envRouteTableID               = "YANDEX_CLOUD_ROUTE_TABLE_ID"
++	envServiceAccountJSON         = "YANDEX_CLOUD_SERVICE_ACCOUNT_JSON"
++	envFolderID                   = "YANDEX_CLOUD_FOLDER_ID"
++	envLbListenerSubnetID         = "YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID"
++	envInternalLbListenerSubnetID = "YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID"
++	envLbTgNetworkID              = "YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID"
++	envInternalNetworkIDs         = "YANDEX_CLOUD_INTERNAL_NETWORK_IDS"
++	envExternalNetworkIDs         = "YANDEX_CLOUD_EXTERNAL_NETWORK_IDS"
+ )
+ 
+ // CloudConfig includes all the necessary configuration for creating Cloud object
+ type CloudConfig struct {
+ 	ClusterName string
+ 
+-	lbListenerSubnetID string
+-	lbTgNetworkID      string
+-	FolderID           string
+-	LocalRegion        string
+-	LocalZone          string
+-	RouteTableID       string
++	lbListenerSubnetID         string
++	internalLbListenerSubnetID string
++	lbTgNetworkID              string
++	FolderID                   string
++	LocalRegion                string
++	LocalZone                  string
++	RouteTableID               string
+ 
+ 	InternalNetworkIDsSet map[string]struct{}
+ 	ExternalNetworkIDsSet map[string]struct{}
+@@ -127,6 +129,8 @@ func NewCloudConfig() (*CloudConfig, error) {
+ 
+ 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
+ 
++	cloudConfig.internalLbListenerSubnetID = os.Getenv(envInternalLbListenerSubnetID)
++
+ 	cloudConfig.lbTgNetworkID = os.Getenv(envLbTgNetworkID)
+ 	if len(cloudConfig.lbTgNetworkID) == 0 {
+ 		log.Fatalf("%q env is required", envLbTgNetworkID)
 diff --git a/pkg/cloudprovider/yandex/load_balancer.go b/pkg/cloudprovider/yandex/load_balancer.go
-index 7b09147..d6e7b7b 100644
+index 7b09147..f18e85c 100644
 --- a/pkg/cloudprovider/yandex/load_balancer.go
 +++ b/pkg/cloudprovider/yandex/load_balancer.go
 @@ -19,6 +19,7 @@ const (
@@ -10,19 +66,14 @@ index 7b09147..d6e7b7b 100644
  
  	nodesHealthCheckPath = "/healthz"
  	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
-@@ -217,8 +218,14 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
- 		lbParams.listenerSubnetID = value
- 	} else if len(yc.config.lbListenerSubnetID) != 0 {
+@@ -219,6 +220,11 @@ func (yc *Cloud) getLoadBalancerParameters(svc *v1.Service) (lbParams loadBalanc
  		lbParams.listenerSubnetID = yc.config.lbListenerSubnetID
--		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
--		lbParams.internal = !isExternal
-+
+ 		_, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]
+ 		lbParams.internal = !isExternal
++	} else if len(yc.config.internalLbListenerSubnetID) != 0 {
 +		if _, isInternal := svc.ObjectMeta.Annotations[loadBalancerInternal]; isInternal {
 +			lbParams.internal = true
-+		}
-+
-+		if _, isExternal := svc.ObjectMeta.Annotations[externalLoadBalancerAnnotation]; isExternal {
-+			lbParams.internal = false
++			lbParams.listenerSubnetID = yc.config.internalLbListenerSubnetID
 +		}
  	}
  

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/README.md
@@ -8,6 +8,6 @@ Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/
 
 ### 002-internal-lb.patch
 
-Added the ability to create an internal load balancer using the annotation yandex.cloud/load-balancer-type: Internal.
+Added the ability to create an internal load balancer using the annotation yandex.cpi.flant.com/loadbalancer-internal: "".
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.29/README.md
@@ -5,3 +5,9 @@
 To set node to the non-default target group add annotation yandex.cpi.flant.com/target-group to the node. Yandex CCM creates new target groups with name yandex.cpi.flant.com/target-group annotation value + network id of instance interfaces.
 
 Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/60)
+
+### 002-internal-lb.patch
+
+Added the ability to create an internal load balancer using the annotation yandex.cloud/load-balancer-type: Internal.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/61)

--- a/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
@@ -125,6 +125,8 @@ spec:
           - name: YANDEX_CLOUD_FOLDER_ID
             value: {{ .Values.cloudProviderYandex.internal.providerClusterConfiguration.provider.folderID | quote }}
           - name: YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID
+            value: {{ .Values.cloudProviderYandex.internal.defaultLbListenerSubnetId | quote }}
+          - name: YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID
             value: {{ index .Values.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap (.Values.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap | keys | first) | quote }}
           - name: YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID
             value: {{ .Values.cloudProviderYandex.internal.providerDiscoveryData.defaultLbTargetGroupNetworkId | quote }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           - name: YANDEX_CLOUD_FOLDER_ID
             value: {{ .Values.cloudProviderYandex.internal.providerClusterConfiguration.provider.folderID | quote }}
           - name: YANDEX_CLOUD_DEFAULT_LB_LISTENER_SUBNET_ID
-            value: {{ .Values.cloudProviderYandex.internal.defaultLbListenerSubnetId | quote }}
+            value: {{ index .Values.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap (.Values.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap | keys | first) | quote }}
           - name: YANDEX_CLOUD_DEFAULT_LB_TARGET_GROUP_NETWORK_ID
             value: {{ .Values.cloudProviderYandex.internal.providerDiscoveryData.defaultLbTargetGroupNetworkId | quote }}
           - name: YANDEX_CLOUD_INTERNAL_NETWORK_IDS


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added annotation `yandex.cpi.flant.com/loadbalancer-internal: ""` to make it easier to create internal load balancers.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checks

<details><summary>Details</summary>

New cluster from the main branch

```shell
root@test-master-0:~# kubectl get no -o wide
NAME                                            STATUS   ROLES                  AGE   VERSION   INTERNAL-IP   EXTERNAL-IP       OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
test-master-0                      Ready    control-plane,master   13h   v1.29.4   10.146.0.24   178.154.231.162   Ubuntu 20.04.4 LTS   5.4.0-107-generic   containerd://1.7.13
test-worker-0e6ab7af-df9b9-jfn4v   Ready    worker                 12h   v1.29.4   10.146.0.14   <none>            Ubuntu 20.04.4 LTS   5.4.0-107-generic   containerd://1.7.13
```

Ingress controllers with the LoadBalancer inlet have been created. One uses external LoadBalancer, the other internal

```yaml
---
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
 name: external-1
spec:
  ingressClass: "nginx"
  inlet: "LoadBalancer"
---
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
 name: internal-1
spec:
  ingressClass: "nginx"
  inlet: "LoadBalancer"
  loadBalancer:
    annotations:
      yandex.cloud/load-balancer-type: Internal
      yandex.cpi.flant.com/listener-subnet-id: e9bvhnjbqu4au5s2va4i
```

Created Load Balancers

```shell
root@test-master-0:~# kubectl -n d8-ingress-nginx get svc | grep LoadBalancer
external-1-load-balancer   LoadBalancer   10.222.39.216    158.160.168.172   80:32019/TCP,443:31130/TCP   2m23s
internal-1-load-balancer   LoadBalancer   10.222.13.26     10.146.0.21       80:30477/TCP,443:30473/TCP   2m22s
```

```yaml
root@test-master-0:~# kubectl -n d8-ingress-nginx get svc external-1-load-balancer -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: ingress-nginx
    meta.helm.sh/release-namespace: d8-system
...
  name: external-1-load-balancer
  namespace: d8-ingress-nginx
...
spec:
...
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: 158.160.168.172
```

```yaml
root@test-master-0:~# kubectl -n d8-ingress-nginx get svc internal-1-load-balancer -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: ingress-nginx
    meta.helm.sh/release-namespace: d8-system
    yandex.cloud/load-balancer-type: Internal
    yandex.cpi.flant.com/listener-subnet-id: e9bvhnjbqu4au5s2va4i
...
  name: internal-1-load-balancer
  namespace: d8-ingress-nginx
...
spec:
...
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: 10.146.0.21
```

Functionality check

```shell
root@test-master-0:~# curl 158.160.168.172
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
root@test-master-0:~# curl 10.146.0.21
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

Image d8 switched to branch pr8274

```shell
root@test-master-0:~# kubectl -n d8-system get deployments.apps deckhouse -o json | jq '.spec.template.spec.containers[0].image'
"dev-registry.deckhouse.io/sys/deckhouse-oss:pr8274"
```

Make sure that a new environment variable has appeared for cloud-controller-manager

```shell
root@test-master-0:~# kubectl -n d8-cloud-provider-yandex get po cloud-controller-manager-65cddb446c-5bdgg -o yaml | grep YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID -A1
    - name: YANDEX_CLOUD_DEFAULT_INTERNAL_LB_LISTENER_SUBNET_ID
      value: e9bvhnjbqu4au5s2va4i
```

We check that the existing balancers are still working

```shell
root@test-master-0:~# kubectl -n d8-ingress-nginx get svc | grep LoadBalancer
external-1-load-balancer   LoadBalancer   10.222.39.216    158.160.168.172   80:32019/TCP,443:31130/TCP   12m
internal-1-load-balancer   LoadBalancer   10.222.13.26     10.146.0.21       80:30477/TCP,443:30473/TCP   12m
root@test-master-0:~# curl 158.160.168.172
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
root@test-master-0:~# curl 10.146.0.21
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

We create balancers similar to the previous ones and one new one

```yaml
---
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
 name: external-2
spec:
  ingressClass: "nginx"
  inlet: "LoadBalancer"
---
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
 name: internal-2
spec:
  ingressClass: "nginx"
  inlet: "LoadBalancer"
  loadBalancer:
    annotations:
      yandex.cloud/load-balancer-type: Internal
      yandex.cpi.flant.com/listener-subnet-id: e9bvhnjbqu4au5s2va4i
---
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
 name: internal-new
spec:
  ingressClass: "nginx"
  inlet: "LoadBalancer"
  loadBalancer:
    annotations:
      yandex.cloud/load-balancer-type: Internal
```

We check that the new load balancers are working.

```shell
root@test-master-0:~# kubectl -n d8-ingress-nginx get svc | grep LoadBalancer
external-1-load-balancer     LoadBalancer   10.222.39.216    158.160.168.172   80:32019/TCP,443:31130/TCP   16m
external-2-load-balancer     LoadBalancer   10.222.218.125   158.160.162.250   80:30551/TCP,443:30784/TCP   2m5s
internal-1-load-balancer     LoadBalancer   10.222.13.26     10.146.0.21       80:30477/TCP,443:30473/TCP   16m
internal-2-load-balancer     LoadBalancer   10.222.220.198   10.146.0.17       80:31607/TCP,443:31835/TCP   2m5s
internal-new-load-balancer   LoadBalancer   10.222.103.45    158.160.170.201   80:30160/TCP,443:30386/TCP   114s
root@test-master-0:~# curl 158.160.162.250
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
root@test-master-0:~# curl 10.146.0.17
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
root@test-master-0:~# curl 158.160.170.201
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Added annotation yandex.cpi.flant.com/loadbalancer-internal: "" to make it easier to create internal load balancers.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
