### PR TITLE
[candi] redos 8.0 support

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -21,7 +21,7 @@ osDistributions:
   ubuntu:
     name: Ubuntu
     url: https://ubuntu.com/download/server
-  '_redos'::
+  '_redos':
     name: 'РЕД ОС'
     url: https://redos.red-soft.ru/product/server/
     ru_support: 'true'

--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -21,7 +21,7 @@ osDistributions:
   ubuntu:
     name: Ubuntu
     url: https://ubuntu.com/download/server
-  redos:
+  '_redos'::
     name: 'РЕД ОС'
     url: https://redos.red-soft.ru/product/server/
     ru_support: 'true'

--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -21,7 +21,7 @@ osDistributions:
   ubuntu:
     name: Ubuntu
     url: https://ubuntu.com/download/server
-  '_redos':
+  redos:
     name: 'РЕД ОС'
     url: https://redos.red-soft.ru/product/server/
     ru_support: 'true'

--- a/docs/documentation/_data/version_map_addition.yml
+++ b/docs/documentation/_data/version_map_addition.yml
@@ -6,7 +6,7 @@
   rocky:
     '8':
     '9':
-  redos:
+  '_redos':
     '7.3':
     '8.0':
   altlinux:

--- a/docs/documentation/_data/version_map_addition.yml
+++ b/docs/documentation/_data/version_map_addition.yml
@@ -6,8 +6,9 @@
   rocky:
     '8':
     '9':
-  '_redos':
+  redos:
     '7.3':
+    '8.0':
   altlinux:
     'p10':
     '10.0':

--- a/ee/be/candi/bashible/bundles/redos/all/003_install_mandatory_packages.sh.tpl
+++ b/ee/be/candi/bashible/bundles/redos/all/003_install_mandatory_packages.sh.tpl
@@ -6,6 +6,9 @@ KUBERNETES_DEPENDENCIES="conntrack-tools ebtables ethtool iproute iptables socat
 if bb-is-redos-version? 7.3; then
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} policycoreutils-python"
 fi
+if bb-is-redos-version? 8.0; then
+  SYSTEM_PACKAGES="${SYSTEM_PACKAGES} policycoreutils-python-utils"
+fi
 
 bb-var BB_YUM_INSTALL_EXTRA_ARGS "--allowerasing"
 

--- a/ee/be/candi/bashible/detect_bundle.sh
+++ b/ee/be/candi/bashible/detect_bundle.sh
@@ -28,7 +28,7 @@ case "$ID" in
     name_is_not_supported
   ;;
   redos)
-    case "$VERSION_ID" in 7|7.*)
+    case "$VERSION_ID" in 7|7.*|8|8.*)
       echo "redos" && exit 0 ;;
     esac
     name_is_not_supported

--- a/ee/be/candi/version_map.yml
+++ b/ee/be/candi/version_map.yml
@@ -1,6 +1,7 @@
 bashible:
   redos: &redos
     '7.3':
+    '8.0':
   astra: &astra
     '1.7':
   altlinux:

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -49,6 +49,6 @@ masterNodeGroup:
   instanceClass:
     rootDiskSize: 20
     flavorName: m1.large
-    imageName: "redos-STD-MINIMAL-7.3.4"
+    imageName: "redos-STD-MINIMAL-8.0.0 "
   volumeTypeMap:
     ru-3a: "fast.ru-3a"

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -47,7 +47,7 @@ provider:
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    rootDiskSize: 20
+    rootDiskSize: 30
     flavorName: m1.large
     imageName: "redos-STD-MINIMAL-8.0.0 "
   volumeTypeMap:

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -49,6 +49,6 @@ masterNodeGroup:
   instanceClass:
     rootDiskSize: 30
     flavorName: m1.large
-    imageName: "redos-STD-MINIMAL-8.0.0 "
+    imageName: "redos-STD-MINIMAL-8.0.0"
   volumeTypeMap:
     ru-3a: "fast.ru-3a"

--- a/testing/cloud_layouts/OpenStack/Standard/resources.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/resources.yaml
@@ -26,7 +26,7 @@ kind: OpenStackInstanceClass
 metadata:
   name: system
 spec:
