### PR TITLE
[deckhouse] use global.discovery where possible

### DIFF
--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
 {{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
               value: "true"
             - name: KUBERNETES_CLUSTER_DOMAIN
-              value: {{ .Values.global.clusterConfiguration.clusterDomain | quote }}
+              value: {{ .Values.global.discovery.clusterDomain | quote }}
 {{- else }}
               value: "false"
 {{- end }}

--- a/modules/470-chrony/template_tests/module_test.go
+++ b/modules/470-chrony/template_tests/module_test.go
@@ -33,8 +33,6 @@ func Test(t *testing.T) {
 const (
 	globalValues = `
   enabledModules: ["vertical-pod-autoscaler-crd"]
-  discovery:
-    clusterDomain: "cluster.local"
   clusterConfiguration:
     apiVersion: deckhouse.io/v1
     kind: ClusterConfiguration
@@ -47,6 +45,7 @@ const (
     placement: {}
   discovery:
     kubernetesVersion: 1.24.5
+    clusterDomain: "cluster.local"
     d8SpecificNodeCountByRole:
       worker: 3
       master: 3

--- a/modules/470-chrony/template_tests/module_test.go
+++ b/modules/470-chrony/template_tests/module_test.go
@@ -33,6 +33,8 @@ func Test(t *testing.T) {
 const (
 	globalValues = `
   enabledModules: ["vertical-pod-autoscaler-crd"]
+  discovery:
+    clusterDomain: "cluster.local"
   clusterConfiguration:
     apiVersion: deckhouse.io/v1
     kind: ClusterConfiguration

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -129,7 +129,7 @@ spec:
         - name: NTP_SERVERS
           value: {{ join " " $ntpServers | quote }}
         - name: CHRONY_MASTERS_SERVICE
-          value: {{ printf "chrony-masters.d8-%s.svc.%s" .Chart.Name .Values.global.clusterConfiguration.clusterDomain | quote }}
+          value: {{ printf "chrony-masters.d8-%s.svc.%s" .Chart.Name .Values.global.discovery.clusterDomain | quote }}
         - name: HOST_IP
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Description
This pr updates a couple of charts (chrony daemonset and deckhouse deployment respectively) to use `globa.discovery.clusterDomain` instead of `global.clusterConfiguration.clusterDomain` because of the possibility of missing `kube-system/d8-cluster-configuration` secret in the cluster (highly likely, such a cluster may have something to do with being previously run in a managed k8s service like EKS).
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
A couple of customers clusters, missing `kube-system/d8-cluster-configuration` secrets, were found. Without the secret the deckhouse deployment manifests can't be rendered if HA mode is enabled, missing `global.clusterConfiguration.clusterDomain` value.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
clusterDomain value must be successfully fetched from `.global.discovery.clusterDomain` path, preventing related rendering issue in a cluster without `kube-system/d8-cluster-configuration` secret.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Fetch clusterDomain value from global.discovery, rather than from global.clusterConfiguration.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
