### PR TITLE
[docs][gs] Trim license key to get valid registryDockerCfg value

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -82,13 +82,13 @@ $(document).ready(function() {
   $.cookie('lang', '{{ page.lang }}');
   $('#enter-license-key').click((e)=> {
     e.preventDefault();
-    let licenseToken = $('[license-token]').val()
+    let licenseToken = $('[license-token]').val().trim();
     getLicenseToken(licenseToken)
   });
 
   $('[license-token]').keypress((e) => {
       const keycode = (event.keyCode ? event.keyCode : event.which);
-      let licenseToken = $('[license-token]').val()
+      let licenseToken = $('[license-token]').val().trim();
       if (keycode == '13') {
         getLicenseToken(licenseToken)
       }

--- a/docs/site/js/getting-started.js
+++ b/docs/site/js/getting-started.js
@@ -172,7 +172,7 @@ function triggerBlockOnItemContent(itemSelector, targetSelector, turnCommonEleme
   const input = $(itemSelector);
   const wrapper = $(targetSelector);
   if (input.val() !== '') {
-    update_license_parameters(input.val());
+    update_license_parameters(input.val().trim());
     wrapper.removeClass('disabled');
   } else if(input.val() === '' && !turnCommonElement) {
     getLicenseToken(input.val());
@@ -189,7 +189,7 @@ function toggleDisabled(tab, inputDataAttr) {
   if (tab === 'tab_layout_ce' ) {
     $('.dimmer-block-content.common').removeClass('disabled');
   } else if (tab === 'tab_layout_ee' ) {
-    const licenseToken = $(inputDataAttr).val();
+    const licenseToken = $(inputDataAttr).val().trim();
     getLicenseToken(licenseToken)
   }
 }


### PR DESCRIPTION
## Description
Trim license key to get valid registryDockerCfg value in the Getting Started.

## Why do we need it, and what problem does it solve?
If there are spaces in license token on the Installation step of the Getting Started, the registryDockerCfg value is incorrect,

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Trim license key to get valid registryDockerCfg value in the Getting Started.
impact_level: low
```
