### PR TITLE
[runtime-audit-engine] Fix path to FalcoAuditRules converter

### DIFF
--- a/ee/modules/650-runtime-audit-engine/docs/FAQ.md
+++ b/ee/modules/650-runtime-audit-engine/docs/FAQ.md
@@ -71,7 +71,7 @@ The script for converting a Falco rules file into a [FalcoAuditRules](cr.html#fa
 
 ```shell
 git clone github.com/deckhouse/deckhouse
-cd deckhouse/ee/modules/650-runtime-audit-engine/hack/fav-converter
+cd deckhouse/ee/modules/650-runtime-audit-engine/hack/far-converter
 go run main.go -input /path/to/falco/rule_example.yaml > ./my-rules-cr.yaml
 ```
 

--- a/ee/modules/650-runtime-audit-engine/docs/FAQ.md
+++ b/ee/modules/650-runtime-audit-engine/docs/FAQ.md
@@ -79,6 +79,9 @@ Example of a script output:
 
 ```yaml
 # /path/to/falco/rule_example.yaml
+- macro: spawned_process
+  condition: (evt.type in (execve, execveat) and evt.dir=<)
+
 - rule: Linux Cgroup Container Escape Vulnerability (CVE-2022-0492)
   desc: "This rule detects an attempt to exploit a container escape vulnerability in the Linux Kernel."
   condition: container.id != "" and proc.name = "unshare" and spawned_process and evt.args contains "mount" and evt.args contains "-o rdma" and evt.args contains "/release_agent"
@@ -94,7 +97,7 @@ kind: FalcoAuditRules
 metadata:
   name: rule-example
 spec:
-    rules:
+  rules:
     - macro:
         name: spawned_process
         condition: (evt.type in (execve, execveat) and evt.dir=<)
@@ -105,6 +108,6 @@ spec:
         output: Detect Linux Cgroup Container Escape Vulnerability (CVE-2022-0492) (user=%user.loginname uid=%user.loginuid command=%proc.cmdline args=%proc.args)
         priority: Critical
         tags:
-        - process
-        - mitre_privilege_escalation
+          - process
+          - mitre_privilege_escalation
 ```

--- a/ee/modules/650-runtime-audit-engine/docs/FAQ_RU.md
+++ b/ee/modules/650-runtime-audit-engine/docs/FAQ_RU.md
@@ -72,7 +72,7 @@ spec:
 
 ```shell
 git clone github.com/deckhouse/deckhouse
-cd deckhouse/ee/modules/650-runtime-audit-engine/hack/fav-converter
+cd deckhouse/ee/modules/650-runtime-audit-engine/hack/far-converter
 go run main.go -input /path/to/falco/rule_example.yaml > ./my-rules-cr.yaml
 ```
 

--- a/ee/modules/650-runtime-audit-engine/docs/FAQ_RU.md
+++ b/ee/modules/650-runtime-audit-engine/docs/FAQ_RU.md
@@ -80,6 +80,9 @@ go run main.go -input /path/to/falco/rule_example.yaml > ./my-rules-cr.yaml
 
 ```yaml
 # /path/to/falco/rule_example.yaml
+- macro: spawned_process
+  condition: (evt.type in (execve, execveat) and evt.dir=<)
+
 - rule: Linux Cgroup Container Escape Vulnerability (CVE-2022-0492)
   desc: "This rule detects an attempt to exploit a container escape vulnerability in the Linux Kernel."
   condition: container.id != "" and proc.name = "unshare" and spawned_process and evt.args contains "mount" and evt.args contains "-o rdma" and evt.args contains "/release_agent"
@@ -95,7 +98,7 @@ kind: FalcoAuditRules
 metadata:
   name: rule-example
 spec:
-    rules:
+  rules:
     - macro:
         name: spawned_process
         condition: (evt.type in (execve, execveat) and evt.dir=<)
@@ -106,6 +109,6 @@ spec:
         output: Detect Linux Cgroup Container Escape Vulnerability (CVE-2022-0492) (user=%user.loginname uid=%user.loginuid command=%proc.cmdline args=%proc.args)
         priority: Critical
         tags:
-        - process
-        - mitre_privilege_escalation
+          - process
+          - mitre_privilege_escalation
 ```

--- a/ee/modules/650-runtime-audit-engine/hack/far-converter/README.md
+++ b/ee/modules/650-runtime-audit-engine/hack/far-converter/README.md
@@ -1,4 +1,4 @@
-## fav-converter
+## far-converter
 
 Converts files with Falco rules to FalcoAuditRules CRD format.
 


### PR DESCRIPTION
## Description
Fix path to FalcoAuditRules converter.
Fix missing macro in example.

## Why do we need it, and what problem does it solve?
Improve documentation.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: chore
summary: Fix path to FalcoAuditRules converter.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
