### PR TITLE
[cloud-provider-yandex] Add requirements for deprecated zone removal in the next release

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/030-cloud-provider-azure/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/030-cloud-provider-gcp/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/030-cloud-provider-yandex/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/030-cloud-provider-yandex/requirements"
 	_ "github.com/deckhouse/deckhouse/modules/031-ceph-csi/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/031-local-path-provisioner/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/035-cni-flannel/hooks"

--- a/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone.go
+++ b/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone.go
@@ -30,7 +30,10 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
-const yandexDeprecatedZoneNodesKey = "node_groups_with_deprecated_region"
+const (
+	yandexDeprecatedZoneNodesKey   = "node_groups_with_deprecated_region"
+	yandexDeprecatedZoneInNodesKey = "yandex:hasDeprecatedZoneInNodes"
+)
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager",
@@ -70,7 +73,9 @@ func alertOnNodesInDeprecatedAvailabilityZones(input *go_hook.HookInput) error {
 	nodeGroupsWithDeprecatedZones := set.NewFromSnapshot(input.Snapshots[yandexDeprecatedZoneNodesKey])
 
 	if len(nodeGroupsWithDeprecatedZones) > 0 {
-		requirements.SaveValue(yandexDeprecatedZoneKey, true)
+		requirements.SaveValue(yandexDeprecatedZoneInNodesKey, true)
+	} else {
+		requirements.SaveValue(yandexDeprecatedZoneInNodesKey, false)
 	}
 
 	for _, nodeGroupName := range nodeGroupsWithDeprecatedZones.Slice() {

--- a/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone.go
+++ b/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
@@ -67,6 +68,10 @@ func filterYandexDeprecatedZoneNodes(obj *unstructured.Unstructured) (go_hook.Fi
 
 func alertOnNodesInDeprecatedAvailabilityZones(input *go_hook.HookInput) error {
 	nodeGroupsWithDeprecatedZones := set.NewFromSnapshot(input.Snapshots[yandexDeprecatedZoneNodesKey])
+
+	if len(nodeGroupsWithDeprecatedZones) > 0 {
+		requirements.SaveValue(yandexDeprecatedZoneKey, true)
+	}
 
 	for _, nodeGroupName := range nodeGroupsWithDeprecatedZones.Slice() {
 		input.MetricsCollector.Set("d8_node_group_node_with_deprecated_availability_zone", 1, map[string]string{

--- a/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone_test.go
@@ -55,6 +55,9 @@ spec:
 
 		It("Should succeed with no collected metrics", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInNodesKey)
+			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeFalse())
 			Expect(f.MetricsCollector.CollectedMetrics()).To(BeEmpty())
 		})
 	})
@@ -89,8 +92,9 @@ spec:
 			collectedMetrics := f.MetricsCollector.CollectedMetrics()
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(collectedMetrics).To(ContainElement(expectedMetric))
-			_, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInNodesKey)
 			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeTrue())
 			Expect(len(collectedMetrics)).Should(Equal(1))
 		})
 	})

