### PR TITLE
[chore][docs] Add rewrite rules for kube-proxy module documentation

### DIFF
--- a/docs/documentation/.werf/nginx.conf
+++ b/docs/documentation/.werf/nginx.conf
@@ -73,6 +73,8 @@ http {
         rewrite ^/(.+)/099-ceph-csi$ /$1/031-ceph-csi/ permanent;
         rewrite ^/(.+)/010-priority-class$ /$1/001-priority-class/ permanent;
         rewrite ^/(.+)/010-priority-class(/.*)$ /$1/001-priority-class$2 permanent;
+        rewrite ^/(.+)/021-kube-proxy$ /$1/036-kube-proxy/ permanent;
+        rewrite ^/(.+)/021-kube-proxy(/.*)$ /$1/036-kube-proxy$2 permanent;
         rewrite ^/(.+)/020-deckhouse$ /$1/002-deckhouse/$2 permanent;
         rewrite ^/(.+)/020-deckhouse(/.*)$ /$1/002-deckhouse$2 permanent;
         rewrite ^/(.+)/810-deckhouse-web$ /$1/810-documentation/$2 permanent;


### PR DESCRIPTION
Added permanent rewrite rules to redirect `021-kube-proxy` to `036-kube-proxy` in the nginx configuration for the documentation. This ensures that the URLs for kube-proxy documentation are correctly mapped to their new locations.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add rewrite rules for kube-proxy module documentation.
impact_level: low
```
