### PR TITLE
[docs] Add description of deckhouse-controller helper change-registry command

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -557,7 +557,7 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
   * Example:
 
     ```shell
-    kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse
+    kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse
     ```
 
   * If the registry uses a self-signed certificate, put the root CA certificate that validates the registry's HTTPS certificate to file `/tmp/ca.crt` in the Deckhouse Pod and add the `--ca-file /tmp/ca.crt` option to the script or put the content of CA into a variable as follows:
@@ -572,17 +572,18 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
     -----END CERTIFICATE-----
     EOF
     )
-    $ kubectl exec  -n d8-system deploy/deckhouse -- bash -c "echo '$CA_CONTENT' > /tmp/ca.crt && deckhouse-controller helper change-registry --ca-file /tmp/ca.crt --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee"
+    $ kubectl exec  -n d8-system deploy/deckhouse -c deckhouse -- bash -c "echo '$CA_CONTENT' > /tmp/ca.crt && deckhouse-controller helper change-registry --ca-file /tmp/ca.crt --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee"
     ```
 
-  * To view the list of available keys of the `deckhouse-controller helper change-registry` command, run:
+  * To view the list of available keys of the `deckhouse-controller helper change-registry` command, run the following command:
 
     ```shell
-    kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --help
+    kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry --help
     ```
+
     Example output:
+
     ```shell
-    Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
     usage: deckhouse-controller helper change-registry [<flags>] <new-registry>
     
     Change registry for deckhouse images.
