### PR TITLE
[dhctl] Reduce bootstrap logs

### DIFF
--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -75,6 +75,11 @@ func InitLoggerWithOptions(loggerType string, opts LoggerOptions) {
 
 		// Wrap them with our default logger
 		logrus.SetOutput(defaultLogger)
+	} else {
+		klog.SetOutput(io.Discard)
+		flags := &flag.FlagSet{}
+		klog.InitFlags(flags)
+		flags.Set("logtostderr", "false")
 	}
 }
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -79,7 +79,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 	}
 
 	cachePath := metaConfig.CachePath()
-	log.InfoF("State config for prefix %s:  %s", metaConfig.ClusterPrefix, cachePath)
+	log.InfoF("State config for prefix %s:  %s\n", metaConfig.ClusterPrefix, cachePath)
 	if err = cache.InitWithOptions(cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
 		return fmt.Errorf(bootstrapAbortInvalidCacheMessage, cachePath, err)
 	}

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -88,12 +88,16 @@ func BootstrapMaster(sshClient *ssh.Client, bundleName, nodeIP string, metaConfi
 					}
 					return fmt.Errorf("script path: %v", err)
 				}
+				logs := make([]string, 0)
 				cmd := sshClient.UploadScript(scriptPath).
-					WithStdoutHandler(func(l string) { log.InfoLn(l) }).
-					Sudo()
+					WithStdoutHandler(func(l string) {
+						logs = append(logs, l)
+						log.DebugLn(l)
+					}).Sudo()
 
 				_, err := cmd.Execute()
 				if err != nil {
+					log.ErrorLn(strings.Join(logs, "\n"))
 					return fmt.Errorf("run %s: %w", scriptPath, err)
 				}
 				return nil


### PR DESCRIPTION
## Description
Output bashible scripts log wen error occurred only.
Suppress klog logs for none debug output 

## Why do we need it, and what problem does it solve?
Improve the user experience. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/deckhouse/deckhouse/assets/30695496/8e5afbe9-b58f-4241-886c-e6d561dbdd59)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/e6bc74f7-40bf-4111-9cbd-ddc397926c3c)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/f0a06084-cc34-4004-aa85-23e964a6b84f)

![image](https://github.com/deckhouse/deckhouse/assets/30695496/93765ad7-1361-48ba-8ab3-1769eb3f50f1)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Reduce bootstrap logs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