-  rootDiskSize: 20
+  rootDiskSize: 30
   flavorName: m1.large
   imageName: "debian-12-genericcloud-amd64"
 ---

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -128,7 +128,7 @@ data "openstack_images_image_v2" "redos_image" {
 
 resource "openstack_blockstorage_volume_v3" "master" {
   name                 = "candi-${PREFIX}-master-0"
-  size                 = "20"
+  size                 = "30"
   image_id             = data.openstack_images_image_v2.astra_image.id
   volume_type          = var.volume_type
   availability_zone    = var.az_zone
@@ -162,7 +162,7 @@ resource "openstack_compute_instance_v2" "master" {
 
 resource "openstack_blockstorage_volume_v3" "bastion" {
   name                 = "candi-${PREFIX}-bastion-0"
-  size                 = "20"
+  size                 = "30"
   image_id             = data.openstack_images_image_v2.astra_image.id
   volume_type          = var.volume_type
   availability_zone    = var.az_zone
@@ -193,7 +193,7 @@ resource "openstack_compute_instance_v2" "bastion" {
 
 resource "openstack_blockstorage_volume_v3" "system" {
   name                 = "candi-${PREFIX}-system-0"
-  size                 = "20"
+  size                 = "30"
   image_id             = data.openstack_images_image_v2.alt_image.id
   volume_type          = var.volume_type
   availability_zone    = var.az_zone
@@ -226,7 +226,7 @@ resource "openstack_compute_instance_v2" "system" {
 
 resource "openstack_blockstorage_volume_v3" "worker" {
   name                 = "candi-${PREFIX}-worker-0"
-  size                 = "20"
+  size                 = "30"
   image_id             = data.openstack_images_image_v2.redos_image.id
   volume_type          = var.volume_type
   availability_zone    = var.az_zone

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -123,7 +123,7 @@ data "openstack_images_image_v2" "alt_image" {
 data "openstack_images_image_v2" "redos_image" {
   most_recent = true
   visibility  = "shared"
-  name        = "redos-STD-MINIMAL-8.0.0 "
+  name        = "redos-STD-MINIMAL-8.0.0"
 }
 
 resource "openstack_blockstorage_volume_v3" "master" {

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -123,7 +123,7 @@ data "openstack_images_image_v2" "alt_image" {
 data "openstack_images_image_v2" "redos_image" {
   most_recent = true
   visibility  = "shared"
-  name        = "redos-STD-MINIMAL-7.3.4"
+  name        = "redos-STD-MINIMAL-8.0.0 "
 }
 
 resource "openstack_blockstorage_volume_v3" "master" {

--- a/testing/cloud_layouts/Static/redos-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/redos-instance-bootstrap.sh
@@ -17,6 +17,6 @@
 cat > /usr/local/bin/is-instance-bootstrapped << EOF
 #!/bin/bash
 set -Eeo pipefail
-cat /etc/redos-release | grep -q "MUROM (7.3.4)"
+cat /etc/redos-release | grep -q "RED OS release (8.0) MINIMAL"
 EOF
 chmod +x /usr/local/bin/is-instance-bootstrapped

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -28,7 +28,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: 'fd8b8v0jaap618cordiu' #RED OS 8.0.0
+    imageID: 'fd86ciomm61qk3o1rta5' #RED OS 8.0.0
     diskSizeGB: 50
     externalIPAddresses:
     - Auto

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -28,7 +28,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: 'fd8556guhfdsb6aklllo' #RED OS 8.0.0
+    imageID: 'fd8b8v0jaap618cordiu' #RED OS 8.0.0
     diskSizeGB: 50
     externalIPAddresses:
     - Auto

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -28,7 +28,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: 'fd8rfb93hae3rsv7a5a1' #RED OS MUROM (7.3.4)
+    imageID: 'fd8556guhfdsb6aklllo' #RED OS 8.0.0
     diskSizeGB: 50
     externalIPAddresses:
     - Auto

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/resources.yaml
@@ -31,7 +31,7 @@ metadata:
   name: system
 spec:
   cores: 2
-  diskSizeGB: 20
+  diskSizeGB: 30
   diskType: network-ssd
   memory: 8192
 ---


### PR DESCRIPTION
## Description
Added support for Red OS 8.0

## Why do we need it, and what problem does it solve?
This update ensures compatibility with the latest version of Red OS

## Why do we need it in the patch release (if we do)?
Not necessarily.

## What is the expected result?
The system should now correctly detect and install necessary packages for Red OS 8.0. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: feature
summary: Added support for Red OS 8.0.
impact: Support for Red OS 8.0 ensures compatibility with the latest OS version, providing updated packages and configurations.
impact_level: default
```