### PR TITLE
[dhctl] Add a resource readiness status check 

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resource_id.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resource_id.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ResourceID struct {
+	Name             string
+	Namespace        string
+	GroupVersionKind schema.GroupVersionKind
+}
+
+func (r *ResourceID) String() string {
+	return r.GroupVersionKindNamespaceNameString()
+}
+
+func (r *ResourceID) GroupVersionKindNamespaceNameString() string {
+	return strings.Join([]string{r.GroupVersionKindNamespaceString(), r.Name}, "/")
+}
+
+func (r *ResourceID) GroupVersionKindNamespaceString() string {
+	var resultElems []string
+
+	if r.Namespace != "" {
+		resultElems = append(resultElems, fmt.Sprint("ns:", r.Namespace))
+	}
+
+	gvk := r.GroupVersionKindString()
+	if gvk != "" {
+		resultElems = append(resultElems, gvk)
+	}
+
+	return strings.Join(resultElems, "/")
+}
+
+func (r *ResourceID) GroupVersionKindString() string {
+	var gvkElems []string
+
+	if r.GroupVersionKind.Group != "" {
+		gvkElems = append(gvkElems, r.GroupVersionKind.Group)
+	}
+
+	if r.GroupVersionKind.Version != "" {
+		gvkElems = append(gvkElems, r.GroupVersionKind.Version)
+	}
+
+	if r.GroupVersionKind.Kind != "" {
+		gvkElems = append(gvkElems, r.GroupVersionKind.Kind)
+	}
+
+	return strings.Join(gvkElems, "/")
+}

