### PR TITLE
[monitoring-applications] Remove ApplicationRabbitMQAckedMessagesRate alert

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/applications/rabbitmq/prometheus-rules/rabbitmq.yaml
+++ b/ee/fe/modules/340-monitoring-applications/applications/rabbitmq/prometheus-rules/rabbitmq.yaml
@@ -97,17 +97,3 @@
 
       summary: |
         RabbitMQ StatefulSet: One or More Replicas Unavailable in `{{$labels.namespace}}`.
-
-  - alert: ApplicationRabbitMQAckedMessagesRate
-    expr: sum by (namespace,vhost,service)(irate(rabbitmq_channel_messages_acked_total{job="rabbitmq"}[2m])) == 0
-    for: 5m
-    labels:
-      severity_level: "5"
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: markdown
-      description: |
-        The RabbitMQ instance `{{$labels.namespace}}/{{$labels.pod}}` has not acknowledged any messages in the last 2 minutes. A lack of acknowledged messages may indicate potential issues with message processing or delivery. Investigate the RabbitMQ channels and message processing to identify and address the root cause.
-
-      summary: |
-        No Acknowledged Messages in RabbitMQ - `{{$labels.namespace}}/{{$labels.pod}}`.


### PR DESCRIPTION
## Description
Remove ApplicationRabbitMQAckedMessagesRate alert from monitoring-applications module

## Why do we need it, and what problem does it solve?
Alerts about message queue are considered unnecessary.
Also it had broken aggregation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-applications
type: chore
summary: Removed ApplicationRabbitMQAckedMessagesRate alert.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
