### PR TITLE
[cloud-provider-vcd][discovery] Support multiple VCD API versions

### DIFF
--- a/ee/candi/cloud-providers/vcd/layouts/standard/base-infrastructure/outputs.tf
+++ b/ee/candi/cloud-providers/vcd/layouts/standard/base-infrastructure/outputs.tf
@@ -6,7 +6,7 @@ output "cloud_discovery_data" {
     "apiVersion"       = "deckhouse.io/v1"
     "kind"             = "VCDCloudProviderDiscoveryData"
     # vcloud director does not contain meaning zones
-    # but out machinery use them. we use default as one zone
+    # but our machinery use them. we use default as one zone
     "zones"            = ["default"]
   }
 }

--- a/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
@@ -44,3 +44,13 @@ apiVersions:
             isDefaultStorageProfile:
               type: boolean
         description: List of storage classes.
+      version:
+        type: object
+        description: VCD version and API version.
+        properties:
+          vcdVersion:
+            type: string
+            minLength: 1
+          apiVersion:
+            type: string
+            minLength: 1

--- a/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
@@ -46,6 +46,7 @@ apiVersions:
         description: List of storage classes.
       version:
         type: object
+        default: {}
         description: VCD version and API version.
         properties:
           vcdVersion:

--- a/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
@@ -50,7 +50,9 @@ apiVersions:
         properties:
           vcdVersion:
             type: string
+            default: "10.3.3.4"
             minLength: 1
           apiVersion:
             type: string
+            default: "36.0"
             minLength: 1

--- a/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cloud_discovery_data.yaml
@@ -44,16 +44,13 @@ apiVersions:
             isDefaultStorageProfile:
               type: boolean
         description: List of storage classes.
-      version:
-        type: object
-        default: {}
-        description: VCD version and API version.
-        properties:
-          vcdVersion:
-            type: string
-            default: "10.3.3.4"
-            minLength: 1
-          apiVersion:
-            type: string
-            default: "36.0"
-            minLength: 1
+      vcdInstallationVersion:
+        type: string
+        description: VCD installation version.
+        default: "10.3.3.4"
+        minLength: 1
+      vcdAPIVersion:
+        type: string
+        description: VCD API version.
+        default: "36.0"
+        minLength: 1

--- a/ee/modules/030-cloud-provider-vcd/candi
+++ b/ee/modules/030-cloud-provider-vcd/candi
@@ -1,1 +1,1 @@
-/deckhouse/candi/cloud-providers/vcd/
+/deckhouse/candi/cloud-providers/vcd

--- a/ee/modules/030-cloud-provider-vcd/hooks/discover.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/discover.go
@@ -58,7 +58,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, handleCloudProviderDiscoveryDataSecret)
 
 func applyCloudProviderDiscoveryDataSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	var secret = &v1.Secret{}
+	secret := &v1.Secret{}
 	err := sdk.FromUnstructured(obj, secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
@@ -68,7 +68,7 @@ func applyCloudProviderDiscoveryDataSecretFilter(obj *unstructured.Unstructured)
 }
 
 func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	var storageClass = &storage.StorageClass{}
+	storageClass := &storage.StorageClass{}
 	err := sdk.FromUnstructured(obj, storageClass)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
@@ -126,7 +126,7 @@ func handleCloudProviderDiscoveryDataSecret(input *go_hook.HookInput) error {
 		return fmt.Errorf("failed to unmarshal 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: %v", err)
 	}
 
