### PR TITLE
[monitoring] Fix caching of empty results with aggregation proxy

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
@@ -37,7 +37,7 @@ data:
                 {{- else }}
                 - prometheus.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:9090
                 {{- end }}
-          ignore_error: true
+          ignore_error: false
           anti_affinity: 30s
           timeout: 5s
           remote_read: false


### PR DESCRIPTION
… if Prometheus is unavailable or on connection timeout.

## Description
Change ignore_error value from true to false in the aggregation proxy config.

## Why do we need it, and what problem does it solve?

When ignore_error is set to true and the aggregation proxy does not receive a response from all Prometheus instances (due to reasons such as large queries causing connection timeouts, or all Prometheus instances being unavailable), an empty result is cached. Consequently, users see empty graphs in Grafana.

This PR changes ignore_error from true to false to prevent caching empty results in these scenarios and returne to Graphana error.


## Why do we need it in the patch release (if we do)?


## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix 
summary: Change ignore_error value from true to false in the aggregation proxy config to prevent caching empty results.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
