### PR TITLE
[okmeter] Restart okagent pods on API token change

### DIFF
--- a/ee/fe/modules/500-okmeter/templates/daemonset.yaml
+++ b/ee/fe/modules/500-okmeter/templates/daemonset.yaml
@@ -42,6 +42,8 @@ spec:
     metadata:
       labels:
         name: okmeter
+      annotations:
+        apiTokenChecksum: {{ .Values.okmeter.apiKey | sha256sum }}
     spec:
       serviceAccountName: okmeter
       hostNetwork: true

--- a/modules/500-okmeter/templates/daemonset.yaml
+++ b/modules/500-okmeter/templates/daemonset.yaml
@@ -42,6 +42,8 @@ spec:
     metadata:
       labels:
         name: okmeter
+      annotations:
+        apiTokenChecksum: {{ .Values.okmeter.apiKey | sha256sum }}
     spec:
       serviceAccountName: okmeter
       hostNetwork: true


### PR DESCRIPTION
## Description

Restart okagent pods on API token change.

## Why do we need it, and what problem does it solve?
Closes #8319 

## What is the expected result?
Okagent pods restarts on API token change

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: okmeter
type: fix
summary: Restart okagent pods on API token change.
impact_level: default
```