### PR TITLE
[candi] add preflight check containerd restart

### DIFF
--- a/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
@@ -40,7 +40,6 @@ fi
 
 # generated using `containerd config default` by containerd version `containerd containerd.io 1.4.3 269548fa27e0089a8b8278fc4fc781d7f65a939b`
 bb-sync-file /etc/containerd/deckhouse.toml - << EOF
-set-error
 version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"

--- a/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
@@ -40,6 +40,7 @@ fi
 
 # generated using `containerd config default` by containerd version `containerd containerd.io 1.4.3 269548fa27e0089a8b8278fc4fc781d7f65a939b`
 bb-sync-file /etc/containerd/deckhouse.toml - << EOF
+set-error
 version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"

--- a/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
@@ -21,6 +21,7 @@ if bb-flag? containerd-need-restart; then
       systemctl restart containerd-deckhouse.service
   else
       bb-log-error "'containerd config dump' return error: $out"
+      exit 1
   fi
   {{- end }}
   bb-flag-set kubelet-need-restart

--- a/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
@@ -16,7 +16,12 @@
 if bb-flag? containerd-need-restart; then
   bb-log-warning "'containerd-need-restart' flag was set, restarting containerd."
   {{- if ne .runType "ImageBuilding" }}
-  systemctl restart containerd-deckhouse.service
+  out=$(containerd config dump 2>&1);
+  if [ $? -eq 0 ]; then
+      systemctl restart containerd-deckhouse.service
+  else
+      bb-log-error "'containerd config dump' return error: $out"
+  fi
   {{- end }}
   bb-flag-set kubelet-need-restart
   bb-flag-unset containerd-need-restart

--- a/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl
@@ -16,8 +16,7 @@
 if bb-flag? containerd-need-restart; then
   bb-log-warning "'containerd-need-restart' flag was set, restarting containerd."
   {{- if ne .runType "ImageBuilding" }}
-  out=$(containerd config dump 2>&1);
-  if [ $? -eq 0 ]; then
+  if out=$(containerd config dump 2>&1); then
       systemctl restart containerd-deckhouse.service
   else
       bb-log-error "'containerd config dump' return error: $out"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add `containerd config dump` check, before restart containerd in bashible step.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Allow restart `containerd` in bashible step only with valid configuration files.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

<img width="1558" alt="image" src="https://github.com/deckhouse/deckhouse/assets/19556745/f4c90db3-416f-40e1-bb13-a777e781878d">


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Add preflight check containerd restart.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
