### PR TITLE
[registry-packages-proxy] Don't replace the system CA certificates if a custom CA is used

### DIFF
--- a/candi/bashible/bashbooster/50_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_registrypackages.sh
@@ -62,16 +62,20 @@ bb-package-fetch-blob() {
 import random
 import ssl
 try:
-    from urllib.request import urlopen, Request
+    from urllib.request import urlopen, Request, HTTPError
 except ImportError as e:
-    from urllib2 import urlopen, Request
+    from urllib2 import urlopen, Request, HTTPError
 # Choose a random endpoint to increase fault tolerance and reduce load on a single endpoint.
 endpoints = "${PACKAGES_PROXY_ADDRESSES}".split(",")
 endpoint = random.choice(endpoints)
 ssl._create_default_https_context = ssl._create_unverified_context
 url = 'https://{}/package?digest=$1&repository=${REPOSITORY}'.format(endpoint)
 request = Request(url, headers={'Authorization': 'Bearer ${PACKAGES_PROXY_TOKEN}'})
-response = urlopen(request, timeout=300)
+try:
+    response = urlopen(request, timeout=300)
+except HTTPError as e:
+    print("HTTP Error {}: {}".format(e.getcode(), e.read()[:255]))
+    raise SystemExit
 with open('$2', 'wb') as f:
     f.write(response.read())
 EOF

--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -30,8 +30,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-type DefaultClient struct {
-}
+type DefaultClient struct{}
 
 func (c *DefaultClient) GetPackage(ctx context.Context, config *ClientConfig, digest string) (int64, io.ReadCloser, error) {
 	repository, err := name.NewRepository(config.Repository)
@@ -42,7 +41,10 @@ func (c *DefaultClient) GetPackage(ctx context.Context, config *ClientConfig, di
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if config.CA != "" {
-		certPool := x509.NewCertPool()
+		certPool, _ := x509.SystemCertPool()
+		if certPool == nil {
+			certPool = x509.NewCertPool()
+		}
 		certPool.AppendCertsFromPEM([]byte(config.CA))
 
 		httpTransport.TLSClientConfig = &tls.Config{

--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -41,10 +42,11 @@ func (c *DefaultClient) GetPackage(ctx context.Context, config *ClientConfig, di
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if config.CA != "" {
-		certPool, _ := x509.SystemCertPool()
-		if certPool == nil {
-			certPool = x509.NewCertPool()
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to load system cert pool: %w", err)
 		}
+
 		certPool.AppendCertsFromPEM([]byte(config.CA))
 
 		httpTransport.TLSClientConfig = &tls.Config{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Don't replace the system CA certificates if a custom CA is used.
- Print response body in case of http error (instead of default `urllib.error.HTTPError: HTTP Error 500: Internal Server Error`)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We want to add CAs to the system ones, not replace them completely.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry-packages-proxy
type: fix
summary: Don't replace the system CA certificates if a custom CA is used.
impact_level: default
---
section: registry-packages-proxy
type: chore
summary: Print response body in case of http error.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
