### PR TITLE
[docs] Update the table of supported registries to include new OCI artifact types

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -70,6 +70,10 @@ registries:
         ALLOWED_OCI_ARTIFACT_TYPES:
           "application/vnd.aquasec.trivy.config.v1+json":
             - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
+          "application/octet-stream":
+            - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
+          "application/vnd.oci.empty.v1+json":
+            - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
         </pre>
       en: |
         <em>It is required to add support for <a href="https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/oci-intro#other-oci-artifacts-with-quay" target="_blank">additional types of OCI artifacts.</a></em>
@@ -78,4 +82,8 @@ registries:
         ALLOWED_OCI_ARTIFACT_TYPES:
           "application/vnd.aquasec.trivy.config.v1+json":
             - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
+          "application/octet-stream":
+            - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
+          "application/vnd.oci.empty.v1+json":
+            - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
         </pre>


### PR DESCRIPTION
## Description
Update the table of supported registries to include new OCI artifact types.

Added support for the following OCI artifact types:
- application/octet-stream with application/deckhouse.io.bdu.layer.v1.tar+gzip
- application/vnd.oci.empty.v1+json with application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip

This update ensures that additional types of OCI artifacts are recognized and supported.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update the table of supported registries to include new OCI artifact types.
impact_level: low
```
