### PR TITLE
[ingress-nginx] replace status with formatted status in logs

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/README.md
@@ -15,6 +15,8 @@ The `sleep` is needed to gracefully shut down ingress controllers behind a cloud
 * Enable our metrics collector instead of the default one.
 * Enable pcre_jit.
 * Add the health check server to provide the way for an external load balancer to check that the ingress controller will be terminated soon.
+* Set default values for upstream_retries and total_upstream_response_time to avoid incorrect logs when it is a raw tcp request.
+* Replace the status field with formatted status field which is explicitly converted to number to avoid incorrect logs when response status is 009.
 
 We do not intend to make a PR to the upstream with these changes, because there are only our custom features.
 

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/nginx-tmpl.patch
@@ -39,7 +39,7 @@ index 958397dd5..8b6de93c5 100755
      }
  
      {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
-@@ -373,6 +373,12 @@ http {
+@@ -373,6 +374,15 @@ http {
          {{ $reqUri }} 0;{{ end }}
          default 1;
      }
@@ -49,10 +49,13 @@ index 958397dd5..8b6de93c5 100755
 +    map $server_name $upstream_retries {
 +        default 0;
 +    }
++    map $server_name $formatted_status {
++        default $status;
++    }
  
      {{ if or $cfg.DisableAccessLog $cfg.DisableHTTPAccessLog }}
      access_log off;
-@@ -910,9 +928,7 @@ stream {
+@@ -910,9 +920,7 @@ stream {
  
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
@@ -63,7 +66,7 @@ index 958397dd5..8b6de93c5 100755
              }
          }
          {{ end }}
-@@ -1203,6 +1219,8 @@ stream {
+@@ -1203,6 +1211,8 @@ stream {
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
  
@@ -72,7 +75,7 @@ index 958397dd5..8b6de93c5 100755
              {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $all.Cfg.OpentracingTrustIncomingSpan $location }}
  
              {{ if $location.Mirror.Source }}
-@@ -1233,11 +1253,9 @@ stream {
+@@ -1233,11 +1243,9 @@ stream {
  
              log_by_lua_block {
                  balancer.log()
@@ -85,7 +88,7 @@ index 958397dd5..8b6de93c5 100755
              }
  
              {{ if not $location.Logs.Access }}
-@@ -1515,13 +1515,14 @@ stream {
+@@ -1515,13 +1523,14 @@ stream {
  
          {{ if eq $server.Hostname "_" }}
          # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}

--- a/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -279,7 +279,8 @@ local function fill_buffer()
   _increment("c01#" .. detail_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 1)
 
   -- responses
-  local var_status = ngx.var.status
+  ngx.var.formatted_status = tonumber(ngx.var.status)
+  local var_status = ngx.var.formatted_status
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
 

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
@@ -15,6 +15,8 @@ The `sleep` is needed to gracefully shut down ingress controllers behind a cloud
 * Enable our metrics collector instead of the default one.
 * Enable pcre_jit.
 * Add the health check server to provide the way for an external load balancer to check that the ingress controller will be terminated soon.
+* Set default values for upstream_retries and total_upstream_response_time to avoid incorrect logs when it is a raw tcp request.
+* Replace the status field with formatted status field which is explicitly converted to number to avoid incorrect logs when response status is 009.
 
 We do not intend to make a PR to the upstream with these changes, because there are only our custom features.
 

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/nginx-tmpl.patch
@@ -56,7 +56,7 @@ index 94dc12412..93b7d2efc 100644
      {{ if $cfg.UseGeoIP2 }}
      # https://github.com/leev/ngx_http_geoip2_module#example-usage
  
-@@ -387,6 +387,12 @@ http {
+@@ -387,6 +398,15 @@ http {
          {{ $reqUri }} 0;{{ end }}
          default 1;
      }
@@ -66,10 +66,13 @@ index 94dc12412..93b7d2efc 100644
 +    map $server_name $upstream_retries {
 +        default 0;
 +    }
++    map $server_name $formatted_status {
++        default $status;
++    }
  
      {{ if or $cfg.DisableAccessLog $cfg.DisableHTTPAccessLog }}
      access_log off;
-@@ -928,9 +939,7 @@ stream {
+@@ -928,9 +948,7 @@ stream {
  
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
@@ -80,7 +83,7 @@ index 94dc12412..93b7d2efc 100644
              }
          }
          {{ end }}
-@@ -1223,6 +1232,8 @@ stream {
+@@ -1223,6 +1241,8 @@ stream {
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
  
@@ -89,7 +92,7 @@ index 94dc12412..93b7d2efc 100644
              {{ buildOpentelemetryForLocation $all.Cfg.EnableOpentelemetry $all.Cfg.OpentelemetryTrustIncomingSpan $location }}
  
              {{ if $location.Mirror.Source }}
-@@ -1253,11 +1266,9 @@ stream {
+@@ -1253,11 +1273,9 @@ stream {
  
              log_by_lua_block {
                  balancer.log()
@@ -102,7 +105,7 @@ index 94dc12412..93b7d2efc 100644
              }
  
              {{ if not $location.Logs.Access }}
-@@ -1531,14 +1542,15 @@ stream {
+@@ -1531,14 +1549,15 @@ stream {
  
          {{ if eq $server.Hostname "_" }}
          # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}

--- a/modules/402-ingress-nginx/images/controller-1-9/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-9/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -279,7 +279,8 @@ local function fill_buffer()
   _increment("c01#" .. detail_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 1)
 
   -- responses
-  local var_status = ngx.var.status
+  ngx.var.formatted_status = tonumber(ngx.var.status)
+  local var_status = ngx.var.formatted_status
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
 

--- a/modules/402-ingress-nginx/templates/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/controller/configmap.yaml
@@ -162,7 +162,7 @@ data:
     "referrer": "$http_referer",
     "user_agent": "$http_user_agent",
     "request_time": $request_time,
-    "status": $status,
+    "status": $formatted_status,
     "content_kind": "$content_kind",
     "upstream_response_time": $total_upstream_response_time,
     "upstream_retries": $upstream_retries,


### PR DESCRIPTION
## Description
It provides fix for ingress-nginx logs format.

## Why do we need it, and what problem does it solve?
In come cases, nginx may have 009 response status, but our log format expects a valid number, so to solve it, we replace the standard status field with a new one, which is explicitly converted to number by lua.

## What is the expected result?
The status field is always a valid number.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix 
summary: Replace status with formatted status in logs.
```
