### PR TITLE
[cloud-provider-yandex]  Change default root disk size for master and cloud permanent nodes to 50 GB

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf
@@ -49,7 +49,7 @@ locals {
   platform              = lookup(local.master_instance_class, "platform", "standard-v2")
   cores                 = local.master_instance_class.cores
   memory                = local.master_instance_class.memory / 1024
-  disk_size_gb          = lookup(local.master_instance_class, "diskSizeGB", 20)
+  disk_size_gb          = lookup(local.master_instance_class, "diskSizeGB", 50)
   disk_type             = lookup(local.master_instance_class, "diskType", "network-ssd")
   etcd_disk_size_gb     = local.master_instance_class.etcdDiskSizeGb
   image_id              = local.master_instance_class.imageID

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
@@ -53,7 +53,7 @@ locals {
   cores             = local.instance_class.cores
   core_fraction     = lookup(local.instance_class, "coreFraction", null)
   memory            = local.instance_class.memory / 1024
-  disk_size_gb      = lookup(local.instance_class, "diskSizeGB", 20)
+  disk_size_gb      = lookup(local.instance_class, "diskSizeGB", 50)
   image_id          = local.instance_class.imageID
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
   ssh_public_key    = var.providerClusterConfiguration.sshPublicKey

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -158,7 +158,7 @@ func createFirstDeschedulerCR(input *go_hook.HookInput) error {
 		},
 	}
 
-	input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", "d8-provider-cluster-configuration")
+	input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", secretName)
 
 	return err
 }

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"k8s.io/utils/pointer"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+/*
+Set diskSizeGB field for master nodegroup instance class and for all instance classes of another nodegroup
+before change diskSizeGB default
+*/
+
+const (
+	providerConfigKey = "cloud-provider-cluster-configuration.yaml"
+	secretNs          = "kube-system"
+	secretName        = "d8-provider-cluster-configuration"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "provider_configuration",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{secretName},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{secretNs},
+				},
+			},
+			ExecuteHookOnEvents: pointer.Bool(false),
+			FilterFunc:          providerConfigurationSecretFilter,
+		},
+		{
+			Name:       "install_version",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"install-data"},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-system"},
+				},
+			},
+			ExecuteHookOnEvents: pointer.Bool(false),
+			FilterFunc:          installDataCMFilter,
+		},
+	},
+}, createFirstDeschedulerCR)
+
+func providerConfigurationSecretFilter(unstructured *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var secret corev1.Secret
+
+	err := sdk.FromUnstructured(unstructured, &secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &secret, nil
+}
+
+func installDataCMFilter(unstructured *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var cm corev1.ConfigMap
+
+	err := sdk.FromUnstructured(unstructured, &cm)
+	if err != nil {
+		return nil, err
+	}
+
+	if version, ok := cm.Data["version"]; ok {
+		return version, nil
+	}
+
+	return "", nil
+}
+
+func createFirstDeschedulerCR(input *go_hook.HookInput) error {
+	providerConfigSecretSnap := input.Snapshots["provider_configuration"]
+	if len(providerConfigSecretSnap) == 0 {
+		return nil
+	}
+
+	needMigration, err := needMigrateForDeckhouseInstallVersion(input.Snapshots)
+	if err != nil {
+		return err
+	}
+
+	if !needMigration {
+		input.LogEntry.Info("Skipping migration diskSizeGB because Deckhouse installation version too ok")
+		return nil
+	}
+
+	providerConfigSecret := providerConfigSecretSnap[0].(*corev1.Secret)
+
+	backupSecret := providerConfigSecret.DeepCopy()
+	backupSecret.Name = backupSecret.Name + `-bkp-disk-gb`
+
+	input.PatchCollector.Create(backupSecret, object_patch.IgnoreIfExists())
+
+	var rawConfig map[string]interface{}
+	err = yaml.Unmarshal(providerConfigSecret.Data[providerConfigKey], &rawConfig)
+	if err != nil {
+		return err
+	}
+
+	needMigratieMasters, err := needMigrateMasterInstanceClass(rawConfig)
+	if err != nil {
+		return err
+	}
+
+	needMigrateNGs, err := needMigrateNodeGroupsInstanceClass(rawConfig)
+	if err != nil {
+		return err
+	}
+
+	if !needMigratieMasters && !needMigrateNGs {
+		input.LogEntry.Info("Skipping migration diskSizeGB because migration already done or diskSizeGB already set")
+		return nil
+	}
+
+	data, err := yaml.Marshal(rawConfig)
+	if err != nil {
+		return err
+	}
+
+	patch := map[string]interface{}{
+		"data": map[string]interface{}{
+			providerConfigKey: data,
+		},
+	}
+
+	input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+
+	return err
+}
+
+func needMigrateNodeGroupsInstanceClass(rawConfig map[string]interface{}) (bool, error) {
+	nodeGroups, found, err := unstructured.NestedSlice(rawConfig, "nodeGroups")
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		// we can do not have nodegroups. skip
+		return false, nil
+	}
+
+	needMigrate := false
+
+	fieldForNG := []string{"instanceClass", "diskSizeGB"}
+
+	resultNgs := make([]interface{}, 0, len(nodeGroups))
+
+	for _, rawNG := range nodeGroups {
+		ng := rawNG.(map[string]interface{})
+		_, found, err := unstructured.NestedInt64(ng, fieldForNG...)
+		if err != nil {
+			return false, err
+		}
+
+		if found {
+			continue
+		}
+
+		err = unstructured.SetNestedField(ng, 20, fieldForNG...)
+		if err != nil {
+			return false, err
+		}
+
+		needMigrate = true
+		resultNgs = append(resultNgs, ng)
+	}
+
+	if !needMigrate {
+		return false, nil
+	}
+
+	err = unstructured.SetNestedSlice(rawConfig, resultNgs, "nodeGroups")
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func needMigrateMasterInstanceClass(rawConfig map[string]interface{}) (bool, error) {
+	fieldForMaster := []string{"masterNodeGroup", "instanceClass", "diskSizeGB"}
+
+	_, found, err := unstructured.NestedInt64(rawConfig, fieldForMaster...)
+	if err != nil {
+		return false, err
+	}
+
+	if found {
+		return false, nil
+	}
+
+	err = unstructured.SetNestedField(rawConfig, 20, fieldForMaster...)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// check install version. if version > 1.61 we do not need migration because right default was set
+func needMigrateForDeckhouseInstallVersion(snaps go_hook.Snapshots) (bool, error) {
+	is := snaps["install_version"]
+	if len(is) == 0 {
+		// install-data configmap available from 1.55
+		// https://github.com/deckhouse/deckhouse/pull/6522
+		// if cm not found we should try to migration
+		return true, nil
+	}
+
+	versionStr := is[0].(string)
+	if versionStr == "dev" {
+		// for dev branches always run migration for testing purposes
+		return true, nil
+	}
+
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return false, err
+	}
+
+	if version.GreaterThan(semver.MustParse("1.61.0")) {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -124,9 +124,6 @@ func createFirstDeschedulerCR(input *go_hook.HookInput) error {
 	providerConfigSecret := providerConfigSecretSnap[0].(*corev1.Secret)
 
 	backupSecret := providerConfigSecret.DeepCopy()
-	backupSecret.Name = backupSecret.Name + `-bkp-disk-gb`
-
-	input.PatchCollector.Create(backupSecret, object_patch.IgnoreIfExists())
 
 	var rawConfig map[string]interface{}
 	err = yaml.Unmarshal(providerConfigSecret.Data[providerConfigKey], &rawConfig)
@@ -148,6 +145,9 @@ func createFirstDeschedulerCR(input *go_hook.HookInput) error {
 		input.LogEntry.Info("Skipping migration diskSizeGB because migration already done or diskSizeGB already set")
 		return nil
 	}
+
+	backupSecret.Name = backupSecret.Name + `-bkp-disk-gb`
+	input.PatchCollector.Create(backupSecret, object_patch.IgnoreIfExists())
 
 	data, err := yaml.Marshal(rawConfig)
 	if err != nil {

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -144,6 +144,7 @@ func createFirstDeschedulerCR(input *go_hook.HookInput) error {
 	}
 
 	backupSecret.Name = backupSecret.Name + `-bkp-disk-gb`
+	backupSecret.ResourceVersion = ""
 	input.PatchCollector.Create(backupSecret, object_patch.IgnoreIfExists())
 
 	data, err := yaml.Marshal(rawConfig)

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -73,7 +73,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc:          installDataCMFilter,
 		},
 	},
-}, createFirstDeschedulerCR)
+}, migrateDiskGBHandler)
 
 func providerConfigurationSecretFilter(unstructured *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var secret corev1.Secret
@@ -101,7 +101,7 @@ func installDataCMFilter(unstructured *unstructured.Unstructured) (go_hook.Filte
 	return "", nil
 }
 
-func createFirstDeschedulerCR(input *go_hook.HookInput) error {
+func migrateDiskGBHandler(input *go_hook.HookInput) error {
 	providerConfigSecretSnap := input.Snapshots["provider_configuration"]
 	if len(providerConfigSecretSnap) == 0 {
 		return nil

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -19,15 +19,12 @@ package hooks
 import (
 	"k8s.io/utils/pointer"
 
-	corev1 "k8s.io/api/core/v1"
-
-	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-
-	"github.com/flant/shell-operator/pkg/kube/object_patch"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -158,7 +158,7 @@ func createFirstDeschedulerCR(input *go_hook.HookInput) error {
 		},
 	}
 
-	input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+	input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", "d8-provider-cluster-configuration")
 
 	return err
 }

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -17,8 +17,6 @@ limitations under the License.
 package hooks
 
 import (
-	"k8s.io/utils/pointer"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -26,6 +24,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 )
 
@@ -143,7 +142,7 @@ func createFirstDeschedulerCR(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	backupSecret.Name = backupSecret.Name + `-bkp-disk-gb`
+	backupSecret.Name += `-bkp-disk-gb`
 	backupSecret.ResourceVersion = ""
 	input.PatchCollector.Create(backupSecret, object_patch.IgnoreIfExists())
 

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default_test.go
@@ -66,7 +66,7 @@ cloudProviderYandex:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: d8-cluster-configuration
+  name: d8-provider-cluster-configuration
   namespace: kube-system
 data:
   "cloud-provider-cluster-configuration.yaml": %s
@@ -104,7 +104,7 @@ metadata:
 `
 
 	assertSetOldDiskSizeForMasterNG := func(f *HookExecutionConfig) {
-		s := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+		s := f.KubernetesResource("Secret", "kube-system", "d8-provider-cluster-configuration")
 		Expect(s.Exists()).To(BeTrue())
 
 		clusterConfig := s.Field("data.cloud-provider-cluster-configuration\\.yaml").String()
@@ -131,7 +131,7 @@ metadata:
 	}
 
 	assertDiskSizeForOtherNG := func(f *HookExecutionConfig, ngs map[string]int) {
-		s := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+		s := f.KubernetesResource("Secret", "kube-system", "d8-provider-cluster-configuration")
 		Expect(s.Exists()).To(BeTrue())
 
 		clusterConfig := s.Field("data.cloud-provider-cluster-configuration\\.yaml").String()
@@ -167,7 +167,7 @@ metadata:
 	}
 
 	assertSaveBackupBeforeMigrate := func(f *HookExecutionConfig, pccs string) {
-		s := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration-bkp-disk-gb")
+		s := f.KubernetesResource("Secret", "kube-system", "d8-provider-cluster-configuration-bkp-disk-gb")
 
 		if pccs != "" {
 			Expect(s.Exists()).To(BeTrue())
@@ -190,7 +190,7 @@ metadata:
 	}
 
 	assertNoChangeSecret := func(f *HookExecutionConfig, pccs string) {
-		s := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+		s := f.KubernetesResource("Secret", "kube-system", "d8-provider-cluster-configuration")
 
 		Expect(s.Exists()).To(BeTrue())
 		Expect(s.ToYaml()).To(MatchYAML(pccs))

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: migrate_disk_gb_size_before_changing_default ::", func() {
+	const (
+		initValuesString = `
+global:
+  discovery: {}
+cloudProviderYandex:
+  internal: {}
+`
+	)
+
+	generateProviderSecret := func(pcc string) string {
+		stateCloudDiscoveryData := base64.StdEncoding.EncodeToString([]byte(`
+{
+  "apiVersion": "deckhouse.io/v1",
+  "defaultLbTargetGroupNetworkId": "test",
+  "internalNetworkIDs": [
+    "test"
+  ],
+  "kind": "YandexCloudDiscoveryData",
+  "region": "test",
+  "routeTableID": "test",
+  "shouldAssignPublicIPAddress": false,
+  "zoneToSubnetIdMap": {
+    "ru-central1-a": "test",
+    "ru-central1-b": "test",
+    "ru-central1-c": "test"
+  },
+  "zones": [
+    "ru-central1-a",
+    "ru-central1-b",
+    "ru-central1-c"
+  ]
+}
+`))
+		return fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(pcc)), stateCloudDiscoveryData)
+	}
+
+	installCM161 := `
+apiVersion: v1
+data:
+  version: v1.61.4
+kind: ConfigMap
+metadata:
+  name: install-data
+  namespace: d8-system
+	`
+
+	installCM160 := `
+apiVersion: v1
+data:
+  version: v1.60.1
+kind: ConfigMap
+metadata:
+  name: install-data
+  namespace: d8-system
+`
+
+	f := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Cluster has empty state", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster has provider cluster configuration secret without diskSizeGB in master nodegroup", func() {
+		const pcc = `
+apiVersion: deckhouse.io/v1
+existingNetworkID: enpma5uvcfbkuac1i1jb
+kind: YandexClusterConfiguration
+layout: WithNATInstance
+masterNodeGroup:
+  instanceClass:
+    cores: 2
+    etcdDiskSizeGb: 10
+    imageID: test
+    memory: 4096
+    platform: standard-v2
+  replicas: 1
+provider:
+  cloudID: test
+  folderID: test
+  serviceAccountJSON: |-
+    {
+      "id": "test"
+    }
+withNATInstance:
+  internalSubnetID: test
+  natInstanceExternalAddress: 84.201.160.148
+  exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
+nodeNetworkCIDR: 84.201.160.148/31
+sshPublicKey: ssh-rsa AAAAAbbbb
+`
+		Context("Cluster has install data config with version >= 1.61", func() {
+			var pccs = generateProviderSecret(pcc)
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(pccs + "\n---\n" + installCM161))
+				f.RunHook()
+			})
+
+			It("Hook should execute successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("Hook should not change provider configuration secret", func() {
+				s := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+
+				Expect(s.Exists()).To(BeTrue())
+				Expect(s.ToYaml()).To(MatchYAML(pccs))
+			})
+		})
+
+		FContext("Cluster has install data config with version < 1.60", func() {
+			var pccs = generateProviderSecret(pcc)
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(pccs + "\n---\n" + installCM160))
+				f.RunHook()
+			})
+
+			It("Hook should execute successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("Hook should not change provider configuration secret", func() {
+				s := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+
+				Expect(s.Exists()).To(BeTrue())
+				Expect(s.ToYaml()).To(MatchYAML(pccs))
+			})
+		})
+	})
+})

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -29,7 +29,6 @@ masterNodeGroup:
     cores: 4
     memory: 8192
     imageID: 'fd86ciomm61qk3o1rta5' #RED OS 8.0.0
-    diskSizeGB: 50
     externalIPAddresses:
     - Auto
 provider:


### PR DESCRIPTION
## Description
Change defaults in terraform.
Add migration for adding old default disk size (20 GB) to provider cluster configuration to prevent terraform state changing.
Remove diskSizeGB from e2e tests.

## Why do we need it, and what problem does it solve?
Difference between documentation and real value in cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Change default root disk size for master and cloud permanent nodes to 50 GB
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
