### PR TITLE
[docs][modules] Updates for module status

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -181,11 +181,14 @@ comparison:
 
 features:
   experimental:
-    en: This feature is actively developed. It might significantly change in the future.
-    ru: Находится в процессе активного развития. Функциональность может существенно измениться.
+    en: The functionality of the module might significantly change. Compatibility with future versions is not guaranteed.
+    ru: Функциональность модуля может сильно измениться. Совместимость с будущими версиями не гарантируется
+  preview:
+    en: The functionality of the module might change, but the main features will remain. Compatibility with future versions is guaranteed, but might require additional migration steps.
+    ru: Функциональность модуля может измениться, но основные возможности сохранятся. Совместимость с будущими версиями обеспечивается, но может потребовать дополнительных действий по миграции.
   deprecated:
-    en: The current version of the module is deprecated.
-    ru: Текущая версия модуля устарела.
+    en: The module is deprecated.
+    ru: Модуль выведен из употребления.
   temporaryDeprecated:
     en: The current version of the module is deprecated, a new version will be published soon.
     ru: Текущая версия модуля устарела, скоро будет опубликована новая версия.

--- a/docs/site/_data/i18n.yaml
+++ b/docs/site/_data/i18n.yaml
@@ -184,11 +184,14 @@ comparison:
 
 features:
   experimental:
-    en: This feature is actively developed. It might significantly change in the future.
-    ru: Находится в процессе активного развития. Функциональность может существенно измениться.
+    en: The functionality of the module might significantly change. Compatibility with future versions is not guaranteed.
+    ru: Функциональность модуля может сильно измениться. Совместимость с будущими версиями не гарантируется
+  preview:
+    en: The functionality of the module might change, but the main features will remain. Compatibility with future versions is guaranteed, but might require additional migration steps.
+    ru: Функциональность модуля может измениться, но основные возможности сохранятся. Совместимость с будущими версиями обеспечивается, но может потребовать дополнительных действий по миграции.
   deprecated:
-    en: The current version of the module is deprecated.
-    ru: Текущая версия модуля устарела.
+    en: The module is deprecated.
+    ru: Модуль выведен из употребления.
   temporaryDeprecated:
     en: The current version of the module is deprecated, a new version will be published soon.
     ru: Текущая версия модуля устарела, скоро будет опубликована новая версия.

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -23,7 +23,9 @@ moduleLinkTitleFAQ: FAQ
 moduleLinkTitleCRD: Custom Resources
 moduleLinkTitleCR: Custom Resources
 module_is_available_in_ee_only: The module is available only in Deckhouse Enterprise Edition.
-module_alert_experimental: The module is actively developed. It might significantly change in the future.
+module_alert_experimental: The functionality of the module might significantly change. Compatibility with future versions is not guaranteed.
+module_alert_preview: The functionality of the module might change, but the main features will remain. Compatibility with future versions is guaranteed, but might require additional migration steps.
+module_alert_deprecated: The module is deprecated.
 deprecated_parameter: Deprecated
 deprecated_parameter_hint: Support for the parameter might be removed in a later release.
 element_of_array: element of the array

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -23,7 +23,9 @@ moduleLinkTitleFAQ: FAQ
 moduleLinkTitleCRD: Custom Resources
 moduleLinkTitleCR: Custom Resources
 module_is_available_in_ee_only: Модуль доступен только в Deckhouse Enterprise Edition.
-module_alert_experimental: Модуль находится в процессе активного развития. Функциональность может существенно измениться.
+module_alert_experimental: Функциональность модуля может сильно измениться. Совместимость с будущими версиями не гарантируется
+module_alert_preview: Функциональность модуля может измениться, но основные возможности сохранятся. Совместимость с будущими версиями обеспечивается, но может потребовать дополнительных действий по миграции.
+module_alert_deprecated: Модуль выведен из употребления.
 deprecated_parameter: Параметр устарел
 deprecated_parameter_hint: Поддержка параметра может быть исключена в следующих версиях.
 element_of_array: элемент массива

--- a/docs/site/backends/docs-builder-template/layouts/_default/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/_default/single.html
@@ -25,8 +25,8 @@
         {{- if eq $d8Edition "ee" }}
           {{- partial "alert" ( dict "level" "warn" "content" (T "module_is_available_in_ee_only") ) }}
         {{- end }}
-        {{- if eq $moduleStatus "experimental" }}
-          {{- partial "alert" ( dict "level" "warn" "content" (T "module_alert_experimental") ) }}
+        {{- if $moduleStatus }}
+          {{- partial "alert" ( dict "level" "warn" "content" (T (printf "module_alert_%s" (lower $moduleStatus))) ) }}
         {{- end }}
 
         {{.Content}}

--- a/docs/site/backends/docs-builder-template/layouts/partials/alert.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/alert.html
@@ -4,9 +4,11 @@
 {{- if and .level (in $levels (lower .level) ) }}{{ $level = lower .level }}{{ end }}
 {{- if eq $level "warn" }}{{ $level = "warning" }}{{ end }}
 
+{{- if $content }}
 <div class="{{ $level }} alert__wrap">
   <svg class="alert__icon icon--{{ $level }}">
     <use xlink:href="/images/sprite.svg#{{ $level }}-icon"></use>
   </svg>
   <div><p>{{ $content }}</p></div>
 </div>
+{{ end }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
@@ -70,7 +70,9 @@
                 <a href='#'>
                   {{- $sidebarItem.title }}
                   {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.d8Edition }}">EE Only</span>{{ end }}
-                  {{- if eq $sidebarItem.moduleStatus "experimental" }}<span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.moduleStatus }}">Experimental</span>{{ end }}
+                  {{- if $sidebarItem.moduleStatus -}}
+                    <span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.moduleStatus }}" title='{{ (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}'>{{ humanize $sidebarItem.moduleStatus }}</span>
+                  {{ end }}
                 </a>
                   {{- template "subpages" (dict "parent" $sidebarItem "pages" $pages "ctx" $ctx) }}
             </li>


### PR DESCRIPTION
## Description
Updates for module status:
- Updated i18n strings for module statuses.
  - Changed or added messages for 'experimental', 'preview' (new), and 'deprecated' (new) statuses.
- Enhanced alerts to support dynamic module status messages.
- Modified sidebar to display status badges with tooltips for better user experience.
- Improved HTML templates to handle different module statuses more efficiently.

To set a status to a module use the `moduleStatus` parameter in the front matter of the README file.

An example (set the preview status to the docs-example module):
```
---
title: "Module docs-example"
description: Module for testing docs render
summary: This is a summary of the docs-example module.
moduleStatus: preview
---
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Updates for module status. Possible module statuses are 'experimental', 'preview' (new), and 'deprecated' (new).
impact_level: default
```
