### PR TITLE
[docs] Add registry-packages-proxy port in network policies

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -66,6 +66,11 @@ groups:
     description:
       en: "*machine-controller-manager* metrics"
       ru: "Метрики компонента *machine-controller-manager*"
+  - ports: "5443"
+    protocol: TCP
+    description:
+      en: "Proxy for registry packages *registry-packages-proxy*"
+      ru: "Прокси для пакетов registry *registry-packages-proxy*"
 - group: NodesToNodes
   description:
     en: Nodes to nodes traffic


### PR DESCRIPTION
## Description
Update `Configuring network policies for Deckhouse` with `registry-packages-proxy` port 5443 TCP
Added in 1.60 https://github.com/deckhouse/deckhouse/pull/7751

## Why do we need it, and what problem does it solve?
We need to keep this information up to date.

## Why do we need it in the patch release (if we do)?

It is not necessary.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update network policies documentation.
impact_level: low
```
