### PR TITLE
[istio] Setting trafficRedirectionSetupMode to InitContainer by default

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -671,7 +671,7 @@ properties:
           Managing the redirection mode of application traffic to be forwarded under Istio control in the Pod's network namespace.
           - `CNIPlugin` — in this mode, the configuration is performed by a CNI plugin when creating a Pod on a node. This mode does not require additional permissions for Pods and is recommended. This mode has [limitations](./examples.html#cniplugin-application-traffic-redirection-mode-restrictions) when using application init-containers that perform network communication with other services.
           - `InitContainer` — classic mode, each application Pod is automatically injected with a special init-container that configures the network environment of the Pod. In order to perform this configuration, the init-container is given additional permissions, which may not meet the security requirements of individual installations.
-        default: "CNIPlugin"
+        default: "InitContainer"
         enum: ["CNIPlugin", "InitContainer"]
         x-examples: ["CNIPlugin", "InitContainer"]
   nodeSelector:


### PR DESCRIPTION
## Description
Setting `trafficRedirectionSetupMode` to `InitContainer` by default.

## Why do we need it, and what problem does it solve?
It is too dangerous to have `CNIPlugin` mode as default.

## Why do we need it in the patch release (if we do)?
It is too dangerous to have `CNIPlugin` mode as default.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: "Set `trafficRedirectionSetupMode` option to `InitContainer` by default".
impact_level: default
```
