### PR TITLE
[flant-integration] fix resources counting and add tests

### DIFF
--- a/ee/be/modules/600-flant-integration/images/flant-pricing/hooks/node_group_resources_metrics.py
+++ b/ee/be/modules/600-flant-integration/images/flant-pricing/hooks/node_group_resources_metrics.py
@@ -33,16 +33,17 @@ def main(ctx: hook.Context):
         ng = snapshot["filterResult"]
         label_key = ""
         for taint in ng.get("nodeTemplate", {}).get("taints", []):
-            match taint.get("key"):
-                case "node-role.kubernetes.io/control-plane" | "node-role.kubernetes.io/master":
-                    label_key = "is_master"
-                case "dedicated.deckhouse.io":
-                    match taint.get("value"):
-                        case "system":
+            if taint.get("key") == "node-role.kubernetes.io/control-plane" or taint.get("key") ==  "node-role.kubernetes.io/master":
+                label_key = "is_master"
+                break
+            elif taint.get("key") == "dedicated.deckhouse.io":
+                    if taint.get("value") == "system":
                             label_key = "is_system"
-                        case "monitoring":
+                            break
+                    elif taint.get("value") == "monitoring":
                             label_key = "is_monitoring"
-                        case "frontend":
+                            break
+                    elif taint.get("value") == "frontend":
                             label_key = "is_frontend"
 
         # empty label key matches worker load

