### PR TITLE
[cloud-provider-yandex] [cloud-provider-aws]  set deckhouse binary path for bootstrap-networks.sh

### DIFF
--- a/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
-
 mkdir -p /opt/deckhouse/bin
 
 export PATH="/opt/deckhouse/bin:$PATH"

--- a/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
@@ -14,10 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+
 mkdir -p /opt/deckhouse/bin
 
+export PATH="/opt/deckhouse/bin:$PATH"
+
 if [ ! -f /var/lib/bashible/hosname-set-as-in-aws ]; then
-  curl -L -o /opt/deckhouse/bin/ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.2/ec2_describe_tags
+  d8-curl -L -o /opt/deckhouse/bin/ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.2/ec2_describe_tags
   chmod +x /opt/deckhouse/bin/ec2_describe_tags
   instance_name=$(/opt/deckhouse/bin/ec2_describe_tags -query_meta | grep -Po '(?<=Name=).+')
   hostnamectl set-hostname "$instance_name"

--- a/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/bootstrap-networks.sh.tpl
@@ -16,8 +16,6 @@
 */}}
 mkdir -p /opt/deckhouse/bin
 
-export PATH="/opt/deckhouse/bin:$PATH"
-
 if [ ! -f /var/lib/bashible/hosname-set-as-in-aws ]; then
   d8-curl -L -o /opt/deckhouse/bin/ec2_describe_tags https://github.com/flant/go-ec2-describe-tags/releases/download/v0.0.1-flant.2/ec2_describe_tags
   chmod +x /opt/deckhouse/bin/ec2_describe_tags

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -16,6 +16,8 @@
 */}}
 shopt -s extglob
 
+export PATH="/opt/deckhouse/bin:$PATH"
+
 function ip_in_subnet(){
   python3 -c "import ipaddress; exit(0) if ipaddress.ip_address('$1') in ipaddress.ip_network('$2') else exit(1)"
   return $?

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -16,8 +16,6 @@
 */}}
 shopt -s extglob
 
