### PR TITLE
[doc] Fix vSphere doc - disktypes changed according to default policy

### DIFF
--- a/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT.md
+++ b/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT.md
@@ -119,6 +119,11 @@ Deckhouse uses `cloud-init` to configure a virtual machine after startup. To do 
 
 To add SSH keys to user's authorized keys, the `default_user` parameter must be specified in the `/etc/cloud/cloud.cfg` file.
 
+{% alert level="warning" %}
+Deckhouse creates virtual machine disks with the `eagerZeroedThick` type, but the disk type of the created VMs will be changed without notification according to the `VM Storage Policy` configured in vSphere.
+You can read more in [documentation](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/website/docs/r/virtual_machine.html.markdown#virtual-disk-provisioning-policies).
+{% endalert %}
+
 ## Infrastructure
 
 ### Networking

--- a/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT_RU.md
+++ b/ee/candi/cloud-providers/vsphere/docs/ENVIRONMENT_RU.md
@@ -125,6 +125,11 @@ Deckhouse использует `cloud-init` для настройки вирту
 
 Для добавления SSH-ключа, в файле `/etc/cloud/cloud.cfg` должен быть указан параметр `default_user`.
 
+{% alert %}
+Deckhouse создаёт виртуальные машин с типом `eagerZeroedThick`, но тип дисков созданных ВМ будет изменён без уведомления согласно настроенным в vSphere `VM Storage Policy`.
+Подробнее можно почитать в [документации](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/website/docs/r/virtual_machine.html.markdown#virtual-disk-provisioning-policies).
+{% endalert %}
+
 ## Инфраструктура
 
 ### Сети


### PR DESCRIPTION
## Description

Clarify disktype changing mechanism during creating VM in vSphere via terraform provider

```changes
section: docs
type: chore
summary: Fix vSphere doc - disktypes changed according to default policy
impact_level: low
```