### PR TITLE
[candi](openstack) Set the default bastion rootDiskSize to 50 gigabytes

### DIFF
--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
@@ -34,8 +34,7 @@ standard:
     instanceClass:
       flavorName: m1.large                      # Required.
       imageName: ubuntu-20-04-cloud-amd64       # Required.
-      # Optional, local disk is used if not specified.
-      rootDiskSize: 50
+      rootDiskSize: 50                          # Optional, default 50 gigabytes.
       additionalTags:
         severity: critical                      # Optional.
         environment: production                 # Optional.

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS_RU.md
@@ -35,8 +35,7 @@ standard:
     instanceClass:
       flavorName: m1.large                      # Обязательный параметр.
       imageName: ubuntu-20-04-cloud-amd64       # Обязательный параметр.
-      # Необязательный параметр. Если не указан — используется локальный диск.
-      rootDiskSize: 50
+      rootDiskSize: 50                          # Обязательный параметр, по умолчанию 50 гигабайт.
       additionalTags:
         severity: critical                      # Необязательный параметр.
         environment: production                 # Необязательный параметр.

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -438,6 +438,7 @@ apiVersions:
 
                       This parameter also has influence on type of volume that will be used for root disk; the ["How to use rootDiskSize and when it is preferred"](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/faq.html#how-to-use-rootdisksize-and-when-it-is-preferred) section describes how to use it.
                     type: integer
+                    default: 50
                   additionalTags:
                     description: |
                       The additional tags to attach to the instance created (in addition to those specified in the cloud provider configuration).


### PR DESCRIPTION
## Description

Set the default `standard.bastion.instanceClass.rootDiskSize` property to 50 gigabytes in the `OpenStackClusterConfiguration` schema.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close #6867.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: 'Set the default `standard.bastion.instanceClass.rootDiskSize` property to 50 gigabytes in the `OpenStackClusterConfiguration` schema.'
impact_level: default
```
