### PR TITLE
[docs] Return DeckhouseRelease CRD on the site

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -66,19 +66,13 @@ entries:
                     ru: Описание
                   url: /modules/002-deckhouse/
                 - title:
+                    en: Configuration
+                    ru: Настройки
+                  url: /modules/002-deckhouse/configuration.html
+                - title:
                     en: Usage
                     ru: Примеры
                   url: /modules/002-deckhouse/usage.html
-                - title:
-                    en: Reference
-                    ru: Справка
-                  folders:
-                    - title:
-                        en: Configuration
-                        ru: Настройки
-                      url: /modules/002-deckhouse/configuration.html
-                    - title: Custom Resources
-                      url: /modules/002-deckhouse/cr.html
                 - title: FAQ
                   url: /modules/002-deckhouse/faq.html
             - title: documentation

--- a/docs/documentation/modules_generate_configuration.sh
+++ b/docs/documentation/modules_generate_configuration.sh
@@ -44,7 +44,11 @@ if [ -d /src/global ]; then
   cp -f /src/global/static_cluster_configuration.yaml _data/schemas/global/static_cluster_configuration.yaml
   echo -e "\ni18n:\n  ru:" >>_data/schemas/global/static_cluster_configuration.yaml
   cat /src/global/doc-ru-static_cluster_configuration.yaml | sed 's/^/    /' >>_data/schemas/global/static_cluster_configuration.yaml
-  # "Global" CRDS (from the deckhouse-controller/crds)
+  # DeckhouseRelease CRD
+  cp -f /src/global/crds/deckhouse-release.yaml _data/schemas/global/crds/deckhouse-release.yaml
+  echo -e "\ni18n:\n  ru:" >>_data/schemas/global/crds/deckhouse-release.yaml
+  cat /src/global/crds/doc-ru-deckhouse-release.yaml | sed 's/^/    /' >>_data/schemas/global/crds/deckhouse-release.yaml
+  # module CRDS
   cp /src/global/crds/module* /srv/jekyll-data/documentation/_data/schemas/global/crds
   for i in /src/global/crds/module* ; do
     cp -v $i /srv/jekyll-data/documentation/_data/schemas/global/crds/

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -107,7 +107,7 @@ It is highly not recommended to disable automatic updates! It will block updates
 
 ### How do I apply an update without having to wait for the update window?
 