-	input.Values.Set("cloudProviderVcd.internal.providerDiscoveryData", discoveryData)
+	input.Values.Set("cloudProviderVcd.internal.discoveryData", discoveryData)
 
 	handleDiscoveryDataVolumeTypes(input, discoveryData.StorageProfiles)
 

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/01-add-iops-calculation.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/01-add-iops-calculation.patch
@@ -1,0 +1,111 @@
+Subject: [PATCH] iops calculate
+---
+Index: pkg/vcdcsiclient/disks.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/vcdcsiclient/disks.go b/pkg/vcdcsiclient/disks.go
+--- a/pkg/vcdcsiclient/disks.go	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
++++ b/pkg/vcdcsiclient/disks.go	(date 1707645953306)
+@@ -9,17 +9,19 @@
+ 	"context"
+ 	"encoding/json"
+ 	"fmt"
+-	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/util"
+-	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/vcdtypes"
+-	"github.com/vmware/cloud-director-named-disk-csi-driver/version"
++	"net/http"
++	"strings"
++	"time"
++
+ 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+ 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_36_0"
+ 	"github.com/vmware/go-vcloud-director/v2/govcd"
+ 	"github.com/vmware/go-vcloud-director/v2/types/v56"
+ 	"k8s.io/klog"
+-	"net/http"
+-	"strings"
+-	"time"
++
++	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/util"
++	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/vcdtypes"
++	"github.com/vmware/cloud-director-named-disk-csi-driver/version"
+ )
+
+ type DiskManager struct {
+@@ -151,6 +153,8 @@
+ 		Xmlns: types.XMLNamespaceVCloud,
+ 		Disk:  d,
+ 	}
++	klog.Infof("Storage profile: %s", storageProfile)
++
+ 	if storageProfile != "" {
+ 		storageReference, err := diskManager.VCDClient.VDC.FindStorageProfileReference(storageProfile)
+ 		if err != nil {
+@@ -161,6 +165,29 @@
+ 		diskParams.Disk.StorageProfile = &types.Reference{
+ 			HREF: storageReference.HREF,
+ 		}
++
++		storageProfileData, err := diskManager.VCDClient.VCDClient.GetStorageProfileByHref(storageReference.HREF)
++		if err != nil {
++			return nil, fmt.Errorf("unable to get storage profile [%s] for disk [%s] by HREF [%s]",
++				storageProfile, diskName, storageReference.HREF)
++		}
++
++		klog.Infof("Storage profile data iops settings [%s]: %v", storageProfileData.Name, storageProfileData.IopsSettings)
++		klog.Infof("Storage profile data iops allocated [%s] %v", storageProfileData.Name, storageProfileData.IopsAllocated)
++
++		if storageProfileData.IopsSettings != nil {
++			if storageProfileData.IopsSettings.Enabled {
++				// If storageProfile Max IOPS per Gb is set
++				iops := storageProfileData.IopsSettings.DiskIopsPerGbMax * d.SizeMb / 1024
++				if iops == 0 {
++					iops = storageProfileData.IopsSettings.DiskIopsMax
++					if iops == 0 {
++						iops = storageProfileData.IopsSettings.DiskIopsDefault
++					}
++				}
++				d.Iops = iops
++			}
++		}
+ 	}
+
+ 	task, err := diskManager.createDisk(diskParams)
+Index: go.sum
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/go.sum b/go.sum
+--- a/go.sum	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
++++ b/go.sum	(date 1707644360350)
+@@ -370,8 +370,8 @@
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+ github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230928223648-8134f65b3f61 h1:5OBXV9Q84GleGRrznPmKsEYKFtbaS8tTFL8d/hsDvy4=
+ github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230928223648-8134f65b3f61/go.mod h1:LXs88jpAH7nny7nQcLaXzjyCvg4Q1JhttSoD9mI5kaQ=
+-github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3 h1:VJolXzgomaRPrgzSr0EduuUtJIJEf5RdoLbktZFQqIc=
+-github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
++github.com/vmware/go-vcloud-director/v2 v2.21.0 h1:zIONrJpM+Fj+rDyXmsRfMAn1sP5WAP87USL0T9GS4DY=
++github.com/vmware/go-vcloud-director/v2 v2.21.0/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+Index: go.mod
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/go.mod b/go.mod
+--- a/go.mod	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
++++ b/go.mod	(date 1707644360350)
+@@ -13,7 +13,7 @@
+ 	github.com/stretchr/testify v1.7.0
+ 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
+ 	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230928223648-8134f65b3f61
+-	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3
++	github.com/vmware/go-vcloud-director/v2 v2.21.0
+ 	golang.org/x/oauth2 v0.4.0 // indirect
+ 	golang.org/x/sys v0.5.0
+ 	google.golang.org/grpc v1.53.0

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/README.md
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/README.md
@@ -1,0 +1,5 @@
+# Patches
+
+## Add IOPS calculation
+
+Added IOPS calculation on disk create in the case of iops limits are enabled. Upstream [patch](https://github.com/vmware/cloud-director-named-disk-csi-driver/pull/241).

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
@@ -45,7 +45,7 @@ shell:
   install:
   - export GO_VERSION=${GOLANG_VERSION}
   - export GOPROXY={{ $.GOPROXY }}
-  - export VERSION="1.6.0"
+  - export VERSION="1.4.1"
   - mkdir -p /src
   - git clone --depth 1 --branch ${VERSION} {{ $.SOURCE_REPO }}/vmware/cloud-director-named-disk-csi-driver.git /src
   - cd /src

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
@@ -1,8 +1,12 @@
+{{- $version103 := "1.4.1" }}
+{{- $version := "1.6.0" }}
+{{- $imageVersion103 := $version103 | replace "." "-" }}
+{{- $imageVersion := $version | replace "." "-" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $imageVersion103 }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $imageVersion103 }}
   add: /src/bin/cloud-director-named-disk-csi-driver
   to: /cloud-director-named-disk-csi-driver
   before: setup
@@ -25,7 +29,33 @@ import:
 docker:
   ENTRYPOINT: ["/cloud-director-named-disk-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $imageVersion }}
+fromImage: common/distroless
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $imageVersion }}
+  add: /src/bin/cloud-director-named-disk-csi-driver
+  to: /cloud-director-named-disk-csi-driver
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  add: /relocate
+  to: /
+  before: install
+  includePaths:
+  - '**/*'
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  add: /lib64
+  to: /lib64
+  before: install
+  includePaths:
+  - 'libresolv*'
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  add: /lib/udev/scsi_id
+  to: /lib/udev/scsi_id
+  before: setup
+docker:
+  ENTRYPOINT: ["/cloud-director-named-disk-csi-driver"]
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $imageVersion103 }}
 from: {{ $.Images.BASE_GOLANG_20_BUSTER }}
 git:
 - add: /{{ $.ModulePath }}/modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -45,13 +75,39 @@ shell:
   install:
   - export GO_VERSION=${GOLANG_VERSION}
   - export GOPROXY={{ $.GOPROXY }}
