### PR TITLE
[ingress-nginx] digital ocean k8s upgrade, update timeoutSeconds 

### DIFF
--- a/modules/402-ingress-nginx/templates/kruise/webhook.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/webhook.yaml
@@ -17,7 +17,7 @@ webhooks:
     admissionReviewVersions:
       - v1
     sideEffects: None
-    timeoutSeconds: 30
+    timeoutSeconds: 28
     name: mdaemonset.kb.io
     rules:
       - apiGroups:


### PR DESCRIPTION
## Description

Addition to PR [7933](https://github.com/deckhouse/deckhouse/pull/7933)

Reduce timeoutSeconds parameter to 28 seconds in 402-ingress-nginx/templates/kruise/webhook.yaml#L20

## Why do we need it, and what problem does it solve?

Can't update k8s in digital ocean. Error:

```
Errors preventing us from upgrading this cluster safely
Validating webhook with a TimeoutSeconds value smaller than 1 second or greater than 29 seconds will block upgrades.
Validating webhook with a TimeoutSeconds value smaller than 1 second or greater than 29 seconds will block upgrades.
Mutating webhook with a TimeoutSeconds value smaller than 1 second or greater than 29 seconds will block upgrades.
Validating webhook is configured in such a way that it may be problematic during upgrades.
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix 
summary: Digital ocean Kubernetes upgrade, update `timeoutSeconds`.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
