### PR TITLE
Try to fix an incorrectly formatted SSH private key before using it

### DIFF
--- a/dhctl/pkg/system/ssh/frontend/agent.go
+++ b/dhctl/pkg/system/ssh/frontend/agent.go
@@ -15,6 +15,7 @@
 package frontend
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -126,6 +127,8 @@ func parsePrivateSSHKey(keyPath string, passphrase []byte) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading key file %q: %w", keyPath, err)
 	}
+
+	keyData = append(bytes.TrimSpace(keyData), '\n')
 
 	var privateKey interface{}
 

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/ssh.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/ssh.go
@@ -38,6 +38,8 @@ func ExecSSHCommand(instanceScope *scope.InstanceScope, command string, stdout i
 		return errors.Wrap(err, "failed to decode private ssh key")
 	}
 
+	privateSSHKey = append(bytes.TrimSpace(privateSSHKey), '\n')
+
 	dir := os.TempDir()
 	sshKey := filepath.Join(dir, "ssh-key")
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Trim all leading and trailing white space and add a newline to the SSH private key before passing the key to the OpenSSH client.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

OpenSSH client has strict requirements for private key files. The private key file must not have any leading or trailing white space. The private key file must also end with a newline character. If the private key file does not meet these requirements, the OpenSSH client will not be able to use the private key file to authenticate with the remote server.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Try to fix an incorrectly formatted SSH private key before using it.
impact_level: default

section: caps
type: fix
summary: Try to fix an incorrectly formatted SSH private key before using it.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
