### PR TITLE
[candi][cloud-provider-yandex] Remove ru-central1-c zone from terraform

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -91,7 +91,6 @@ apiVersions:
               enum:
               - ru-central1-a
               - ru-central1-b
-              - ru-central1-c
               - ru-central1-d
             uniqueItems: true
           instanceClass:
@@ -210,7 +209,6 @@ apiVersions:
                 enum:
                 - ru-central1-a
                 - ru-central1-b
-                - ru-central1-c
                 - ru-central1-d
               uniqueItems: true
             nodeTemplate:
@@ -311,7 +309,6 @@ apiVersions:
         x-examples:
           - ru-central1-a: e2lu8r1tbbtryhdpa9ro
             ru-central1-b: e2lu8r1tbbtryhdpa9ro
-            ru-central1-c: e2lu8r1tbbtryhdpa9ro
             ru-central1-d: e2lu8r1tbbtryhdpa9ro
         additionalProperties:
           type: string
@@ -448,7 +445,6 @@ apiVersions:
           enum:
             - ru-central1-a
             - ru-central1-b
-            - ru-central1-c
             - ru-central1-d
         uniqueItems: true
     oneOf:

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -18,7 +18,6 @@ locals {
   zone_to_subnet = length(local.mapping) == 0 ? {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
     "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
-    "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
     "ru-central1-d" = length(data.yandex_vpc_subnet.kube_d) > 0 ? data.yandex_vpc_subnet.kube_d[0] : object({})
   } : data.yandex_vpc_subnet.existing
 
@@ -48,11 +47,6 @@ data "yandex_vpc_subnet" "kube_a" {
 data "yandex_vpc_subnet" "kube_b" {
   count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-b"
-}
-
-data "yandex_vpc_subnet" "kube_c" {
-  count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-c"
 }
 
 data "yandex_vpc_subnet" "kube_d" {

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -18,7 +18,6 @@ locals {
   zone_to_subnet = length(local.mapping) == 0 ? {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
     "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
-    "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
     "ru-central1-d" = length(data.yandex_vpc_subnet.kube_d) > 0 ? data.yandex_vpc_subnet.kube_d[0] : object({})
   } : data.yandex_vpc_subnet.existing
 
@@ -47,11 +46,6 @@ data "yandex_vpc_subnet" "kube_a" {
 data "yandex_vpc_subnet" "kube_b" {
   count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-b"
-}
-
-data "yandex_vpc_subnet" "kube_c" {
-  count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-c"
 }
 
 data "yandex_vpc_subnet" "kube_d" {

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -17,12 +17,10 @@ locals {
 
   kube_a_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 0) : null
   kube_b_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 1) : null
-  kube_c_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 2) : null
   kube_d_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 3) : null
 
   not_have_existing_subnet_a = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null)
   not_have_existing_subnet_b = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null)
-  not_have_existing_subnet_c = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null)
   not_have_existing_subnet_d = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-d", null) == null)
 
   is_with_nat_instance = var.layout == "WithNATInstance"
