### PR TITLE
[multitenancy-manager] fix: replace special characters in metadata.name

### DIFF
--- a/ee/modules/160-multitenancy-manager/templates/user-resources/_helpers.tpl
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/_helpers.tpl
@@ -1,6 +1,0 @@
-{{- define "slugify" }}
-  {{- $newName := lower . }}
-  {{- $newName = regexReplaceAll "\\W+" $newName "-" }}
-  {{- $newName = regexReplaceAll "(^-+|-+$)" $newName "" }}
-  {{- print $newName }}
-{{- end }}

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/_helpers.tpl
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "slugify" }}
+  {{- $newName := lower . }}
+  {{- $newName = regexReplaceAll "\\W+" $newName "-" }}
+  {{- $newName = regexReplaceAll "(^-+|-+$)" $newName "" }}
+  {{- print $newName }}
+{{- end }}

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
@@ -128,7 +128,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name | include "slugify" }}
+      name: {{ $administrator.name | include "normalize" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
@@ -128,7 +128,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name | replace "@" "-" }}
+      name: {{ $administrator.name | include "slugify" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
@@ -128,7 +128,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name }}
+      name: {{ $administrator.name | replace "@" "-" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
@@ -165,7 +165,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name | include "slugify" }}
+      name: {{ $administrator.name | include "normalize" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
@@ -165,7 +165,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name }}
+      name: {{ $administrator.name | include "slugify" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
@@ -212,7 +212,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name | include "slugify" }}
+      name: {{ $administrator.name | include "normalize" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
@@ -212,7 +212,7 @@ spec:
     apiVersion: deckhouse.io/v1alpha1
     kind: AuthorizationRule
     metadata:
-      name: {{ $administrator.name }}
+      name: {{ $administrator.name | include "slugify" }}
     spec:
       accessLevel: Admin
       subjects:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/templates/_helpers.tpl
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/templates/_helpers.tpl
@@ -6,3 +6,36 @@
 {{- end }}
 {{- trimPrefix "," $result }}
 {{- end }}
+
+{{- define "slugify" }}
+  {{- /* https://gitlab.com/gitlab-org/gitlab/-/blob/6db59634ecbb1581bbb16b627b9631ca96ce2e8d/lib/gitlab/utils.rb#L100 */}}
+  {{- $oldName := index . 0 }}
+  {{- $rootContext := index . 1 }}
+
+  {{- $newName := lower $oldName }}
+  {{- $newName = regexReplaceAllLiteral "[^a-z0-9]" $newName "-" }}
+
+  {{- if gt (len $newName) 63 }}
+    {{- if not ( index $rootContext.Release "bigNamePostfixes" ) }}
+      {{- $_ := set $rootContext.Release "bigNamePostfixes" dict }}
+    {{- end }}
+
+    {{- /* This will allow us to reuse random string after helm release upgrade */}}
+    {{- if not ( index $rootContext.Release.bigNamePostfixes $newName ) }}
+      {{- $_ := set $rootContext.Release.bigNamePostfixes $newName ( randAlphaNum 10 | lower ) }}
+    {{- end }}
+
+    {{- $newNameShortened := substr 0 52 $newName }}
+    {{- $newName = printf "%s-%s" $newNameShortened ( index $rootContext.Release.bigNamePostfixes $newName ) }}
+  {{- end }}
+
+  {{- $newName = regexReplaceAllLiteral "(^-+|-+$)" $newName "" }}
+  {{- print $newName }}
+{{- end }}
+
+{{- define "normalize" }}
+  {{- $newName := lower . }}
+  {{- $newName = regexReplaceAll "\\W+" $newName "-" }}
+  {{- $newName = regexReplaceAll "(^-+|-+$)" $newName "" }}
+  {{- print $newName }}
+{{- end }}

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/templates/user-resources-templates.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/templates/user-resources-templates.yaml
@@ -12,32 +12,6 @@ metadata:
 
 {{- end }}
 
-{{- define "slugify" }}
-  {{- /* https://gitlab.com/gitlab-org/gitlab/-/blob/6db59634ecbb1581bbb16b627b9631ca96ce2e8d/lib/gitlab/utils.rb#L100 */}}
-  {{- $oldName := index . 0 }}
-  {{- $rootContext := index . 1 }}
-
-  {{- $newName := lower $oldName }}
-  {{- $newName = regexReplaceAllLiteral "[^a-z0-9]" $newName "-" }}
-
-  {{- if gt (len $newName) 63 }}
-    {{- if not ( index $rootContext.Release "bigNamePostfixes" ) }}
-      {{- $_ := set $rootContext.Release "bigNamePostfixes" dict }}
-    {{- end }}
-
-    {{- /* This will allow us to reuse random string after helm release upgrade */}}
-    {{- if not ( index $rootContext.Release.bigNamePostfixes $newName ) }}
-      {{- $_ := set $rootContext.Release.bigNamePostfixes $newName ( randAlphaNum 10 | lower ) }}
-    {{- end }}
-
-    {{- $newNameShortened := substr 0 52 $newName }}
-    {{- $newName = printf "%s-%s" $newNameShortened ( index $rootContext.Release.bigNamePostfixes $newName ) }}
-  {{- end }}
-
-  {{- $newName = regexReplaceAllLiteral "(^-+|-+$)" $newName "" }}
-  {{- print $newName }}
-{{- end }}
-
 {{- define "prepare.template" }}
   {{- $template := index . 0 }}
   {{- $projectName := index . 1 }}


### PR DESCRIPTION
## Description

When describing the project, we fill in the block of authorisation rules.

In the authorisation rules template, the variable user.name used twice:
- in the name of the rule
- in the user name

Email can and often is used in the username. But we cannot use the special characters in the rule name due to restrictions on the part of k8s.

## Why do we need it, and what problem does it solve?

Now, when using a template, if the user's email is used in the username, we get a template generation error.

As a result, the necessary users are not created.

## What is the expected result?

We are replacing the special characters with `-` in the rule name. And as a result, the template is generated and the necessary users are created.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: replace special characters in a AuthorizationRule metadata.name
impact_level: default
```

