### PR TITLE
[docs][vcd] Fix getting started configs

### DIFF
--- a/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.ee.inc
@@ -6,7 +6,7 @@ apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 clusterType: Cloud
 cloud:
-  provider: vSphere
+  provider: VCD
   # [<en>] A prefix of objects that are created in the cloud during the installation.
   # [<en>] You might consider changing this.
   # [<ru>] Префикс объектов, создаваемых в облаке при установке.
@@ -178,7 +178,7 @@ nodeGroups:
     # [<en>] Example: "catalog/ubuntu-jammy-22.04".
     # [<ru>] Имя образа, созданного с учетом каталога размещения образа в vCloudDirector.
     # [<ru>] Пример: "catatlog/ubuntu-jammy-22.04".
-    template: flant-df-lab_DC1/ubuntu-22.04-template-23-03
+    template: *!CHANGE_TEMPLATE_NAME*
   name: frontend
   replicas: 1
   nodeTemplate:
@@ -204,7 +204,7 @@ virtualApplicationName: *!CHANGE_VAPP*
 virtualDataCenter: *!CHANGE__DC*
 # [<en>] Внутренняя сеть узлов.
 # [<ru>] Internal network name.
-mainNetwork: *!CHANGE_SSH_KEY_MAIN_NETWORK*
+mainNetwork: *!CHANGE_MAIN_NETWORK*
 # [<en>] Public SSH key for accessing cloud nodes.
 # [<en>] This key will be added to the user on created nodes (the user name depends on the image used).
 # [<ru>] Публичная часть SSH-ключа для доступа к узлам облака.

--- a/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.ee.inc
@@ -6,7 +6,7 @@ apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 clusterType: Cloud
 cloud:
-  provider: vSphere
+  provider: VCD
   # [<en>] A prefix of objects that are created in the cloud during the installation.
   # [<en>] You might consider changing this.
   # [<ru>] Префикс объектов, создаваемых в облаке при установке.
@@ -178,7 +178,7 @@ nodeGroups:
     # [<en>] Example: "catalog/ubuntu-jammy-22.04".
     # [<ru>] Имя образа, созданного с учетом каталога размещения образа в vCloudDirector.
     # [<ru>] Пример: "catatlog/ubuntu-jammy-22.04".
-    template: flant-df-lab_DC1/ubuntu-22.04-template-23-03
+    template: *!CHANGE_TEMPLATE_NAME*
   name: frontend
   replicas: 1
   nodeTemplate:
@@ -204,7 +204,7 @@ virtualApplicationName: *!CHANGE_VAPP*
 virtualDataCenter: *!CHANGE__DC*
 # [<en>] Внутренняя сеть узлов.
 # [<ru>] Internal network name.
-mainNetwork: *!CHANGE_SSH_KEY_MAIN_NETWORK*
+mainNetwork: *!CHANGE_MAIN_NETWORK*
 # [<en>] Public SSH key for accessing cloud nodes.
 # [<en>] This key will be added to the user on created nodes (the user name depends on the image used).
 # [<ru>] Публичная часть SSH-ключа для доступа к узлам облака.

--- a/docs/site/_includes/getting_started/vcd/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/resources.yml.minimal.inc
@@ -11,9 +11,9 @@ spec:
   sizingPolicy: *!CHANGE_SIZING_POLICY*
   storageProfile: *!CHANGE_STORAGE_PROFILE*
   # [<en>] The name of the image, taking into account the vCloudDirector without catalog path.
-  # [<en>] Example: "catalog/ubuntu-jammy-22.04".
+  # [<en>] Example: "ubuntu-jammy-22.04".
   # [<ru>] Имя образа, созданного с без учета каталога размещения образа в vCloudDirector.
-  # [<ru>] Пример: "catatlog/ubuntu-jammy-22.04".
+  # [<ru>] Пример: "ubuntu-jammy-22.04".
   template: *!CHANGE_TEMPLATE_NAME*
 ---
 # [<en>] Section containing the parameters of worker node group.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix getting started configs for VCD provider
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix getting started configs for VCD provider.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
