### PR TITLE
[cloud-provider-vsphere] Fix bootstrap to existing folder

### DIFF
--- a/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/main.tf
@@ -17,7 +17,7 @@ data "vsphere_dynamic" "datacenter_id" {
 
 data "vsphere_folder" "main" {
   count         = var.providerClusterConfiguration.vmFolderExists ? 1 : 0
-  path = format("/%s/vm/%s", var.providerClusterConfiguration.region, var.providerClusterConfiguration.vmFolderPath)
+  path = format("/%s/vm/%s", data.vsphere_tag.region_tag, var.providerClusterConfiguration.vmFolderPath)
 }
 
 resource "vsphere_folder" "main" {

--- a/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/main.tf
@@ -15,11 +15,6 @@ data "vsphere_dynamic" "datacenter_id" {
   type       = "Datacenter"
 }
 
-data "vsphere_folder" "main" {
-  count         = var.providerClusterConfiguration.vmFolderExists ? 1 : 0
-  path = format("/%s/vm/%s", data.vsphere_tag.region_tag, var.providerClusterConfiguration.vmFolderPath)
-}
-
 resource "vsphere_folder" "main" {
   count         = var.providerClusterConfiguration.vmFolderExists ? 0 : 1
   path          = var.providerClusterConfiguration.vmFolderPath

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -366,8 +366,6 @@ apiVersions:
         default: false
         description: |
           Set the value to `true` if the path specified in `vmFolderPath` exists. Installing more than one cluster in a folder is not possible.
-        x-examples:
-          - "dev/test"
         x-unsafe: true
       region:
         type: string


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed bootstrap to existing folder.
Tested in l* and selectel.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Fix bootstrap to existing folder.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
