### PR TITLE
[cloud-provider-aws] fix non-type-lb patch 1.29

### DIFF
--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.29/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.29/002-non-type-lb.patch
@@ -1,8 +1,8 @@
 diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
-index 39dab8f..af8217e 100644
+index 1e276f2..c79f262 100644
 --- a/pkg/providers/v1/aws.go
 +++ b/pkg/providers/v1/aws.go
-@@ -310,6 +310,13 @@ var backendProtocolMapping = map[string]string{
+@@ -321,6 +321,13 @@ var backendProtocolMapping = map[string]string{
  	"tcp":   "ssl",
  }
 
@@ -16,7 +16,7 @@ index 39dab8f..af8217e 100644
  // MaxReadThenCreateRetries sets the maximum number of attempts we will make when
  // we read to see if something exists and then try to create it if we didn't find it.
  // This can fail once in a consistent system if done in parallel
-@@ -3992,7 +3999,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
+@@ -4066,7 +4073,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  			continue
  		}
 
@@ -25,8 +25,7 @@ index 39dab8f..af8217e 100644
  			portMapping := nlbPortMapping{
  				FrontendPort:     int64(port.Port),
  				FrontendProtocol: string(port.Protocol),
-@@ -4003,7 +4010,11 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
- 			if portMapping.HealthCheckConfig, err = c.buildNLBHealthCheckConfiguration(apiService); err != nil {
+@@ -4078,6 +4085,12 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  				return nil, err
  			}
 -
@@ -35,11 +34,11 @@ index 39dab8f..af8217e 100644
 +				portMapping.HealthCheckConfig.Port = "10256" // ProxyHealthzPort
 +				portMapping.HealthCheckConfig.Path = "/healthz"
 +			}
++
  			certificateARN := annotations[ServiceAnnotationLoadBalancerCertificate]
  			if port.Protocol != v1.ProtocolUDP && certificateARN != "" && (sslPorts == nil || sslPorts.numbers.Has(int64(port.Port)) || sslPorts.names.Has(port.Name)) {
  				portMapping.FrontendProtocol = elbv2.ProtocolEnumTls
-@@ -4014,7 +4025,18 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
- 					portMapping.TrafficProtocol = elbv2.ProtocolEnumTls
+@@ -4089,6 +4102,19 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  				}
  			}
 -
@@ -58,8 +57,7 @@ index 39dab8f..af8217e 100644
  			v2Mappings = append(v2Mappings, portMapping)
  		} else {
  			listener, err := buildListener(port, annotations, sslPorts)
-@@ -4047,7 +4069,58 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
- 	} else if internalAnnotation != "" {
+@@ -4122,6 +4148,57 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  		internalELB = true
  	}
 +	if isNone(annotations) {
@@ -116,8 +114,8 @@ index 39dab8f..af8217e 100644
 +	}
  	if isNLB(annotations) {
  		// Find the subnets that the ELB will live in
- 		subnetIDs, err := c.getLoadBalancerSubnets(apiService, internalELB)
-@@ -4365,7 +4438,34 @@ func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
+ 		discoveredSubnetIDs, err := c.getLoadBalancerSubnets(apiService, internalELB)
+@@ -4448,6 +4525,34 @@ func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
  		return nil, false, nil
  	}
  	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
@@ -151,8 +149,7 @@ index 39dab8f..af8217e 100644
 +	}
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
- 		if err != nil {
-@@ -4629,6 +4729,25 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
+@@ -4712,6 +4817,26 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
  	}
  	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
@@ -178,7 +175,7 @@ index 39dab8f..af8217e 100644
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
  		if err != nil {
-@@ -4819,6 +4938,10 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
+@@ -4902,6 +5027,10 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
  		return err
  	}
  	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
@@ -189,7 +186,7 @@ index 39dab8f..af8217e 100644
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
  		if err != nil {
-@@ -5183,6 +5306,10 @@ func getInitialAttachDetachDelay(status string) time.Duration {
+@@ -5262,6 +5391,10 @@ func getInitialAttachDetachDelay(status string) time.Duration {
  	return volumeAttachmentStatusInitialDelay
  }
 
@@ -201,7 +198,7 @@ index 39dab8f..af8217e 100644
  func (c *Cloud) describeNetworkInterfaces(nodeName string) (*ec2.NetworkInterface, error) {
  	eniEndpoint := strings.TrimPrefix(nodeName, fargateNodeNamePrefix)
 diff --git a/pkg/providers/v1/aws_loadbalancer.go b/pkg/providers/v1/aws_loadbalancer.go
-index 8f9884c..280caf1 100644
+index c39ea3d..7f90505 100644
 --- a/pkg/providers/v1/aws_loadbalancer.go
 +++ b/pkg/providers/v1/aws_loadbalancer.go
 @@ -87,6 +87,13 @@ func isLBExternal(annotations map[string]string) bool {
@@ -238,7 +235,7 @@ index 8f9884c..280caf1 100644
 +}
 +
  // ensureLoadBalancerv2 ensures a v2 load balancer is created
- func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, subnetIDs []string, internalELB bool, annotations map[string]string) (*elbv2.LoadBalancer, error) {
+ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, discoveredSubnetIDs []string, internalELB bool, annotations map[string]string) (*elbv2.LoadBalancer, error) {
  	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -576,7 +598,7 @@ func (c *Cloud) deleteListenerV2(listener *elbv2.Listener) error {
  }
@@ -260,7 +257,7 @@ index 8f9884c..280caf1 100644
  		if mapping.HealthCheckConfig.Protocol != elbv2.ProtocolEnumTcp {
  			input.HealthCheckPath = aws.String(mapping.HealthCheckConfig.Path)
  		}
-@@ -622,6 +648,21 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
+@@ -626,6 +652,21 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  		return tg, nil
  	}
 

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
   - mkdir /src
   - wget https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/{{ $value.ccm.aws }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/
   - cd /src
-  - test -d /patches/{{ $version }} && for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
+  - find /patches/{{ $version }} -name '*.patch' | xargs git apply --verbose
   - export VERSION={{ $value.ccm.aws }}
   - make aws-cloud-controller-manager
   - chown 64535:64535 /src/aws-cloud-controller-manager


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
