### PR TITLE
[bashible] Fix incorrect condition for hostname discovery

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -188,7 +188,7 @@ function main() {
 {{- else }}
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
-{{- if or (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
+{{- if and (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
   export D8_NODE_HOSTNAME=$(hostname -s)
 {{- else }}
   export D8_NODE_HOSTNAME=$(hostname)

--- a/candi/bashible/bootstrap.sh.tpl
+++ b/candi/bashible/bootstrap.sh.tpl
@@ -53,7 +53,7 @@ export no_proxy=${NO_PROXY}
 {{- else }}
 unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 {{- end }}
-{{- if or (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
+{{- if and (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
 export D8_NODE_HOSTNAME=$(hostname -s)
 {{- else }}
 export D8_NODE_HOSTNAME=$(hostname)

--- a/candi/bashible/common-steps/node-group/003_set_short_hostname.sh.tpl
+++ b/candi/bashible/common-steps/node-group/003_set_short_hostname.sh.tpl
@@ -1,4 +1,4 @@
-{{- if or (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
+{{- if and (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic" )}}
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

In the previous PR we have multiple errors with detecting host name. For static nodes we have incorrect condition in template for discovery nodegroup type

## Why do we need it, and what problem does it solve?
For static instances hostname was short (`hostname -s`)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Cloud cluster
![image](https://github.com/deckhouse/deckhouse/assets/30695496/7a462a5d-7fe4-4baa-9635-fa58dc571f4f)
![image](https://github.com/deckhouse/deckhouse/assets/30695496/5bb3838a-50bd-4597-8733-f1da70248dcc)
Static
![image](https://github.com/deckhouse/deckhouse/assets/30695496/a8efea45-5da8-40ca-9083-e5b857a19183)


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: bashible
type: fix
summary: Fix incorrect condition for hostname discovery
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
