### PR TITLE
[docs] Improvements in Getting Started for install in VK Cloud

### DIFF
--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -96,6 +96,20 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cloud-provider-openstack module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+# [<ru>] Настройки модуля cloud-provider-openstack.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-openstack
+spec:
+  version: 1
+  enabled: true
+  settings:
+    ignoreVolumeMicroversion: true
+---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 # [<ru>] Настройки облачного провайдера.
@@ -162,7 +176,7 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    imageName: Ubuntu-22.04-202208
+    imageName: ubuntu-22-202404160933.gitd6495fe9
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
     rootDiskSize: 40

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
@@ -96,6 +96,20 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
+# [<en>] cloud-provider-openstack module settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+# [<ru>] Настройки модуля cloud-provider-openstack.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/030-cloud-provider-openstack/configuration.html
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-openstack
+spec:
+  version: 1
+  enabled: true
+  settings:
+    ignoreVolumeMicroversion: true
+---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html
 # [<ru>] Настройки облачного провайдера.
@@ -162,7 +176,7 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    imageName: Ubuntu-22.04-202208
+    imageName: ubuntu-22-202404160933.gitd6495fe9
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
     rootDiskSize: 40

--- a/docs/site/_includes/getting_started/openstack_vk/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/resources.yml.minimal.inc
@@ -17,7 +17,7 @@ spec:
   # [<ru>] Используемый образ виртуальной машины.
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
-  imageName: Ubuntu-22.04-202208
+  imageName: ubuntu-22-202404160933.gitd6495fe9
 ---
 # [<en>] Section containing the parameters of worker node group.
 # [<en>] https://deckhouse.io/documentation/v1/modules/040-node-manager/cr.html#nodegroup


### PR DESCRIPTION
## Description
Fix default image, because `Ubuntu-22.04-202208` was removed.
Add mc to fix problem that PVC does not create with error
```
  Warning  ProvisioningFailed    9m24s (x15 over 37m)  cinder.csi.openstack.org_test-metallb-master-0_12a4fb37-e11d-4405-910d-c70659134e9f  failed to provision volume with StorageClass "ceph-hdd": rpc error: code = Internal desc = Failed to get volumes: Expected HTTP response code [200 204 300] when accessing [GET https://public.infra.mail.ru:8776/v3/bbf506e3ece54e21b2acf1bf9db4f62c/volumes/detail?name=pvc-c3374e05-ac6b-4d76-8874-e79999e0ec7d], but got 406 instead
{"computeFault": {"message": "Version 3.34 is not supported by the API. Minimum is 3.0 and maximum is 3.27.", "code": 406}}
```

## Why do we need it, and what problem does it solve?
Improve Getting Started

## Why do we need it in the patch release (if we do)?
Not necessarily

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Improvements in Getting Started for VK Cloud.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
