### PR TITLE
[dhctl] Preflight check registry credentials

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -25,6 +25,7 @@ var (
 	PreflightSkipRegistryThroughProxy      = false
 	PreflightSkipPublicDomainTemplateCheck = false
 	PreflightSkipSSHCredentialsCheck       = false
+	PreflightSkipRegistryCredentials   = false
 )
 
 const (
@@ -35,6 +36,7 @@ const (
 	RegistryThroughProxyCheckArgName = "preflight-skip-registry-through-proxy"
 	PublicDomainTemplateCheckArgName = "preflight-skip-public-domain-template-check"
 	SSHCredentialsCheckArgName       = "preflight-skip-ssh-credentials-check"
+	RegistryCredentialsCheckArgName  = "preflight-skip-registry-credential"
 )
 
 func DefinePreflight(cmd *kingpin.CmdClause) {
@@ -62,4 +64,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(SSHCredentialsCheckArgName, "Skip verifying PublicDomainTemplate check").
 		Envar(configEnvName("PREFLIGHT_SKIP_SSH_CREDENTIAL_CHECK")).
 		BoolVar(&PreflightSkipSSHCredentialsCheck)
+	cmd.Flag(RegistryCredentialsCheckArgName, "Skip verifying regestry credentials").
+		Envar(configEnvName("PREFLIGHT_SKIP_REGISTRY_CREDENTIALS")).
+		BoolVar(&PreflightSkipRegistryCredentials)
 }

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -74,7 +74,7 @@ func (pc *Checker) Static() error {
 		{
 			fun:            pc.CheckLocalhostDomain,
 			successMessage: "resolve the localhost domain",
-			skipFlag:       app.ResolvingLocalhostArgName,
+			skipFlag:       app.RegistryCredentialsCheckArgName,
 		},
 	})
 }
@@ -89,6 +89,11 @@ func (pc *Checker) Global() error {
 			fun:            pc.CheckPublicDomainTemplate,
 			successMessage: "PublicDomainTemplate is correctly",
 			skipFlag:       app.PublicDomainTemplateCheckArgName,
+		},
+		{
+			fun:            pc.CheckRegistryCredentials,
+			successMessage: "regestry credentials are correct",
+			skipFlag:       app.RegistryCredentialsCheckArgName,
 		},
 	})
 }

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -233,7 +233,7 @@ func (pc *Checker) CheckRegistryCredentials() error {
 	}
 
 	if authData == "" {
-		return fmt.Errorf("%w, credentials are not specified", ErrAuthFailed)
+		return fmt.Errorf("%w, credentials are not specified. If you are using CE edition in a closed environment, this check can be skipped by specifying the --preflight-skip-registry-credential flag", ErrAuthFailed)
 	}
 
 	req, err := prepareAuthRequest(ctx, pc.metaConfig, authData)

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -326,7 +326,7 @@ func getAuthRealmAndService(ctx context.Context, metaConfig *config.MetaConfig, 
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
 		return authURL, registryService, fmt.Errorf(
 			"%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\n"+
-				"Check if container registry address is correct and if there is any reverse proxies that might be misconfigured",
+				"Check if container registry address is correct",
 			ErrAuthFailed,
 		)
 	}
@@ -385,7 +385,7 @@ func checkBasicRegistryAuth(
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
 		return fmt.Errorf(
 			"%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\n"+
-				"Check if container registry address is correct and if there is any reverse proxies that might be misconfigured",
+				"Check if container registry address is correct",
 			ErrAuthFailed,
 		)
 	}

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -348,6 +348,7 @@ func getAuthRealmAndService(ctx context.Context, metaConfig *config.MetaConfig, 
 }
 
 func checkResponseError(resp *http.Response) error {
+	log.DebugF("%v", resp.Header)
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
 		return fmt.Errorf(
 			"%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\n"+

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -210,6 +210,9 @@ func (pc *Checker) CheckRegistryCredentials() error {
 		return nil
 	}
 
+	image := pc.installConfig.GetImage(false)
+	log.DebugF("Image: %s", image)
+
 	log.DebugLn("Checking registry credentials")
 
 	req, err := prepareAuthRequest(pc.metaConfig)

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -235,7 +235,6 @@ func (pc *Checker) CheckRegistryCredentials() error {
 	if authData == "" {
 		return fmt.Errorf("%w, credentials are not specified. If you are using CE edition in a closed environment, this check can be skipped by specifying the --preflight-skip-registry-credential flag", ErrAuthFailed)
 	}
-	log.DebugF("Auth data: %s\n", authData)
 
 	req, err := prepareAuthRequest(ctx, pc.metaConfig, authData)
 	if err != nil {
@@ -253,7 +252,7 @@ func (pc *Checker) CheckRegistryCredentials() error {
 	}
 	defer resp.Body.Close()
 
-	log.DebugF("Status Code: %d", resp.StatusCode)
+	log.DebugF("Status Code: %d\n", resp.StatusCode)
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrAuthFailed

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -348,7 +348,8 @@ func getAuthRealmAndService(ctx context.Context, metaConfig *config.MetaConfig, 
 }
 
 func checkResponseError(resp *http.Response) error {
-	log.DebugF("%v", resp.Header)
+	log.DebugF("Docker-Distribution-API-Version: %s\n", resp.Header.Get("Docker-Distribution-API-Version"))
+
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
 		return fmt.Errorf(
 			"%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\n"+


### PR DESCRIPTION
## Description
Preflight check registry credentials before start instalations
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Before performing bootstrap, checks the possibility of autorize in registry
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Preventing failures before bootstrap execution
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Preflight check registry credentials before start instalations
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
