### PR TITLE
[node-manager] fix add nodeuser

### DIFF
--- a/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
@@ -69,7 +69,7 @@ function nodeuser_patch() {
           -H "Content-Type: application/json-patch+json" \
           --cacert "$BOOTSTRAP_DIR/ca.crt" \
           --data "${data}" \
-          "https://$server/apis/deckhouse.io/v1/nodeusers/${username}/status" ; then
+          "https://$server/apis/deckhouse.io/v1/nodeusers/${username}/status" > /dev/null; then
 
           bb-log-info "Successfully patched NodeUser."
           patch_pending=false

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -168,6 +168,9 @@ roleRef:
   name: d8:node-manager:bashible:nodeuser-bootstrapped-nodes
 subjects:
   - kind: Group
+    name: system:bootstrappers:d8-node-manager
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
     name: system:nodes
     apiGroup: rbac.authorization.k8s.io
 


### PR DESCRIPTION
## Description
Fix RBAC permissions and startup schedule cleanup of NodeUser creation errors.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fixing errors at bootstrap node for fast up a node
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Affected customer
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix RBAC permissions and startup schedule cleanup of NodeUser creation errors.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
