### PR TITLE
[operator-trivy] add storageClass field

### DIFF
--- a/ee/modules/500-operator-trivy/hooks/storage_class_change.go
+++ b/ee/modules/500-operator-trivy/hooks/storage_class_change.go
@@ -8,7 +8,7 @@ package hooks
 import "github.com/deckhouse/deckhouse/go_lib/hooks/storage_class_change"
 
 var _ = storage_class_change.RegisterHook(storage_class_change.Args{
-	ModuleName:         "operator-trivy",
+	ModuleName:         "operatorTrivy",
 	Namespace:          "d8-operator-trivy",
 	LabelSelectorKey:   "name",
 	LabelSelectorValue: "trivy-server",

--- a/ee/modules/500-operator-trivy/hooks/storage_class_change_test.go
+++ b/ee/modules/500-operator-trivy/hooks/storage_class_change_test.go
@@ -1,17 +1,6 @@
 /*
 Copyright 2024 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/modules/500-operator-trivy/hooks/storage_class_change_test.go
+++ b/ee/modules/500-operator-trivy/hooks/storage_class_change_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: operator-trivy :: hooks :: storage_class_change ::", func() {
+	f := HookExecutionConfigInit(`{"operatorTrivy":{"internal":{}}}`, "")
+
+	Context("Storage class is not set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+		It("Should set effectiveClass to false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("operatorTrivy.internal.effectiveStorageClass").String()).To(Equal("false"))
+		})
+	})
+
+	Context("Global storage class is set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ConfigValuesSet("global.storageClass", "test")
+			f.RunHook()
+		})
+		It("Should set effectiveClass to test", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("operatorTrivy.internal.effectiveStorageClass").String()).To(Equal("test"))
+		})
+	})
+
+	Context("Storage class is set", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ConfigValuesSet("operatorTrivy.storageClass", "test1")
+			f.RunHook()
+		})
+		It("Should set effectiveClass to test1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("operatorTrivy.internal.effectiveStorageClass").String()).To(Equal("test1"))
+		})
+	})
+})

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -1,5 +1,12 @@
 type: object
 properties:
+  storageClass:
+    type: string
+    x-examples: [ "ceph-ssd", "false" ]
+    description: |
+      The name of the StorageClass to use.
+
+      `false` — forces the `emptyDir` usage. Manually delete the old PVC and restart Pod, after setting the parameter.
   severities:
     type: array
     description: |

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -1,5 +1,11 @@
 type: object
 properties:
+  storageClass:
+    description: |
+      Имя StorageClass.
+
+      `false` — принудительное использование `emptyDir`. После установки необходимо вручную удалить старый PVC и перезапустить под.
+
   severities:
     description: |
       Фильтрация отчетов уязвимостей по их уровню критичности.


### PR DESCRIPTION
## Description
It provides the storageClass field for trivy.

## Why do we need it, and what problem does it solve?
Solves #8337
We could not explicitly set the storage class for trivy, now we can.

## What is the expected result?
The storage class can be set explicitly.
```
root@dev-master-0:~# cat trivy.yaml 
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: operator-trivy
spec:
  version: 1
  enabled: true
  settings:
     storageClass: ceph-ssd 
```

```
root@dev-master-0:~# dcm values operator-trivy
internal:
  effectiveStorageClass: ceph-ssd
  enabledNamespaces: []
  reportUpdater: {}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: feature 
summary: add ability to explicitly set storageClass.
```