-  - export VERSION="1.6.0"
   - mkdir -p /src
-  - git clone --depth 1 --branch ${VERSION} {{ $.SOURCE_REPO }}/vmware/cloud-director-named-disk-csi-driver.git /src
+  - git clone --depth 1 --branch {{ $version103 }} {{ $.SOURCE_REPO }}/vmware/cloud-director-named-disk-csi-driver.git /src
   - cd /src
   - find /patches -name '*.patch' -exec git apply {} \;
   - go mod vendor
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version=${VERSION}" -o bin/cloud-director-named-disk-csi-driver cmd/csi/main.go
+  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version={{ $version103 }}" -o bin/cloud-director-named-disk-csi-driver cmd/csi/main.go
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $imageVersion }}
+from: {{ $.Images.BASE_GOLANG_20_BUSTER }}
+git:
+- add: /{{ $.ModulePath }}/modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  beforeInstall:
+  - |
+    apt-get update && apt-get install -y --no-install-recommends \
+      git ca-certificates && apt-get clean -y && \
+      rm -rf /var/cache/debconf/* /var/lib/apt/lists/* /var/log/* /tmp/* /var/tmp/*
+  install:
+  - export GO_VERSION=${GOLANG_VERSION}
+  - export GOPROXY={{ $.GOPROXY }}
+  - mkdir -p /src
+  - git clone --depth 1 --branch {{ $version }} {{ $.SOURCE_REPO }}/vmware/cloud-director-named-disk-csi-driver.git /src
+  - cd /src
+  - find /patches -name '*.patch' -exec git apply {} \;
+  - go mod vendor
+  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version={{ $version }}" -o bin/cloud-director-named-disk-csi-driver cmd/csi/main.go
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 ---

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -318,6 +318,9 @@ properties:
         - apiVersion: deckhouse.io/v1
           kind: VCDCloudProviderDiscoveryData
           zones: ["default"]
+          version:
+            apiVersion: "36.0"
+            vcdVersion: "10.3.3.4"
         properties:
           apiVersion:
             type: string

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -360,19 +360,16 @@ properties:
                 isDefaultStorageProfile:
                   type: boolean
             description: List of storage classes.
-          version:
-            type: object
-            default: {}
-            description: VCD version and API version.
-            properties:
-              vcdVersion:
-                type: string
-                default: "10.3.3.4"
-                minLength: 1
-              apiVersion:
-                type: string
-                default: "36.0"
-                minLength: 1
+          vcdInstallationVersion:
+            type: string
+            description: VCD installation version.
+            default: "10.3.3.4"
+            minLength: 1
+          vcdAPIVersion:
+            type: string
+            description: VCD API version.
+            default: "36.0"
+            minLength: 1
       providerDiscoveryData:
         type: object
         additionalProperties: false
@@ -420,19 +417,16 @@ properties:
                 isDefaultStorageProfile:
                   type: boolean
             description: List of storage classes.
-          version:
-            type: object
-            default: {}
-            description: VCD version and API version.
-            properties:
-              vcdVersion:
-                type: string
-                default: "10.3.3.4"
-                minLength: 1
-              apiVersion:
-                type: string
-                default: "36.0"
-                minLength: 1
+          vcdInstallationVersion:
+            type: string
+            description: VCD installation version.
+            default: "10.3.3.4"
+            minLength: 1
+          vcdAPIVersion:
+            type: string
+            description: VCD API version.
+            default: "36.0"
+            minLength: 1
       storageClasses:
         type: array
         items:

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -309,6 +309,64 @@ properties:
           ca:
             type: string
             x-examples: [ "YjY0ZW5jX3N0cmluZwo=" ]
+      discoveryData:
+        type: object
+        default: {}
+        additionalProperties: false
+        required: [ apiVersion, kind ]
+        x-examples:
+        - apiVersion: deckhouse.io/v1
+          kind: VCDCloudProviderDiscoveryData
+          zones: ["default"]
+        properties:
+          apiVersion:
+            type: string
+            enum: [ deckhouse.io/v1 ]
+          kind:
+            type: string
+            enum: [ VCDCloudProviderDiscoveryData ]
+          sizingPolicies:
+            type: array
+            items:
+              type: string
+              minLength: 1
+            description: List of flavors.
+            uniqueItems: true
+          zones:
+            type: array
+            items:
+              type: string
+          internalNetworks:
+            type: array
+            items:
+              type: string
+              minLength: 1
+            description: List of internal networks.
+            uniqueItems: true
+          storageProfiles:
+            type: array
+            items:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                isEnabled:
+                  type: boolean
+                isDefaultStorageProfile:
+                  type: boolean
+            description: List of storage classes.
+          version:
+            type: object
+            description: VCD version and API version.
+            properties:
+              vcdVersion:
+                type: string
+                minLength: 1
+              apiVersion:
+                type: string
+                minLength: 1
       providerDiscoveryData:
         type: object
         additionalProperties: false
@@ -356,6 +414,16 @@ properties:
                 isDefaultStorageProfile:
                   type: boolean
             description: List of storage classes.
+          version:
+            type: object
+            description: VCD version and API version.
+            properties:
+              vcdVersion:
+                type: string
+                minLength: 1
+              apiVersion:
+                type: string
+                minLength: 1
       storageClasses:
         type: array
         items:
@@ -367,3 +435,4 @@ properties:
               type: string
       defaultStorageClass:
         type: string
+

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -359,6 +359,7 @@ properties:
             description: List of storage classes.
           version:
             type: object
+            default: {}
             description: VCD version and API version.
             properties:
               vcdVersion:
@@ -418,6 +419,7 @@ properties:
             description: List of storage classes.
           version:
             type: object
+            default: {}
             description: VCD version and API version.
             properties:
               vcdVersion:

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -363,9 +363,11 @@ properties:
             properties:
               vcdVersion:
                 type: string
+                default: "10.3.3.4"
                 minLength: 1
               apiVersion:
                 type: string
+                default: "36.0"
                 minLength: 1
       providerDiscoveryData:
         type: object
@@ -420,9 +422,11 @@ properties:
             properties:
               vcdVersion:
                 type: string
+                default: "10.3.3.4"
                 minLength: 1
               apiVersion:
                 type: string
+                default: "36.0"
                 minLength: 1
       storageClasses:
         type: array

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -318,9 +318,8 @@ properties:
         - apiVersion: deckhouse.io/v1
           kind: VCDCloudProviderDiscoveryData
           zones: ["default"]
-          version:
-            apiVersion: "36.0"
-            vcdVersion: "10.3.3.4"
+          vcdInstallationVersion: "10.4.2"
+          vcdAPIVersion: "37.2"
         properties:
           apiVersion:
             type: string

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -61,9 +61,8 @@ const moduleValuesA = `
       discoveryData:
         kind: VCDCloudProviderDiscoveryData
         apiVersion: deckhouse.io/v1
-        version:
-          vcdVersion: "10.4.2"
-          apiVersion: "37.2"
+        vcdInstallationVersion: "10.4.2"
+        vcdAPIVersion: "37.2"
       providerClusterConfiguration:
         apiVersion: deckhouse.io/v1
         kind: VCDClusterConfiguration

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -58,6 +58,12 @@ const moduleValuesA = `
         apiVersion: deckhouse.io/v1
         zones:
         - default
+      discoveryData:
+        kind: VCDCloudProviderDiscoveryData
+        apiVersion: deckhouse.io/v1
+        version:
+          vcdVersion: "10.4.2"
+          apiVersion: "37.2"
       providerClusterConfiguration:
         apiVersion: deckhouse.io/v1
         kind: VCDClusterConfiguration

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
@@ -62,9 +62,9 @@
 
 {{- define "csi_node_image_name" }}
 {{- if semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion }}
-vcdCsiPlugin160
+vcdCsiPlugin
 {{- else }}
-vcdCsiPlugin141
+vcdCsiPluginLegacy
 {{- end }}
 {{- end }}
 

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
@@ -60,13 +60,22 @@
   readOnly: true
 {{- end }}
 
-{{- $csiControllerImage := include "helm_lib_module_image_no_fail" (list . "vcdCsiPlugin") }}
+{{- define "csi_node_image_name" }}
+{{- if semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion }}
+vcdCsiPlugin160
+{{- else }}
+vcdCsiPlugin141
+{{- end }}
+{{- end }}
+
+{{- $csiControllerImage := include "helm_lib_module_image_no_fail" (list . (include "csi_node_image_name" .)) }}
+
 {{- if $csiControllerImage }}
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
   {{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
-  {{- $_ := set $csiControllerConfig "resizerEnabled" true }}
+  {{- $_ := set $csiControllerConfig "resizerEnabled" (semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion) }}
   {{- $_ := set $csiControllerConfig "topologyEnabled" false }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
@@ -61,7 +61,7 @@
 {{- end }}
 
 {{- define "csi_node_image_name" -}}
-{{- if semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion -}}
+{{- if semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.vcdAPIVersion -}}
 vcdCsiPlugin
 {{- else -}}
 vcdCsiPluginLegacy
@@ -75,7 +75,7 @@ vcdCsiPluginLegacy
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
   {{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
-  {{- $_ := set $csiControllerConfig "resizerEnabled" (semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion) }}
+  {{- $_ := set $csiControllerConfig "resizerEnabled" (semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.vcdAPIVersion) }}
   {{- $_ := set $csiControllerConfig "topologyEnabled" false }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
@@ -60,10 +60,10 @@
   readOnly: true
 {{- end }}
 
-{{- define "csi_node_image_name" }}
-{{- if semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion }}
+{{- define "csi_node_image_name" -}}
+{{- if semverCompare ">=37.2" .Values.cloudProviderVcd.internal.discoveryData.version.apiVersion -}}
 vcdCsiPlugin
-{{- else }}
+{{- else -}}
 vcdCsiPluginLegacy
 {{- end }}
 {{- end }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/storage-classes.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/storage-classes.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ $storageClass.name | quote }}
 provisioner: named-disk.csi.cloud-director.vmware.com
 reclaimPolicy: Delete
-allowVolumeExpansion: {{ semverCompare ">=37.2" $.Values.cloudProviderVcd.internal.discoveryData.version.apiVersion }}
+allowVolumeExpansion: {{ semverCompare ">=37.2" $.Values.cloudProviderVcd.internal.discoveryData.vcdAPIVersion }}
 volumeBindingMode: WaitForFirstConsumer
 parameters:
   storageProfile: {{ $storageClass.storageProfile | quote }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/storage-classes.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/storage-classes.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ $storageClass.name | quote }}
 provisioner: named-disk.csi.cloud-director.vmware.com
 reclaimPolicy: Delete
-allowVolumeExpansion: true
+allowVolumeExpansion: {{ semverCompare ">=37.2" $.Values.cloudProviderVcd.internal.discoveryData.version.apiVersion }}
 volumeBindingMode: WaitForFirstConsumer
 parameters:
   storageProfile: {{ $storageClass.storageProfile | quote }}

--- a/go_lib/cloud-data/apis/v1alpha1/vcd_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1alpha1/vcd_cloud_provider_discovery_data.go
@@ -21,10 +21,16 @@ type VCDCloudProviderDiscoveryData struct {
 	SizingPolicies   []string            `json:"sizingPolicies,omitempty"`
 	InternalNetworks []string            `json:"internalNetworks,omitempty"`
 	StorageProfiles  []VCDStorageProfile `json:"storageProfiles,omitempty"`
+	Version          VCDVersion          `json:"version,omitempty"`
 }
 
 type VCDStorageProfile struct {
 	Name                    string `json:"name"`
 	IsEnabled               bool   `json:"isEnabled,omitempty"`
 	IsDefaultStorageProfile bool   `json:"isDefaultStorageProfile,omitempty"`
+}
+
+type VCDVersion struct {
+	VCDVersion string `json:"vcdVersion,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
 }

--- a/go_lib/cloud-data/apis/v1alpha1/vcd_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1alpha1/vcd_cloud_provider_discovery_data.go
@@ -18,19 +18,15 @@ type VCDCloudProviderDiscoveryData struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	Kind       string `json:"kind,omitempty"`
 
-	SizingPolicies   []string            `json:"sizingPolicies,omitempty"`
-	InternalNetworks []string            `json:"internalNetworks,omitempty"`
-	StorageProfiles  []VCDStorageProfile `json:"storageProfiles,omitempty"`
-	Version          VCDVersion          `json:"version,omitempty"`
+	SizingPolicies         []string            `json:"sizingPolicies,omitempty"`
+	InternalNetworks       []string            `json:"internalNetworks,omitempty"`
+	StorageProfiles        []VCDStorageProfile `json:"storageProfiles,omitempty"`
+	VCDAPIVersion          string              `json:"vcdAPIVersion,omitempty"`
+	VCDInstallationVersion string              `json:"vcdInstallationVersion,omitempty"`
 }
 
 type VCDStorageProfile struct {
 	Name                    string `json:"name"`
 	IsEnabled               bool   `json:"isEnabled,omitempty"`
 	IsDefaultStorageProfile bool   `json:"isDefaultStorageProfile,omitempty"`
-}
-
-type VCDVersion struct {
-	VCDVersion string `json:"vcdVersion,omitempty"`
-	APIVersion string `json:"apiVersion,omitempty"`
 }

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -81,7 +81,8 @@ var DefaultImagesDigests = map[string]interface{}{
 		"cloudControllerManager128": "imageHash-cloudProviderVcd-cloudControllerManager128",
 		"cloudControllerManager129": "imageHash-cloudProviderVcd-cloudControllerManager129",
 		"cloudDataDiscoverer":       "imageHash-cloudProviderVcd-cloudDataDiscoverer",
-		"vcdCsiPlugin":              "imageHash-cloudProviderVcd-vcdCsiPlugin",
+		"vcdCsiPlugin141":           "imageHash-cloudProviderVcd-vcdCsiPlugin141",
+		"vcdCsiPlugin160":           "imageHash-cloudProviderVcd-vcdCsiPlugin160",
 	},
 	"cloudProviderVsphere": map[string]interface{}{
 		"cloudControllerManager125": "imageHash-cloudProviderVsphere-cloudControllerManager125",

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -81,8 +81,8 @@ var DefaultImagesDigests = map[string]interface{}{
 		"cloudControllerManager128": "imageHash-cloudProviderVcd-cloudControllerManager128",
 		"cloudControllerManager129": "imageHash-cloudProviderVcd-cloudControllerManager129",
 		"cloudDataDiscoverer":       "imageHash-cloudProviderVcd-cloudDataDiscoverer",
-		"vcdCsiPlugin141":           "imageHash-cloudProviderVcd-vcdCsiPlugin141",
-		"vcdCsiPlugin160":           "imageHash-cloudProviderVcd-vcdCsiPlugin160",
+		"vcdCsiPlugin":              "imageHash-cloudProviderVcd-vcdCsiPlugin",
+		"vcdCsiPluginLegacy":        "imageHash-cloudProviderVcd-vcdCsiPluginLegacy",
 	},
 	"cloudProviderVsphere": map[string]interface{}{
 		"cloudControllerManager125": "imageHash-cloudProviderVsphere-cloudControllerManager125",

--- a/testing/openapi_validation/validators/enum.go
+++ b/testing/openapi_validation/validators/enum.go
@@ -133,6 +133,7 @@ var (
 		},
 		"modules/030-cloud-provider-vcd/openapi/values.yaml": {
 			// ignore internal values
+			"properties.internal.properties.discoveryData.properties.apiVersion",
 			"properties.internal.properties.providerDiscoveryData.properties.apiVersion",
 			"properties.internal.properties.providerClusterConfiguration.properties.apiVersion",
 		},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Support multiple VCD API versions.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We want to support the online volume expansion, which is available since vcd-csi-driver version 1.6.0, but we need to support an older version of the VCD API (< 37.2), which is not compliant with 1.6.0 vcd-csi-driver.

Compatibility matrix: https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/15142e09f9ac1dfcb4860e3f307d28f092b947de/README.md

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: feature
summary: Support multiple VCD API versions.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
