### PR TITLE
[cloud-provider-yandex] Add SSD IO DiskType to YIC

### DIFF
--- a/candi/cloud-providers/yandex/openapi/doc-ru-instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-instance_class.yaml
@@ -100,6 +100,8 @@ spec:
                     Тип диска у виртуальных машин.
 
                     Подробнее о возможных типах дисков можно узнать в [документации провайдера](https://cloud.yandex.com/docs/compute/concepts/disk#disks_types).
+
+                    Размер дисков `network-ssd-nonreplicated` и `network-ssd-io-m3` должен быть кратен 93 GB.
                 diskSizeGB:
                   description: |
                     Размер диска у виртуальных машин. Значение указывается в `ГиБ`.

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -82,7 +82,6 @@ spec:
                   - "network-ssd"
                   - "network-hdd"
                   - "network-ssd-nonreplicated"
-                  - "network-ssd-io-m3"
                 diskSizeGB:
                   description: |
                     Yandex Compute Instance disk size in gibibytes.
@@ -193,6 +192,8 @@ spec:
                 diskType:
                   description: |
                     Instance [disk type](https://cloud.yandex.com/en-ru/docs/compute/concepts/disk#disks_types).
+
+                    Size of `network-ssd-nonreplicated` and `network-ssd-io-m3` disks must be a multiple of 93 GB.
                   x-doc-examples: ["network-hdd"]
                   x-doc-default: "network-hdd"
                   type: string

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -200,6 +200,7 @@ spec:
                     - "network-ssd"
                     - "network-hdd"
                     - "network-ssd-nonreplicated"
+                    - "network-ssd-io-m3"
                 diskSizeGB:
                   description: |
                     Yandex Compute Instance disk size in gibibytes.

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -82,6 +82,7 @@ spec:
                   - "network-ssd"
                   - "network-hdd"
                   - "network-ssd-nonreplicated"
+                  - "network-ssd-io-m3"
                 diskSizeGB:
                   description: |
                     Yandex Compute Instance disk size in gibibytes.


### PR DESCRIPTION
## Description
Add `network-ssd-io-m3` disk type to `YandexInstanceClass`.

Closes https://github.com/deckhouse/deckhouse/issues/7349

Ref https://github.com/deckhouse/deckhouse/pull/8384

## Why do we need it, and what problem does it solve?
Support for SSD IO StorageClass was added a while ago https://github.com/deckhouse/deckhouse/pull/5684
This PR adds `network-ssd-io-m3` to the CRD.

Was tested manually in a cluster by creating CloudEphemeral nodegroup.

## What is the expected result?
High-performance redundant storage SSD IO is available for node root disks. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Added option to create nodes with SSD IO root disks.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
