### PR TITLE
[dhctl] Use the `errors.As` function to handle errors

### DIFF
--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"path"
@@ -149,7 +150,8 @@ func DefineTestUploadExecCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 		var stdout []byte
 		stdout, err = cmd.Execute()
 		if err != nil {
-			if ee, ok := err.(*exec.ExitError); ok {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
 				return fmt.Errorf("script '%s' error: %w stderr: %s", ScriptPath, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("script '%s' error: %w", ScriptPath, err)
@@ -187,7 +189,8 @@ func DefineTestBundle(parent *kingpin.CmdClause) *kingpin.CmdClause {
 		bundleDir := path.Base(BundleDir)
 		stdout, err := cmd.ExecuteBundle(parentDir, bundleDir)
 		if err != nil {
-			if ee, ok := err.(*exec.ExitError); ok {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
 				return fmt.Errorf("bundle '%s' error: %w\nstderr: %s\n", bundleDir, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("bundle '%s' error: %w", bundleDir, err)

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -125,7 +125,8 @@ func ExecuteBashibleBundle(sshClient *ssh.Client, tmpDir string) error {
 
 		_, err := bundleCmd.ExecuteBundle(parentDir, bundleDir)
 		if err != nil {
-			if ee, ok := err.(*exec.ExitError); ok {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
 				return fmt.Errorf("bundle '%s' error: %v\nstderr: %s", bundleDir, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("bundle '%s' error: %v", bundleDir, err)
@@ -369,7 +370,8 @@ func DetermineBundleName(sshClient *ssh.Client) (string, error) {
 			detectCmd := sshClient.UploadScript(file)
 			stdout, err := detectCmd.Execute()
 			if err != nil {
-				if ee, ok := err.(*exec.ExitError); ok {
+				var ee *exec.ExitError
+				if errors.As(err, &ee) {
 					return fmt.Errorf("detect_bundle.sh: %v, %s", err, string(ee.Stderr))
 				}
 				return fmt.Errorf("detect_bundle.sh: %v", err)

--- a/dhctl/pkg/preflight/domain.go
+++ b/dhctl/pkg/preflight/domain.go
@@ -16,6 +16,7 @@ package preflight
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -42,7 +43,8 @@ func (pc *Checker) CheckLocalhostDomain() error {
 	out, err := scriptCmd.Execute()
 	if err != nil {
 		log.ErrorLn(strings.Trim(string(out), "\n"))
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			return fmt.Errorf("Localhost domain resolving check failed: %w, %s", err, string(ee.Stderr))
 		}
 		return fmt.Errorf("Could not execute a script to check for localhost domain resolution: %w", err)

--- a/dhctl/pkg/preflight/ports.go
+++ b/dhctl/pkg/preflight/ports.go
@@ -15,6 +15,7 @@
 package preflight
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -41,7 +42,8 @@ func (pc *Checker) CheckAvailabilityPorts() error {
 	out, err := scriptCmd.Execute()
 	if err != nil {
 		log.ErrorLn(strings.Trim(string(out), "\n"))
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			return fmt.Errorf("Required ports check failed: %w, %s", err, string(ee.Stderr))
 		}
 		return fmt.Errorf("Could not execute a script to check if all necessary ports are open on the node: %w", err)

--- a/dhctl/pkg/terraform/pipeline.go
+++ b/dhctl/pkg/terraform/pipeline.go
@@ -99,7 +99,7 @@ func CheckPipeline(r RunnerInterface, name string, opts PlanOptions) (int, Terra
 		rawPlan, err := r.GetTerraformExecutor().Output("show", "-json", r.GetPlanPath())
 		if err != nil {
 			var ee *exec.ExitError
-			if ok := errors.As(err, &ee); ok {
+			if errors.As(err, &ee) {
 				err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 			}
 			return fmt.Errorf("can't get terraform plan for %q\n%v", r.GetPlanPath(), err)
@@ -182,7 +182,7 @@ func CheckBaseInfrastructurePipeline(r RunnerInterface, name string) (int, Terra
 		rawPlan, err := r.GetTerraformExecutor().Output("show", "-json", r.GetPlanPath())
 		if err != nil {
 			var ee *exec.ExitError
-			if ok := errors.As(err, &ee); ok {
+			if errors.As(err, &ee) {
 				err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 			}
 			return fmt.Errorf("can't get terraform plan for %q\n%v", r.GetPlanPath(), err)

--- a/dhctl/pkg/terraform/runner.go
+++ b/dhctl/pkg/terraform/runner.go
@@ -488,7 +488,8 @@ func (r *Runner) GetTerraformOutput(output string) ([]byte, error) {
 
 	result, err := r.terraformExecutor.Output(args...)
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 		}
 		return nil, fmt.Errorf("can't get terraform output for %q\n%v", output, err)
@@ -653,7 +654,7 @@ func (r *Runner) getPlanDestructiveChanges(planFile string) (*PlanDestructiveCha
 	result, err := r.terraformExecutor.Output(args...)
 	if err != nil {
 		var ee *exec.ExitError
-		if ok := errors.As(err, &ee); ok {
+		if errors.As(err, &ee) {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 		}
 		return nil, fmt.Errorf("can't get terraform plan for %q\n%v", planFile, err)

--- a/dhctl/pkg/util/tomb/tomb_test.go
+++ b/dhctl/pkg/util/tomb/tomb_test.go
@@ -16,6 +16,7 @@ package tomb
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -69,7 +70,8 @@ func runAction(p *testActionParams) *testRunResult {
 	err = cmd.Wait()
 
 	exitCode := 0
-	if exitError, ok := err.(*exec.ExitError); ok {
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
 		exitCode = exitError.ExitCode()
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Use the `errors.As` function to handle errors.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

An error can be wrapped in another error, and we need to unwrap it to get the original error. The `errors.As` function helps us to do that. It unwraps the error and checks if it is of the specified type.

Close #8356.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix incorrect error handling.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
