### PR TITLE
[deckhouse] fix the number of replicas if cluster isn't bootstrapped and add extra labels

### DIFF
--- a/modules/002-deckhouse/hooks/set-deckhouse-ready-nodes.go
+++ b/modules/002-deckhouse/hooks/set-deckhouse-ready-nodes.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/kubectl/pkg/util/podutils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+const deckhouseReadyLabel = "node.deckhouse.io/deckhouse-ready"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Settings:     &go_hook.HookConfigSettings{},
+	Queue:        "/modules/deckhouse/set-deckhouse-ready-nodes",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "control-plane-pods",
+			ApiVersion:                   "v1",
+			Kind:                         "Pod",
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			ExecuteHookOnEvents:          pointer.Bool(true),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"tier":      "control-plane",
+					"component": "kube-apiserver",
+				},
+			},
+			FilterFunc: applyPodFilter,
+		},
+		{
+			Name:                         "control-plane-nodes",
+			ApiVersion:                   "v1",
+			Kind:                         "Node",
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			ExecuteHookOnEvents:          pointer.Bool(true),
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-role.kubernetes.io/control-plane": "",
+				},
+			},
+			FilterFunc: applyNodeFilter,
+		},
+	},
+}, setDeckhouseReadyNodes)
+
+type statusPod struct {
+	Name    string
+	Node    string
+	IsReady bool
+}
+
+type statusNode struct {
+	Name    string
+	IsReady bool
+}
+
+func applyNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var node corev1.Node
+
+	err := sdk.FromUnstructured(obj, &node)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
+	}
+
+	var isReady bool
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+			isReady = true
+			break
+		}
+	}
+
+	return statusNode{
+		Name:    node.Name,
+		IsReady: isReady,
+	}, nil
+}
+
+func applyPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod corev1.Pod
+
+	err := sdk.FromUnstructured(obj, &pod)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
+	}
+
+	return statusPod{
+		Name:    pod.Name,
+		Node:    pod.Spec.NodeName,
+		IsReady: podutils.IsPodReady(&pod),
+	}, nil
+}
+
+func setDeckhouseReadyNodes(input *go_hook.HookInput) (err error) {
+	pods := input.Snapshots["control-plane-pods"]
+	if len(pods) == 0 {
+		return nil
+	}
+
+	nodes := input.Snapshots["control-plane-nodes"]
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	podPerNode := make(map[string]bool, len(pods))
+	for _, pod := range pods {
+		p := pod.(statusPod)
+		podPerNode[p.Node] = p.IsReady
+	}
+
+	deckhouseReadyNodes := make(map[string]bool, 0)
+	for _, node := range nodes {
+		n := node.(statusNode)
+		if !n.IsReady {
+			deckhouseReadyNodes[n.Name] = false
+			continue
+		}
+
+		deckhouseReadyNodes[n.Name] = podPerNode[n.Name]
+	}
+
+	for nodeName, nodeStatus := range deckhouseReadyNodes {
+		input.LogEntry.Infof("Labeling %s node with %s=%v label", nodeName, deckhouseReadyLabel, nodeStatus)
+		metadata := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					deckhouseReadyLabel: strconv.FormatBool(nodeStatus),
+				},
+			},
+		}
+		input.PatchCollector.MergePatch(metadata, "v1", "Node", "", nodeName)
+	}
+
+	return nil
+}

--- a/modules/002-deckhouse/hooks/set_deckhouse_ready_nodes.go
+++ b/modules/002-deckhouse/hooks/set_deckhouse_ready_nodes.go
@@ -23,10 +23,10 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	"k8s.io/kubectl/pkg/util/podutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kubectl/pkg/util/podutils"
 	"k8s.io/utils/pointer"
 )
 
