### PR TITLE
[deckhouse] Fix stale errors for ModuleSource

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
@@ -71,7 +71,7 @@ type ModuleSourceStatus struct {
 	ModulesCount     int               `json:"modulesCount"`
 	AvailableModules []AvailableModule `json:"modules"`
 	Msg              string            `json:"message"`
-	ModuleErrors     []ModuleError     `json:"moduleErrors"`
+	ModuleErrors     []ModuleError     `json:"moduleErrors" patchStrategy:"retainKeys" patchKey:"name"`
 }
 
 type AvailableModule struct {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
-
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	crfake "github.com/google/go-containerregistry/pkg/v1/fake"
 	"github.com/pkg/errors"
@@ -43,6 +41,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
 )
 
 var golden bool
@@ -156,11 +155,11 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 
 	suite.Run("With stale registry error", func() {
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{"foo", "bar"}, nil) // baz module was removed
-		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (i1 v1.Image, err error) {
-			return &crfake.FakeImage{LayersStub: func() ([]v1.Layer, error) {
+		dependency.TestDC.CRClient.ImageMock.Return(
+			&crfake.FakeImage{LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "v1.2.3"}`}}}, nil
-			}}, nil
-		})
+			}}, nil,
+		)
 
 		suite.setupController(string(suite.fetchTestFileData("with-stale-error.yaml")))
 		ms := suite.getModuleSource(suite.testMSName)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/with-error.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/with-error.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    meta.helm.sh/release-name: deckhouse
+    meta.helm.sh/release-namespace: d8-system
+    modules.deckhouse.io/registry-spec-checksum: 81fdf7f3b8420e50645c30d01c2f052c
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    module: deckhouse
+  name: deckhouse
+  resourceVersion: "1000"
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: registry.deckhouse.io/deckhouse/ee/modules
+    scheme: HTTPS
+  releaseChannel: ""
+status:
+  message: Some errors occurred. Inspect status for details
+  moduleErrors:
+  - error: |-
+      fetch image error: fetch image error: GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/baz/release/manifests/alpha:
+            MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]
+    name: baz
+  modules:
+  - name: bar
+  - name: baz
+    policy: deckhouse-baz
+  - name: foo
+  modulesCount: 3
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  creationTimestamp: null
+  labels:
+    module: bar
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 853ae90f0351324bd73ea615e6487517
+    source: deckhouse
+  name: bar-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: deckhouse
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: bar
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  creationTimestamp: null
+  labels:
+    module: foo
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 853ae90f0351324bd73ea615e6487517
+    source: deckhouse
+  name: foo-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: deckhouse
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: foo
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/with-stale-error.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/with-stale-error.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    meta.helm.sh/release-name: deckhouse
+    meta.helm.sh/release-namespace: d8-system
+    modules.deckhouse.io/registry-spec-checksum: 81fdf7f3b8420e50645c30d01c2f052c
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    module: deckhouse
+  name: deckhouse
+  resourceVersion: "1000"
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: registry.deckhouse.io/deckhouse/ee/modules
+    scheme: HTTPS
+  releaseChannel: ""
+status:
+  message: ""
+  moduleErrors: []
+  modules:
+  - name: bar
+  - name: foo
+  modulesCount: 2
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  creationTimestamp: null
+  labels:
+    module: bar
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 853ae90f0351324bd73ea615e6487517
+    source: deckhouse
+  name: bar-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: deckhouse
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: bar
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  creationTimestamp: null
+  labels:
+    module: foo
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 853ae90f0351324bd73ea615e6487517
+    source: deckhouse
+  name: foo-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: deckhouse
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: foo
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/with-error.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/with-error.yaml
@@ -1,0 +1,48 @@
+# Error from registry should be kept in the status field
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    meta.helm.sh/release-name: deckhouse
+    meta.helm.sh/release-namespace: d8-system
+    modules.deckhouse.io/registry-spec-checksum: 81fdf7f3b8420e50645c30d01c2f052c
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    module: deckhouse
+  name: deckhouse
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: registry.deckhouse.io/deckhouse/ee/modules
+    scheme: HTTPS
+status:
+  message: Some errors occurred. Inspect status for details
+  moduleErrors:
+    - error: 'fetch image error: GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/baz/release/manifests/alpha:
+      MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]'
+      name: baz
+  modules:
+    - name: foo
+      policy: deckhouse
+    - name: bar
+      policy: deckhouse
+  modulesCount: 2
+  syncTime: "2024-05-20T13:20:21Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleUpdatePolicy
+metadata:
+  name: deckhouse-baz
+spec:
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        source: deckhouse
+        module: baz
+  releaseChannel: Alpha
+  update:
+    mode: Auto

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/with-stale-error.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/with-stale-error.yaml
@@ -1,0 +1,34 @@
+# Old stale error should be deleted from status
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    meta.helm.sh/release-name: deckhouse
+    meta.helm.sh/release-namespace: d8-system
+    modules.deckhouse.io/registry-spec-checksum: 81fdf7f3b8420e50645c30d01c2f052c
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    heritage: deckhouse
+    module: deckhouse
+  name: deckhouse
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: registry.deckhouse.io/deckhouse/ee/modules
+    scheme: HTTPS
+status:
+  message: Some errors occurred. Inspect status for details
+  moduleErrors:
+    - error: 'fetch image error: GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/baz/release/manifests/alpha:
+      MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]'
+      name: baz
+  modules:
+    - name: foo
+      policy: deckhouse
+    - name: bar
+      policy: deckhouse
+  modulesCount: 2
+  syncTime: "2024-05-20T13:20:21Z"


### PR DESCRIPTION
## Description
Remove stale errors from ModuleSource status
```
status:
  message: Some errors occurred. Inspect status for details
  moduleErrors:
  - error: 'fetch image error: GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/operator-redisfailover/release/manifests/alpha:
      MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]'
    name: operator-redisfailover
```

## Why do we need it, and what problem does it solve?
If a wrong module is deleted from registry, ModuleSource will have a stale error in the status. We can remove it gracefully


## Why do we need it in the patch release (if we do)?
To avoid errors in a client's clusters

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Remove stale errors in a ModuleSource status.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
