### PR TITLE
[docs] Add information about immediately updates to the Deckhouse FAQ

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -105,9 +105,13 @@ In this case, Deckhouse does not check for updates and even doesn't apply patch 
 It is highly not recommended to disable automatic updates! It will block updates to patch releases that may contain critical vulnerabilities and bugs fixes.
 {% endalert %}
 
-### How do I apply an update without having to wait for the update window?
+### How do I apply an update withou having to wait for the update windows, canary-release and manual update mode?
 
-To apply an update immediately without having to wait for the update window, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](cr.html#deckhouserelease) resource.
+To apply an update immediately, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](cr.html#deckhouserelease) resource.
+
+{% alert level="info" %}
+**Caution!** In this case, the update windows, settings [canary-release](modules/002-deckhouse/cr.html#deckhouserelease-v1alpha1-spec-applyafter) and [manual cluster update](modules/002-deckhouse/configuration.html#parameters-update-disruptionapprovalmode) will be ignored. The update will be applied immediately after the annotation is installed.
+{% endalert %}
 
 An example of a command to set the annotation to skip the update windows for version `v1.56.2`:
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -105,7 +105,7 @@ In this case, Deckhouse does not check for updates and even doesn't apply patch 
 It is highly not recommended to disable automatic updates! It will block updates to patch releases that may contain critical vulnerabilities and bugs fixes.
 {% endalert %}
 
-### How do I apply an update withou having to wait for the update windows, canary-release and manual update mode?
+### How do I apply an update without having to wait for the update window, canary-release and manual update mode?
 
 To apply an update immediately, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](cr.html#deckhouserelease) resource.
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -110,7 +110,7 @@ It is highly not recommended to disable automatic updates! It will block updates
 To apply an update immediately, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](cr.html#deckhouserelease) resource.
 
 {% alert level="info" %}
-**Caution!** In this case, the update windows, settings [canary-release](modules/002-deckhouse/cr.html#deckhouserelease-v1alpha1-spec-applyafter) and [manual cluster update](modules/002-deckhouse/configuration.html#parameters-update-disruptionapprovalmode) will be ignored. The update will be applied immediately after the annotation is installed.
+**Caution!** In this case, the update windows, settings [canary-release](modules/002-deckhouse/cr.html#deckhouserelease-v1alpha1-spec-applyafter) and [manual cluster update mode](modules/002-deckhouse/configuration.html#parameters-update-disruptionapprovalmode) will be ignored. The update will be applied immediately after the annotation is installed.
 {% endalert %}
 
 An example of a command to set the annotation to skip the update windows for version `v1.56.2`:

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -106,12 +106,12 @@ spec:
 Крайне не рекомендуется отключать автоматическое обновление! Это заблокирует обновления на patch-релизы, которые могут содержать исправления критических уязвимостей и ошибок.
 {% endalert %}
 
-### Как применить обновление минуя окна обновлений, canary-release и ручной режим обновлений (manual)?
+### Как применить обновление минуя окна обновлений, canary-release и ручной режим обновлений?
 
 Чтобы применить обновление немедленно, установите в соответствующем ресурсе [DeckhouseRelease](cr.html#deckhouserelease) аннотацию `release.deckhouse.io/apply-now: "true"`.
 
 {% alert level="info" %}
-**Обратите внимание!** В этом случае будут проигнорированы окна обновления, настройки [canary-release](modules/002-deckhouse/cr.html#deckhouserelease-v1alpha1-spec-applyafter) и [ручное обновление кластера](modules/002-deckhouse/configuration.html#parameters-update-disruptionapprovalmode). Обновление применится сразу после установки аннотации.
+**Обратите внимание!** В этом случае будут проигнорированы окна обновления, настройки [canary-release](modules/002-deckhouse/cr.html#deckhouserelease-v1alpha1-spec-applyafter) и режим [ручного обновления кластера](modules/002-deckhouse/configuration.html#parameters-update-disruptionapprovalmode). Обновление применится сразу после установки аннотации.
 {% endalert %}
 
 Пример команды установки аннотации пропуска окон обновлений для версии `v1.56.2`:

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -106,9 +106,13 @@ spec:
 Крайне не рекомендуется отключать автоматическое обновление! Это заблокирует обновления на patch-релизы, которые могут содержать исправления критических уязвимостей и ошибок.
 {% endalert %}
 
-### Как применить обновление минуя окна обновлений?
+### Как применить обновление минуя окна обновлений, canary-release и ручной режим обновлений (manual)?
 
-Чтобы применить обновление немедленно, не дожидаясь ближайшего окна обновлений, установите в соответствующем ресурсе [DeckhouseRelease](cr.html#deckhouserelease) аннотацию `release.deckhouse.io/apply-now: "true"`.
+Чтобы применить обновление немедленно, установите в соответствующем ресурсе [DeckhouseRelease](cr.html#deckhouserelease) аннотацию `release.deckhouse.io/apply-now: "true"`.
+
+{% alert level="info" %}
+**Обратите внимание!** В этом случае будут проигнорированы окна обновления, настройки [canary-release](modules/002-deckhouse/cr.html#deckhouserelease-v1alpha1-spec-applyafter) и [ручное обновление кластера](modules/002-deckhouse/configuration.html#parameters-update-disruptionapprovalmode). Обновление применится сразу после установки аннотации.
+{% endalert %}
 
 Пример команды установки аннотации пропуска окон обновлений для версии `v1.56.2`:
 


### PR DESCRIPTION
## Description

Added clarification about the immediate update annotation in the Deckhouse FAQ.

## Why do we need it, and what problem does it solve?

The documentation in its current form did not reflect the nuances of updating with this annotation.

## Why do we need it in the patch release (if we do)?

## What is the expected result?

The documentation will become more understandable for the user.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Added clarification about the immediate update annotation in the Deckhouse FAQ.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
