### PR TITLE
Nginx ingress underscores in headers fix

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/controller/configmap.yaml
@@ -197,6 +197,10 @@ data:
   custom-http-errors: {{ $crd.spec.customErrors.codes | join "," | quote }}
   {{- end }}
 
+  {{- if $crd.spec.underscoresInHeaders }}
+  enable-underscores-in-headers: {{ $crd.spec.underscoresInHeaders  | quote }}
+  {{- end }}
+
   {{- if $crd.spec.config }}
     {{- range $key, $additionalConfig := $crd.spec.config }}
   {{ $key }}: {{ $additionalConfig | quote }}
@@ -211,6 +215,7 @@ data:
   {{- if eq $crd.spec.inlet "HostWithFailover" }}
     {{ include "configmap" (list $context $crd (printf "%s-failover" $crd.name) true) }}
   {{- end }}
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/modules/402-ingress-nginx/templates/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/controller/configmap.yaml
@@ -215,7 +215,6 @@ data:
   {{- if eq $crd.spec.inlet "HostWithFailover" }}
     {{ include "configmap" (list $context $crd (printf "%s-failover" $crd.name) true) }}
   {{- end }}
-
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Description

`IngressNginxController.spec.underscoresInHeaders` should change `enable-underscores-in-headers` parameter in  `nginx-config` configmap. It looks like we forgot to add this parameter to the template

https://deckhouse.io/documentation/v1/modules/402-ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-underscoresinheaders

https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#enable-underscores-in-headers

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

`IngressNginxController.spec.underscoresInHeaders` will change `enable-underscores-in-headers`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```
section: ingress-nginx
type: fix
summary: Ability to change enable-underscores-in-headers
impact: Ability to change enable-underscores-in-headers
impact_level: default
```
