### PR TITLE
[kube-dns] fix cluster-domain-alias webhook

### DIFF
--- a/modules/042-kube-dns/webhooks/validating/cluster-domain-alias
+++ b/modules/042-kube-dns/webhooks/validating/cluster-domain-alias
@@ -50,7 +50,7 @@ function __main__() {
   mcName=$(context::jq -r '.review.request.object.metadata.name')
   if [[ "$mcName" == "kube-dns" ]]; then
     publicDomainTemplate=$(context::jq -r '.snapshots.["global-module-config"][].filterResult["publicDomainTemplate"]' | sed s/%s.//)
-    clusterDomainAliases=$(context::jq -r '.review.request.object.spec.settings.clusterDomainAliases[]')
+    clusterDomainAliases=$(context::jq -r '.review.request.object.spec.settings.clusterDomainAliases[]?')
 
     for alias in $clusterDomainAliases; do
       if [[ $publicDomainTemplate == $alias ]]; then


### PR DESCRIPTION
## Description

Fix empty array jq error in domain alias validation webhook.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fixes #8484 

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Why do we need it in the patch release (if we do)?

Restores the ability to edit mc of kube-dns module.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

```
root@dev2-master-0:~# kubectl  get mc kube-dns  -o yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  creationTimestamp: "2024-05-27T14:07:06Z"
  generation: 5
  name: kube-dns
  resourceVersion: "4260293"
  uid: 6ed0d9de-fd1a-4807-8285-8ba51d98e08e
spec:
  enabled: true
status:
  message: ""
  version: "1"

root@dev2-master-0:~# kubectl patch --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "cluster-resources", "meta.helm.sh/release-namespace": "cluster-resources"}}}' ModuleConfig/kube-dns
moduleconfig.deckhouse.io/kube-dns patched
root@dev2-master-0:~#
```

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: fix
summary: Fix empty array error in domain alias validation webhook.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
