### PR TITLE
[user-authn] unify usage enabled instead of enable

### DIFF
--- a/modules/150-user-authn/docs/FAQ.md
+++ b/modules/150-user-authn/docs/FAQ.md
@@ -107,7 +107,7 @@ Configure the [publishAPI](configuration.html#parameters-publishapi) parameter:
 
   ```yaml
   publishAPI:
-    enable: true
+    enabled: true
   ```
 
 The name `kubeconfig` is reserved for accessing the web interface that allows generating `kubeconfig`. The URL for access depends on the value of the parameter [publicDomainTemplate](../../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) (for example, for `publicDomainTemplate: %s.kube.my` it will be `kubeconfig.kube.my`, and for `publicDomainTemplate: %s-kube.company.my` it will be `kubeconfig-kube.company.my`).  

--- a/modules/150-user-authn/docs/FAQ_RU.md
+++ b/modules/150-user-authn/docs/FAQ_RU.md
@@ -106,7 +106,7 @@ title: "Модуль user-authn: FAQ"
 
   ```yaml
   publishAPI:
-    enable: true
+    enabled: true
   ```
 
 Для доступа к веб-интерфейсу, позволяющему сгенерировать `kubeconfig`, зарезервировано имя `kubeconfig`. URL для доступа зависит от значения параметра [publicDomainTemplate](../../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) (например, для `publicDomainTemplate: %s.kube.my` это будет `kubeconfig.kube.my`, а для `publicDomainTemplate: %s-kube.company.my` — `kubeconfig-kube.company.my`)  

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -22,7 +22,7 @@ spec:
       masterURI: https://159.89.5.247:6443
       description: "Direct access to kubernetes API"
     publishAPI:
-      enable: true
+      enabled: true
 ```
 
 {% endraw %}

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -22,7 +22,7 @@ spec:
       masterURI: https://159.89.5.247:6443
       description: "Direct access to kubernetes API"
     publishAPI:
-      enable: true
+      enabled: true
 ```
 
 {% endraw %}

--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
@@ -104,7 +104,7 @@ func discoverApiserverEndpoints(input *go_hook.HookInput) error {
 		targetPortPath = "userAuthn.internal.kubernetesApiserverTargetPort"
 	)
 
-	publishAPIEnabled := input.Values.Get("userAuthn.publishAPI.enable").Bool()
+	publishAPIEnabled := input.Values.Get("userAuthn.publishAPI.enabled").Bool()
 	if !publishAPIEnabled {
 		input.Values.Remove(addressesPath)
 		input.Values.Remove(targetPortPath)

--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints_test.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("User Authn hooks :: discover apiserver endpoints ::", func() {
-	f := HookExecutionConfigInit(`{"userAuthn":{"publishAPI":{"enable": true},"internal": {}}}`, "")
+	f := HookExecutionConfigInit(`{"userAuthn":{"publishAPI":{"enabled": true},"internal": {}}}`, "")
 
 	Context("Fresh cluster", func() {
 		BeforeEach(func() {

--- a/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
@@ -40,7 +40,7 @@ global:
     kubernetesCA: "discoveredKubernetesCA"
 userAuthn:
   publishAPI:
-    enable: true
+    enabled: true
     https:
       mode: SelfSigned
   internal: {}

--- a/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert.go
+++ b/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert.go
@@ -99,7 +99,7 @@ type provider struct {
 
 func generateProxyAuthCert(input *go_hook.HookInput, dc dependency.Container) error {
 	// check proxy rollout conditions
-	if !input.Values.Get("userAuthn.publishAPI.enable").Bool() {
+	if !input.Values.Get("userAuthn.publishAPI.enabled").Bool() {
 		return nil
 	}
 

--- a/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert_test.go
+++ b/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert_test.go
@@ -44,7 +44,7 @@ var _ = Describe("User Authn hooks :: generate crowd auth proxy ::", func() {
       "users"
     ]
   }
-}]}, "publishAPI": {"enable": true}}}`, "")
+}]}, "publishAPI": {"enabled": true}}}`, "")
 
 	Context("Fresh cluster", func() {
 		BeforeEach(func() {

--- a/modules/150-user-authn/hooks/generate_selfsigned_ca.go
+++ b/modules/150-user-authn/hooks/generate_selfsigned_ca.go
@@ -67,7 +67,7 @@ func generateSelfSignedCA(input *go_hook.HookInput) error {
 		keyPath  = "userAuthn.internal.selfSignedCA.key"
 	)
 
-	publishAPIEnabled := input.Values.Get("userAuthn.publishAPI.enable").Bool()
+	publishAPIEnabled := input.Values.Get("userAuthn.publishAPI.enabled").Bool()
 	publishAPIMode := input.Values.Get("userAuthn.publishAPI.https.mode").String()
 
 	if !publishAPIEnabled && publishAPIMode != "SelfSigned" {

--- a/modules/150-user-authn/hooks/generate_selfsigned_ca_test.go
+++ b/modules/150-user-authn/hooks/generate_selfsigned_ca_test.go
@@ -32,7 +32,7 @@ var _ = Describe("User Authn hooks :: generate selfsigned ca ::", func() {
 	Context("Without secret", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-			f.ValuesSet("userAuthn.publishAPI.enable", true)
+			f.ValuesSet("userAuthn.publishAPI.enabled", true)
 			f.ValuesSet("userAuthn.publishAPI.https.mode", "SelfSigned")
 			f.RunHook()
 		})
@@ -62,7 +62,7 @@ data:
   tls.crt: dGVzdA==
   tls.key: dGVzdA==
 `))
-			f.ValuesSet("userAuthn.publishAPI.enable", true)
+			f.ValuesSet("userAuthn.publishAPI.enabled", true)
 			f.ValuesSet("userAuthn.publishAPI.https.mode", "SelfSigned")
 			f.RunHook()
 		})

--- a/modules/150-user-authn/openapi/config-values.yaml
+++ b/modules/150-user-authn/openapi/config-values.yaml
@@ -1,3 +1,4 @@
+x-config-version: 2
 type: object
 properties:
   publishAPI:
@@ -5,7 +6,7 @@ properties:
     default: {}
     description: 'Settings for exposing the API server using Ingress.'
     properties:
-      enable:
+      enabled:
         type: boolean
         default: false
         description: 'Setting it to `true` will create an Ingress resource in the `d8-user-authn` namespace in the cluster (it exposes the Kubernetes API).'

--- a/modules/150-user-authn/openapi/conversions/conversions_test.go
+++ b/modules/150-user-authn/openapi/conversions/conversions_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/deckhouse-config/conversion"
 )
 
-func TestIstioConversions(t *testing.T) {
+func TestUserAuthnConversions(t *testing.T) {
 	conversions := "."
 	cases := []struct {
 		name            string

--- a/modules/150-user-authn/openapi/conversions/conversions_test.go
+++ b/modules/150-user-authn/openapi/conversions/conversions_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversions
+
+import (
+	"testing"
+
+	"github.com/deckhouse/deckhouse/go_lib/deckhouse-config/conversion"
+)
+
+func TestIstioConversions(t *testing.T) {
+	conversions := "."
+	cases := []struct {
+		name            string
+		settings        string
+		expected        string
+		currentVersion  int
+		expectedVersion int
+	}{
+		{
+			name: "should convert from 1 to 2 version",
+			settings: `
+publishAPI:
+  enable: true
+`,
+			expected: `
+publishAPI:
+  enabled: true
+`,
+			currentVersion:  1,
+			expectedVersion: 2,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := conversion.TestConvert(c.settings, c.expected, conversions, c.currentVersion, c.expectedVersion)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/modules/150-user-authn/openapi/conversions/v2.yaml
+++ b/modules/150-user-authn/openapi/conversions/v2.yaml
@@ -1,3 +1,3 @@
 version: 2
 conversions:
-  - .publishAPI.enabled = .publishAPI.enable | del(.publishAPI.enable)
+  - if .publishAPI.enable != null then .publishAPI.enabled = .publishAPI.enable | del(.publishAPI.enable) end

--- a/modules/150-user-authn/openapi/conversions/v2.yaml
+++ b/modules/150-user-authn/openapi/conversions/v2.yaml
@@ -1,3 +1,3 @@
 version: 2
 conversions:
-  - if .publishAPI and .publishAPI.enable then .publishAPI.enabled = .publishAPI.enable | del(.publishAPI.enable) else . end
+  - .publishAPI.enabled = .publishAPI.enable | del(.publishAPI.enable)

--- a/modules/150-user-authn/openapi/conversions/v2.yaml
+++ b/modules/150-user-authn/openapi/conversions/v2.yaml
@@ -1,0 +1,3 @@
+version: 2
+conversions:
+  - if .publishAPI and .publishAPI.enable then .publishAPI.enabled = .publishAPI.enable | del(.publishAPI.enable) else . end

--- a/modules/150-user-authn/openapi/doc-ru-config-values.yaml
+++ b/modules/150-user-authn/openapi/doc-ru-config-values.yaml
@@ -3,7 +3,7 @@ properties:
   publishAPI:
     description: 'Настройки публикации API-сервера Kubernetes через Ingress для обеспечения его публичного доступа.'
     properties:
-      enable:
+      enabled:
         description: 'Если указать `true`, в namespace `d8-user-authn` кластера будет создан Ingress-ресурс, который откроет публичный доступ к API-серверу.'
       ingressClass:
         description: 'Ingress-класс, который будет использован для публикации API Kubernetes через Ingress.'

--- a/modules/150-user-authn/template_tests/copy_custom_certificate_test.go
+++ b/modules/150-user-authn/template_tests/copy_custom_certificate_test.go
@@ -70,7 +70,7 @@ discovery:
 			f.ValuesSetFromYaml("userAuthn.internal.dexTLS", `{"crt":"plainstring","key":"plainstring"}`)
 			f.ValuesSetFromYaml("userAuthn.internal.customCertificateData", `{"tls.crt":"CRTCRTCRT","tls.key":"KEYKEYKEY"}`)
 			f.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")
-			f.ValuesSet("userAuthn.publishAPI.enable", true)
+			f.ValuesSet("userAuthn.publishAPI.enabled", true)
 			f.ValuesSet("userAuthn.publishAPI.https.mode", "Global")
 			f.HelmRender()
 		})

--- a/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
+++ b/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
@@ -92,7 +92,7 @@ Multiline
 
 	Context("Default config", func() {
 		BeforeEach(func() {
-			hec.ValuesSet("userAuthn.publishAPI.enable", true)
+			hec.ValuesSet("userAuthn.publishAPI.enabled", true)
 			hec.ValuesSet("userAuthn.publishAPI.addKubeconfigGeneratorEntry", true)
 
 			hec.HelmRender()
@@ -119,7 +119,7 @@ Multiline
 
 		Context("With discoveredDexCA", func() {
 			BeforeEach(func() {
-				hec.ValuesSet("userAuthn.publishAPI.enable", true)
+				hec.ValuesSet("userAuthn.publishAPI.enabled", true)
 				hec.ValuesSet("userAuthn.publishAPI.addKubeconfigGeneratorEntry", true)
 				hec.ValuesSet("userAuthn.internal.discoveredDexCA", "discoveredDexCAText")
 				hec.HelmRender()
@@ -136,7 +136,7 @@ Multiline
 
 		Context("Publish API", func() {
 			JustBeforeEach(func() {
-				hec.ValuesSet("userAuthn.publishAPI.enable", true)
+				hec.ValuesSet("userAuthn.publishAPI.enabled", true)
 				hec.ValuesSet("userAuthn.publishAPI.addKubeconfigGeneratorEntry", true)
 				hec.HelmRender()
 			})

--- a/modules/150-user-authn/template_tests/publish_api_test.go
+++ b/modules/150-user-authn/template_tests/publish_api_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Module :: user-authn :: helm template :: publish api", func() 
 		hec.ValuesSet("userAuthn.internal.selfSignedCA.cert", "test")
 		hec.ValuesSet("userAuthn.internal.selfSignedCA.key", "test")
 
-		hec.ValuesSet("userAuthn.publishAPI.enable", true)
+		hec.ValuesSet("userAuthn.publishAPI.enabled", true)
 		hec.ValuesSet("userAuthn.publishAPI.addKubeconfigGeneratorEntry", true)
 	})
 

--- a/modules/150-user-authn/template_tests/values.yaml
+++ b/modules/150-user-authn/template_tests/values.yaml
@@ -6,7 +6,7 @@ userAuthn:
     dexAuthenticatorCRDs: []
     providers: []
   publishAPI:
-    enable: false
+    enabled: false
     https:
       mode: SelfSigned
   controlPlaneConfigurator:

--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -9,7 +9,7 @@
 
 
 {{- define "publish_api_deploy_certificate" }}
-  {{- if .Values.userAuthn.publishAPI.enable }}
+  {{- if .Values.userAuthn.publishAPI.enabled }}
     {{- if eq .Values.userAuthn.publishAPI.https.mode "Global" -}}
       {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
       "not empty string"

--- a/modules/150-user-authn/templates/crowd-basic-auth-proxy/_helpers.tpl
+++ b/modules/150-user-authn/templates/crowd-basic-auth-proxy/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "is_basic_auth_enabled_in_any_crowd" }}
-  {{- if .Values.userAuthn.publishAPI.enable }}
+  {{- if .Values.userAuthn.publishAPI.enabled }}
     {{- range $provider := .Values.userAuthn.internal.providers }}
       {{- if eq $provider.type "Crowd" }}
         {{- if $provider.crowd.enableBasicAuth }}

--- a/modules/150-user-authn/templates/dex/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex/oauth2client.yaml
@@ -8,7 +8,7 @@
 
 
 {{- $context := . }}
-{{- if or (include "dex_authenticators_with_access_to_kubernetes_api" $context) $context.Values.userAuthn.publishAPI.enable $context.Values.userAuthn.kubeconfigGenerator }}
+{{- if or (include "dex_authenticators_with_access_to_kubernetes_api" $context) $context.Values.userAuthn.publishAPI.enabled $context.Values.userAuthn.kubeconfigGenerator }}
 apiVersion: dex.coreos.com/v1
 kind: OAuth2Client
 metadata:
@@ -26,7 +26,7 @@ trustedPeers:
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if $context.Values.userAuthn.publishAPI.enable }}
+{{- if $context.Values.userAuthn.publishAPI.enabled }}
 - kubeconfig-generator
 {{- end }}
 {{- if $context.Values.userAuthn.kubeconfigGenerator}}
@@ -40,7 +40,7 @@ redirectURIs:
 - https://{{ include "helm_lib_module_public_domain" (list $context "kubeconfig") }}/callback/{{ $index }}
     {{- end }}
   {{- end }}
-  {{- if $context.Values.userAuthn.publishAPI.enable }}
+  {{- if $context.Values.userAuthn.publishAPI.enabled }}
 - https://{{ include "helm_lib_module_public_domain" (list $context "kubeconfig") }}/callback/
   {{- end }}
   {{- if $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}

--- a/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.global.modules.publicDomainTemplate) (or (and (.Values.userAuthn.publishAPI.enable) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator)) }}
+{{- if and (.Values.global.modules.publicDomainTemplate) (or (and (.Values.userAuthn.publishAPI.enabled) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator)) }}
   {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
 ---
 apiVersion: cert-manager.io/v1

--- a/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (.Values.userAuthn.publishAPI.enable) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
+{{- if or (and (.Values.userAuthn.publishAPI.enabled) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -40,7 +40,7 @@ clusters:
   {{- $_ := set $publish_api_cluster "description" $publish_api_master_url }}
   {{- $_ := set $publish_api_cluster "masterCA" .Values.userAuthn.internal.publishedAPIKubeconfigGeneratorMasterCA }}
 
-  {{- if and (.Values.userAuthn.publishAPI.enable) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry) }}
+  {{- if and (.Values.userAuthn.publishAPI.enabled) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry) }}
 {{- include "kubeconfig_settings" (list $ "" $publish_api_cluster) }}
   {{- end }}
 

--- a/modules/150-user-authn/templates/kubeconfig-generator/deployment.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
-{{- if or (and (.Values.userAuthn.publishAPI.enable) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
+{{- if or (and (.Values.userAuthn.publishAPI.enabled) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1

--- a/modules/150-user-authn/templates/kubeconfig-generator/ingress.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (.Values.userAuthn.publishAPI.enable) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
+{{- if or (and (.Values.userAuthn.publishAPI.enabled) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/modules/150-user-authn/templates/kubeconfig-generator/oauth2client.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/oauth2client.yaml
@@ -1,5 +1,5 @@
 {{- $context := . }}
-{{- if $context.Values.userAuthn.publishAPI.enable }}
+{{- if $context.Values.userAuthn.publishAPI.enabled }}
 ---
 apiVersion: dex.coreos.com/v1
 kind: OAuth2Client

--- a/modules/150-user-authn/templates/kubeconfig-generator/service.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (.Values.userAuthn.publishAPI.enable) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
+{{- if or (and (.Values.userAuthn.publishAPI.enabled) (.Values.userAuthn.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
 ---
 apiVersion: v1
 kind: Service

--- a/modules/150-user-authn/templates/kubernetes-api/custom-certificate.yaml
+++ b/modules/150-user-authn/templates/kubernetes-api/custom-certificate.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.userAuthn.publishAPI.enable -}}
+{{ if .Values.userAuthn.publishAPI.enabled -}}
   {{- if eq .Values.userAuthn.publishAPI.https.mode "Global" -}}
     {{- if eq (include "helm_lib_module_https_mode" .) "CustomCertificate" }}
 {{- include "helm_lib_module_https_copy_custom_certificate" (list . "d8-user-authn" "kubernetes-tls") -}}

--- a/modules/150-user-authn/templates/kubernetes-api/issuer.yaml
+++ b/modules/150-user-authn/templates/kubernetes-api/issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.userAuthn.publishAPI.enable) (eq .Values.userAuthn.publishAPI.https.mode "SelfSigned") (.Values.global.enabledModules | has "cert-manager") }}
+{{- if and (.Values.userAuthn.publishAPI.enabled) (eq .Values.userAuthn.publishAPI.https.mode "SelfSigned") (.Values.global.enabledModules | has "cert-manager") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/modules/150-user-authn/templates/kubernetes-api/kubernetes-api.yaml
+++ b/modules/150-user-authn/templates/kubernetes-api/kubernetes-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.userAuthn.publishAPI.enable }}
+{{- if .Values.userAuthn.publishAPI.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/modules/150-user-authn/templates/kubernetes-api/service.yaml
+++ b/modules/150-user-authn/templates/kubernetes-api/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.userAuthn.publishAPI.enable }}
+{{- if .Values.userAuthn.publishAPI.enabled }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description
It provides conversions and replacements for using only the `enabled` field.

## Why do we need it, and what problem does it solve?
Fixes #5627
People see the `enable` parameter in publishAPI field and may start to use it in some other places, but there is only the `enabled` field there.

## What is the expected result?
The `publishAPI` field has the `enabled` field instead of `enable`.

```
root@dev-master-0:~# dcm values user-authn
publishAPI:
  addKubeconfigGeneratorEntry: true
  enabled: false
  https:
    mode: SelfSigned
```

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Replace the `enable` option with the `enabled` in the `publishAPI` field.
```