--- a/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/alert_on_deprecated_availability_zone_test.go
@@ -22,11 +22,18 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: alert_on_deprecated_availability_zone ::", func() {
-	f := HookExecutionConfigInit(`{}`, `{}`)
+	const initValuesString = `
+global:
+  discovery: {}
+cloudProviderYandex:
+  internal: {}
+`
+	f := HookExecutionConfigInit(initValuesString, `{}`)
 
 	initialKubeState := `
 apiVersion: v1
@@ -82,6 +89,8 @@ spec:
 			collectedMetrics := f.MetricsCollector.CollectedMetrics()
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(collectedMetrics).To(ContainElement(expectedMetric))
+			_, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			Expect(exists).To(BeTrue())
 			Expect(len(collectedMetrics)).Should(Equal(1))
 		})
 	})

--- a/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration.go
+++ b/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration.go
@@ -88,28 +88,29 @@ func setDeprecatedZoneInUseFlag(input *go_hook.HookInput) error {
 		return fmt.Errorf("Failed to unmarshall d8-provider-cluster-configuration from the secret: %v", err)
 	}
 
-	hasDeprecatedZone := false
 	for _, zone := range pcc.Zones {
 		if zone == "ru-central1-c" {
-			hasDeprecatedZone = true
+			requirements.SaveValue(yandexDeprecatedZoneInConfigKey, true)
+			return nil
 		}
 	}
 
 	for _, zone := range pcc.MasterNodeGroup.Zones {
 		if zone == "ru-central1-c" {
-			hasDeprecatedZone = true
+			requirements.SaveValue(yandexDeprecatedZoneInConfigKey, true)
+			return nil
 		}
 	}
 
 	for _, ng := range pcc.NodeGroups {
 		for _, zone := range ng.Zones {
 			if zone == "ru-central1-c" {
-				hasDeprecatedZone = true
+				requirements.SaveValue(yandexDeprecatedZoneInConfigKey, true)
+				return nil
 			}
 		}
 	}
 
-	requirements.SaveValue(yandexDeprecatedZoneInConfigKey, hasDeprecatedZone)
-
+	requirements.SaveValue(yandexDeprecatedZoneInConfigKey, false)
 	return nil
 }

--- a/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration.go
+++ b/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"gopkg.in/yaml.v3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	yandexDeprecatedZoneKey = "yandex:deprecatedZoneInUse"
+)
+
+type NodeGroupZones struct {
+	Zones []string `yaml:"zones"`
+}
+
+type ProviderClusterConfigZones struct {
+	MasterNodeGroup NodeGroupZones   `yaml:"masterNodeGroup"`
+	NodeGroups      []NodeGroupZones `yaml:"nodeGroups"`
+	Zones           []string         `yaml:"zones"`
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "provider_cluster_configuration",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-provider-cluster-configuration"},
+			},
+			FilterFunc: applyProviderClusterConfigurationSecretFilter,
+		},
+	},
+}, setDeprecatedZoneInUseFlag)
+
+func applyProviderClusterConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
+	}
+
+	return secret, nil
+}
+
+func setDeprecatedZoneInUseFlag(input *go_hook.HookInput) error {
+	if len(input.Snapshots["provider_cluster_configuration"]) == 0 {
+		return fmt.Errorf("%s", "Can't find Secret d8-provider-cluster-configuration in Namespace kube-system")
+	}
+
+	secret := input.Snapshots["provider_cluster_configuration"][0].(*v1.Secret)
+
+	data := secret.Data["cloud-provider-cluster-configuration.yaml"]
+
+	pcc := ProviderClusterConfigZones{}
+
+	err := yaml.Unmarshal(data, &pcc)
+	if err != nil {
+		return fmt.Errorf("Failed to unmarshall d8-provider-cluster-configuration from the secret: %v", err)
+	}
+
+	hasDeprecatedZone := false
+	for _, zone := range pcc.Zones {
+		if zone == "ru-central1-c" {
+			hasDeprecatedZone = true
+		}
+	}
+
+	for _, zone := range pcc.MasterNodeGroup.Zones {
+		if zone == "ru-central1-c" {
+			hasDeprecatedZone = true
+		}
+	}
+
+	for _, ng := range pcc.NodeGroups {
+		for _, zone := range ng.Zones {
+			if zone == "ru-central1-c" {
+				hasDeprecatedZone = true
+			}
+		}
+	}
+
+	requirements.SaveValue(yandexDeprecatedZoneKey, hasDeprecatedZone)
+
+	return nil
+}

--- a/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration.go
+++ b/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	yandexDeprecatedZoneKey = "yandex:deprecatedZoneInUse"
+	yandexDeprecatedZoneInConfigKey = "yandex:hasDeprecatedZoneInConfig"
 )
 
 type NodeGroupZones struct {
@@ -109,7 +109,7 @@ func setDeprecatedZoneInUseFlag(input *go_hook.HookInput) error {
 		}
 	}
 
-	requirements.SaveValue(yandexDeprecatedZoneKey, hasDeprecatedZone)
+	requirements.SaveValue(yandexDeprecatedZoneInConfigKey, hasDeprecatedZone)
 
 	return nil
 }

--- a/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration_test.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: deprecated_zone_in_cluster_configuration ::", func() {
+	var (
+		initValuesString = `
+global:
+  discovery: {}
+cloudProviderYandex:
+  internal: {}
+`
+
+		clusterConfigurationWithDeprecatedZone = `
+apiVersion: deckhouse.io/v1
+existingNetworkID: enpma5uvcfbkuac1i1jb
+kind: YandexClusterConfiguration
+layout: WithNATInstance
+masterNodeGroup:
+  instanceClass:
+    cores: 2
+    etcdDiskSizeGb: 10
+    imageID: test
+    memory: 4096
+    platform: standard-v2
+  replicas: 1
+provider:
+  cloudID: test
+  folderID: test
+  serviceAccountJSON: |-
+    {
+      "id": "test"
+    }
+withNATInstance:
+  internalSubnetID: test
+  natInstanceExternalAddress: 84.201.160.148
+  exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
+nodeNetworkCIDR: 84.201.160.148/31
+sshPublicKey: ssh-rsa AAAAAbbbb
+zones:
+- ru-central1-a
+- ru-central1-b
+- ru-central1-c
+`
+		clusterConfigurationWithZones = `
+apiVersion: deckhouse.io/v1
+existingNetworkID: enpma5uvcfbkuac1i1jb
+kind: YandexClusterConfiguration
+layout: WithNATInstance
+masterNodeGroup:
+  instanceClass:
+    cores: 2
+    etcdDiskSizeGb: 10
+    imageID: test
+    memory: 4096
+    platform: standard-v2
+  replicas: 1
+provider:
+  cloudID: test
+  folderID: test
+  serviceAccountJSON: |-
+    {
+      "id": "test"
+    }
+withNATInstance:
+  internalSubnetID: test
+  natInstanceExternalAddress: 84.201.160.148
+  exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
+nodeNetworkCIDR: 84.201.160.148/31
+sshPublicKey: ssh-rsa AAAAAbbbb
+zones:
+- ru-central1-a
+- ru-central1-b
+- ru-central1-d
+`
+		clusterConfigurationWithoutZones = `
+apiVersion: deckhouse.io/v1
+existingNetworkID: enpma5uvcfbkuac1i1jb
+kind: YandexClusterConfiguration
+layout: WithNATInstance
+masterNodeGroup:
+  instanceClass:
+    cores: 2
+    etcdDiskSizeGb: 10
+    imageID: test
+    memory: 4096
+    platform: standard-v2
+  replicas: 1
+provider:
+  cloudID: test
+  folderID: test
+  serviceAccountJSON: |-
+    {
+      "id": "test"
+    }
+withNATInstance:
+  internalSubnetID: test
+  natInstanceExternalAddress: 84.201.160.148
+  exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
+nodeNetworkCIDR: 84.201.160.148/31
+sshPublicKey: ssh-rsa AAAAAbbbb
+`
+		clusterConfigurationWithMasterDeprecatedZone = `
+apiVersion: deckhouse.io/v1
+existingNetworkID: enpma5uvcfbkuac1i1jb
+kind: YandexClusterConfiguration
+layout: WithNATInstance
+masterNodeGroup:
+  instanceClass:
+    cores: 2
+    etcdDiskSizeGb: 10
+    imageID: test
+    memory: 4096
+    platform: standard-v2
+  replicas: 1
+  zones:
+    - ru-central1-a
+    - ru-central1-b
+    - ru-central1-c
+provider:
+  cloudID: test
+  folderID: test
+  serviceAccountJSON: |-
+    {
+      "id": "test"
+    }
+withNATInstance:
+  internalSubnetID: test
+  natInstanceExternalAddress: 84.201.160.148
+  exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
+nodeNetworkCIDR: 84.201.160.148/31
+sshPublicKey: ssh-rsa AAAAAbbbb
+`
+		clusterConfigurationWithNGDeprecatedZone = `
+apiVersion: deckhouse.io/v1
+existingNetworkID: enpma5uvcfbkuac1i1jb
+kind: YandexClusterConfiguration
+layout: WithNATInstance
+masterNodeGroup:
+  instanceClass:
+    cores: 2
+    etcdDiskSizeGb: 10
+    imageID: test
+    memory: 4096
+    platform: standard-v2
+  replicas: 1
+nodeGroups:
+  - name: worker
+    replicas: 1
+    zones:
+      - ru-central1-a
+      - ru-central1-b
+      - ru-central1-c
+    instanceClass:
+      cores: 4
+      memory: 8192
+      imageID: fd8nb7ecsbvj76dfaa8b
+      coreFraction: 50
+      externalIPAddresses:
+        - 198.51.100.5
+        - Auto
+provider:
+  cloudID: test
+  folderID: test
+  serviceAccountJSON: |-
+    {
+      "id": "test"
+    }
+withNATInstance:
+  internalSubnetID: test
+  natInstanceExternalAddress: 84.201.160.148
+  exporterAPIKey: ""
+  natInstanceResources:
+    cores: 2
+    memory: 2048
+nodeNetworkCIDR: 84.201.160.148/31
+sshPublicKey: ssh-rsa AAAAAbbbb
+`
+
+		stateWithDeprecatedZone = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(clusterConfigurationWithDeprecatedZone)), "e30=")
+		stateWithMasterDeprecatedZone = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(clusterConfigurationWithMasterDeprecatedZone)), "e30=")
+		stateWithNGDeprecatedZone = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(clusterConfigurationWithNGDeprecatedZone)), "e30=")
+
+		stateWithZones = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(clusterConfigurationWithZones)), "e30=")
+
+		stateWithoutZones = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(clusterConfigurationWithoutZones)), "e30=")
+	)
+
+	a := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Cluster has empty state", func() {
+		BeforeEach(func() {
+			a.BindingContexts.Set(a.KubeStateSet(``))
+			a.RunHook()
+		})
+
+		It("Hook should fail with errors", func() {
+			Expect(a).To(Not(ExecuteSuccessfully()))
+
+			Expect(a.GoHookError.Error()).Should(ContainSubstring(`Can't find Secret d8-provider-cluster-configuration in Namespace kube-system`))
+		})
+	})
+
+	b := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Provider cluster configuration contains deprecated zone", func() {
+		BeforeEach(func() {
+			b.BindingContexts.Set(b.KubeStateSet(stateWithDeprecatedZone))
+			b.RunHook()
+		})
+
+		It("Should set deprecatedZoneInUse to true", func() {
+			Expect(b).To(ExecuteSuccessfully())
+			requirements.GetValue(yandexDeprecatedZoneKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeTrue())
+		})
+	})
+
+	c := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Provider cluster configuration contains zones without deprecated one", func() {
+		BeforeEach(func() {
+			c.BindingContexts.Set(c.KubeStateSet(stateWithZones))
+			c.RunHook()
+		})
+
+		It("Should set deprecatedZoneInUse to false", func() {
+			Expect(c).To(ExecuteSuccessfully())
+
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeFalse())
+		})
+	})
+
+	d := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Provider cluster configuration doesn't contain zones", func() {
+		BeforeEach(func() {
+			d.BindingContexts.Set(d.KubeStateSet(stateWithoutZones))
+			d.RunHook()
+		})
+
+		It("Should set deprecatedZoneInUse to false", func() {
+			Expect(d).To(ExecuteSuccessfully())
+
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeFalse())
+		})
+	})
+
+	e := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Provider cluster configuration contains master deprecated zone", func() {
+		BeforeEach(func() {
+			e.BindingContexts.Set(e.KubeStateSet(stateWithMasterDeprecatedZone))
+			e.RunHook()
+		})
+
+		It("Should set deprecatedZoneInUse to true", func() {
+			Expect(e).To(ExecuteSuccessfully())
+			requirements.GetValue(yandexDeprecatedZoneKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeTrue())
+		})
+	})
+	f := HookExecutionConfigInit(initValuesString, `{}`)
+	Context("Provider cluster configuration contains ng deprecated zone", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(stateWithNGDeprecatedZone))
+			f.RunHook()
+		})
+
+		It("Should set deprecatedZoneInUse to true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			requirements.GetValue(yandexDeprecatedZoneKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			Expect(exists).To(BeTrue())
+			Expect(hasDeprecatedZone).To(BeTrue())
+		})
+	})
+})