@@ -40,11 +38,6 @@ data "yandex_vpc_subnet" "kube_a" {
 data "yandex_vpc_subnet" "kube_b" {
   count     = local.not_have_existing_subnet_b ? 0 : 1
   subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-b
-}
-
-data "yandex_vpc_subnet" "kube_c" {
-  count     = local.not_have_existing_subnet_c ? 0 : 1
-  subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-c
 }
 
 data "yandex_vpc_subnet" "kube_d" {
@@ -113,31 +106,6 @@ resource "yandex_vpc_subnet" "kube_b" {
   v4_cidr_blocks = [local.kube_b_v4_cidr_block]
   route_table_id = yandex_vpc_route_table.kube.id
   zone           = "ru-central1-b"
-
-  dynamic "dhcp_options" {
-    for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []
-    content {
-      domain_name         = var.dhcp_domain_name
-      domain_name_servers = var.dhcp_domain_name_servers
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      v4_cidr_blocks,
-    ]
-  }
-
-  labels = var.labels
-}
-
-resource "yandex_vpc_subnet" "kube_c" {
-  count          = local.should_create_subnets ? 1 : 0
-  name           = "${var.prefix}-c"
-  network_id     = var.network_id
-  v4_cidr_blocks = [local.kube_c_v4_cidr_block]
-  route_table_id = yandex_vpc_route_table.kube.id
-  zone           = "ru-central1-c"
 
   dynamic "dhcp_options" {
     for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -35,7 +35,6 @@ locals {
   zone_to_subnet_id = tomap({
       "ru-central1-a" = local.should_create_subnets ? yandex_vpc_subnet.kube_a[0].id : (local.not_have_existing_subnet_a ? null : data.yandex_vpc_subnet.kube_a[0].id)
       "ru-central1-b" = local.should_create_subnets ? yandex_vpc_subnet.kube_b[0].id : (local.not_have_existing_subnet_b ? null : data.yandex_vpc_subnet.kube_b[0].id)
-      "ru-central1-c" = local.should_create_subnets ? yandex_vpc_subnet.kube_c[0].id : (local.not_have_existing_subnet_c ? null : data.yandex_vpc_subnet.kube_c[0].id)
       "ru-central1-d" = local.should_create_subnets ? yandex_vpc_subnet.kube_d[0].id : (local.not_have_existing_subnet_d ? null : data.yandex_vpc_subnet.kube_d[0].id)
     })
 
@@ -44,7 +43,6 @@ locals {
   zone_to_cidr = tomap({
     "ru-central1-a" = local.should_create_subnets ? local.kube_a_v4_cidr_block : (local.not_have_existing_subnet_a ? null : data.yandex_vpc_subnet.kube_a[0].v4_cidr_blocks[0])
     "ru-central1-b" = local.should_create_subnets ? local.kube_b_v4_cidr_block : (local.not_have_existing_subnet_b ? null : data.yandex_vpc_subnet.kube_b[0].v4_cidr_blocks[0])
-    "ru-central1-c" = local.should_create_subnets ? local.kube_c_v4_cidr_block : (local.not_have_existing_subnet_c ? null : data.yandex_vpc_subnet.kube_c[0].v4_cidr_blocks[0])
     "ru-central1-d" = local.should_create_subnets ? local.kube_d_v4_cidr_block : (local.not_have_existing_subnet_d ? null : data.yandex_vpc_subnet.kube_d[0].v4_cidr_blocks[0])
   })
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
@@ -15,8 +15,7 @@
 locals {
   zone_to_subnet_id_map_a = merge({}, (length(data.yandex_vpc_subnet.kube_a) > 0 ? {(data.yandex_vpc_subnet.kube_a[0].zone): data.yandex_vpc_subnet.kube_a[0].id } : {} ))
   zone_to_subnet_id_map_b = merge(local.zone_to_subnet_id_map_a, (length(data.yandex_vpc_subnet.kube_b) > 0 ?{(data.yandex_vpc_subnet.kube_b[0].zone): data.yandex_vpc_subnet.kube_b[0].id } : {} ))
-  zone_to_subnet_id_map_c = merge(local.zone_to_subnet_id_map_b, (length(data.yandex_vpc_subnet.kube_c) > 0 ? {(data.yandex_vpc_subnet.kube_c[0].zone): data.yandex_vpc_subnet.kube_c[0].id } : {} ))
-  zone_to_subnet_id_map_d_final = merge(local.zone_to_subnet_id_map_c, (length(data.yandex_vpc_subnet.kube_d) > 0 ? {(data.yandex_vpc_subnet.kube_d[0].zone): data.yandex_vpc_subnet.kube_d[0].id } : {} ))
+  zone_to_subnet_id_map_d_final = merge(local.zone_to_subnet_id_map_b, (length(data.yandex_vpc_subnet.kube_d) > 0 ? {(data.yandex_vpc_subnet.kube_d[0].zone): data.yandex_vpc_subnet.kube_d[0].id } : {} ))
 }
 
 output "route_table_id" {
@@ -27,7 +26,6 @@ output "zone_to_subnet_id_map" {
     value = local.should_create_subnets ? {
       (yandex_vpc_subnet.kube_a[0].zone): yandex_vpc_subnet.kube_a[0].id
       (yandex_vpc_subnet.kube_b[0].zone): yandex_vpc_subnet.kube_b[0].id
-      (yandex_vpc_subnet.kube_c[0].zone): yandex_vpc_subnet.kube_c[0].id
       (yandex_vpc_subnet.kube_d[0].zone): yandex_vpc_subnet.kube_d[0].id
     } : local.zone_to_subnet_id_map_d_final
 }

--- a/release.yaml
+++ b/release.yaml
@@ -32,6 +32,8 @@ requirements:
   "nodesMinimalOSVersionDebian": "10" # modules/040-node-manager/requirements/check.go
   "containerdOnAllNodes": "true" # modules/040-node-manager/requirements/check.go
   "istioMinimalVersion": "1.16" # modules/110-istio/requirements/check.go
+  "yandexHasDeprecatedZoneInConfig": "false" # modules/030-cloud-provider-yandex/requirements/check.go
+  "yandexHasDeprecatedZoneInNodes": "false" # modules/030-cloud-provider-yandex/requirements/check.go
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove deprecated `ru-central1-c` zone from terraform.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Closes #7781.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: feature
summary: Remove deprecated `ru-central1-c` zone from terraform.
impact_level: high
impact: Yandex.Cloud `ru-central1-c` zone has been removed from terraform. If you use `ru-central1-c` zone in Yandex.Cloud, you need to manually run converge to remove subnets from the cloud.
```
