### PR TITLE
[dhctl] Change interface for tee debug logger

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -206,7 +206,6 @@ func runApplication(kpApp *kingpin.Application) {
 }
 
 func isRunningInContainer() (bool, error) {
-	return true, nil
 	_, err := os.Stat(app.VersionFile)
 	_, inClusterEnvExists := os.LookupEnv("DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER")
 	switch {

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -165,7 +165,12 @@ func runApplication(kpApp *kingpin.Application) {
 			logPath = path.Join(app.TmpDirName, logFile)
 		}
 
-		err := log.WrapWithTeeLogger(logPath, 1024)
+		outFile, err := os.Create(logPath)
+		if err != nil {
+			return err
+		}
+
+		err = log.WrapWithTeeLogger(outFile, 1024)
 		if err != nil {
 			return err
 		}
@@ -201,6 +206,7 @@ func runApplication(kpApp *kingpin.Application) {
 }
 
 func isRunningInContainer() (bool, error) {
+	return true, nil
 	_, err := os.Stat(app.VersionFile)
 	_, inClusterEnvExists := os.LookupEnv("DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER")
 	switch {

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -53,10 +53,10 @@ func InitLogger(loggerType string) {
 	InitLoggerWithOptions(loggerType, LoggerOptions{IsDebug: app.IsDebug})
 }
 
-func WrapLoggerWithTeeLogger(pathToTeeFile string, bufSize int) error {
+func WrapLoggerWithTeeLogger(writer io.WriteCloser, bufSize int) error {
 	previousLogger := defaultLogger
 	var err error
-	defaultLogger, err = NewTeeLogger(defaultLogger, pathToTeeFile, bufSize)
+	defaultLogger, err = NewTeeLogger(defaultLogger, writer, bufSize)
 	if err != nil {
 		defaultLogger = previousLogger
 		return err
@@ -98,8 +98,8 @@ func InitLoggerWithOptions(loggerType string, opts LoggerOptions) {
 	}
 }
 
-func WrapWithTeeLogger(outFile string, bufSize int) error {
-	l, err := NewTeeLogger(defaultLogger, outFile, bufSize)
+func WrapWithTeeLogger(writer io.WriteCloser, bufSize int) error {
+	l, err := NewTeeLogger(defaultLogger, writer, bufSize)
 	if err != nil {
 		return err
 	}
@@ -581,21 +581,16 @@ type TeeLogger struct {
 
 	bufMutex sync.Mutex
 	buf      *bufio.Writer
-	out      *os.File
+	out      io.WriteCloser
 }
 
-func NewTeeLogger(l Logger, outFile string, bufferSize int) (*TeeLogger, error) {
-	out, err := os.Create(outFile)
-	if err != nil {
-		return nil, err
-	}
-
-	buf := bufio.NewWriterSize(out, bufferSize)
+func NewTeeLogger(l Logger, writer io.WriteCloser, bufferSize int) (*TeeLogger, error) {
+	buf := bufio.NewWriterSize(writer, bufferSize)
 
 	return &TeeLogger{
 		l:   l,
 		buf: buf,
-		out: out,
+		out: writer,
 	}, nil
 }
 


### PR DESCRIPTION
## Description
Debug tee logger needs WriteCloser interface instead of path name.

## Why do we need it, and what problem does it solve?
Need for implement debug logs in deckhouse-commander.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Change interface for tee debug logger
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