--- a/dhctl/pkg/kubernetes/actions/resources/resource_is_ready.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resource_is_ready.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
+)
+
+type resourceIsReadyChecker struct {
+	mutex            sync.Mutex
+	kubeCl           *client.KubernetesClient
+	resourceID       ResourceID
+	watcherIsRunning bool
+	isReady          bool
+}
+
+func newResourceIsReadyChecker(kubeCl *client.KubernetesClient, resource *template.Resource) (Checker, error) {
+	resourceID := ResourceID{
+		Name:             resource.Object.GetName(),
+		Namespace:        resource.Object.GetNamespace(),
+		GroupVersionKind: resource.GVK,
+	}
+
+	checker := &resourceIsReadyChecker{
+		kubeCl:     kubeCl,
+		resourceID: resourceID,
+	}
+
+	return checker, nil
+}
+
+func (c *resourceIsReadyChecker) IsReady(ctx context.Context) (bool, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if !c.watcherIsRunning {
+		watcher := NewWatcher(c.kubeCl)
+
+		err := watcher.Watch(ctx, c.resourceID, func(_ *unstructured.Unstructured, isReady bool) {
+			c.setIsReady(isReady)
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to watch resource '%s': %w", c.resourceID.String(), err)
+		}
+
+		c.watcherIsRunning = true
+	}
+
+	return c.isReady, nil
+}
+
+func (c *resourceIsReadyChecker) setIsReady(isReady bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.isReady = isReady
+}
+
+func (c *resourceIsReadyChecker) Name() string {
+	return "resourceIsReadyChecker"
+}

--- a/dhctl/pkg/kubernetes/actions/resources/resource_is_ready_test.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resource_is_ready_test.go
@@ -1,0 +1,301 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
+)
+
+type fakeKubeClient struct {
+	client.KubeClient
+}
+
+func (c *fakeKubeClient) Discovery() discovery.DiscoveryInterface {
+	return &cachedDiscoveryClient{c.KubeClient.Discovery()}
+}
+
+type cachedDiscoveryClient struct {
+	discovery.DiscoveryInterface
+}
+
+func (*cachedDiscoveryClient) Fresh() bool {
+	return true
+}
+
+func (*cachedDiscoveryClient) Invalidate() {}
+
+func TestResourcesWatcher(t *testing.T) {
+	apiResources := []metav1.APIResource{
+		{
+			Kind:    "NodeGroup",
+			Name:    "nodegroups",
+			Verbs:   metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+			Group:   "deckhouse.io",
+			Version: "v1",
+		},
+		{
+			Kind:    "StaticInstance",
+			Name:    "staticinstances",
+			Verbs:   metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+			Group:   "deckhouse.io",
+			Version: "v1alpha1",
+		},
+	}
+
+	var (
+		resources []*metav1.APIResourceList
+		gvr       = make(map[schema.GroupVersionResource]string)
+	)
+
+	for _, apiResource := range apiResources {
+		gvr[schema.GroupVersionResource{
+			Group:    apiResource.Group,
+			Version:  apiResource.Version,
+			Resource: apiResource.Name,
+		}] = apiResource.Kind + "List"
+
+		resources = append(resources, &metav1.APIResourceList{
+			GroupVersion: apiResource.Group + "/" + apiResource.Version,
+			APIResources: []metav1.APIResource{apiResource},
+		})
+	}
+
+	newFakeClient := func() *client.KubernetesClient {
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(gvr)
+
+		discovery := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
+		discovery.Resources = append(discovery.Resources, resources...)
+
+		fakeClient.KubeClient = &fakeKubeClient{fakeClient.KubeClient}
+
+		return fakeClient
+	}
+
+	getGroupVersionResource := func(resource *template.Resource) schema.GroupVersionResource {
+		for _, apiResource := range apiResources {
+			if apiResource.Kind == resource.GVK.Kind && apiResource.Group == resource.GVK.Group && apiResource.Version == resource.GVK.Version {
+				return schema.GroupVersionResource{
+					Group:    apiResource.Group,
+					Version:  apiResource.Version,
+					Resource: apiResource.Name,
+				}
+			}
+		}
+
+		panic("api resource not found")
+	}
+
+	const resourcesYAML = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: test
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: test
+`
+
+	t.Run("By default not ready", func(t *testing.T) {
+		resources, err := template.ParseResourcesContent(resourcesYAML, nil)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+
+		fakeClient := newFakeClient()
+
+		for _, resource := range resources {
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).Create(context.TODO(), &resource.Object, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			checker, err := newResourceIsReadyChecker(fakeClient, resource)
+			require.NoError(t, err)
+
+			var ready bool
+
+			for i := 0; i < 5; i++ {
+				ready, err = checker.IsReady(context.TODO())
+				require.NoError(t, err)
+				if !ready {
+					break
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			require.False(t, ready)
+		}
+	})
+
+	const nodeGroupYAML = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: test
+`
+
+	t.Run("NodeGroup is ready", func(t *testing.T) {
+		resources, err := template.ParseResourcesContent(nodeGroupYAML, nil)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		fakeClient := newFakeClient()
+
+		for _, resource := range resources {
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).Create(context.TODO(), &resource.Object, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			checker, err := newResourceIsReadyChecker(fakeClient, resource)
+			require.NoError(t, err)
+
+			resource.Object.Object["status"] = map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+			}
+
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).UpdateStatus(context.TODO(), &resource.Object, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			var ready bool
+
+			for i := 0; i < 5; i++ {
+				ready, err = checker.IsReady(context.TODO())
+				require.NoError(t, err)
+				if ready {
+					break
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			require.True(t, ready)
+
+			resource.Object.Object["status"] = map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "False",
+					},
+				},
+			}
+
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).UpdateStatus(context.TODO(), &resource.Object, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			for i := 0; i < 5; i++ {
+				ready, err = checker.IsReady(context.TODO())
+				require.NoError(t, err)
+				if !ready {
+					break
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			require.False(t, ready)
+		}
+	})
+
+	const staticInstanceYAML = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: test
+`
+
+	t.Run("StaticInstance is ready", func(t *testing.T) {
+		resources, err := template.ParseResourcesContent(staticInstanceYAML, nil)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		fakeClient := newFakeClient()
+
+		for _, resource := range resources {
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).Create(context.TODO(), &resource.Object, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			checker, err := newResourceIsReadyChecker(fakeClient, resource)
+			require.NoError(t, err)
+
+			resource.Object.Object["status"] = map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+			}
+
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).UpdateStatus(context.TODO(), &resource.Object, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			var ready bool
+
+			for i := 0; i < 5; i++ {
+				ready, err = checker.IsReady(context.TODO())
+				require.NoError(t, err)
+				if ready {
+					break
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			require.True(t, ready)
+
+			resource.Object.Object["status"] = map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "False",
+					},
+				},
+			}
+
+			_, err = fakeClient.Dynamic().Resource(getGroupVersionResource(resource)).UpdateStatus(context.TODO(), &resource.Object, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			for i := 0; i < 5; i++ {
+				ready, err = checker.IsReady(context.TODO())
+				require.NoError(t, err)
+				if !ready {
+					break
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			require.False(t, ready)
+		}
+	})
+}

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -238,36 +241,69 @@ func (c *Creator) createSingleResource(resource *template.Resource) error {
 	})
 }
 
-func CreateResourcesLoop(kubeCl *client.KubernetesClient, resources template.Resources, checkers []Checker) error {
-	endChannel := time.After(app.ResourcesTimeout)
-
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
+func CreateResourcesLoop(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, resources template.Resources, checkers []Checker) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), app.ResourcesTimeout)
+	defer cancel()
 
 	resourceCreator := NewCreator(kubeCl, resources)
 
-	waiter := NewWaiter(checkers)
-	for {
-		err := resourceCreator.TryToCreate()
-		if err != nil && !errors.Is(err, ErrNotAllResourcesCreated) {
-			return err
-		}
-
-		ready, errWaiter := waiter.ReadyAll()
-		if errWaiter != nil {
-			return errWaiter
-		}
-
-		if ready && err == nil {
-			return nil
-		}
-
-		select {
-		case <-endChannel:
-			return fmt.Errorf("creating resources failed after %s waiting", app.ResourcesTimeout)
-		case <-ticker.C:
-		}
+	clusterIsBootstrappedChecker, err := tryToGetClusterIsBootstrappedChecker(kubeCl, resources, metaConfig)
+	if err != nil {
+		return err
 	}
+
+	isBootstrapped := false
+
+	err = retry.NewSilentLoop("Wait for resources creation", math.MaxInt, 10*time.Second).
+		WithContext(ctx).
+		Run(func() error {
+			err := resourceCreator.TryToCreate()
+			if err != nil && !errors.Is(err, ErrNotAllResourcesCreated) {
+				return err
+			}
+
+			if clusterIsBootstrappedChecker != nil && !isBootstrapped {
+				var err error
+
+				isBootstrapped, err = clusterIsBootstrappedChecker.IsBootstrapped()
+				if err != nil {
+					return err
+				}
+			}
+
+			if isBootstrapped && err == nil {
+				return nil
+			}
+
+			clusterIsBootstrappedChecker.outputProgressInfo()
+
+			return ErrNotAllResourcesCreated
+		})
+	if err != nil {
+		return err
+	}
+
+	waiter := NewWaiter(checkers)
+
+	err = retry.NewSilentLoop("Wait for resources readiness", math.MaxInt, 5*time.Second).
+		WithContext(ctx).
+		Run(func() error {
+			ready, err := waiter.ReadyAll(ctx)
+			if err != nil {
+				return err
+			}
+
+			if !ready {
+				return fmt.Errorf("not all resources are ready")
+			}
+
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func getUnstructuredName(obj *unstructured.Unstructured) string {

--- a/dhctl/pkg/kubernetes/actions/resources/waiter_test.go
+++ b/dhctl/pkg/kubernetes/actions/resources/waiter_test.go
@@ -15,6 +15,7 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -53,9 +54,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 2)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 0)
+		require.Nil(t, checker)
 	})
 
 	t.Run("with cloud static nodegroup", func(t *testing.T) {
@@ -71,9 +72,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 3)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 0, "should skip")
+		require.Nil(t, checker, "should skip")
 	})
 
 	t.Run("with cloud ephemeral nodegroup, but min and max per zone not set", func(t *testing.T) {
@@ -100,9 +101,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 3)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 0, "should skip")
+		require.Nil(t, checker, "should skip")
 	})
 
 	ngTemplate := func(name string, min, max int) string {
@@ -137,9 +138,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 3)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 0, "should skip")
+		require.Nil(t, checker, "should skip")
 	})
 
 	t.Run("with cloud ephemeral nodegroup, but min = 0 and max not zero", func(t *testing.T) {
@@ -149,11 +150,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 3)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 1, "should get check")
-
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get check")
 	})
 
 	t.Run("with cloud ephemeral nodegroup, but min not zero and max not zero", func(t *testing.T) {
@@ -163,11 +162,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 3)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 1, "should get check")
-
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get check")
 	})
 
 	t.Run("with multiple cloud ephemeral nodegroup", func(t *testing.T) {
@@ -179,11 +176,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 4)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 1, "should get one check")
-
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get one check")
 	})
 
 	t.Run("with multiple cloud ephemeral nodegroup", func(t *testing.T) {
@@ -195,11 +190,9 @@ spec:
 		require.NoError(t, err)
 		require.Len(t, resources, 4)
 
-		checkers, err := GetCheckers(nil, resources, nil)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, nil)
 		require.NoError(t, err)
-		require.Len(t, checkers, 1, "should get one check")
-
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get one check")
 	})
 
 	t.Run("with one terra node without replicas", func(t *testing.T) {
@@ -215,9 +208,9 @@ spec:
 			},
 		}
 
-		checkers, err := GetCheckers(nil, resources, cnf)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, cnf)
 		require.NoError(t, err)
-		require.Len(t, checkers, 0, "should not get check")
+		require.Nil(t, checker, "should not get check")
 	})
 
 	t.Run("with one terra node with replicas", func(t *testing.T) {
@@ -227,11 +220,9 @@ spec:
 			},
 		}
 
-		checkers, err := GetCheckers(nil, nil, cnf)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, nil, cnf)
 		require.NoError(t, err)
-		require.Len(t, checkers, 1, "should get one check")
-
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get one check")
 	})
 
 	t.Run("with multiple terra node with replicas", func(t *testing.T) {
@@ -242,11 +233,9 @@ spec:
 			},
 		}
 
-		checkers, err := GetCheckers(nil, nil, cnf)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, nil, cnf)
 		require.NoError(t, err)
-		require.Len(t, checkers, 1, "should get one check")
-
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get one check")
 	})
 
 	t.Run("with one terra node with replicas an ephemeral node group", func(t *testing.T) {
@@ -262,11 +251,9 @@ spec:
 			},
 		}
 
-		checkers, err := GetCheckers(nil, resources, cnf)
+		checker, err := tryToGetClusterIsBootstrappedChecker(nil, resources, cnf)
 		require.NoError(t, err)
-
-		require.Len(t, checkers, 1, "should get one check")
-		require.Equal(t, checkers[0].Name(), "Waiting for the cluster to become bootstrapped.")
+		require.NotNil(t, checker, "should get one check")
 	})
 }
 
@@ -282,7 +269,7 @@ func newTestChecker(returns bool, err error) *testChecker {
 	}
 }
 
-func (n *testChecker) IsReady() (bool, error) {
+func (n *testChecker) IsReady(_ context.Context) (bool, error) {
 	return n.returns, n.err
 }
 
@@ -293,7 +280,7 @@ func (n *testChecker) Name() string {
 func TestWaiterStep(t *testing.T) {
 	t.Run("without checks", func(t *testing.T) {
 		w := NewWaiter(make([]Checker, 0))
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(context.TODO())
 
 		require.NoError(t, err)
 		require.True(t, ready, "should ready")
@@ -301,7 +288,7 @@ func TestWaiterStep(t *testing.T) {
 
 	t.Run("with one ready check", func(t *testing.T) {
 		w := NewWaiter([]Checker{newTestChecker(true, nil)})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(context.TODO())
 
 		require.NoError(t, err)
 		require.True(t, ready, "should ready")
@@ -313,7 +300,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(true, nil),
 			newTestChecker(true, nil),
 		})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(context.TODO())
 
 		require.NoError(t, err)
 		require.True(t, ready, "should ready")
@@ -325,8 +312,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(false, fmt.Errorf("error")),
 			newTestChecker(true, nil),
 		})
-		w.WithAttempts(0)
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(context.TODO())
 
 		require.Error(t, err, "should error")
 		require.False(t, ready)
@@ -338,7 +324,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(false, nil),
 			newTestChecker(true, nil),
 		})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(context.TODO())
 
 		require.NoError(t, err)
 		require.False(t, ready, "should not ready")
@@ -351,7 +337,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(true, nil),
 		})
 
-		_, err := w.ReadyAll()
+		_, err := w.ReadyAll(context.TODO())
 
 		require.NoError(t, err)
 		require.Len(t, w.checkers, 1, "should remove ready checks")

--- a/dhctl/pkg/kubernetes/actions/resources/watcher.go
+++ b/dhctl/pkg/kubernetes/actions/resources/watcher.go
@@ -1,0 +1,170 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+type Watcher struct {
+	client   client.KubeClient
+	isReady  func(object *unstructured.Unstructured) bool
+	onDelete func(object *unstructured.Unstructured)
+}
+
+func NewWatcher(client client.KubeClient) *Watcher {
+	return &Watcher{
+		client: client,
+	}
+}
+
+func (w *Watcher) WithIsReady(isReady func(object *unstructured.Unstructured) bool) *Watcher {
+	w.isReady = isReady
+	return w
+}
+
+func (w *Watcher) WithOnDelete(onDelete func(object *unstructured.Unstructured)) *Watcher {
+	w.onDelete = onDelete
+	return w
+}
+
+func (w *Watcher) Watch(ctx context.Context, resourceID ResourceID, onReady func(*unstructured.Unstructured, bool)) (err error) {
+	if w.isReady == nil {
+		w.isReady = isReady
+	}
+
+	if w.onDelete == nil {
+		w.onDelete = func(_ *unstructured.Unstructured) {}
+	}
+
+	apiVersion, kind := resourceID.GroupVersionKind.ToAPIVersionAndKind()
+
+	groupVersionResource, err := w.client.GroupVersionResource(apiVersion, kind)
+	if err != nil {
+		return fmt.Errorf("error getting GroupVersionResource: %w", err)
+	}
+
+	informer := dynamicinformer.NewFilteredDynamicInformer(
+		w.client.Dynamic(),
+		groupVersionResource,
+		resourceID.Namespace,
+		0,
+		cache.Indexers{},
+		func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", resourceID.Name).String()
+		},
+	)
+
+	_, err = informer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(object interface{}) {
+				unstructuredObject := object.(*unstructured.Unstructured)
+
+				onReady(unstructuredObject, w.isReady(unstructuredObject))
+			},
+			UpdateFunc: func(_, object interface{}) {
+				unstructuredObject := object.(*unstructured.Unstructured)
+
+				onReady(unstructuredObject, w.isReady(unstructuredObject))
+			},
+			DeleteFunc: func(object interface{}) {
+				unstructuredObject := object.(*unstructured.Unstructured)
+
+				w.onDelete(unstructuredObject)
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add event handler: %w", err)
+	}
+
+	runCtx, runCancelFn := context.WithCancel(ctx)
+	defer func() {
+		panicValue := recover()
+		if panicValue != nil {
+			runCancelFn()
+
+			panic(panicValue)
+		}
+
+		if err != nil {
+			runCancelFn()
+		}
+	}()
+
+	err = setWatchErrorHandler(runCancelFn, resourceID.String(), informer.Informer().SetWatchErrorHandler)
+	if err != nil {
+		return fmt.Errorf("failed to set watch error handler: %w", err)
+	}
+
+	go informer.Informer().Run(runCtx.Done())
+
+	return nil
+}
+
+func isReady(object *unstructured.Unstructured) bool {
+	status, ok := object.Object["status"].(map[string]interface{})
+	if !ok {
+		return true
+	}
+
+	conditions, ok := status["conditions"].([]interface{})
+	if !ok {
+		return true
+	}
+
+	for _, condition := range conditions {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if conditionMap["type"] == "Ready" && conditionMap["status"] == "False" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func setWatchErrorHandler(cancelFn context.CancelFunc, resourceName string, setWatchErrorHandler func(handler cache.WatchErrorHandler) error) error {
+	return setWatchErrorHandler(
+		func(_ *cache.Reflector, err error) {
+			switch {
+			case apierrors.IsResourceExpired(err):
+				log.InfoF("watch of %q closed with: %s\n", resourceName, err)
+			case err == io.EOF:
+				// watch closed normally
+			case err == io.ErrUnexpectedEOF:
+				log.InfoF("watch of %q closed with unexpected EOF: %s\n", resourceName, err)
+			default:
+				log.WarnF("failed to watch %q: %s\n", resourceName, err)
+				cancelFn()
+			}
+		},
+	)
+}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -76,11 +76,11 @@ func (b *ClusterBootstrapper) CreateResources() error {
 			return err
 		}
 
-		checkers, err := resources.GetCheckers(kubeCl, resourcesToCreate, nil)
+		checkers, err := resources.GetCheckers(kubeCl, resourcesToCreate)
 		if err != nil {
 			return err
 		}
 
-		return resources.CreateResourcesLoop(kubeCl, resourcesToCreate, checkers)
+		return resources.CreateResourcesLoop(kubeCl, nil, resourcesToCreate, checkers)
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -563,12 +563,12 @@ func createResources(kubeCl *client.KubernetesClient, resourcesToCreate template
 	}
 
 	return log.Process("bootstrap", "Create Resources", func() error {
-		checkers, err := resources.GetCheckers(kubeCl, resourcesToCreate, metaConfig)
+		checkers, err := resources.GetCheckers(kubeCl, resourcesToCreate)
 		if err != nil {
 			return err
 		}
 
-		return resources.CreateResourcesLoop(kubeCl, resourcesToCreate, checkers)
+		return resources.CreateResourcesLoop(kubeCl, metaConfig, resourcesToCreate, checkers)
 	})
 }
 

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -294,12 +294,12 @@ func (i *Attacher) capture(
 			return fmt.Errorf("unable to parse resources: %w", err)
 		}
 
-		checkers, err := resources.GetCheckers(kubeClient, attachResources, nil)
+		checkers, err := resources.GetCheckers(kubeClient, attachResources)
 		if err != nil {
 			return fmt.Errorf("unable to get resource checkers: %w", err)
 		}
 
-		err = resources.CreateResourcesLoop(kubeClient, attachResources, checkers)
+		err = resources.CreateResourcesLoop(kubeClient, nil, attachResources, checkers)
 		if err != nil {
 			return fmt.Errorf("unable to create resources: %w", err)
 		}

--- a/dhctl/pkg/operations/commander/detach/detacher.go
+++ b/dhctl/pkg/operations/commander/detach/detacher.go
@@ -85,12 +85,12 @@ func (op *Detacher) Detach(ctx context.Context) error {
 			return fmt.Errorf("unable to get kube client: %w", err)
 		}
 
-		checkers, err := resources.GetCheckers(kubeClient, detachResources, nil)
+		checkers, err := resources.GetCheckers(kubeClient, detachResources)
 		if err != nil {
 			return fmt.Errorf("unable to get resource checkers: %w", err)
 		}
 
-		err = resources.CreateResourcesLoop(kubeClient, detachResources, checkers)
+		err = resources.CreateResourcesLoop(kubeClient, nil, detachResources, checkers)
 		if err != nil {
 			return fmt.Errorf("unable to create resources: %w", err)
 		}

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/instance_scope.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/instance_scope.go
@@ -114,7 +114,6 @@ func (i *InstanceScope) SetPhase(phase deckhousev1.StaticInstanceStatusCurrentSt
 func (i *InstanceScope) Patch(ctx context.Context) error {
 	conditions.SetSummary(i.Instance,
 		conditions.WithConditions(
-			infrav1.StaticInstanceAddedToNodeGroupCondition,
 			infrav1.StaticInstanceBootstrapSucceededCondition,
 		),
 		conditions.WithStepCounterIf(i.Instance.ObjectMeta.DeletionTimestamp.IsZero()),


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add a Kubernetes resources checker to the `dhctl bootstrap` command.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to wait until the Kubernetes resources specified in the `dhctl bootstrap` `--config` option are in the `Ready` status.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: 'The `dhctl bootstrap` command will wait until the status of each resource in the `--config` option changes to `Ready`.'
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
