### PR TITLE
[testing] Fix linter for spellchecking documentation

### DIFF
--- a/tools/spelling/clean-files.py
+++ b/tools/spelling/clean-files.py
@@ -22,23 +22,28 @@ import argparse
 
 from pathlib import Path
 
+
 def clean_html(text):
     text = re.sub(r'(\<(/?[^>]+)>)', ' ', text)
     return text
+
 
 def clean_liquid(text):
     text = re.sub(r'(\{{(/?[^}}]+)}})', ' ', text)
     text = re.sub(r'(\{%(/?[^%}]+)%})', ' ', text)
     return text
 
+
 def clean_scripts(text):
     text = re.sub(r'<script>[\s\S]+?<\/script>', ' ', text)
     text = re.sub(r'<script [\s\S]+?>[\s\S]+?<\/script>', ' ', text)
     return text
 
+
 def clean_preamble(text):
     text = re.sub(r'---[\s\S]+?---', ' ', text)
     return text
+
 
 def delete_code_blocks(text):
     text = re.sub(r'```[\s\S]+?```', ' ', text)
@@ -47,13 +52,16 @@ def delete_code_blocks(text):
     text = re.sub(r'<code [\s\S]+?>[\s\S]+?<\/code>', ' ', text)
     return text
 
+
 def delete_md_links(text):
     text = re.sub(r'(?:__|\[*#])|\[(.*?)\]\(.*?\)', ' ', text)
     return text
 
+
 def delete_nbsp(text):
     text = text.replace('nbsp', ' ')
     return text
+
 
 def find_all_keys(input_dict: dict) -> list:
     result = []
@@ -67,6 +75,7 @@ def find_all_keys(input_dict: dict) -> list:
             result.extend(find_all_keys(val))
     return result
 
+
 # Create the parser
 parser = argparse.ArgumentParser(description='Process some integers.')
 
@@ -75,7 +84,8 @@ parser.add_argument('--stdin', action='store_true',
                     help='Read file content from stdin')
 
 # Add the arguments
-parser.add_argument('filename', help='File name to check spelling (use it also with --stdin parameter to help recognize file type)')
+parser.add_argument('filename',
+                    help='File name to check spelling (use it also with --stdin parameter to help recognize file type)')
 
 # Parse the arguments
 args = parser.parse_args()
@@ -84,10 +94,10 @@ file_extension = args.filename.split('.')[-1]
 
 if file_extension == 'html' or file_extension == 'md' or file_extension == 'liquid':
     if args.stdin:
-      text = sys.stdin.read()
+        text = sys.stdin.read()
     else:
-      with open(sys.argv[1], 'r') as f:
-        text = f.read()
+        with open(sys.argv[1], 'r') as f:
+            text = f.read()
 
     text = clean_preamble(text)
     text = delete_code_blocks(text)
@@ -99,10 +109,15 @@ if file_extension == 'html' or file_extension == 'md' or file_extension == 'liqu
     print(text)
 elif file_extension == 'yml' or file_extension == 'yaml':
     if args.stdin:
-      data = yaml.safe_load(sys.stdin.read())
+        try:
+            data = yaml.safe_load(sys.stdin.read())
+        except Exception as e:
+            # Don't check for errors as yaml is not valid.
+            # It is because a yaml from the PR diff in STDIN may not be valid. @TODO
+            sys.exit(1)
     else:
-       with open(sys.argv[1], 'r') as f:
-           data = yaml.safe_load(Path(sys.argv[1]).read_text())
+        with open(sys.argv[1], 'r') as f:
+            data = yaml.safe_load(Path(sys.argv[1]).read_text())
 
     descriptions = find_all_keys(data)
     if bool(descriptions):


### PR DESCRIPTION
## Description

Linter fails when tries unmarshall YAML structure from the PR diff. Just add try-except block to handle potential YAML parsing errors and fix it later.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: chore
summary: Fix linter for spellchecking documentation.
impact_level: low
```
