### PR TITLE
[registry-proxy] fix registry path calculation

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -200,7 +200,9 @@ func newRegistryClientConfigGetter(config config.RegistryData) (*registryClientC
 
 	return &registryClientConfigGetter{
 		ClientConfig: registry.ClientConfig{
-			Repository: strings.Join([]string{config.Address, config.Path}, "/"),
+			// path contains leading /, so we need to truncate them
+			// also we truncate address to prevent / in the end
+			Repository: strings.Join([]string{strings.Trim(config.Address, "/"), strings.Trim(config.Path, "/")}, "/"),
 			Scheme:     config.Scheme,
 			CA:         config.CA,
 			Auth:       auth,

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret.go
@@ -65,7 +65,9 @@ func (d registrySecretData) toClientConfig() (*registry.ClientConfig, error) {
 	}
 
 	return &registry.ClientConfig{
-		Repository: strings.Join([]string{d.Address, d.Path}, "/"),
+		// path contains leading /, so we need to truncate them
+		// also we truncate address to prevent / in the end
+		Repository: strings.Join([]string{strings.Trim(d.Address, "/"), strings.Trim(d.Path, "/")}, "/"),
 		Scheme:     d.Scheme,
 		CA:         d.CA,
 		Auth:       auth,


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix error in registry path calculation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Registry parameters passed by two values:
* registry address
* registry path

This parameters concatenated by '/', but we pass registry path with trailing '/' symbol.
For example:
* registry address = `registry.deckhouse.io`
* registry path = `/deckhouse/ee`

That leads to wrong full registry path calculation - `registry.deckhouse.io//deckhouse/ee`.
Some registry implementations works with this wrong url, but some implementations return code 500.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: fix registry path calculation
impact: registry packages proxy should be restarted ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
