### PR TITLE
[testing] Fix documentation linter

### DIFF
--- a/tools/validation/copyright.go
+++ b/tools/validation/copyright.go
@@ -37,7 +37,7 @@ var CELicenseRe = regexp.MustCompile(`(?s)[/#{!-]*(\s)*Copyright 202[1-9] Flant 
 [/#{!-]*(\s)*limitations under the License.[-!}\n]*`)
 
 var fileToCheckRe = regexp.MustCompile(`\.go$|/[^/.]+$|\.sh$|\.lua$|\.py$|^\.github/(scripts|workflows|workflow_templates)/.+\.(js|yml|yaml|sh)$`)
-var fileToSkipRe = regexp.MustCompile(`geohash.lua$|\.github/CODEOWNERS|Dockerfile$|Makefile$|/docs/documentation/|/docs/site/|bashrc$|inputrc$|modules_menu_skip$|LICENSE$`)
+var fileToSkipRe = regexp.MustCompile(`geohash.lua$|\.github/CODEOWNERS|Dockerfile$|Makefile$|/docs/documentation/|/docs/site/|bashrc$|inputrc$|modules_menu_skip$|LICENSE$|tools/spelling/.+`)
 
 func RunCopyrightValidation(info *DiffInfo) (exitCode int) {
 	fmt.Printf("Run 'copyright' validation ...\n")

--- a/tools/validation/no_cyrillic.go
+++ b/tools/validation/no_cyrillic.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-var skipDocRe = regexp.MustCompile(`doc-ru-.+\.y[a]?ml$|_RU\.md$|_ru\.html$|docs/site/_.+|docs/documentation/_.+`)
+var skipDocRe = regexp.MustCompile(`doc-ru-.+\.y[a]?ml$|_RU\.md$|_ru\.html$|docs/site/_.+|docs/documentation/_.+|tools/spelling/.+`)
 var skipI18NRe = regexp.MustCompile(`/i18n/`)
 var skipSelfRe = regexp.MustCompile(`no_cyrillic(_test)?.go$`)
 


### PR DESCRIPTION
## Description

Update validation rules to exclude files in tools/spelling/

- Modified `fileToSkipRe` in `copyright.go` to skip files in `tools/spelling/`.
- Updated `skipDocRe` in `no_cyrillic.go` to skip files in `tools/spelling/`.

These changes ensure that validation checks do not process files in the `tools/spelling/` directory.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Fix documentation linter
impact_level: low
```
