### PR TITLE
[deckhouse] fix default ms ca template

### DIFF
--- a/modules/002-deckhouse/templates/default-module-source.yaml
+++ b/modules/002-deckhouse/templates/default-module-source.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   registry:
     {{- if $.Values.global.modulesImages.registry.CA }}
-    ca: {{ $.Values.global.modulesImages.registry.CA | nindent 6 }}
+    ca: |
+      {{ $.Values.global.modulesImages.registry.CA | nindent 6 }}
     {{- end }}
     dockerCfg: {{ $.Values.global.modulesImages.registry.dockercfg }}
     repo: {{ printf "%s/modules" $.Values.global.modulesImages.registry.base }}

--- a/modules/002-deckhouse/templates/default-module-source.yaml
+++ b/modules/002-deckhouse/templates/default-module-source.yaml
@@ -8,8 +8,7 @@ metadata:
 spec:
   registry:
     {{- if $.Values.global.modulesImages.registry.CA }}
-    ca: |
-      {{ $.Values.global.modulesImages.registry.CA | nindent 6 }}
+    ca: | {{ $.Values.global.modulesImages.registry.CA | nindent 6 }}
     {{- end }}
     dockerCfg: {{ $.Values.global.modulesImages.registry.dockercfg }}
     repo: {{ printf "%s/modules" $.Values.global.modulesImages.registry.base }}


### PR DESCRIPTION
## Description
This pr fixes default module source template in terms of CA field.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Currently, CA value is rendered incorrectly in default module source.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It blocks use of private registries for storing modules.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
CA values is rendered correctly, as a multi-line value (See examples below).
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix default module source template.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
