### PR TITLE
[dhctl] chore(dhctl-for-commander): add deckhouse_uuid into commander/attach scan result

### DIFF
--- a/dhctl/pkg/operations/commander/attach/attach_result.go
+++ b/dhctl/pkg/operations/commander/attach/attach_result.go
@@ -30,6 +30,7 @@ type ScanResult struct {
 	ProviderSpecificClusterConfiguration string `json:"provider_specific_cluster_configuration"`
 	SSHPrivateKey                        string `json:"ssh_private_key"`
 	SSHPublicKey                         string `json:"ssh_public_key"`
+	DeckhouseUUID                        string `json:"deckhouse_uuid"`
 }
 
 type AttachResult struct {

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -191,6 +191,7 @@ func (i *Attacher) scan(
 		if err != nil {
 			return fmt.Errorf("unable to get cluster uuid: %w", err)
 		}
+		res.DeckhouseUUID = metaConfig.UUID
 
 		if err = stateCache.Save("uuid", []byte(metaConfig.UUID)); err != nil {
 			return fmt.Errorf("unable to save cluster uuid to cache: %w", err)

--- a/dhctl/pkg/server/rpc/dhctl/dhctl.go
+++ b/dhctl/pkg/server/rpc/dhctl/dhctl.go
@@ -75,7 +75,7 @@ func operationCtx(server grpc.ServerStream) context.Context {
 	case pb.DHCTL_AbortServer:
 		operation = "abort"
 	case pb.DHCTL_AttachCommanderServer:
-		operation = "import"
+		operation = "commander/attach"
 	default:
 		operation = "unknown"
 	}


### PR DESCRIPTION
Deckhouse uuid needed by the commander to perform uniqueness check of clusters.