-export PATH="/opt/deckhouse/bin:$PATH"
-
 function ip_in_subnet(){
   python3 -c "import ipaddress; exit(0) if ipaddress.ip_address('$1') in ipaddress.ip_network('$2') else exit(1)"
   return $?

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -70,13 +70,14 @@ function get_phase2() {
   done
 }
 
-function prepary_binary() {
+function prepary_base_d8_binaries() {
 	export PATH="/opt/deckhouse/bin:$PATH"
 	export LANG=C
 	export REPOSITORY=""
 	export BB_INSTALLED_PACKAGES_STORE="/var/cache/registrypackages"
 	export BB_FETCHED_PACKAGES_STORE="/${TMPDIR}/registrypackages"
-	{{- if .proxy }}
+{{- with $context.Values.global.clusterConfiguration }}
+{{- if .proxy }}
 		{{- if .proxy.httpProxy }}
 	export HTTP_PROXY={{ .proxy.httpProxy | quote }}
 	export http_proxy=${HTTP_PROXY}
@@ -96,8 +97,11 @@ function prepary_binary() {
 	export PACKAGES_PROXY_ADDRESSES="{{ .packagesProxy.addresses | join "," }}"
 	export PACKAGES_PROXY_TOKEN="{{ .packagesProxy.token }}"
 	{{- end }}
-	bb-package-install "jq:{{ .images.registrypackages.jq16 }}" "curl:{{ .images.registrypackages.d8Curl821 }}" "netcat:{{ .images.registrypackages.netcat110481 }}"
+{{- with $context.Values.global.modulesImages.digests.registrypackages }}
+	bb-package-install "jq:{{ .jq16 }}" "curl:{{ .d8Curl821 }}" "netcat:{{ .netcat110481 }}"
+{{- end }}
 }
+{{- end }}
 
   {{- if not (hasKey $ng "staticInstances") }}
 function run_cloud_network_setup() {
@@ -146,7 +150,7 @@ function run_log_output() {
 }
  {{- end }}
 BUNDLE="$(detect_bundle)"
-prepary_binary
+prepary_base_d8_binaries
   {{- if not (hasKey $ng "staticInstances") }}
 run_cloud_network_setup
   {{- end }}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -158,17 +158,17 @@ function prepary_base_d8_binaries() {
 	export no_proxy=${NO_PROXY}
 		{{- end }}
 	{{- else }}
-		unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
-	{{- end }}
-	{{- if $context.Values.global.internal.packagesProxy }}
-	export PACKAGES_PROXY_ADDRESSES="{{ $context.Values.global.internal.packagesProxy.addresses | join "," }}"
-	export PACKAGES_PROXY_TOKEN="{{ $context.Values.global.internal.packagesProxy.token }}"
+	unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
+{{- end }}
+	{{- if $context.Values.nodeManager.internal.packagesProxy }}
+	export PACKAGES_PROXY_ADDRESSES="{{ $context.Values.nodeManager.internal.packagesProxy.addresses | join "," }}"
+	export PACKAGES_PROXY_TOKEN="{{ $context.Values.nodeManager.internal.packagesProxy.token }}"
 	{{- end }}
 {{- with $context.Values.global.modulesImages.digests.registrypackages }}
 	bb-package-install "jq:{{ .jq16 }}" "curl:{{ .d8Curl821 }}" "netcat:{{ .netcat110481 }}"
 {{- end }}
-}
 {{- end }}
+}
 
   {{- if not (hasKey $ng "staticInstances") }}
 function run_cloud_network_setup() {

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -34,6 +34,74 @@ function check_python() {
   return 1
 }
 
+bb-package-install() {
+  local PACKAGE_WITH_DIGEST
+  for PACKAGE_WITH_DIGEST in "$@"; do
+    local PACKAGE=""
+    local DIGEST=""
+    PACKAGE="$(awk -F ":" '{print $1}' <<< "${PACKAGE_WITH_DIGEST}")"
+    DIGEST="$(awk -F ":" '{print $2":"$3}' <<< "${PACKAGE_WITH_DIGEST}")"
+    bb-package-fetch "${PACKAGE_WITH_DIGEST}"
+    local TMP_DIR=""
+    TMP_DIR="$(mktemp -d)"
+    tar -xf "${BB_FETCHED_PACKAGES_STORE}/${PACKAGE}/${DIGEST}.tar.gz" -C "${TMP_DIR}"
+
+    # shellcheck disable=SC2164
+    pushd "${TMP_DIR}" >/dev/null
+    ./install
+    popd >/dev/null
+    mkdir -p "${BB_INSTALLED_PACKAGES_STORE}/${PACKAGE}"
+    echo "${DIGEST}" > "${BB_INSTALLED_PACKAGES_STORE}/${PACKAGE}/digest"
+    cp "${TMP_DIR}/install" "${TMP_DIR}/uninstall" "${BB_INSTALLED_PACKAGES_STORE}/${PACKAGE}"
+    rm -rf "${TMP_DIR}" "${BB_FETCHED_PACKAGES_STORE:?}/${PACKAGE}"
+  done
+}
+
+bb-package-fetch() {
+  mkdir -p "${BB_FETCHED_PACKAGES_STORE}"
+  declare -A PACKAGES_MAP
+  local PACKAGE_WITH_DIGEST
+  for PACKAGE_WITH_DIGEST in "$@"; do
+    local PACKAGE=""
+    local DIGEST=""
+    PACKAGE="$(awk -F ":" '{print $1}' <<< "${PACKAGE_WITH_DIGEST}")"
+    DIGEST="$(awk -F ":" '{print $2":"$3}' <<< "${PACKAGE_WITH_DIGEST}")"
+    PACKAGES_MAP[$DIGEST]="${PACKAGE}"
+  done
+  bb-package-fetch-blobs PACKAGES_MAP
+}
+
+bb-package-fetch-blobs() {
+  local PACKAGE_DIGEST
+  for PACKAGE_DIGEST in "${!PACKAGES_MAP[@]}"; do
+    local PACKAGE_DIR="${BB_FETCHED_PACKAGES_STORE}/${PACKAGES_MAP[$PACKAGE_DIGEST]}"
+    mkdir -p "${PACKAGE_DIR}"
+    bb-package-fetch-blob "${PACKAGE_DIGEST}" "${PACKAGE_DIR}/${PACKAGE_DIGEST}.tar.gz"
+  done
+}
+
+bb-package-fetch-blob() {
+  check_python
+
+  cat - <<EOF | $python_binary
+import random
+import ssl
+try:
+    from urllib.request import urlopen, Request
+except ImportError as e:
+    from urllib2 import urlopen, Request
+# Choose a random endpoint to increase fault tolerance and reduce load on a single endpoint.
+endpoints = "${PACKAGES_PROXY_ADDRESSES}".split(",")
+endpoint = random.choice(endpoints)
+ssl._create_default_https_context = ssl._create_unverified_context
+url = 'https://{}/package?digest=$1&repository=${REPOSITORY}'.format(endpoint)
+request = Request(url, headers={'Authorization': 'Bearer ${PACKAGES_PROXY_TOKEN}'})
+response = urlopen(request, timeout=300)
+with open('$2', 'wb') as f:
+    f.write(response.read())
+EOF
+}
+
 function load_phase2_script() {
   cat - <<EOF
 import sys
@@ -55,7 +123,6 @@ EOF
 
 
 function get_phase2() {
-  check_python
   bootstrap_bundle_name="${BUNDLE}.{{ $ng.name }}"
   token="$(<${BOOTSTRAP_DIR}/bootstrap-token)"
   while true; do

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -160,9 +160,9 @@ function prepary_base_d8_binaries() {
 	{{- else }}
 		unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy
 	{{- end }}
-	{{- if .packagesProxy }}
-	export PACKAGES_PROXY_ADDRESSES="{{ .packagesProxy.addresses | join "," }}"
-	export PACKAGES_PROXY_TOKEN="{{ .packagesProxy.token }}"
+	{{- if $context.Values.global.internal.packagesProxy }}
+	export PACKAGES_PROXY_ADDRESSES="{{ $context.Values.global.internal.packagesProxy.addresses | join "," }}"
+	export PACKAGES_PROXY_TOKEN="{{ $context.Values.global.internal.packagesProxy.token }}"
 	{{- end }}
 {{- with $context.Values.global.modulesImages.digests.registrypackages }}
 	bb-package-install "jq:{{ .jq16 }}" "curl:{{ .d8Curl821 }}" "netcat:{{ .netcat110481 }}"


### PR DESCRIPTION
## Description

Add `/opt/deckhouse/bin` in `PATH` env for bootstrap-networks.sh.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

d8-curl (which may be used in bootstrap-networks.sh) doesn't exist in the default system PATH.

## What is the expected result?

`bootstrap-networks.sh` use binaries from `/opt/deckhouse/bin`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Add /opt/deckhouse/bin in `PATH` env for bootstrap-networks.sh.
impact_level: low
```
```changes
section: cloud-provider-aws
type: fix
summary: Add /opt/deckhouse/bin in `PATH` env for bootstrap-networks.sh.
impact_level: low
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