--- a/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/deprecated_zone_in_cluster_configuration_test.go
@@ -291,8 +291,8 @@ data:
 
 		It("Should set deprecatedZoneInUse to true", func() {
 			Expect(b).To(ExecuteSuccessfully())
-			requirements.GetValue(yandexDeprecatedZoneKey)
-			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			requirements.GetValue(yandexDeprecatedZoneInConfigKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInConfigKey)
 			Expect(exists).To(BeTrue())
 			Expect(hasDeprecatedZone).To(BeTrue())
 		})
@@ -308,7 +308,7 @@ data:
 		It("Should set deprecatedZoneInUse to false", func() {
 			Expect(c).To(ExecuteSuccessfully())
 
-			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInConfigKey)
 			Expect(exists).To(BeTrue())
 			Expect(hasDeprecatedZone).To(BeFalse())
 		})
@@ -324,7 +324,7 @@ data:
 		It("Should set deprecatedZoneInUse to false", func() {
 			Expect(d).To(ExecuteSuccessfully())
 
-			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInConfigKey)
 			Expect(exists).To(BeTrue())
 			Expect(hasDeprecatedZone).To(BeFalse())
 		})
@@ -339,8 +339,8 @@ data:
 
 		It("Should set deprecatedZoneInUse to true", func() {
 			Expect(e).To(ExecuteSuccessfully())
-			requirements.GetValue(yandexDeprecatedZoneKey)
-			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			requirements.GetValue(yandexDeprecatedZoneInConfigKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInConfigKey)
 			Expect(exists).To(BeTrue())
 			Expect(hasDeprecatedZone).To(BeTrue())
 		})
