### PR TITLE
[monitoring] Update owners for okmeter module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@
 500-cilium-hubble/              @apolovov
 500-dashboard/                  @nabokihms
 500-upmeter/                    @nabokihms
-500-okmeter/                    @nabokihms
+500-okmeter/                    @nabokihms @vladimirGuryanov @lazovskiy @kolashtov
 500-operator-trivy/             @miklezzzz @yalosev
 502-delivery/                   @shvgn
 600-flant-integration/          @nabokihms


### PR DESCRIPTION
## Description
Add new people to CODEOWNERS for okmeter module.

Add:
- Andrey Kolashtov
- Vadim Lazovskiy
- Vladimir Guryanov

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Update owners for okmeter module.
impact_level: low
```

