### PR TITLE
Fix oom_kills:normalized metric for cgroup_path with cri-containerd in name

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
@@ -15,9 +15,9 @@
   - record: oom_kills:normalized
     expr: |-
       max by (namespace, pod, container) (
-        label_replace(kube_pod_container_info, "raw_container_id", "$1", "container_id", "containerd://(.+)")
+        label_replace(kube_pod_container_info{container_id!=""}, "raw_container_id", "$1", "container_id", "containerd://(.+)")
         * on (raw_container_id) group_left
-        max by (raw_container_id) (label_replace(ebpf_exporter_oom_kills{cgroup_path=~".*slice.*"}, "raw_container_id", "$1", "cgroup_path", ".+cri-containerd-(.+).scope"))
+        max by (raw_container_id) (label_replace(ebpf_exporter_oom_kills{cgroup_path=~".+cri-containerd-.+.scope"}, "raw_container_id", "$1", "cgroup_path", ".+cri-containerd-(.+).scope"))
       )
   - record: oom_kills:normalized
     expr: |-


### PR DESCRIPTION
## Description

Precomputed `oom_kills:normalized` contains more results than the original `ebpf_exporter_oom_kills`

You can see it in the screenshots:

#### `ebpf_exporter_oom_kills` metric
![`ebpf_exporter_oom_kills` metric](https://github.com/deckhouse/deckhouse/assets/6770225/3cdf09d4-5578-438a-a63a-8d29ba08da6e)

#### `oom_kills:normalized` precomputed metric
![`oom_kills:normalized` precomputed metric](https://github.com/deckhouse/deckhouse/assets/6770225/1fb407f5-2b9d-4ace-97b1-e94ed77ea8f7)

## Fix details

There were 2 problems:

1. metric `ebpf_exporter_oom_kills` was filtered using the wrong regexp `.*slice.*` in cgroup_path label (probably copied from previous prometheus rule). Then cgroup_path was parsed to get `raw_container_id` but since it's not in the expected format parsing has always given `raw_container_id=""`.
2. `kube_pod_container_info` sometimes doesn't have `container_id` label. The label is sometimes not there briefly after container creation (for 1 probe).

As a result, 2 metrics were merged by an empty raw_container_id label giving false-positive results. Basically, for every `kube_pod_container_info` metric without the `container_id` label false-positive metric was generated if there is even 1 OOM kill in the cluster.

I resolved the problem by fixing `cgroup_path` filter. I've also added `container_id!=""` filter to `kube_pod_container_info` metric since we don't need to include metrics that can't be relabeled.

## Why do we need it, and what problem does it solve?

It removes false-positive results from precomputed metric

## Why do we need it in the patch release (if we do)?

It fixes a bug and does not introduce breaking changes.

## What is the expected result?

Only `PrometheusRule` `monitoring-kubernetes-kubernetes-ebpf-exporter` in namespace `d8-monitoring` must change

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes
type: fix
summary: Fix false-positive results in precomputed metric `oom_kills:normalized`
impact_level: default
```