@@ -354,8 +354,8 @@ data:
 
 		It("Should set deprecatedZoneInUse to true", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			requirements.GetValue(yandexDeprecatedZoneKey)
-			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneKey)
+			requirements.GetValue(yandexDeprecatedZoneInConfigKey)
+			hasDeprecatedZone, exists := requirements.GetValue(yandexDeprecatedZoneInConfigKey)
 			Expect(exists).To(BeTrue())
 			Expect(hasDeprecatedZone).To(BeTrue())
 		})

--- a/modules/030-cloud-provider-yandex/requirements/check.go
+++ b/modules/030-cloud-provider-yandex/requirements/check.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirements
+
+import (
+	"errors"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	yandexDeprecatedZoneKey             = "yandex:deprecatedZoneInUse"
+	yandexDeprecatedZoneRequirementsKey = "yandexDeprecatedZoneInUse"
+)
+
+func init() {
+	f := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		hasDepracatedZone, exists := getter.Get(yandexDeprecatedZoneKey)
+		if exists {
+			if hasDepracatedZone.(bool) {
+				return false, errors.New("cluster use deprecated zone \"ru-central1-c\". Remove it from provider-cluster-config and nodes")
+			}
+		}
+
+		return true, nil
+	}
+
+	requirements.RegisterCheck(yandexDeprecatedZoneRequirementsKey, f)
+}

