### PR TITLE
[deckhouse-controller] fix mpo sync in HA mode

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
@@ -43,6 +43,7 @@ import (
 
 const (
 	defaultModuleWeight = 900
+	DefaultDevVersion   = "dev"
 )
 
 type ModuleDownloader struct {
@@ -75,7 +76,7 @@ type ModuleDownloadResult struct {
 // if checksum is equal to a module image digest - do nothing
 // otherwise return new digest
 func (md *ModuleDownloader) DownloadDevImageTag(moduleName, imageTag, checksum string) (string, *models.DeckhouseModuleDefinition, error) {
-	moduleStorePath := path.Join(md.externalModulesDir, moduleName, "dev")
+	moduleStorePath := path.Join(md.externalModulesDir, moduleName, DefaultDevVersion)
 
 	img, err := md.fetchImage(moduleName, imageTag)
 	if err != nil {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
@@ -134,7 +134,7 @@ func (c *modulePullOverrideReconciler) moduleOverrideReconcile(ctx context.Conte
 	if _, set := mo.GetAnnotations()[RegistrySpecChangedAnnotation]; set {
 		// if module is enabled - push runModule task in the main queue
 		c.logger.Infof("Applying new registry settings to the %s module", mo.Name)
-		err := c.modulesValidator.RunModuleWithNewStaticValues(mo.Name, mo.ObjectMeta.Labels["source"], filepath.Join(c.externalModulesDir, mo.Name, downloader.DefaultDevVersion))
+		err := c.moduleManager.RunModuleWithNewStaticValues(mo.Name, mo.ObjectMeta.Labels["source"], filepath.Join(c.externalModulesDir, mo.Name, downloader.DefaultDevVersion))
 		if err != nil {
 			return ctrl.Result{Requeue: true}, err
 		}


### PR DESCRIPTION
## Description
This PR fixes the situation described below, in the `Why do we need it section`.
Also, there are several minor changes/fixes/improvements related to the deckhouse-controller:
- release and override controllers' got separate PreflightChecks and corresponding methods of restoring absent modules on start up;
- a minor bug in override controller, related to restoring MPO modules, was fixed;
- a minor bug in release and override controllers, related to filtering out some update events, was fixed;
- some other small improvements.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
A Deckhouse installation running in HA mode is susceptible to the situation when the modules, deployed by ModulePullOverrides, get out of sync with the registry due to the fact that we keep current module image's hash in the MPO object, but there might be a drift between versions of the module on the node's file systems. Thus, current master pod can't clearly determine if the MPO module in question has to be updated as the MPO already contains up-to-date image digest.
Closes #8315 
 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Current Deckhouse master pod (and the node it's running on) has up to date versions of the modules, deployed by MPOs. It can be verified by checking the MPOs' annotations for `modules.deckhouse.io/deployed-on` annotations containing current master pod's node name.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix MPO out of sync in HA mode.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