@@ -122,10 +122,6 @@ func applyPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error
 
 func setDeckhouseReadyNodes(input *go_hook.HookInput) (err error) {
 	pods := input.Snapshots["control-plane-pods"]
-	if len(pods) == 0 {
-		return nil
-	}
-
 	nodes := input.Snapshots["control-plane-nodes"]
 	if len(nodes) == 0 {
 		return nil

--- a/modules/002-deckhouse/hooks/set_deckhouse_ready_nodes_test.go
+++ b/modules/002-deckhouse/hooks/set_deckhouse_ready_nodes_test.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("deckhouse :: hooks :: safe_deckhouse_ready_nodes ::", func() {
+	f := HookExecutionConfigInit("", "")
+
+	Context("One master - one ready kube-apiserver", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+  name: kube-apiserver-master-0
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+  nodeName: master-0
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2023-03-24T15:02:56Z"
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-0
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-0
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Shouldn put label to the master node", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			master := f.KubernetesResource("Node", "", "master-0")
+			Expect(master.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("true"))
+			worker := f.KubernetesResource("Node", "", "worker-0")
+			Expect(worker.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("One master - one not-ready kube-apiserver", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+  name: kube-apiserver-master-0
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+  nodeName: master-0
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2023-03-24T15:02:56Z"
+    status: "False"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-0
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-0
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Should attach false label to the master node", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			master := f.KubernetesResource("Node", "", "master-0")
+			Expect(master.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("false"))
+			worker := f.KubernetesResource("Node", "", "worker-0")
+			Expect(worker.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("One not-ready master - one ready kube-apiserver", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+  name: kube-apiserver-master-0
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+  nodeName: master-0
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2023-03-24T15:02:56Z"
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-0
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "False"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-0
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Should attach false label to the master node", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			master := f.KubernetesResource("Node", "", "master-0")
+			Expect(master.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("false"))
+			worker := f.KubernetesResource("Node", "", "worker-0")
+			Expect(worker.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Two ready masters - one ready kube-apiserver", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    tier: control-plane
+    component: kube-apiserver
+  name: kube-apiserver-master-1
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+  nodeName: master-1
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2023-03-24T15:02:56Z"
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-0
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-1
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-0
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Should attach false label to the master-0 node and true to the master-1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			master0 := f.KubernetesResource("Node", "", "master-0")
+			Expect(master0.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("false"))
+			master1 := f.KubernetesResource("Node", "", "master-1")
+			Expect(master1.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("true"))
+			worker := f.KubernetesResource("Node", "", "worker-0")
+			Expect(worker.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Two ready masters - no kube-apiserver", func() {
+		BeforeEach(func() {
+			st := f.KubeStateSet(`
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-0
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-1
+  labels:
+    node-role.kubernetes.io/control-plane: ""
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-0
+status:
+  conditions:
+  - lastHeartbeatTime: "2024-05-30T10:49:14Z"
+    lastTransitionTime: "2024-05-29T12:56:08Z"
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+`)
+
+			f.BindingContexts.Set(st)
+			f.RunHook()
+		})
+
+		It("Should attach false label to the master-0 node and true to the master-1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			master0 := f.KubernetesResource("Node", "", "master-0")
+			Expect(master0.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("false"))
+			master1 := f.KubernetesResource("Node", "", "master-1")
+			Expect(master1.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").String()).To(Equal("false"))
+			worker := f.KubernetesResource("Node", "", "worker-0")
+			Expect(worker.Field("metadata.labels.node\\.deckhouse\\.io/deckhouse-ready").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -72,8 +72,17 @@ spec:
       annotations:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
     spec:
-{{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                - key: node.deckhouse.io/deckhouse-ready
+                  operator: In
+                  values:
+                  - "true"
+              weight: 100
+{{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -56,7 +56,11 @@ metadata:
     core.deckhouse.io/edition: {{ .Values.global.deckhouseEdition | quote }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
 spec:
+{{- if .Values.global.clusterIsBootstrapped }}
   {{- include "helm_lib_deployment_on_master_custom_strategy_and_replicas_for_ha" (list . (dict "strategy" "Recreate")) | nindent 2 }}
+{{- else }}
+  replicas: 1
+{{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -68,7 +72,7 @@ spec:
       annotations:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
     spec:
-{{- if (include "helm_lib_ha_enabled" .) }}
+{{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Description
- Throws in a conditional for the replicas number of the Deckhouse deployment to set it to 1 if the cluster isn't bootstrapped yet.
- Adds a hook to to check if a master node has a kube-apiserver pod running and ready and label the node with `node.deckhouse.io/deckhouse-ready: true/false` label.
- Adds nodeAfinity of preferredDuringScheduling type to the deckhouse deployment so that it would prefer to be scheduled on the masters with the `node.deckhouse.io/deckhouse-ready: true` labels. 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Without checking whether the cluster is bootstrapped or not it's not safe to set the Deckhouse deployment replicas to something bigger than 1 as it may end up having multiple Deckhouse instances, running simulateneously, in the cluster.
Also, extra labels on master nodes and the dechkouse deployment's nodeAffinity settings should help circumvent in a situation when not all master nodes are ready to run a deckhouse pod.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It's a moderate bug affecting bootstrapping new multi-master clusters.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
If a cluster isn't bootstrapped, it must have Deckhouse running in 1 replica and HA mode must be disabled.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix the number of deckhouse replicas for not bootstrapped clusters.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
