### PR TITLE
[deckhouse] Source for doubled module

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -466,9 +466,8 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 			moduleName := m.GetBasicModule().GetName()
 			src := dml.sourceModules[moduleName]
 			if src != "" {
-				fmt.Println("MPATH", m.GetBasicModule().GetPath())
+				// if module is not from external path - take it as Embedded one
 				if !strings.HasPrefix(m.GetBasicModule().GetPath(), os.Getenv("EXTERNAL_MODULES_DIR")) {
-					fmt.Println("MPATH2")
 					src = ""
 				}
 			}

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager"
@@ -464,6 +465,13 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			moduleName := m.GetBasicModule().GetName()
 			src := dml.sourceModules[moduleName]
+			if src != "" {
+				fmt.Println("MPATH", m.GetBasicModule().GetPath())
+				if !strings.HasPrefix(m.GetBasicModule().GetPath(), os.Getenv("EXTERNAL_MODULES_DIR")) {
+					fmt.Println("MPATH2")
+					src = ""
+				}
+			}
 			newModule := m.AsKubeObject(src)
 			newModule.SetLabels(map[string]string{epochLabelKey: epochLabelValue})
 

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -229,6 +229,10 @@ func (dml *DeckhouseController) setupSourceModules(ctx context.Context) error {
 		if rl.Status.Phase != v1alpha1.PhaseDeployed {
 			continue
 		}
+		if !rl.ObjectMeta.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		dml.sourceModules[rl.GetModuleName()] = rl.GetModuleSource()
 	}
 

--- a/deckhouse-controller/pkg/controller/loader.go
+++ b/deckhouse-controller/pkg/controller/loader.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/utils"
@@ -143,6 +144,10 @@ func (dml *DeckhouseController) searchAndLoadDeckhouseModules() error {
 					continue
 				}
 				return err
+			}
+
+			if !strings.HasPrefix(def.Path, os.Getenv("EXTERNAL_MODULES_DIR")) {
+				dml.sourceModules[def.Name] = "Embedded"
 			}
 
 			dml.deckhouseModules[def.Name] = dm

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -682,6 +682,11 @@ func (c *moduleReleaseReconciler) restoreAbsentModulesFromReleases(ctx context.C
 			continue
 		}
 
+		// ignore deleted Releases
+		if !item.ObjectMeta.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		moduleWeight := item.Spec.Weight
 		moduleVersion := "v" + item.Spec.Version.String()
 		moduleName := item.Spec.ModuleName

--- a/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/override-controller.go
@@ -294,6 +294,11 @@ func (c *modulePullOverrideReconciler) restoreAbsentModulesFromOverrides(ctx con
 	}
 
 	for _, item := range mpoList.Items {
+		// ignore deleted Releases
+		if !item.ObjectMeta.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		moduleName := item.Name
 		moduleSource := item.Spec.Source
 		moduleImageTag := item.Spec.ImageTag


### PR DESCRIPTION
## Description
If we have doubled module (Embedded and External one), deckhouse will use the embedded one but print an external source in modules list output
Also ignore deleted resource on startup module restoration

## Why do we need it, and what problem does it solve?
When we are rewriting a module, we can have doubled modules for some period of time. We want to use and show the embedded one, until it is deleted

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Before:
```yaml
NAME                  WEIGHT   STATE       SOURCE           STAGE        STATUS
flant-integration    600       Disabled    flint-registry
```

After:
```yaml
NAME                WEIGHT   STATE      SOURCE     STAGE   STATUS
flant-integration   600      Disabled   Embedded
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Print the right source for doubled (Embedded + External) modules.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
