### PR TITLE
[dhctl] Remove terraform plan and destructive changes from check output

### DIFF
--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -15,11 +15,9 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
@@ -81,20 +79,9 @@ func DefineTerraformCheckCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		var data []byte
-		switch app.OutputFormat {
-		case "yaml":
-			data, err = yaml.Marshal(statistic)
-			if err != nil {
-				return err
-			}
-		case "json":
-			data, err = json.Marshal(statistic)
-			if err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("Unknown output format %s", app.OutputFormat)
+		data, err := statistic.Format(app.OutputFormat)
+		if err != nil {
+			return fmt.Errorf("Failed to format check result: %w", err)
 		}
 
 		fmt.Print(string(data))

--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
@@ -89,7 +90,6 @@ require (
 	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/dhctl/pkg/kubernetes/actions/converge/check_test.go
+++ b/dhctl/pkg/kubernetes/actions/converge/check_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package converge_test
+
+import (
+	"testing"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
+)
+
+func TestStatistics_Format(t *testing.T) {
+	t.Parallel()
+
+	var statistics converge.Statistics
+	err := yaml.Unmarshal([]byte(statisticsYAML), &statistics)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, expectedStatistics, statistics)
+
+	formattedStatistics, err := statistics.Format("yaml")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, expectedStatistics, statistics)
+	assert.Equal(t, statisticsYAMLPrintable, string(formattedStatistics))
+}
+
+const (
+	statisticsYAML = `cluster:
+  status: ok
+  destructive_changes:
+    resourced_recreated:
+    - current_value:
+        zone: ru-central1-a
+      next_value:
+        zone: ru-central1-b
+node_templates:
+- name: master
+  status: ok
+- name: khm
+  status: ok
+nodes:
+- destructive_changes:
+    resourced_recreated:
+    - current_value:
+        zone: ru-central1-a
+      next_value:
+        zone: ru-central1-b
+  group: master
+  name: akul-master-0
+  status: destructively_changed
+terraform_plan:
+- configuration: {}
+  format_version: "0.1"`
+
+	statisticsYAMLPrintable = `cluster:
+  status: ok
+node_templates:
+- name: master
+  status: ok
+- name: khm
+  status: ok
+nodes:
+- group: master
+  name: akul-master-0
+  status: destructively_changed
+`
+)
+
+var expectedStatistics = converge.Statistics{
+	Cluster: converge.ClusterCheckResult{
+		Status: "ok",
+		DestructiveChanges: &terraform.BaseInfrastructureDestructiveChanges{
+			PlanDestructiveChanges: terraform.PlanDestructiveChanges{
+				ResourcesRecreated: []terraform.ValueChange{
+					{
+						CurrentValue: map[string]any{"zone": "ru-central1-a"},
+						NextValue:    map[string]any{"zone": "ru-central1-b"},
+					},
+				},
+			},
+		},
+	},
+	NodeTemplates: []converge.NodeGroupCheckResult{
+		{
+			Name:   "master",
+			Status: "ok",
+		},
+		{
+			Name:   "khm",
+			Status: "ok",
+		},
+	},
+	Node: []converge.NodeCheckResult{
+		{
+			Group:  "master",
+			Name:   "akul-master-0",
+			Status: "destructively_changed",
+			DestructiveChanges: &terraform.PlanDestructiveChanges{
+				ResourcesRecreated: []terraform.ValueChange{
+					{
+						CurrentValue: map[string]any{"zone": "ru-central1-a"},
+						NextValue:    map[string]any{"zone": "ru-central1-b"},
+					},
+				},
+			},
+		},
+	},
+	TerraformPlan: []terraform.TerraformPlan{
+		{
+			"configuration":  map[string]any{},
+			"format_version": "0.1",
+		},
+	},
+}


### PR DESCRIPTION
## Description
Hide raw terraform plan and destructive changes from check result in CLI. It was added by mistake.

## Why do we need it, and what problem does it solve?
Improved user experience, more readable Check operation output.

```changes
section: dhctl
type: fix
summary: Hide raw terraform plan and destructive changes from check result
impact_level: low
```