### PR TITLE
[ingress-nginx] fix pod descheduling from a not-ready node

### DIFF
--- a/modules/402-ingress-nginx/images/kruise/patches/add-pdb.patch
+++ b/modules/402-ingress-nginx/images/kruise/patches/add-pdb.patch
@@ -147,10 +147,10 @@ index ea7633fe..b8b479da 100644
 +	return obj.(*autoscalingv1.Scale), err
 +}
 diff --git a/pkg/controller/daemonset/daemonset_controller.go b/pkg/controller/daemonset/daemonset_controller.go
-index 3de1446b..0e1f5efb 100644
+index 1934f145..0333961e 100644
 --- a/pkg/controller/daemonset/daemonset_controller.go
 +++ b/pkg/controller/daemonset/daemonset_controller.go
-@@ -496,7 +496,7 @@ func NewPod(ds *appsv1alpha1.DaemonSet, nodeName string) *corev1.Pod {
+@@ -505,7 +505,7 @@ func NewPod(ds *appsv1alpha1.DaemonSet, nodeName string) *corev1.Pod {
  	// newPod.Spec.NodeName = nodeName
  
  	// Added default tolerations for DaemonSet pods.
@@ -159,7 +159,7 @@ index 3de1446b..0e1f5efb 100644
  
  	newPodForDSCache.Store(ds.UID, &newPodForDS{generation: ds.Generation, pod: newPod})
  	return newPod
-@@ -551,6 +551,11 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
+@@ -560,6 +560,11 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
  		return fmt.Errorf("error storing status for DaemonSet %v: %v", ds.Name, err)
  	}
  
@@ -171,7 +171,7 @@ index 3de1446b..0e1f5efb 100644
  	// Resync the DaemonSet after MinReadySeconds as a last line of defense to guard against clock-skew.
  	if ds.Spec.MinReadySeconds >= 0 && numberReady != numberAvailable {
  		durationStore.Push(keyFunc(ds), time.Duration(ds.Spec.MinReadySeconds)*time.Second)
-@@ -558,6 +563,94 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
+@@ -567,6 +572,94 @@ func (dsc *ReconcileDaemonSet) updateDaemonSetStatus(ds *appsv1alpha1.DaemonSet,
  	return nil
  }
  
@@ -266,6 +266,17 @@ index 3de1446b..0e1f5efb 100644
  func (dsc *ReconcileDaemonSet) storeDaemonSetStatus(ds *appsv1alpha1.DaemonSet, desiredNumberScheduled, currentNumberScheduled, numberMisscheduled, numberReady, updatedNumberScheduled, numberAvailable, numberUnavailable int, updateObservedGen bool, hash string) error {
  	if int(ds.Status.DesiredNumberScheduled) == desiredNumberScheduled &&
  		int(ds.Status.CurrentNumberScheduled) == currentNumberScheduled &&
+@@ -830,7 +923,9 @@ func (dsc *ReconcileDaemonSet) podsShouldBeOnNode(
+ 	hash string,
+ ) (nodesNeedingDaemonPods, podsToDelete []string) {
+ 
+-	shouldRun, shouldContinueRunning := nodeShouldRunDaemonPod(node, ds)
++	// a new for a not-ready pod shouln't be created, but a running one shoult stay on the node
++	shouldRun, _ := nodeShouldRunDaemonPod(node, ds)
++	_, shouldContinueRunning := nodeShouldRunDaemonPod(node, ds, true)
+ 	daemonPods, exists := nodeToDaemonPods[node.Name]
+ 
+ 	switch {
 diff --git a/pkg/controller/daemonset/daemonset_event_handler.go b/pkg/controller/daemonset/daemonset_event_handler.go
 index 26a33f3d..68c5ec35 100644
 --- a/pkg/controller/daemonset/daemonset_event_handler.go
@@ -295,7 +306,7 @@ index 26a33f3d..68c5ec35 100644
  
  func (e *nodeEventHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 diff --git a/pkg/controller/daemonset/daemonset_util.go b/pkg/controller/daemonset/daemonset_util.go
-index 420188f0..91911fbe 100644
+index 420188f0..fb72ddaa 100644
 --- a/pkg/controller/daemonset/daemonset_util.go
 +++ b/pkg/controller/daemonset/daemonset_util.go
 @@ -98,8 +98,16 @@ func nodeInSameCondition(old []corev1.NodeCondition, cur []corev1.NodeCondition)
@@ -304,10 +315,10 @@ index 420188f0..91911fbe 100644
  //     running on that node.
 -func nodeShouldRunDaemonPod(node *corev1.Node, ds *appsv1alpha1.DaemonSet) (bool, bool) {
 -	pod := NewPod(ds, node.Name)
-+func nodeShouldRunDaemonPod(node *corev1.Node, ds *appsv1alpha1.DaemonSet, countReplicasFlag ...bool) (bool, bool) {
++func nodeShouldRunDaemonPod(node *corev1.Node, ds *appsv1alpha1.DaemonSet, addDefaultDSTolerations ...bool) (bool, bool) {
 +	var pod *corev1.Pod
-+	// add standard demonset tolerations if countReplicasFlag isn't empty
-+	if len(countReplicasFlag) > 0 {
++	// add standard demonset tolerations if addDefaultDSTolerations isn't empty
++	if len(addDefaultDSTolerations) > 0 {
 +		pod = &corev1.Pod{Spec: ds.Spec.Template.Spec, ObjectMeta: ds.Spec.Template.ObjectMeta}
 +		pod.Namespace = ds.Namespace
 +		util.AddOrUpdateDaemonPodTolerations(&pod.Spec)


### PR DESCRIPTION
## Description
The step of the logic where kruise controller checks if a pod should continue running on the node has been slightly updated so that the controller adds [default daemonset tolerations](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#taints-and-tolerations) (two of which have "NoExecute" effect) when calculating the resulting set of the pod's tolerations.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Currently, kruise controller deschedules ingress nginx pods from a node that becomes not-ready because of "NoExecute" taints. It happens because kruise's logic of checking if a pod should run on a particular node doesn't take into account default daemonset tolerations. While it could make sense in some other environments, having ingress nginx pods descheduled even from not-ready nodes is highly undesirable.
Closes #8645 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
It's a bug that may affect a whole cluster availability.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
The expected result would be not to deschedule ingress nginx pods even if a node becomes not-ready. All other operations related to creating/updating/deleting ingress-nginx pods should follow the same logic as previously.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix pod descheduling from a not-ready node.
impact: Kruise controller's pods will be recreadted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
