### PR TITLE
[istio] Optimizing matrix tests

### DIFF
--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -39,23 +39,6 @@ properties:
       deployDexAuthenticator:
         type: boolean
         x-examples: [true]
-      dataPlane:
-        type: object
-        default: {}
-        properties:
-          trafficRedirectionSetupMode:
-            type: string
-            description: |
-              Managing application traffic redirection modes using Istio in the Pod Network.
-              - `InitContainer` — the classic mode, in which `sidecar-injector` adds an init container to application pods, configuring traffic redirection at the start of the pod. This mode requires superuser rights and does not work if one of the strict modes is enabled in the `admission-policy-engine` module.
-              - `CNIPlugin` — In this mode, the CNI plugin, which runs on each cluster node and does not require privileges at the pod manifest level, is responsible for configuring the pod network environment.
-              There is CNIPlugin trafficRedirectionSetupMode in Istio module by default
-              To change this mode to InitContainer we should create secret
-              d8-istio-configuration in d8-istio namespace with trafficRedirectionSetupMode key
-              kubectl -n d8-istio create secret generic d8-istio-configuration --from-literal=trafficRedirectionSetupMode=InitContainer
-            default: "CNIPlugin"
-            enum: ["CNIPlugin", "InitContainer"]
-            x-examples: ["CNIPlugin", "InitContainer"]
       ca:
         type: object
         default: {}


### PR DESCRIPTION
## Description
Optimizing matrix tests for istio module.

## Why do we need it, and what problem does it solve?
There are too many configuration options for the module and tests can't made it during 15m timeout.

## Why do we need it in the patch release (if we do)?

Can't publish the 1.59.11 release.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Optimize matrix tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
