### PR TITLE
[ingress-nginx] fix usage custom logs formats without our fields

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-tmpl.patch
@@ -65,7 +65,15 @@ index 4c0da2eb9..7dfa3f8f6 100644
  
          ssl_certificate_by_lua_block {
              certificate.call()
-@@ -960,9 +973,7 @@ stream {
+@@ -955,14 +968,15 @@ stream {
+             proxy_set_header       Host               $best_http_host;
+ 
+             set $proxy_upstream_name {{ $upstreamName | quote }};
++            set $formatted_status $status;
++            set $upstream_retries "0";
++            set $$total_upstream_response_time "0";
+ 
+             rewrite                (.*) / break;
  
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
@@ -76,7 +84,7 @@ index 4c0da2eb9..7dfa3f8f6 100644
              }
          }
          {{ end }}
-@@ -1008,6 +1019,9 @@ stream {
+@@ -1008,8 +1022,14 @@ stream {
  
          {{ buildHTTPListener  $all $server.Hostname }}
          {{ buildHTTPSListener $all $server.Hostname }}
@@ -85,8 +93,13 @@ index 4c0da2eb9..7dfa3f8f6 100644
 +        {{ end }}
  
          set $proxy_upstream_name "-";
++        set $formatted_status $status;
++        set $upstream_retries "0";
++        set $$total_upstream_response_time "0";
  
-@@ -1247,6 +1261,9 @@ stream {
+         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
+         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
+@@ -1247,6 +1267,9 @@ stream {
          {{ end }}
  
          location {{ $path }} {
@@ -96,7 +109,7 @@ index 4c0da2eb9..7dfa3f8f6 100644
              {{ $ing := (getIngressInformation $location.Ingress $server.Hostname $location.IngressPath) }}
              set $namespace      {{ $ing.Namespace | quote}};
              set $ingress_name   {{ $ing.Rule | quote }};
-@@ -1255,6 +1272,8 @@ stream {
+@@ -1255,6 +1278,8 @@ stream {
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
  
@@ -105,7 +118,7 @@ index 4c0da2eb9..7dfa3f8f6 100644
              {{ buildOpentelemetryForLocation $all.Cfg.EnableOpentelemetry $all.Cfg.OpentelemetryTrustIncomingSpan $location }}
  
              {{ if $location.Mirror.Source }}
-@@ -1285,11 +1304,9 @@ stream {
+@@ -1285,11 +1310,9 @@ stream {
  
              log_by_lua_block {
                  balancer.log()
@@ -118,7 +131,7 @@ index 4c0da2eb9..7dfa3f8f6 100644
              }
  
              {{ if not $location.Logs.Access }}
-@@ -1570,14 +1587,15 @@ stream {
+@@ -1570,14 +1593,15 @@ stream {
  
          {{ if eq $server.Hostname "_" }}
          # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-tmpl.patch
@@ -71,7 +71,7 @@ index 4c0da2eb9..7dfa3f8f6 100644
              set $proxy_upstream_name {{ $upstreamName | quote }};
 +            set $formatted_status $status;
 +            set $upstream_retries "0";
-+            set $$total_upstream_response_time "0";
++            set $total_upstream_response_time "0";
  
              rewrite                (.*) / break;
  
@@ -95,7 +95,7 @@ index 4c0da2eb9..7dfa3f8f6 100644
          set $proxy_upstream_name "-";
 +        set $formatted_status $status;
 +        set $upstream_retries "0";
-+        set $$total_upstream_response_time "0";
++        set $total_upstream_response_time "0";
  
          {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
          {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}

--- a/modules/402-ingress-nginx/images/controller-1-10/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-10/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -280,7 +280,7 @@ local function fill_buffer()
 
   -- responses
   ngx.var.formatted_status = tonumber(ngx.var.status)
-  local var_status = ngx.var.formatted_status
+  local var_status = tonumber(ngx.var.status)
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
 

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/nginx-tmpl.patch
@@ -55,7 +55,15 @@ index 958397dd5..8b6de93c5 100755
  
      {{ if or $cfg.DisableAccessLog $cfg.DisableHTTPAccessLog }}
      access_log off;
-@@ -910,9 +920,7 @@ stream {
+@@ -905,14 +915,15 @@ stream {
+             proxy_set_header       Host               $best_http_host;
+ 
+             set $proxy_upstream_name {{ $upstreamName | quote }};
++            set $formatted_status $status;
++            set $upstream_retries "0";
++            set $$total_upstream_response_time "0";
+ 
+             rewrite                (.*) / break;
  
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
@@ -66,7 +74,17 @@ index 958397dd5..8b6de93c5 100755
              }
          }
          {{ end }}
-@@ -1203,6 +1211,8 @@ stream {
+@@ -960,6 +971,9 @@ stream {
+         {{ buildHTTPSListener $all $server.Hostname }}
+ 
+         set $proxy_upstream_name "-";
++        set $formatted_status $status;
++        set $upstream_retries "0";
++        set $$total_upstream_response_time "0";
+ 
+         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
+         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
+@@ -1203,6 +1217,8 @@ stream {
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
  
@@ -75,7 +93,7 @@ index 958397dd5..8b6de93c5 100755
              {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $all.Cfg.OpentracingTrustIncomingSpan $location }}
  
              {{ if $location.Mirror.Source }}
-@@ -1233,11 +1243,9 @@ stream {
+@@ -1233,11 +1249,9 @@ stream {
  
              log_by_lua_block {
                  balancer.log()
@@ -88,7 +106,7 @@ index 958397dd5..8b6de93c5 100755
              }
  
              {{ if not $location.Logs.Access }}
-@@ -1515,13 +1523,14 @@ stream {
+@@ -1515,13 +1529,14 @@ stream {
  
          {{ if eq $server.Hostname "_" }}
          # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}

--- a/modules/402-ingress-nginx/images/controller-1-6/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-6/patches/nginx-tmpl.patch
@@ -61,7 +61,7 @@ index 958397dd5..8b6de93c5 100755
              set $proxy_upstream_name {{ $upstreamName | quote }};
 +            set $formatted_status $status;
 +            set $upstream_retries "0";
-+            set $$total_upstream_response_time "0";
++            set $total_upstream_response_time "0";
  
              rewrite                (.*) / break;
  
@@ -80,7 +80,7 @@ index 958397dd5..8b6de93c5 100755
          set $proxy_upstream_name "-";
 +        set $formatted_status $status;
 +        set $upstream_retries "0";
-+        set $$total_upstream_response_time "0";
++        set $total_upstream_response_time "0";
  
          {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
          {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}

--- a/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -279,13 +279,10 @@ local function fill_buffer()
   _increment("c01#" .. detail_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 1)
 
   -- responses
-  local var_status
-  if ngx.var.formatted_status then
+  if ngx.var.formatted_status ~= nil then
         ngx.var.formatted_status = tonumber(ngx.var.status)
-        var_status = ngx.var.formatted_status
-  else
-        var_status = tonumber(ngx.var.status)
   end
+  local var_status = tonumber(ngx.var.status)
 
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)

--- a/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -279,11 +279,8 @@ local function fill_buffer()
   _increment("c01#" .. detail_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 1)
 
   -- responses
-  if ngx.var.formatted_status ~= nil then
-        ngx.var.formatted_status = tonumber(ngx.var.status)
-  end
+  ngx.var.formatted_status = tonumber(ngx.var.status)
   local var_status = tonumber(ngx.var.status)
-
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
 

--- a/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-6/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -279,8 +279,14 @@ local function fill_buffer()
   _increment("c01#" .. detail_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 1)
 
   -- responses
-  ngx.var.formatted_status = tonumber(ngx.var.status)
-  local var_status = ngx.var.formatted_status
+  local var_status
+  if ngx.var.formatted_status then
+        ngx.var.formatted_status = tonumber(ngx.var.status)
+        var_status = ngx.var.formatted_status
+  else
+        var_status = tonumber(ngx.var.status)
+  end
+
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
 

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/nginx-tmpl.patch
@@ -72,7 +72,15 @@ index 94dc12412..93b7d2efc 100644
  
      {{ if or $cfg.DisableAccessLog $cfg.DisableHTTPAccessLog }}
      access_log off;
-@@ -928,9 +948,7 @@ stream {
+@@ -923,14 +943,15 @@ stream {
+             proxy_set_header       Host               $best_http_host;
+ 
+             set $proxy_upstream_name {{ $upstreamName | quote }};
++            set $formatted_status $status;
++            set $upstream_retries "0";
++            set $$total_upstream_response_time "0";
+ 
+             rewrite                (.*) / break;
  
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
@@ -83,7 +91,17 @@ index 94dc12412..93b7d2efc 100644
              }
          }
          {{ end }}
-@@ -1223,6 +1241,8 @@ stream {
+@@ -978,6 +999,9 @@ stream {
+         {{ buildHTTPSListener $all $server.Hostname }}
+ 
+         set $proxy_upstream_name "-";
++        set $formatted_status $status;
++        set $upstream_retries "0";
++        set $$total_upstream_response_time "0";
+ 
+         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
+         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
+@@ -1223,6 +1247,8 @@ stream {
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
  
@@ -92,7 +110,7 @@ index 94dc12412..93b7d2efc 100644
              {{ buildOpentelemetryForLocation $all.Cfg.EnableOpentelemetry $all.Cfg.OpentelemetryTrustIncomingSpan $location }}
  
              {{ if $location.Mirror.Source }}
-@@ -1253,11 +1273,9 @@ stream {
+@@ -1253,11 +1279,9 @@ stream {
  
              log_by_lua_block {
                  balancer.log()
@@ -105,7 +123,7 @@ index 94dc12412..93b7d2efc 100644
              }
  
              {{ if not $location.Logs.Access }}
-@@ -1531,14 +1549,15 @@ stream {
+@@ -1531,14 +1555,15 @@ stream {
  
          {{ if eq $server.Hostname "_" }}
          # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/nginx-tmpl.patch
@@ -78,7 +78,7 @@ index 94dc12412..93b7d2efc 100644
              set $proxy_upstream_name {{ $upstreamName | quote }};
 +            set $formatted_status $status;
 +            set $upstream_retries "0";
-+            set $$total_upstream_response_time "0";
++            set $total_upstream_response_time "0";
  
              rewrite                (.*) / break;
  
@@ -97,7 +97,7 @@ index 94dc12412..93b7d2efc 100644
          set $proxy_upstream_name "-";
 +        set $formatted_status $status;
 +        set $upstream_retries "0";
-+        set $$total_upstream_response_time "0";
++        set $total_upstream_response_time "0";
  
          {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
          {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}

--- a/modules/402-ingress-nginx/images/controller-1-9/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-9/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -280,7 +280,7 @@ local function fill_buffer()
 
   -- responses
   ngx.var.formatted_status = tonumber(ngx.var.status)
-  local var_status = ngx.var.formatted_status
+  local var_status = tonumber(ngx.var.status)
   _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
   _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
 


### PR DESCRIPTION
## Description
It provides fix for ingress-nginx to avoid crashes when using custom logs formats without our fields(e.g. formatted_status).

## Why do we need it, and what problem does it solve?
When a client uses custom logs formats without our fields, they cause error in lua code.

## What is the expected result?
No crashes when using custom logs formats without our fields.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: fix usage custom logs formats without our fields
```