### PR TITLE
[ci][docs] Skip building documentation on some cases

### DIFF
--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -113,6 +113,7 @@ jobs:
 
   doc_web_build:
     name: Doc web build
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -121,6 +122,7 @@ jobs:
 
   main_web_build:
     name: Main web build
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -60,12 +60,14 @@ jobs:
   doc_web_build:
     name: Doc web build
     # Wait for success build of modules.
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     needs:
       - git_info
 {!{ tmpl.Exec "web_build_template" (slice $ctx "doc" "release") | strings.Indent 4 }!}
 
   main_web_build:
     name: Main web build
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -106,7 +108,7 @@ jobs:
 
   web_links_test:
     name: Web links test
-    if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     needs:
       - git_info
       - doc_web_build

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -143,6 +143,7 @@ jobs:
 {!{ $jobNames = coll.Merge $jobNames (dict "doc_web_build" "Doc web build") }!}
   doc_web_build:
     name: {!{ $jobNames.doc_web_build }!}
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -152,6 +153,7 @@ jobs:
 {!{ $jobNames = coll.Merge $jobNames (dict "main_web_build" "Main web build") }!}
   main_web_build:
     name: {!{ $jobNames.main_web_build }!}
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -204,7 +206,7 @@ jobs:
 {!{ $jobNames = coll.Merge $jobNames (dict "web_links_test" "Web links test") }!}
   web_links_test:
     name: {!{ $jobNames.web_links_test }!}
-    if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     needs:
       - git_info
       - doc_web_build
@@ -278,7 +280,6 @@ jobs:
       - dhctl_tests
       - golangci_lint
       - openapi_test_cases
-      - web_links_test
       - validators
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -759,6 +759,7 @@ jobs:
 
   doc_web_build:
     name: Doc web build
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -817,6 +818,7 @@ jobs:
 
   main_web_build:
     name: Main web build
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -473,6 +473,7 @@ jobs:
   doc_web_build:
     name: Doc web build
     # Wait for success build of modules.
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     needs:
       - git_info
     # <template: web_build_template>
@@ -558,6 +559,7 @@ jobs:
 
   main_web_build:
     name: Main web build
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -1058,7 +1060,7 @@ jobs:
 
   web_links_test:
     name: Web links test
-    if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
     needs:
       - git_info
       - doc_web_build

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -1843,6 +1843,7 @@ jobs:
 
   doc_web_build:
     name: Doc web build
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -1961,6 +1962,7 @@ jobs:
 
   main_web_build:
     name: Main web build
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     # Wait for success build of modules.
     needs:
       - git_info
@@ -2683,7 +2685,7 @@ jobs:
 
   web_links_test:
     name: Web links test
-    if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     needs:
       - git_info
       - doc_web_build
@@ -3232,7 +3234,6 @@ jobs:
       - dhctl_tests
       - golangci_lint
       - openapi_test_cases
-      - web_links_test
       - validators
     if: ${{ always() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Update CI to skip building documentation on some cases.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Update CI to skip building documentation on some cases.
impact_level: low
```
