### PR TITLE
Added mirror support for image_availability_exporter

### DIFF
--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -13,7 +13,7 @@ ENV GOPROXY=${GOPROXY}
 WORKDIR /src
 ENV GOARCH=amd64
 RUN apk add patch git
-RUN git clone --depth 1 --branch v0.7.0 ${SOURCE_REPO}/deckhouse/k8s-image-availability-exporter.git .
+RUN git clone --depth 1 --branch v0.8.0 ${SOURCE_REPO}/deckhouse/k8s-image-availability-exporter.git .
 COPY patches/001-support-legacy-annotation.patch /src/
 RUN patch -p1 < 001-support-legacy-annotation.patch
 RUN CGO_ENABLED=0 go build -a -ldflags '-s -w -extldflags "-static"' -o /k8s-image-availability-exporter main.go && \

--- a/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -47,6 +47,24 @@ properties:
                 type: string
                 description: |
                   Root CA certificate to validate the container registry's HTTPS certificate (if self-signed certificates are used).
+      mirrors:
+        type: array
+        description: |
+          List of mirror repositories for container registries.
+        x-examples:
+          mirrors:
+          - original: docker.io
+            mirror: mirror.gcr.io
+        items:
+          type: object
+          required:
+          - original
+          - mirror
+          properties:
+            original:
+              type: string
+            mirror:
+              type: string
       forceCheckDisabledControllers:
         type: array
         x-examples:

--- a/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -50,7 +50,7 @@ properties:
       mirrors:
         type: array
         description: |
-          List of mirror repositories for container registries.
+          List of mirrors for container registries.
         x-examples:
         - - original: docker.io
             mirror: mirror.gcr.io

--- a/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -52,9 +52,10 @@ properties:
         description: |
           List of mirror repositories for container registries.
         x-examples:
-          - mirrors:
-            - original: docker.io
-              mirror: mirror.gcr.io
+        - - original: docker.io
+            mirror: mirror.gcr.io
+          - original: internal-registry.com
+            mirror: mirror.internal-registry.com
         items:
           type: object
           required:

--- a/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -52,9 +52,9 @@ properties:
         description: |
           List of mirror repositories for container registries.
         x-examples:
-          mirrors:
-          - original: docker.io
-            mirror: mirror.gcr.io
+          - mirrors:
+            - original: docker.io
+              mirror: mirror.gcr.io
         items:
           type: object
           required:

--- a/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
@@ -26,6 +26,10 @@ properties:
               ca:
                 description: |
                   Корневой сертификат, которым можно проверить сертификат container registry при работе по HTTPS (если registry использует самоподписанные SSL-сертификаты).
+      mirrors:
+        type: array
+        description: |
+          Список зеркал для container registry
       forceCheckDisabledControllers:
         description: |
           Список контроллеров, которые необходимо проверять, даже если количество реплик подов равняется 0 или контроллер находится в статусе `suspend` (приостановленный).

--- a/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
@@ -29,7 +29,7 @@ properties:
       mirrors:
         type: array
         description: |
-          Список зеркал для container registry
+          Список зеркал для container registry.
       forceCheckDisabledControllers:
         description: |
           Список контроллеров, которые необходимо проверять, даже если количество реплик подов равняется 0 или контроллер находится в статусе `suspend` (приостановленный).

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -88,6 +88,11 @@ spec:
         {{- if .Values.extendedMonitoring.imageAvailability.forceCheckDisabledControllers }}
         - '--force-check-disabled-controllers={{ .Values.extendedMonitoring.imageAvailability.forceCheckDisabledControllers | join "," | replace "All" "*" }}'
         {{- end }}
+        {{- if .Values.extendedMonitoring.imageAvailability.mirrors }}
+        {{- range $mirror := .Values.extendedMonitoring.imageAvailability.mirrors }}
+        - '--image-mirror={{ printf "%s=%s" $mirror.original $mirror.mirror }}'
+        {{- end }}
+        {{- end }}
         env:
           {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
         resources:


### PR DESCRIPTION
## Description
Added mirror support for `image_availability_exporter`.

## Why do we need it, and what problem does it solve?
In some cases we use mirrors in the containerd configuration, so we need to check the availability of the image through the mirrors.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: extended-monitoring
type: fix
summary: Add support of mirrors for container registries for `image_availability_exporter`.
```