### PR TITLE
feat(dhctl-for-commander): add commander-uuid consistency checks and commander-uuid storing in the dh cluster

### DIFF
--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"os"
 	"strings"
 
@@ -101,6 +102,9 @@ type DeckhouseInstaller struct {
 
 	ReleaseChannel   string
 	InstallerVersion string
+
+	CommanderMode bool
+	CommanderUUID uuid.UUID
 }
 
 func (c *DeckhouseInstaller) GetImage(forceVersionTag bool) string {

--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"sort"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,6 +74,7 @@ type Runner struct {
 	skipPhases    map[Phase]bool
 
 	commanderMode       bool
+	commanderUUID       uuid.UUID
 	commanderModeParams *commander.CommanderModeParams
 
 	stateCache dstate.Cache
@@ -99,6 +101,11 @@ func (r *Runner) WithCommanderModeParams(params *commander.CommanderModeParams) 
 
 func (r *Runner) WithCommanderMode(commanderMode bool) *Runner {
 	r.commanderMode = commanderMode
+	return r
+}
+
+func (r *Runner) WithCommanderUUID(commanderUUID uuid.UUID) *Runner {
+	r.commanderUUID = commanderUUID
 	return r
 }
 
@@ -288,7 +295,13 @@ func (r *Runner) converge() error {
 		if err != nil {
 			return fmt.Errorf("unable to get provider cluster config yaml: %w", err)
 		}
-		if err := deckhouse.ConvergeDeckhouseConfiguration(context.TODO(), r.kubeCl, metaConfig.UUID, clusterConfigurationData, providerClusterConfigurationData); err != nil {
+
+		clusterUUID, err := uuid.Parse(metaConfig.UUID)
+		if err != nil {
+			return fmt.Errorf("unable to parse cluster uuid %q: %w", metaConfig.UUID, err)
+		}
+
+		if err := deckhouse.ConvergeDeckhouseConfiguration(context.TODO(), r.kubeCl, clusterUUID, r.commanderUUID, clusterConfigurationData, providerClusterConfigurationData); err != nil {
 			return fmt.Errorf("unable to update deckhouse configuration: %w", err)
 		}
 

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
@@ -17,6 +17,9 @@ package deckhouse
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
+	"github.com/google/uuid"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +35,7 @@ import (
 // ConvergeDeckhouseConfiguration – reconciles deckhouse in-cluster configmaps and secrets.
 // This function used in commander-mode, which stores primary configuration in the storage outside of cluster,
 // and periodically reconciles configuration inside cluster to match configuration stored outside of cluster.
-func ConvergeDeckhouseConfiguration(ctx context.Context, kubeCl *client.KubernetesClient, clusterUUID string, clusterConfig []byte, providerClusterConfig []byte) error {
+func ConvergeDeckhouseConfiguration(ctx context.Context, kubeCl *client.KubernetesClient, clusterUUID, commanderUUID uuid.UUID, clusterConfig []byte, providerClusterConfig []byte) error {
 	tasks := []actions.ManifestTask{
 		{
 			Name:     `Secret "d8-cluster-configuration"`,
@@ -74,7 +77,7 @@ func ConvergeDeckhouseConfiguration(ctx context.Context, kubeCl *client.Kubernet
 		{
 			Name: `ConfigMap "d8-cluster-uuid"`,
 			Manifest: func() interface{} {
-				return manifests.ClusterUUIDConfigMap(clusterUUID)
+				return manifests.ClusterUUIDConfigMap(clusterUUID.String())
 			},
 			CreateFunc: func(manifest interface{}) error {
 				// NOTE: Uuid configmap uses "more careful" update task,
@@ -99,6 +102,10 @@ func ConvergeDeckhouseConfiguration(ctx context.Context, kubeCl *client.Kubernet
 				return err
 			},
 		},
+	}
+
+	if commanderUUID != uuid.Nil {
+		tasks = append(tasks, commander.ConstructManagedByCommanderConfigMapTask(commanderUUID, kubeCl))
 	}
 
 	return log.Process("default", "Converge deckhouse configuration", func() error {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
+	"github.com/google/uuid"
 	"os"
 	"strings"
 	"time"
@@ -427,6 +429,10 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				return err
 			},
 		})
+	}
+
+	if cfg.CommanderMode && cfg.CommanderUUID != uuid.Nil {
+		tasks = append(tasks, commander.ConstructManagedByCommanderConfigMapTask(cfg.CommanderUUID, kubeCl))
 	}
 
 	if cfg.KubeDNSAddress != "" {

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -630,6 +630,22 @@ func ClusterUUIDConfigMap(uuid string) *apiv1.ConfigMap {
 	}
 }
 
+const (
+	CommanderUUIDCmKey       = "commander-uuid"
+	CommanderUUIDCm          = "d8-commander-uuid"
+	CommanderUUIDCmNamespace = "kube-system"
+)
+
+func CommanderUUIDConfigMap(uuid string) *apiv1.ConfigMap {
+	return &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CommanderUUIDCm,
+			Namespace: CommanderUUIDCmNamespace,
+		},
+		Data: map[string]string{CommanderUUIDCmKey: uuid},
+	}
+}
+
 func KubeDNSService(ipAddress string) *apiv1.Service {
 	return &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -78,6 +78,7 @@ type Params struct {
 	DisableBootstrapClearCache bool
 	OnPhaseFunc                phases.DefaultOnPhaseFunc
 	CommanderMode              bool
+	CommanderUUID              uuid.UUID
 	TerraformContext           *terraform.TerraformContext
 
 	ConfigPaths             []string
@@ -218,6 +219,14 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	deckhouseInstallConfig, err := config.PrepareDeckhouseInstallConfig(metaConfig)
 	if err != nil {
 		return err
+	}
+
+	if b.CommanderMode {
+		if b.CommanderUUID == uuid.Nil {
+			panic("CommanderUUID required for bootstrap operation in commander mode!")
+		}
+		deckhouseInstallConfig.CommanderMode = b.CommanderMode
+		deckhouseInstallConfig.CommanderUUID = b.CommanderUUID
 	}
 
 	// During full bootstrap we use the "kubeadm and deckhouse on master nodes" hack

--- a/dhctl/pkg/operations/commander/helpers.go
+++ b/dhctl/pkg/operations/commander/helpers.go
@@ -1,0 +1,75 @@
+package commander
+
+import (
+	"context"
+	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/google/uuid"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewErrClusterManagedByAnotherCommander(managedByCommanderUUID, requiredCommanderUUID uuid.UUID) error {
+	return fmt.Errorf("cluster managed by another commander %s unable to perform operations from your commander %s", managedByCommanderUUID.String(), requiredCommanderUUID.String())
+}
+
+func doCheckShouldUpdateCommanderUUID(cm *v1.ConfigMap, requiredCommanderUUID uuid.UUID) (bool, error) {
+	if val, hasKey := cm.Data[manifests.CommanderUUIDCmKey]; hasKey {
+		valUUID, err := uuid.Parse(val)
+		if err != nil {
+			// ignore incorrect value, and take over with required commander uuid
+			return true, nil
+		}
+		if valUUID != requiredCommanderUUID {
+			return false, NewErrClusterManagedByAnotherCommander(valUUID, requiredCommanderUUID)
+		}
+		return false, nil
+	}
+	// if no commander uuid data found then should update
+	return true, nil
+}
+
+func CheckShouldUpdateCommanderUUID(ctx context.Context, kubeCl *client.KubernetesClient, requiredCommanderUUID uuid.UUID) (bool, error) {
+	cm, err := kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Get(ctx, manifests.CommanderUUIDCm, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// if no commander uuid found then should update
+			return true, nil
+		}
+		return false, fmt.Errorf("unable to get cm/%s in ns/%s: %w", manifests.CommanderUUIDCm, manifests.CommanderUUIDCmNamespace)
+	}
+	return doCheckShouldUpdateCommanderUUID(cm, requiredCommanderUUID)
+}
+
+func ConstructManagedByCommanderConfigMapTask(commanderUUID uuid.UUID, kubeCl *client.KubernetesClient) actions.ManifestTask {
+	return actions.ManifestTask{
+		Name: `ConfigMap "d8-commander-uuid"`,
+		Manifest: func() interface{} {
+			return manifests.CommanderUUIDConfigMap(commanderUUID.String())
+		},
+		CreateFunc: func(manifest interface{}) error {
+			_, err := kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Create(context.TODO(), manifest.(*v1.ConfigMap), metav1.CreateOptions{})
+			return err
+		},
+		UpdateFunc: func(manifest interface{}) error {
+			existingCm, err := kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Get(context.TODO(), manifests.CommanderUUIDCm, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to get existing cm %q: %w")
+			}
+
+			shouldUpdate, err := doCheckShouldUpdateCommanderUUID(existingCm, commanderUUID)
+			if err != nil {
+				return fmt.Errorf("managed by commander check failed: %w", err)
+			}
+
+			if shouldUpdate {
+				_, err = kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Update(context.TODO(), manifest.(*v1.ConfigMap), metav1.UpdateOptions{})
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -21,10 +21,12 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+	"github.com/google/uuid"
 )
 
 type DeckhouseDestroyerOptions struct {
 	CommanderMode bool
+	CommanderUUID uuid.UUID
 }
 
 type DeckhouseDestroyer struct {


### PR DESCRIPTION
## Description

Internal PR aimed only for commander-specific branch for current EA+EE version (1.60.2 at the moment).