### PR TITLE
[documentation] Fix search and access to assets

### DIFF
--- a/modules/810-documentation/templates/configmap.yaml
+++ b/modules/810-documentation/templates/configmap.yaml
@@ -90,8 +90,12 @@ data:
             return 200;
         }
 
-        location ~* ^(/(ru|en))?/(presentations|assets|images|js|css)/(.+)$ {
-            try_files /platform/$3/$4 /platform/$3/$4/ =404;
+        location /config {
+            try_files $uri $uri/ =404;
+        }
+
+        location ~* ^(/(ru|en))?/(platform/)?(presentations|assets|images|js|css)/(.+)$ {
+            try_files /platform/$4/$5 /platform/$4/$5/ =404;
         }
 
         location ~* ^/(ru|en)/modules/([^0-9]+[^/]+)/(.*)$ {


### PR DESCRIPTION
## Description

- Fix the badge on the top of cluster documentation pages.
- Fix search in the cluster documentation.

## Why do we need it, and what problem does it solve?
- Search in the cluster documentation doesn't work because of an inaccessible URL.
- Version and revision badge on the top of cluster documentation pages is not displayed.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: documentation
type: fix
summary: Fix search. Fix version badge.
impact_level: default
```