### PR TITLE
Disable wait for guest network routable by default in vSphere Provider

### DIFF
--- a/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -201,4 +201,5 @@ resource "vsphere_virtual_machine" "master" {
       firmware,
     ]
   }
+  wait_for_guest_net_routable = var.wait_for_guest_net_routable
 }

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -201,5 +201,5 @@ resource "vsphere_virtual_machine" "master" {
       firmware,
     ]
   }
-  wait_for_guest_net_routable = var.wait_for_guest_net_routable
+  wait_for_guest_net_routable = false
 }

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
@@ -34,6 +34,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "wait_for_guest_net_routable" {
+  type = bool
+  default = false
+}
+
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
 

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
@@ -34,10 +34,6 @@ variable "clusterUUID" {
   type = string
 }
 
-variable "wait_for_guest_net_routable" {
-  type = bool
-  default = false
-}
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -173,4 +173,5 @@ resource "vsphere_virtual_machine" "node" {
       firmware,
     ]
   }
+  wait_for_guest_net_routable = var.wait_for_guest_net_routable
 }

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -173,5 +173,5 @@ resource "vsphere_virtual_machine" "node" {
       firmware,
     ]
   }
-  wait_for_guest_net_routable = var.wait_for_guest_net_routable
+  wait_for_guest_net_routable = false
 }

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
@@ -37,6 +37,11 @@ variable "nodeGroupName" {
   type = string
 }
 
+variable "wait_for_guest_net_routable" {
+  type = bool
+  default = false
+}
+
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
 

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
@@ -37,11 +37,6 @@ variable "nodeGroupName" {
   type = string
 }
 
-variable "wait_for_guest_net_routable" {
-  type = bool
-  default = false
-}
-
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
 


### PR DESCRIPTION
Signed-off-by: borg-z <me@nikolay-z.top>

## Description
This pull request changes the default behavior of the vSphere provider by setting `wait_for_guest_net_routable` to `false`. This means that Terraform will no longer wait for the VM's network to become routable by default.

## Why do we need it, and what problem does it solve?

In some scenarios, virtual machines (VMs) may be launched in environments without a default gateway. This situation, although rare, can occur in isolated environments where a default route is not provided, and access to repositories and other resources is either within the network or through a proxy. Our current Terraform configuration does the following:
1. Launches the VM.
2. Waits for the VM to have the "guest.net" and "guest.ipStack" properties.
3. Waits for a default route to appear in "guest.IpRouteConfig".

If a default route does not appear, Terraform waits for 5 minutes and then times out. By setting `wait_for_guest_net_routable` to `false`, we avoid unnecessary delays and failures in such environments.


## Why do we need it in the patch release (if we do)?

Not necessarily.

## What is the expected result?

After applying these changes, Terraform will not wait for the VM's network to become routable by default, but it will still wait for an IP address to be assigned. 

## See Also

https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine#wait_for_guest_net_routable



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: "Set `wait_for_guest_net_routable` to `false` by default in the vSphere provider to prevent unnecessary timeouts in environments without a default gateway."
impact: "VMs in isolated environments without a default gateway will no longer cause Terraform to wait for 5 minutes and timeout."
impact_level: low

```