### PR TITLE
[snapshot-controller] Added csi-nfs support in volume snapshot controller,

### DIFF
--- a/modules/045-snapshot-controller/docs/README.md
+++ b/modules/045-snapshot-controller/docs/README.md
@@ -11,4 +11,5 @@ Deckhouse CSI-drivers that support snapshots:
 - [cloud-provider-aws](../030-cloud-provider-aws/)
 - [cloud-provider-azure](../030-cloud-provider-azure/)
 - [cloud-provider-gcp](../030-cloud-provider-gcp/)
-- [sds-replicated-volume](https://deckhouse.io/modules/sds-replicated-volume/stable/).
+- [sds-replicated-volume](https://deckhouse.io/modules/sds-replicated-volume/stable/)
+- [csi-nfs](https://deckhouse.io/modules/csi-nfs/stable/).

--- a/modules/045-snapshot-controller/docs/README_RU.md
+++ b/modules/045-snapshot-controller/docs/README_RU.md
@@ -11,4 +11,5 @@ CSI-драйверы в Deckhouse, которые поддерживают сн�
 - [cloud-provider-aws](../030-cloud-provider-aws/);
 - [cloud-provider-azure](../030-cloud-provider-azure/);
 - [cloud-provider-gcp](../030-cloud-provider-gcp/);
-- [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/).
+- [sds-replicated-volume](https://deckhouse.ru/modules/sds-replicated-volume/stable/)
+- [csi-nfs](https://deckhouse.ru/modules/csi-nfs/stable/).

--- a/modules/045-snapshot-controller/enabled
+++ b/modules/045-snapshot-controller/enabled
@@ -27,6 +27,7 @@ function __main__() {
       cloud-provider-openstack \
       cloud-provider-vsphere \
       sds-replicated-volume \
+      csi-nfs \
     ; do
     if values::array_has global.enabledModules "$module"; then
       enabled=true


### PR DESCRIPTION
## Description

This PR fixes the documentation and scripts in the snapshot-controller module by adding support for `csi-nfs`.

## Why do we need it, and what problem does it solve?
Now snapshot controller have no support for `csi-nfs` module.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Snapshot controller module supports for csi-nfs module

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: snapshot-controller
type: chore
summary: Fix the documentation. Fix the enabled script to add support for `csi-nfs` module.
impact_level: low
```