--- a/modules/030-cloud-provider-yandex/requirements/check.go
+++ b/modules/030-cloud-provider-yandex/requirements/check.go
@@ -30,7 +30,7 @@ const (
 )
 
 func init() {
-	checkRequirementInConfigFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+	checkRequirementInConfigFunc := func(_ string, getter requirements.ValueGetter) (bool, error) {
 		hasDeprecatedZone, exists := getter.Get(yandexDeprecatedZoneInConfigKey)
 		if exists {
 			if hasDeprecatedZone.(bool) {
@@ -40,7 +40,7 @@ func init() {
 
 		return true, nil
 	}
-	checkRequirementInZonesFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+	checkRequirementInZonesFunc := func(_ string, getter requirements.ValueGetter) (bool, error) {
 		hasDeprecatedZone, exists := getter.Get(yandexDeprecatedZoneInNodesKey)
 		if exists {
 			if hasDeprecatedZone.(bool) {

--- a/modules/030-cloud-provider-yandex/requirements/check.go
+++ b/modules/030-cloud-provider-yandex/requirements/check.go
@@ -23,21 +23,34 @@ import (
 )
 
 const (
-	yandexDeprecatedZoneKey             = "yandex:deprecatedZoneInUse"
-	yandexDeprecatedZoneRequirementsKey = "yandexDeprecatedZoneInUse"
+	yandexDeprecatedZoneInConfigKey             = "yandex:hasDeprecatedZoneInConfig"
+	yandexDeprecatedZoneInNodesKey              = "yandex:hasDeprecatedZoneInNodes"
+	yandexDeprecatedZoneInConfigRequirementsKey = "yandexHasDeprecatedZoneInConfig"
+	yandexDeprecatedZoneInNodesRequirementsKey  = "yandexHasDeprecatedZoneInNodes"
 )
 
 func init() {
-	f := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
-		hasDepracatedZone, exists := getter.Get(yandexDeprecatedZoneKey)
+	checkRequirementInConfigFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		hasDeprecatedZone, exists := getter.Get(yandexDeprecatedZoneInConfigKey)
 		if exists {
-			if hasDepracatedZone.(bool) {
-				return false, errors.New("cluster use deprecated zone \"ru-central1-c\". Remove it from provider-cluster-config and nodes")
+			if hasDeprecatedZone.(bool) {
+				return false, errors.New("cluster use deprecated zone \"ru-central1-c\". Remove it from provider-cluster-config")
+			}
+		}
+
+		return true, nil
+	}
+	checkRequirementInZonesFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		hasDeprecatedZone, exists := getter.Get(yandexDeprecatedZoneInNodesKey)
+		if exists {
+			if hasDeprecatedZone.(bool) {
+				return false, errors.New("cluster use deprecated zone \"ru-central1-c\". Remove it from NodeGroups and check nodes")
 			}
 		}
 
 		return true, nil
 	}
 
-	requirements.RegisterCheck(yandexDeprecatedZoneRequirementsKey, f)
+	requirements.RegisterCheck(yandexDeprecatedZoneInConfigRequirementsKey, checkRequirementInConfigFunc)
+	requirements.RegisterCheck(yandexDeprecatedZoneInNodesRequirementsKey, checkRequirementInZonesFunc)
 }

--- a/modules/030-cloud-provider-yandex/requirements/check_test.go
+++ b/modules/030-cloud-provider-yandex/requirements/check_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+func TestKubernetesVersionRequirement(t *testing.T) {
+	t.Run("requirement met", func(t *testing.T) {
+		requirements.SaveValue(yandexDeprecatedZoneKey, false)
+		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneRequirementsKey, "")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("requirement failed", func(t *testing.T) {
+		requirements.SaveValue(yandexDeprecatedZoneKey, true)
+		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneRequirementsKey, "")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+}

--- a/modules/030-cloud-provider-yandex/requirements/check_test.go
+++ b/modules/030-cloud-provider-yandex/requirements/check_test.go
@@ -26,16 +26,28 @@ import (
 )
 
 func TestKubernetesVersionRequirement(t *testing.T) {
-	t.Run("requirement met", func(t *testing.T) {
-		requirements.SaveValue(yandexDeprecatedZoneKey, false)
-		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneRequirementsKey, "")
+	t.Run("in-config requirement met", func(t *testing.T) {
+		requirements.SaveValue(yandexDeprecatedZoneInConfigKey, false)
+		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneInConfigRequirementsKey, "")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+	t.Run("in-nodes requirement met", func(t *testing.T) {
+		requirements.SaveValue(yandexDeprecatedZoneInNodesKey, false)
+		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneInNodesRequirementsKey, "")
 		assert.True(t, ok)
 		require.NoError(t, err)
 	})
 
-	t.Run("requirement failed", func(t *testing.T) {
-		requirements.SaveValue(yandexDeprecatedZoneKey, true)
-		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneRequirementsKey, "")
+	t.Run("in-config requirement failed", func(t *testing.T) {
+		requirements.SaveValue(yandexDeprecatedZoneInConfigKey, true)
+		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneInConfigRequirementsKey, "")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+	t.Run("in-nodes requirement failed", func(t *testing.T) {
+		requirements.SaveValue(yandexDeprecatedZoneInNodesKey, true)
+		ok, err := requirements.CheckRequirement(yandexDeprecatedZoneInNodesRequirementsKey, "")
 		assert.False(t, ok)
 		require.Error(t, err)
 	})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add requirements for deprecated zone removal in the next release.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We want to remove deprecated zone from candi (terraform) and configs in the next release. We need to check if cluster is ready for this.

#7781 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We don't.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Add requirements for deprecated zone removal in the next release. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
