### PR TITLE
[docs] kube-bench apply without yq

### DIFF
--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -21,7 +21,7 @@ Then you have to select which node you want to run kube-bench.
 * Run on specific node, e.g. control-plane node:
 
   ```shell
-  curl -s https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml | yq r - -j | jq '.spec.template.spec.tolerations=[{"operator": "Exists"}] | .spec.template.spec.nodeSelector={"node-role.kubernetes.io/control-plane": ""}' | kubectl create -f -
+  curl -s https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml | kubectl apply -f - --dry-run=client -o json | jq '.spec.template.spec.tolerations=[{"operator": "Exists"}] | .spec.template.spec.nodeSelector={"node-role.kubernetes.io/control-plane": ""}' | kubectl create -f -
   ```
 
 Then you can check report:

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -21,7 +21,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- bash
 * Запуск на конкретном узле, например на control-plane:
 
   ```shell
-  curl -s https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml | yq r - -j | jq '.spec.template.spec.tolerations=[{"operator": "Exists"}] | .spec.template.spec.nodeSelector={"node-role.kubernetes.io/control-plane": ""}' | kubectl create -f -
+  curl -s https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml | kubectl apply -f - --dry-run=client -o json | jq '.spec.template.spec.tolerations=[{"operator": "Exists"}] | .spec.template.spec.nodeSelector={"node-role.kubernetes.io/control-plane": ""}' | kubectl create -f -
   ```
 
 Далее можно проверить результат выполнения:


### PR DESCRIPTION
## Description

Updated the documentation for running kube-bench to remove dependency on yq, which is not available in the container. The new instructions use kubectl and jq only.

## Why do we need it, and what problem does it solve?

The change resolves the issue where yq is not available in the container, allowing users to run kube-bench using available tools only.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## What is the expected result?

Users should be able to run kube-bench on specific nodes without the need for yq. The command provided in the documentation should work correctly.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Update kube-bench documentation to use `kubectl` and `jq` instead of `yq`.
impact_level: default