-To apply an update immediately without having to wait for the update window, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) resource.
+To apply an update immediately without having to wait for the update window, set the `release.deckhouse.io/apply-now : "true"` annotation on the [DeckhouseRelease](cr.html#deckhouserelease) resource.
 
 An example of a command to set the annotation to skip the update windows for version `v1.56.2`:
 
@@ -144,7 +144,7 @@ During the update:
 
 If the `DeckhouseUpdating` alert is resolved, then the update is complete.
 
-You can also check the status of Deckhouse [releases](modules/002-deckhouse/cr.html#deckhouserelease).
+You can also check the status of Deckhouse [releases](cr.html#deckhouserelease).
 
 An example:
 
@@ -187,7 +187,7 @@ Possible options for action if something went wrong:
 
 As soon as a new version of Deckhouse appears on the release channel installed in the cluster:
 - The alert `DeckhouseReleaseIsWaitingManualApproval` fires, if the cluster uses manual update mode (the [update.mode](modules/002-deckhouse/configuration.html#parameters-update-mode) parameter is set to `Manual`).
-- There is a new custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease). Use the `kubectl get deckhousereleases` command, to view the list of releases. If the `DeckhouseRelease` is in the `Pending` state, the specified version has not yet been installed. Possible reasons why `DeckhouseRelease` may be in `Pending`:
+- There is a new custom resource [DeckhouseRelease](cr.html#deckhouserelease). Use the `kubectl get deckhousereleases` command, to view the list of releases. If the `DeckhouseRelease` is in the `Pending` state, the specified version has not yet been installed. Possible reasons why `DeckhouseRelease` may be in `Pending`:
   - Manual update mode is set (the [update.mode](modules/002-deckhouse/configuration.html#parameters-update-mode) parameter is set to `Manual`).
   - The automatic update mode is set, and the [update windows](modules/002-deckhouse/usage.html#update-windows-configuration) are configured, the interval of which has not yet come.
   - The automatic update mode is set, update windows are not configured, but the installation of the version has been postponed for a random time due to the mechanism of reducing the load on the repository of container images. There will be a corresponding message in the `status.message` field of the `DeckhouseRelease` resource.
@@ -196,8 +196,8 @@ As soon as a new version of Deckhouse appears on the release channel installed i
 ### How do I get information about the upcoming update in advance?
 
 You can get information in advance about updating minor versions of Deckhouse on the release channel in the following ways:
-- Configure manual [update mode](modules/002-deckhouse/configuration.html#parameters-update-mode). In this case, when a new version appears on the release channel, the alert `DeckhouseReleaseIsWaitingManualApproval` will fire and a new custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) will appear in the cluster.
-- Configure automatic [update mode](modules/002-deckhouse/configuration.html#parameters-update-mode) and specify the minimum time in the [minimalNotificationTime](modules/002-deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime) parameter for which the update will be postponed. In this case, when a new version appears on the release channel, a new custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) will appear in the cluster. And if you specify a URL in the [update.notification.webhook](modules/002-deckhouse/configuration.html#parameters-update-notification-webhook) parameter, then the webhook will be called additionally.
+- Configure manual [update mode](modules/002-deckhouse/configuration.html#parameters-update-mode). In this case, when a new version appears on the release channel, the alert `DeckhouseReleaseIsWaitingManualApproval` will fire and a new custom resource [DeckhouseRelease](cr.html#deckhouserelease) will appear in the cluster.
+- Configure automatic [update mode](modules/002-deckhouse/configuration.html#parameters-update-mode) and specify the minimum time in the [minimalNotificationTime](modules/002-deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime) parameter for which the update will be postponed. In this case, when a new version appears on the release channel, a new custom resource [DeckhouseRelease](cr.html#deckhouserelease) will appear in the cluster. And if you specify a URL in the [update.notification.webhook](modules/002-deckhouse/configuration.html#parameters-update-notification-webhook) parameter, then the webhook will be called additionally.
 
 ### How do I find out which version of Deckhouse is on which release channel?
 
@@ -207,7 +207,7 @@ Information about which version of Deckhouse is on which release channel can be 
 
 Every minute Deckhouse checks a new release appeared in the release channel specified by the [releaseChannel](modules/002-deckhouse/configuration.html#parameters-releasechannel) parameter.
 
-When a new release appears on the release channel, Deckhouse downloads it and creates CustomResource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease).
+When a new release appears on the release channel, Deckhouse downloads it and creates CustomResource [DeckhouseRelease](cr.html#deckhouserelease).
 
 After creating a `DeckhouseRelease` custom resource in a cluster, Deckhouse updates the `deckhouse` Deployment and sets the image tag to a specified release tag according to [selected](modules/002-deckhouse/configuration.html#parameters-update) update mode and update windows (automatic at any time by default).
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -108,7 +108,7 @@ spec:
 
 ### Как применить обновление минуя окна обновлений?
 
-Чтобы применить обновление немедленно, не дожидаясь ближайшего окна обновлений, установите в соответствующем ресурсе [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease) аннотацию `release.deckhouse.io/apply-now: "true"`.
+Чтобы применить обновление немедленно, не дожидаясь ближайшего окна обновлений, установите в соответствующем ресурсе [DeckhouseRelease](cr.html#deckhouserelease) аннотацию `release.deckhouse.io/apply-now: "true"`.
 
 Пример команды установки аннотации пропуска окон обновлений для версии `v1.56.2`:
 
@@ -145,7 +145,7 @@ metadata:
 
 Если алерт `DeckhouseUpdating` погас, значит, обновление завершено.
 
-Вы также можете проверить состояние [релизов](modules/002-deckhouse/cr.html#deckhouserelease) Deckhouse.
+Вы также можете проверить состояние [релизов](cr.html#deckhouserelease) Deckhouse.
 
 Пример:
 
@@ -188,7 +188,7 @@ deckhouse-7844b47bcd-qtbx9  1/1   Running  0       1d
 
 Как только на установленном в кластере канале обновления появляется новая версия Deckhouse:
 - Загорается алерт `DeckhouseReleaseIsWaitingManualApproval`, если кластер использует ручной режим обновлений (параметр [update.mode](modules/002-deckhouse/configuration.html#parameters-update-mode) установлен в `Manual`).
-- Появляется новый custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease). Используйте команду `kubectl get deckhousereleases`, чтобы посмотреть список релизов. Если `DeckhouseRelease` новой версии находится в состоянии `Pending`, указанная версия еще не установлена. Возможные причины, при которых `DeckhouseRelease` может находиться в `Pending`:
+- Появляется новый custom resource [DeckhouseRelease](cr.html#deckhouserelease). Используйте команду `kubectl get deckhousereleases`, чтобы посмотреть список релизов. Если `DeckhouseRelease` новой версии находится в состоянии `Pending`, указанная версия еще не установлена. Возможные причины, при которых `DeckhouseRelease` может находиться в `Pending`:
   - Установлен ручной режим обновлений (параметр [update.mode](modules/002-deckhouse/configuration.html#parameters-update-mode) установлен в `Manual`).
   - Установлен автоматический режим обновлений и настроены [окна обновлений](modules/002-deckhouse/usage.html#конфигурация-окон-обновлений), интервал которых еще не наступил.
   - Установлен автоматический режим обновлений, окна обновлений не настроены, но применение версии отложено на случайный период времени из-за механизма снижения нагрузки на репозиторий образов контейнеров. В поле `status.message` ресурса `DeckhouseRelease` будет соответствующее сообщение.
@@ -197,8 +197,8 @@ deckhouse-7844b47bcd-qtbx9  1/1   Running  0       1d
 ### Как заранее получать информацию о предстоящем обновлении?
 
 Получать заранее информацию об обновлении минорных версий Deckhouse на канале обновлений можно следующими способами:
-- Настроить ручной [режим обновлений](modules/002-deckhouse/configuration.html#parameters-update-mode). В этом случае при появлении новой версии на канале обновлений загорится алерт `DeckhouseReleaseIsWaitingManualApproval` и в кластере появится новый custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease).
-- Настроить автоматический [режим обновлений](modules/002-deckhouse/configuration.html#parameters-update-mode) и указать минимальное время в параметре [minimalNotificationTime](modules/002-deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime), на которое будет отложено обновление. В этом случае при появлении новой версии на канале обновлений в кластере появится новый custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease). А если указать URL в параметре [update.notification.webhook](modules/002-deckhouse/configuration.html#parameters-update-notification-webhook), дополнительно произойдет вызов webhook'а.
+- Настроить ручной [режим обновлений](modules/002-deckhouse/configuration.html#parameters-update-mode). В этом случае при появлении новой версии на канале обновлений загорится алерт `DeckhouseReleaseIsWaitingManualApproval` и в кластере появится новый custom resource [DeckhouseRelease](cr.html#deckhouserelease).
+- Настроить автоматический [режим обновлений](modules/002-deckhouse/configuration.html#parameters-update-mode) и указать минимальное время в параметре [minimalNotificationTime](modules/002-deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime), на которое будет отложено обновление. В этом случае при появлении новой версии на канале обновлений в кластере появится новый custom resource [DeckhouseRelease](cr.html#deckhouserelease). А если указать URL в параметре [update.notification.webhook](modules/002-deckhouse/configuration.html#parameters-update-notification-webhook), дополнительно произойдет вызов webhook'а.
 
 ### Как узнать, какая версия Deckhouse находится на каком канале обновлений?
 
@@ -208,7 +208,7 @@ deckhouse-7844b47bcd-qtbx9  1/1   Running  0       1d
 
 При указании в конфигурации модуля `deckhouse` параметра `releaseChannel` Deckhouse будет каждую минуту проверять данные о релизе на канале обновлений.
 
-При появлении нового релиза Deckhouse скачивает его в кластер и создает custom resource [DeckhouseRelease](modules/002-deckhouse/cr.html#deckhouserelease).
+При появлении нового релиза Deckhouse скачивает его в кластер и создает custom resource [DeckhouseRelease](cr.html#deckhouserelease).
 
 После появления custom resource'а `DeckhouseRelease` в кластере Deckhouse выполняет обновление на соответствующую версию согласно установленным [параметрам обновления](modules/002-deckhouse/configuration.html#parameters-update) (по умолчанию — автоматически, в любое время).
 

--- a/docs/documentation/pages/DECKHOUSE_CR.md
+++ b/docs/documentation/pages/DECKHOUSE_CR.md
@@ -3,6 +3,7 @@ title: "Custom Resources"
 permalink: en/cr.html
 ---
 
+{{ site.data.schemas.global.crds.deckhouse-release | format_crd: "global" }}
 {{ site.data.schemas.global.crds.module | format_crd: "global" }}
 {{ site.data.schemas.global.crds.module-config | format_crd: "global" }}
 {{ site.data.schemas.global.crds.module-pull-override | format_crd: "global" }}

--- a/docs/documentation/pages/DECKHOUSE_CR_RU.md
+++ b/docs/documentation/pages/DECKHOUSE_CR_RU.md
@@ -4,6 +4,7 @@ permalink: ru/cr.html
 lang: ru
 ---
 
+{{ site.data.schemas.global.crds.deckhouse-release | format_crd: "global" }}
 {{ site.data.schemas.global.crds.module | format_crd: "global" }}
 {{ site.data.schemas.global.crds.module-config | format_crd: "global" }}
 {{ site.data.schemas.global.crds.module-pull-override | format_crd: "global" }}

--- a/modules/002-deckhouse/docs/CR.md
+++ b/modules/002-deckhouse/docs/CR.md
@@ -1,5 +1,0 @@
----
-title: "The deckhouse module: Custom Resources"
----
-
-<!-- SCHEMA -->

--- a/modules/002-deckhouse/docs/CR_RU.md
+++ b/modules/002-deckhouse/docs/CR_RU.md
@@ -1,5 +1,0 @@
----
-title: "Модуль deckhouse: Custom Resources"
----
-
-<!-- SCHEMA -->


### PR DESCRIPTION
## Description

The DeckhouseRelease CRD was moved in https://github.com/deckhouse/deckhouse/pull/8301 and the `deckhouse` module now has no CRDs.

Update sidebar structure and add DeckhouseRelease CRD from the `deckhouse-controller/crds` folder.

## Why do we need it in the patch release (if we do)?
We need to fix the documentation.

## What is the expected result?
`DeckhouseRelease` CRD appears on the [page](https://deckhouse.io/documentation/latest/cr.html).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Return DeckhouseRelease CRD on the site.
impact_level: low
```
