### PR TITLE
[cni-cilium] Orthographic mistake in alert

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -13,7 +13,7 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Some nodes' health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
+      summary: Some nodes health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: |
         Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
 

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -13,7 +13,7 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Some nodes health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
+      summary: Some node's health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: |
         Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
 


### PR DESCRIPTION
## Description
Fix typo in the CiliumAgentUnreachableHealthEndpoints alert.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: 021-cni-cilium
type: chore
summary: Fix typo in the CiliumAgentUnreachableHealthEndpoints alert.
impact_level: low
```