--- a/ee/be/modules/600-flant-integration/images/flant-pricing/hooks/node_group_resources_metrics_test.py
+++ b/ee/be/modules/600-flant-integration/images/flant-pricing/hooks/node_group_resources_metrics_test.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Flant JSC Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+#
+
+from node_group_resources_metrics import main
+from shell_operator import hook
+
+
+def test_node_node_group_resources_metrics():
+    out = hook.testrun(main, binding_context)
+
+    assert out.metrics.data == expected_metrics
+    assert not out.kube_operations.data
+
+binding_context = [
+    {
+        "binding": "main",
+        "type": "Group",
+        "snapshots": {
+            "nodes": [
+                {
+                    "filterResult": {
+                      "node_group": "application-nodes",
+                      "capacity": {
+                        "cpu": "8",
+                        "ephemeral-storage": "39359968Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "16351048Ki",
+                        "pods": "150"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "application-nodes",
+                      "capacity": {
+                        "cpu": "8",
+                        "ephemeral-storage": "39359968Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "16351056Ki",
+                        "pods": "150"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "d8-loki",
+                      "capacity": {
+                        "cpu": "4",
+                        "ephemeral-storage": "49677140Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "8105804Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "dam",
+                      "capacity": {
+                        "cpu": "16",
+                        "ephemeral-storage": "39359968Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "3983184Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "dam",
+                      "capacity": {
+                        "cpu": "16",
+                        "ephemeral-storage": "39359968Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "3983192Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "dam",
+                      "capacity": {
+                        "cpu": "16",
+                        "ephemeral-storage": "39359968Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "3983184Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "dam",
+                      "capacity": {
+                        "cpu": "16",
+                        "ephemeral-storage": "39359968Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "3983192Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "loadbalancer",
+                      "capacity": {
+                        "cpu": "2",
+                        "ephemeral-storage": "49967180Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "4001708Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "loadbalancer",
+                      "capacity": {
+                        "cpu": "2",
+                        "ephemeral-storage": "49967180Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "4001700Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "master",
+                      "capacity": {
+                        "cpu": "8",
+                        "ephemeral-storage": "49677140Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "16384592Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "odfe-common",
+                      "capacity": {
+                        "cpu": "4",
+                        "ephemeral-storage": "29042796Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "8105812Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "odfe-common",
+                      "capacity": {
+                        "cpu": "4",
+                        "ephemeral-storage": "29042796Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "8105804Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "opendistro",
+                      "capacity": {
+                        "cpu": "2",
+                        "ephemeral-storage": "29042796Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "10157908Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "opendistro",
+                      "capacity": {
+                        "cpu": "2",
+                        "ephemeral-storage": "29042796Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "10157900Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "router",
+                      "capacity": {
+                        "cpu": "2",
+                        "ephemeral-storage": "29324176Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "4030560Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "system",
+                      "capacity": {
+                        "cpu": "4",
+                        "ephemeral-storage": "49677140Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "16351056Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "node_group": "system",
+                      "capacity": {
+                        "cpu": "4",
+                        "ephemeral-storage": "49677140Ki",
+                        "hugepages-1Gi": "0",
+                        "hugepages-2Mi": "0",
+                        "memory": "16351056Ki",
+                        "pods": "110"
+                      }
+                    }
+                },
+            ],
+            "ngs": [
+                {
+                    "filterResult": {
+                      "name": "application-nodes",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role/application": ""
+                        }
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "d8-loki",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role/d8-loki": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoExecute",
+                            "key": "dedicated",
+                            "value": "d8-loki"
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "dam",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role/application": "",
+                          "node-role/dam": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoExecute",
+                            "key": "dedicated",
+                            "value": "dam"
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "loadbalancer",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role/loadbalancer": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoExecute",
+                            "key": "node-role/loadbalancer",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "master",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role.kubernetes.io/control-plane": "",
+                          "node-role.kubernetes.io/master": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoSchedule",
+                            "key": "node-role.kubernetes.io/master"
+                          },
+                          {
+                            "effect": "NoSchedule",
+                            "key": "node-role.kubernetes.io/control-plane"
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "odfe-common",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role/opendistro-common": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoSchedule",
+                            "key": "dedicated",
+                            "value": "opendistro-common"
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "opendistro",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role/opendistro": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoSchedule",
+                            "key": "dedicated",
+                            "value": "opendistro"
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "router",
+                      "nodeTemplate": {
+                        "labels": {
+                            "node-role.deckhouse.io/frontend": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoExecute",
+                            "key": "dedicated.deckhouse.io",
+                            "value": "frontend"
+                          }
+                        ]
+                      }
+                    }
+                },
+                {
+                    "filterResult": {
+                      "name": "system",
+                      "nodeTemplate": {
+                        "labels": {
+                          "node-role.deckhouse.io/system": "",
+                          "node-role/logging": "",
+                          "node-role/monitoring": ""
+                        },
+                        "taints": [
+                          {
+                            "effect": "NoExecute",
+                            "key": "dedicated.deckhouse.io",
+                            "value": "system"
+                          }
+                        ]
+                      }
+                    }
+                },
+            ],
+        },
+    }
+]
+
+expected_metrics = [
+    {"action": "expire", "group": "group_node_group_resources_metrics"},
+    {
+        "name": "flant_pricing_node_group_cpu_cores",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "false", "is_master": "false", "is_monitoring": "false", "is_system": "false"},
+         "set": 100.0,
+    },
+    {
+        "name": "flant_pricing_node_group_memory",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "false", "is_master": "false", "is_monitoring": "false", "is_system": "false"},
+         "set": 103702007808.0,
+    },
+    {
+        "name": "flant_pricing_node_group_cpu_cores",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "false", "is_master": "true", "is_monitoring": "false", "is_system": "false"},
+         "set": 8.0,
+    },
+    {
+        "name": "flant_pricing_node_group_memory",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "false", "is_master": "true", "is_monitoring": "false", "is_system": "false"},
+         "set": 16777822208.0,
+    },
+    {
+        "name": "flant_pricing_node_group_cpu_cores",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "true", "is_master": "false", "is_monitoring": "false", "is_system": "false"},
+         "set": 2.0,
+    },
+    {
+        "name": "flant_pricing_node_group_memory",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "true", "is_master": "false", "is_monitoring": "false", "is_system": "false"},
+         "set": 4127293440.0,
+    },
+    {
+        "name": "flant_pricing_node_group_cpu_cores",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "false", "is_master": "false", "is_monitoring": "false", "is_system": "true"},
+         "set": 8.0,
+    },
+    {
+        "name": "flant_pricing_node_group_memory",
+        "group": "group_node_group_resources_metrics",
+         "labels": {"is_frontend": "false", "is_master": "false", "is_monitoring": "false", "is_system": "true"},
+         "set": 33486962688.0,
+    },
+]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix count resources for the different nodegroup roles.
Added tests.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Wrong counting of the worker nodegroups resources.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: flant-integration
type: fix
summary: fix resources counting
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
