### PR TITLE
[prometheus-operator] Add TLS-assets for email and webhook receivers into secret which mount into alertmanager and revert to global alertmanagerConfiguration

### DIFF
--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/003_alertmanager_tls_assets.patch
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/003_alertmanager_tls_assets.patch
@@ -1,0 +1,30 @@
+Subject: [PATCH] Fix not save TLS in assets secret
+---
+Index: pkg/alertmanager/amcfg.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/alertmanager/amcfg.go b/pkg/alertmanager/amcfg.go
+--- a/pkg/alertmanager/amcfg.go	(revision 52526e3b0cfb5f3deaa967998ff88a5133f1ec0f)
++++ b/pkg/alertmanager/amcfg.go	(date 1714746403104)
+@@ -1047,6 +1047,9 @@
+ 	}
+
+ 	if in.TLSConfig != nil {
++		if err := cb.store.AddSafeTLSConfig(ctx, crKey.Namespace, in.TLSConfig); err != nil {
++			return nil, err
++		}
+ 		out.TLSConfig = cb.convertTLSConfig(in.TLSConfig, crKey)
+ 	}
+
+@@ -1476,6 +1479,9 @@
+ 	}
+
+ 	if in.TLSConfig != nil {
++		if err := cb.store.AddSafeTLSConfig(ctx, crKey.Namespace, in.TLSConfig); err != nil {
++			return nil, err
++		}
+ 		out.TLSConfig = cb.convertTLSConfig(in.TLSConfig, crKey)
+ 	}
+

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/README.md
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/README.md
@@ -28,3 +28,6 @@ __meta_kubernetes_endpoint_port_protocol - __meta_kubernetes_endpointslice_port_
 __meta_kubernetes_endpoint_address_target_kind - __meta_kubernetes_endpointslice_address_target_kind
 __meta_kubernetes_endpoint_address_target_name - __meta_kubernetes_endpointslice_address_target_name
 ```
+
+### 003_alertmanager_tls_assets
+Prometheus operator does not save TLS assets for alertmanager Webhook and Email recievers in the secret which mounted in alert manager pod. This patch fix it.

--- a/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
@@ -8,9 +8,8 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list $ (dict "app" "alertmanager")) | nindent 2 }}
 spec:
-  alertmanagerConfigSelector:
-    matchLabels:
-      alertmanagerConfig: {{ .name }}
+  alertmanagerConfiguration:
+    name: {{ .name }}
   replicas: {{ include "helm_lib_is_ha_to_value" (list $ 2 1) }}
   image: {{ include "helm_lib_module_image" (list $ "alertmanager") }}
   imagePullSecrets:


### PR DESCRIPTION
## Description
Revert  https://github.com/deckhouse/deckhouse/pull/8158 and patch prometheus-operator for addding TLS-assets for email and webhook receivers into secret which mount into alertmanager

## Why do we need it, and what problem does it solve?
Previous fix will work only d8-monitorig namespace.

## Why do we need it in the patch release (if we do)?
Alert manager does not work properly.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus-operator
type: fix
summary: Add TLS-assets for email and webhook receivers into secret which mount into alertmanager.
impact_level: default
---
section: prometheus
type: fix
summary: Switch Alertmanager configuration selector from `alertmanagerConfigSelector` to `alertmanagerConfiguration`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
