### PR TITLE
[candi](kubelet) Fix server certificate rotation

### DIFF
--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -190,13 +190,6 @@ function dynamic_memory_sizing {
     echo -n "${recommended_systemreserved_memory}Gi"
 }
 
-# CIS becnhmark purposes
-tls_params=""
-if [ -f /var/lib/kubelet/pki/kubelet-server-current.pem ]; then
-  tls_params="tlsCertFile: /var/lib/kubelet/pki/kubelet-server-current.pem
-tlsPrivateKeyFile: /var/lib/kubelet/pki/kubelet-server-current.pem"
-fi
-
 bb-sync-file /var/lib/kubelet/config.yaml - << EOF
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
@@ -261,7 +254,6 @@ tlsCipherSuites: ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_
 # serverTLSBootstrap flag should be enable after bootstrap of first master.
 # This flag affects logs from kubelet, for period of time between kubelet start and certificate request approve by Deckhouse hook.
 serverTLSBootstrap: true
-${tls_params}
 {{- end }}
 {{/*
 RotateKubeletServerCertificate default is true, but CIS becnhmark wants it to be explicitly enabled

--- a/ee/modules/500-operator-trivy/templates/reports/cis-benchmark-1.23.yaml
+++ b/ee/modules/500-operator-trivy/templates/reports/cis-benchmark-1.23.yaml
@@ -607,14 +607,6 @@ spec:
         checks:
           - id: AVD-KCV-0087
         severity: HIGH
-      - id: 4.2.10
-        name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
-          set as appropriate
-        description: Setup TLS connection on the Kubelets
-        checks:
-          - id: AVD-KCV-0088
-          - id: AVD-KCV-0089
-        severity: CRITICAL
       - id: 4.2.11
         name: Ensure that the --rotate-certificates argument is not set to false
         description: Enable kubelet client certificate rotation


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Remove fields `tlsCertFile` and `tlsPrivateKeyFile` from the kubelet configuration file
- Remove the `operator-trivy` compliance control with id `4.2.10`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The kubelet always uses the certificate and key from the `tlsCertFile` and `tlsPrivateKeyFile` files unless the client request contains the TLS server name. By default, in Deckhouse, all nodes communicate using IP addresses rather than hostnames.
Close #8245.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed kubelet server certificate rotation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
