### PR TITLE
[docs] Add information and command to access Deckhouse controller in HA mode 

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -891,14 +891,11 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
 
 ### How do I get access to Deckhouse controller in multimaster cluster?
 
-In clusters with multiple master nodes, Deckhouse runs in high availability mode. This is why you have to use the following command to access the Deckhouse controller:
+In clusters with multiple master nodes Deckhouse runs in high availability mode (in several instances). To access the active Deckhouse controller, you can use the following command (as an example of the command `deckhouse-controller queue list`):
 
 ```shell
 kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list
 ```
-
-> In the example above, the `queue list` command lists the Deckhouse queue. It is used for illustrative purposes only. You can replace it with any command you need.
-
 ## How do I upgrade the Kubernetes version in a cluster?
 
 To upgrade the Kubernetes version in a cluster change the [kubernetesVersion](installing/configuration.html#clusterconfiguration-kubernetesversion) parameter in the [ClusterConfiguration](installing/configuration.html#clusterconfiguration) structure by making the following steps:

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -889,6 +889,16 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
 
    The output of the command should be empty.
 
+### How do I get access to Deckhouse controller in multimaster cluster?
+
+In clusters with multiple master-nodes, Deckhouse runs in high availability mode. Therefore, for the usual access to the Deckhouse controller, you need to use the command:
+
+```shell
+kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list
+```
+
+> In the example above, the `queue list` command is specified to view the Deckhouse queue, it can be replaced with any command you need.
+
 ## How do I upgrade the Kubernetes version in a cluster?
 
 To upgrade the Kubernetes version in a cluster change the [kubernetesVersion](installing/configuration.html#clusterconfiguration-kubernetesversion) parameter in the [ClusterConfiguration](installing/configuration.html#clusterconfiguration) structure by making the following steps:

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -891,13 +891,13 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
 
 ### How do I get access to Deckhouse controller in multimaster cluster?
 
-In clusters with multiple master-nodes, Deckhouse runs in high availability mode. Therefore, for the usual access to the Deckhouse controller, you need to use the command:
+In clusters with multiple master nodes, Deckhouse runs in high availability mode. This is why you have to use the following command to access the Deckhouse controller:
 
 ```shell
 kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list
 ```
 
-> In the example above, the `queue list` command is specified to view the Deckhouse queue, it can be replaced with any command you need.
+> In the example above, the `queue list` command lists the Deckhouse queue. It is used for illustrative purposes only. You can replace it with any command you need.
 
 ## How do I upgrade the Kubernetes version in a cluster?
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -893,14 +893,11 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 
 ### Как получить доступ к контроллеру Deckhouse в multi-master кластере?
 
-В кластерах с несколькими master-узлами Deckhouse запускается в режиме высокой доступности. Поэтому для привычного доступа к контроллеру Deckhouse нужно использовать команду:
+В кластерах с несколькими master-узлами Deckhouse запускается в режиме высокой доступности (в нескольких экземплярах). Для доступа к активному контроллеру Deckhouse можно использовать следующую команду (на примере команды `deckhouse-controller queue list`):
 
 ```shell
 kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list
 ```
-
-> В примере выше указана команда `queue list` для просмотра очереди Deckhouse. Её можно заменить на любую привычную вам команду.
-
 ### Как обновить версию Kubernetes в кластере?
 
 Чтобы обновить версию Kubernetes в кластере, измените параметр [kubernetesVersion](installing/configuration.html#clusterconfiguration-kubernetesversion) в структуре [ClusterConfiguration](installing/configuration.html#clusterconfiguration) выполнив следующие шаги:

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -891,9 +891,9 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 
    Вывод команды должен быть пуст.
 
-### Как получить доступ к контроллеру Deckhouse в мультимастер кластере?
+### Как получить доступ к контроллеру Deckhouse в multi-master кластере?
 
-В кластерах с несколькими мастер-нодами Deckhouse запускается в режиме высокой доступности. Поэтому для привычного доступна к контроллеру Deckhouse нужно использовать команду:
+В кластерах с несколькими master-узлами Deckhouse запускается в режиме высокой доступности. Поэтому для привычного доступна к контроллеру Deckhouse нужно использовать команду:
 
 ```shell
 kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -893,7 +893,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 
 ### Как получить доступ к контроллеру Deckhouse в multi-master кластере?
 
-В кластерах с несколькими master-узлами Deckhouse запускается в режиме высокой доступности. Поэтому для привычного доступна к контроллеру Deckhouse нужно использовать команду:
+В кластерах с несколькими master-узлами Deckhouse запускается в режиме высокой доступности. Поэтому для привычного доступа к контроллеру Deckhouse нужно использовать команду:
 
 ```shell
 kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -891,6 +891,16 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 
    Вывод команды должен быть пуст.
 
+### Как получить доступ к контроллеру Deckhouse в мультимастер кластере?
+
+В кластерах с несколькими мастер-нодами Deckhouse запускается в режиме высокой доступности. Поэтому для привычного доступна к контроллеру Deckhouse нужно использовать команду:
+
+```shell
+kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list
+```
+
+> В примере выше указана команда `queue list` для просмотра очереди Deckhouse, её можно заменить на любую привычную вам команду.
+
 ### Как обновить версию Kubernetes в кластере?
 
 Чтобы обновить версию Kubernetes в кластере, измените параметр [kubernetesVersion](installing/configuration.html#clusterconfiguration-kubernetesversion) в структуре [ClusterConfiguration](installing/configuration.html#clusterconfiguration) выполнив следующие шаги:

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -899,7 +899,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s.io deckhouse-leader-election -o jsonpath='{.spec.holderIdentity}' | awk -F'.' '{ print $1 }') -c deckhouse -- deckhouse-controller queue list
 ```
 
-> В примере выше указана команда `queue list` для просмотра очереди Deckhouse, её можно заменить на любую привычную вам команду.
+> В примере выше указана команда `queue list` для просмотра очереди Deckhouse. Её можно заменить на любую привычную вам команду.
 
 ### Как обновить версию Kubernetes в кластере?
 


### PR DESCRIPTION
## Description

This PR will add information and command to access Deckhouse controller in HA mode.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Add information and command to access Deckhouse controller in HA mode.
impact_level: default