### PR TITLE
[common] add patch for kube-scheduller 1.27.14

### DIFF
--- a/modules/000-common/images/kubernetes/patches/kube-scheduler/1.27/01-kube-scheduler-fix-int-divide-by-zero.patch
+++ b/modules/000-common/images/kubernetes/patches/kube-scheduler/1.27/01-kube-scheduler-fix-int-divide-by-zero.patch
@@ -1,0 +1,89 @@
+diff --git a/pkg/scheduler/schedule_one.go b/pkg/scheduler/schedule_one.go
+index 974f82b02f6..01c6b31b988 100644
+--- a/pkg/scheduler/schedule_one.go
++++ b/pkg/scheduler/schedule_one.go
+@@ -451,7 +451,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
+ 	// always try to update the sched.nextStartNodeIndex regardless of whether an error has occurred
+ 	// this is helpful to make sure that all the nodes have a chance to be searched
+ 	processedNodes := len(feasibleNodes) + len(diagnosis.NodeToStatusMap)
+-	sched.nextStartNodeIndex = (sched.nextStartNodeIndex + processedNodes) % len(nodes)
++	sched.nextStartNodeIndex = (sched.nextStartNodeIndex + processedNodes) % len(allNodes)
+ 	if err != nil {
+ 		return nil, diagnosis, err
+ 	}
+diff --git a/pkg/scheduler/schedule_one_test.go b/pkg/scheduler/schedule_one_test.go
+index ca20134c1f4..7571d738918 100644
+--- a/pkg/scheduler/schedule_one_test.go
++++ b/pkg/scheduler/schedule_one_test.go
+@@ -2080,6 +2080,33 @@ func TestSchedulerSchedulePod(t *testing.T) {
+ 			pod:       st.MakePod().Name("ignore").UID("ignore").Obj(),
+ 			wantNodes: sets.NewString("node1", "node2"),
+ 		},
++		{
++			name: "test prefilter plugin returned an invalid node",
++			registerPlugins: []st.RegisterPluginFunc{
++				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
++				st.RegisterPreFilterPlugin(
++					"FakePreFilter",
++					st.NewFakePreFilterPlugin("FakePreFilter", &framework.PreFilterResult{
++						NodeNames: sets.NewString("invalid-node"),
++					}, nil),
++				),
++				st.RegisterFilterPlugin("TrueFilter", st.NewTrueFilterPlugin),
++				st.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
++			},
++			nodes:     []string{"1", "2"},
++			pod:       st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
++			wantNodes: nil,
++			wErr: &framework.FitError{
++				Pod:         st.MakePod().Name("test-prefilter").UID("test-prefilter").Obj(),
++				NumAllNodes: 2,
++				Diagnosis: framework.Diagnosis{
++					NodeToStatusMap: framework.NodeToStatusMap{
++						"1": framework.NewStatus(framework.UnschedulableAndUnresolvable, "node is filtered out by the prefilter result"),
++						"2": framework.NewStatus(framework.UnschedulableAndUnresolvable, "node is filtered out by the prefilter result"),
++					},
++				},
++			},
++		},
+ 	}
+ 	for _, test := range tests {
+ 		t.Run(test.name, func(t *testing.T) {
+diff --git a/test/integration/scheduler/scheduler_test.go b/test/integration/scheduler/scheduler_test.go
+index 2443857671d..9ef76e803d1 100644
+--- a/test/integration/scheduler/scheduler_test.go
++++ b/test/integration/scheduler/scheduler_test.go
+@@ -476,6 +476,33 @@ func TestSchedulerInformers(t *testing.T) {
+ 			}),
+ 			preemptedPodIndexes: map[int]struct{}{2: {}},
+ 		},
++		{
++			name:         "The pod cannot be scheduled when nodeAffinity specifies a non-existent node.",
++			nodes:        []*nodeConfig{{name: "node-1", res: defaultNodeRes}},
++			existingPods: []*v1.Pod{},
++			pod: testutils.InitPausePod(&testutils.PausePodConfig{
++				Name:      "unschedulable-pod",
++				Namespace: testCtx.NS.Name,
++				Affinity: &v1.Affinity{
++					NodeAffinity: &v1.NodeAffinity{
++						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
++							NodeSelectorTerms: []v1.NodeSelectorTerm{
++								{
++									MatchFields: []v1.NodeSelectorRequirement{
++										{
++											Key:      "metadata.name",
++											Operator: v1.NodeSelectorOpIn,
++											Values:   []string{"invalid-node"},
++										},
++									},
++								},
++							},
++						},
++					},
++				},
++				Resources: defaultPodRes,
++			}),
++		},
+ 	}
+ 
+ 	for _, test := range tests {

--- a/modules/000-common/images/kubernetes/patches/kube-scheduler/README.md
+++ b/modules/000-common/images/kubernetes/patches/kube-scheduler/README.md
@@ -1,0 +1,6 @@
+### kube-scheduler-fix-int-divide-by-zero.patch
+
+Fixed a bug in the scheduler where it would crash when prefilter returns a non-existent node.
+https://github.com/kubernetes/kubernetes/issues/124930
+
+TODO: Delete this patch after version k8s 1.27.15


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed a bug in the scheduler (version 1.27.14) where it would crash when prefilter returns a non-existent node.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Cherry pick of https://github.com/kubernetes/kubernetes/pull/124933

## Why do we need it in the patch release (if we do)?

Scheduler fix for the current default version of k8s(1.27.14).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed a bug in the scheduler (version 1.27.14) where it would crash when prefilter returns a non-existent node.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
