### PR TITLE
[metallb] Metallb alert group naming fix

### DIFF
--- a/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -9,8 +9,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: D8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: D8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       description: |
         {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has not loaded.
         To figure out the problem, check controller logs:
@@ -28,8 +28,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: D8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: D8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       description: |
         {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has run on a stale configuration, because the latest config failed to load.
         To figure out the problem, check controller logs:
@@ -47,8 +47,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: D8MetalLBBGPSessionDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: D8MetalLBBGPSessionDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       description: |
         {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has BGP session {{ $labels.peer }} down.
         Details are in logs:

--- a/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -28,8 +28,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigStale,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigStales,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigStales,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       description: |
         {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has run on a stale configuration, because the latest config failed to load.
         To figure out the problem, check controller logs:
@@ -47,8 +47,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionsDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionsDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       description: |
         {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has BGP session {{ $labels.peer }} down.
         Details are in logs:


### PR DESCRIPTION
## Description
Metallb alert group naming fix.
Fix error like:
`ERROR: #<EventsSeries::AnnotationsService::BadAnnotations: Usage of current alert's trigger (D8MetalLBConfigStale) is forbidden in grouping to prevent circular dependencies!>`
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: 380-metallb
type: chore
summary: Metallb alert group naming fix
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
