### PR TITLE
[user-authn] update  getting-started to use the enabled option instead of enable in user-authn

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
@@ -86,7 +86,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -96,7 +96,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
@@ -84,7 +84,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -94,7 +94,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -76,7 +76,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -86,7 +86,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -84,7 +84,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -94,7 +94,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
@@ -84,7 +84,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -94,7 +94,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ee.inc
@@ -83,7 +83,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -93,7 +93,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
@@ -74,7 +74,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -84,7 +84,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ee.inc
@@ -83,7 +83,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -93,7 +93,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.ru.yml.ce.inc
@@ -96,7 +96,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -106,7 +106,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -96,7 +96,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -106,7 +106,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ce.inc
@@ -79,7 +79,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -89,7 +89,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.ru.yml.ee.inc
@@ -77,7 +77,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -87,7 +87,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ce.inc
@@ -69,7 +69,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -79,7 +79,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
+++ b/docs/site/_includes/getting_started/bm/partials/config.yml.ee.inc
@@ -77,7 +77,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -87,7 +87,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
@@ -84,7 +84,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -94,7 +94,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
@@ -74,7 +74,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -84,7 +84,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.ee.inc
@@ -68,7 +68,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -78,7 +78,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
@@ -84,7 +84,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -94,7 +94,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
@@ -74,7 +74,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -84,7 +84,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
@@ -80,7 +80,7 @@ kind: ModuleConfig
 metadata:
   name: user-authn
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     controlPlaneConfigurator:
@@ -90,7 +90,7 @@ spec:
     # [<en>] Enabling access to the API server through Ingress.
     # [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/configuration.html#parameters-publishapi
     publishAPI:
-      enable: true
+      enabled: true
       https:
         mode: Global
         global:


### PR DESCRIPTION
## Description
It provides  getting-started updates for PR: https://github.com/deckhouse/deckhouse/pull/8441

## What is the expected result?
There are getting-starteds with the `enabled` option in the `publishAPI` field.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Update Getting Started to use the `enabled` option instead of `enable` in the user-authn module.
impact_level: low
```