@@ -698,7 +699,7 @@ The general cluster parameters are stored in the [ClusterConfiguration](installi
 To change the general cluster parameters, run the command:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
 After saving the changes, Deckhouse will bring the cluster configuration to the state according to the changed configuration. Depending on the size of the cluster, this may take some time.
@@ -710,7 +711,7 @@ Cloud provider setting of a cloud of hybrid cluster are stored in the `<PROVIDER
 Regardless of the cloud provider used, its settings can be changed using the following command:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit provider-cluster-configuration
 ```
 
 ### How do I change the configuration of a static cluster?
@@ -720,7 +721,7 @@ Settings of a static cluster are stored in the [StaticClusterConfiguration](inst
 To change the settings of a static cluster, run the command:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit static-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit static-cluster-configuration
 ```
 
 ### How to switch Deckhouse EE to CE?
@@ -740,7 +741,7 @@ To switch Deckhouse Enterprise Edition to Community Edition, follow these steps:
 1. Run the following command:
 
    ```shell
-   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry registry.deckhouse.io/deckhouse/ce
+   kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry registry.deckhouse.io/deckhouse/ce
    ```
 
 1. Wait for the Deckhouse Pod to become `Ready`:
@@ -758,20 +759,20 @@ To switch Deckhouse Enterprise Edition to Community Edition, follow these steps:
 1. Wait for Deckhouse to restart and to complete all tasks in the queue:
 
    ```shell
-   kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    ```
 
    Example of output when there are still jobs in the queue (`length 38`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 38, status: 'run first task'
    ```
 
    Example of output when the queue is empty (`length 0`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 0, status: 'waiting for task 0s'
    ```
 
@@ -819,7 +820,7 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
 
    ```shell
    LICENSE_TOKEN=<PUT_YOUR_LICENSE_TOKEN_HERE>
-   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password $LICENSE_TOKEN registry.deckhouse.io/deckhouse/ee
+   kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry --user license-token --password $LICENSE_TOKEN registry.deckhouse.io/deckhouse/ee
    ```
 
 1. Wait for the Deckhouse Pod to become `Ready`:
@@ -837,20 +838,20 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
 1. Wait for Deckhouse to restart and to complete all tasks in the queue:
 
    ```shell
-   kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    ```
 
    Example of output when there are still jobs in the queue (`length 38`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 38, status: 'run first task'
    ```
 
    Example of output when the queue is empty (`length 0`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 0, status: 'waiting for task 0s'
    ```
 
@@ -890,7 +891,7 @@ To upgrade the Kubernetes version in a cluster change the [kubernetesVersion](in
 1. Run the command:
 
    ```shell
-   kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+   kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
    ```
 
 1. Change the `kubernetesVersion` field.

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -575,6 +575,35 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
     $ kubectl exec  -n d8-system deploy/deckhouse -- bash -c "echo '$CA_CONTENT' > /tmp/ca.crt && deckhouse-controller helper change-registry --ca-file /tmp/ca.crt --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee"
     ```
 
+  * To view the list of available keys of the `deckhouse-controller helper change-registry` command, run:
+
+    ```shell
+    kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --help
+    ```
+    Example output:
+    ```shell
+    Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
+    usage: deckhouse-controller helper change-registry [<flags>] <new-registry>
+    
+    Change registry for deckhouse images.
+    
+    Flags:
+    --help               Show context-sensitive help (also try --help-long and --help-man).
+    --user=USER          User with pull access to registry.
+    --password=PASSWORD  Password/token for registry user.
+    --ca-file=CA-FILE    Path to registry CA.
+    --insecure           Use HTTP while connecting to new registry.
+    --dry-run            Don't change deckhouse resources, only print them.
+    --new-deckhouse-tag=NEW-DECKHOUSE-TAG
+    New tag that will be used for deckhouse deployment image (by default
+    current tag from deckhouse deployment will be used).
+    
+    Args:
+    <new-registry>  Registry that will be used for deckhouse images (example:
+    registry.deckhouse.io/deckhouse/ce). By default, https will be used, if you need
+    http - provide '--insecure' flag
+    ```
+
 * Wait for the Deckhouse Pod to become `Ready`. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
 * If you want to disable Deckhouse automatic updates, remove the [releaseChannel](modules/002-deckhouse/configuration.html#parameters-releasechannel) parameter from the `deckhouse` module configuration.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -558,7 +558,7 @@ Deckhouse поддерживает работу только с Bearer token-с�
   * Пример запуска:
 
     ```shell
-    kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry \
+    kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry \
       --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee
     ```
 
@@ -574,17 +574,18 @@ Deckhouse поддерживает работу только с Bearer token-с�
     -----END CERTIFICATE-----
     EOF
     )
-    $ kubectl exec  -n d8-system deploy/deckhouse -- bash -c "echo '$CA_CONTENT' > /tmp/ca.crt && deckhouse-controller helper change-registry --ca-file /tmp/ca.crt --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee"
+    $ kubectl exec -n d8-system deploy/deckhouse -c deckhouse -- bash -c "echo '$CA_CONTENT' > /tmp/ca.crt && deckhouse-controller helper change-registry --ca-file /tmp/ca.crt --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee"
     ```
   
-  * Просмотреть список доступных ключей команды `deckhouse-controller helper change-registry` можно, выполнив:
+  * Просмотреть список доступных ключей команды `deckhouse-controller helper change-registry` можно, выполнив следующую команду:
 
     ```shell
-    kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --help
+    kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry --help
     ```
+
     Пример вывода:
+
     ```shell
-    Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
     usage: deckhouse-controller helper change-registry [<flags>] <new-registry>
     
     Change registry for deckhouse images.
@@ -700,7 +701,7 @@ proxy:
 Чтобы изменить общие параметры кластера, выполните команду:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
 После сохранения изменений Deckhouse приведет конфигурацию кластера к измененному состоянию. В зависимости от размеров кластера это может занять какое-то время.
@@ -712,7 +713,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit clus
 Независимо от используемого облачного провайдера его настройки можно изменить с помощью следующей команды:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit provider-cluster-configuration
 ```
 
 ### Как изменить конфигурацию статического кластера?
@@ -722,7 +723,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit prov
 Чтобы изменить параметры статического кластера, выполните команду:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit static-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit static-cluster-configuration
 ```
 
 ### Как переключить Deckhouse EE на CE?
@@ -742,7 +743,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 1. Выполните следующую команду:
 
    ```shell
-   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry registry.deckhouse.ru/deckhouse/ce
+   kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry registry.deckhouse.ru/deckhouse/ce
    ```
 
 1. Дождитесь перехода пода Deckhouse в статус `Ready`:
@@ -760,20 +761,20 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 1. Дождитесь перезапуска Deckhouse и выполнения всех задач в очереди:
 
    ```shell
-   kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    ```
 
    Пример вывода, когда в очереди еще есть задания (`length 38`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 38, status: 'run first task'
    ```
 
    Пример вывода, когда очередь пуста (`length 0`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 0, status: 'waiting for task 0s'
    ```
 
@@ -821,7 +822,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 
    ```shell
    LICENSE_TOKEN=<PUT_YOUR_LICENSE_TOKEN_HERE>
-   kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --user license-token --password $LICENSE_TOKEN registry.deckhouse.ru/deckhouse/ee
+   kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry --user license-token --password $LICENSE_TOKEN registry.deckhouse.ru/deckhouse/ee
    ```
 
 1. Дождитесь перехода пода Deckhouse в статус `Ready`:
@@ -839,20 +840,20 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 1. Дождитесь перезапуска Deckhouse и выполнения всех задач в очереди:
 
    ```shell
-   kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    ```
 
    Пример вывода, когда в очереди еще есть задания (`length 38`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 38, status: 'run first task'
    ```
 
    Пример вывода, когда очередь пуста (`length 0`):
 
    ```console
-   # kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller queue main | grep status:
+   # kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue main | grep status:
    Queue 'main': length 0, status: 'waiting for task 0s'
    ```
 
@@ -892,7 +893,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 1. Выполните команду:
 
    ```shell
-   kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+   kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
    ```
 
 1. Измените параметр `kubernetesVersion`.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -576,6 +576,35 @@ Deckhouse поддерживает работу только с Bearer token-с�
     )
     $ kubectl exec  -n d8-system deploy/deckhouse -- bash -c "echo '$CA_CONTENT' > /tmp/ca.crt && deckhouse-controller helper change-registry --ca-file /tmp/ca.crt --user MY-USER --password MY-PASSWORD registry.example.com/deckhouse/ee"
     ```
+  
+  * Просмотреть список доступных ключей команды `deckhouse-controller helper change-registry` можно, выполнив:
+
+    ```shell
+    kubectl exec -ti -n d8-system deploy/deckhouse -- deckhouse-controller helper change-registry --help
+    ```
+    Пример вывода:
+    ```shell
+    Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
+    usage: deckhouse-controller helper change-registry [<flags>] <new-registry>
+    
+    Change registry for deckhouse images.
+    
+    Flags:
+    --help               Show context-sensitive help (also try --help-long and --help-man).
+    --user=USER          User with pull access to registry.
+    --password=PASSWORD  Password/token for registry user.
+    --ca-file=CA-FILE    Path to registry CA.
+    --insecure           Use HTTP while connecting to new registry.
+    --dry-run            Don't change deckhouse resources, only print them.
+    --new-deckhouse-tag=NEW-DECKHOUSE-TAG
+    New tag that will be used for deckhouse deployment image (by default
+    current tag from deckhouse deployment will be used).
+    
+    Args:
+    <new-registry>  Registry that will be used for deckhouse images (example:
+    registry.deckhouse.io/deckhouse/ce). By default, https will be used, if you need
+    http - provide '--insecure' flag
+    ```
 
 * Дождитесь перехода пода Deckhouse в статус `Ready`. Если под будет находиться в статусе `ImagePullBackoff`, перезапустите его.
 * Дождитесь применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.


### PR DESCRIPTION
## Description

Add info about `deckhouse-controller helper change-registry` command into docs.

## Why do we need it, and what problem does it solve?

It will help the documentation to be more friendly to beginners.

## Why do we need it in the patch release (if we do)?

## What is the expected result?

The documentation will become more complete.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Add description of `deckhouse-controller helper change-registry` command into documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
