### PR TITLE
[deckhouse] fix public-domain-template webhook

### DIFF
--- a/modules/002-deckhouse/webhooks/validating/public-domain-template
+++ b/modules/002-deckhouse/webhooks/validating/public-domain-template
@@ -53,8 +53,8 @@ EOF
 function __main__() {
   mcName=$(context::jq -r '.review.request.object.metadata.name')
   if [[ "$mcName" == "global" ]]; then
-    kubeDNSConf=$(context::jq -r '.snapshots.["d8-kube-dns-cm-wh"][].filterResult.["kube-dns-conf"]')
-    dnsDomains=$(echo $kubeDNSConf | grep -oP  'kubernetes .*? ip6.arpa')
+    kubeDNSConf=$(context::jq -r '.snapshots.["d8-kube-dns-cm-wh"][]?.filterResult.["kube-dns-conf"] // empty')
+    dnsDomains=$(echo $kubeDNSConf | grep -oP 'kubernetes .*? ip6.arpa')
     publicDomainTemplate=$(context::jq -r '.review.request.object.spec.settings.modules.publicDomainTemplate' | sed s/%s.//)
 
     for domain in $dnsDomains; do


### PR DESCRIPTION
## Description

Fix an jq error in `public-domain-template` validation webhook when the `kube-dns` module is disabled and the ConfigMap `d8-kube-dns` is absent.

## Why do we need it, and what problem does it solve?

Fixes #8660

## Why do we need it in the patch release (if we do)?

Restores the ability to edit global ModuleConfig.

## What is the expected result?
```
> kubectl get mc global -o yaml                                                                                                                                                                                                                                                   

apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  creationTimestamp: "2023-01-11T15:52:30Z"
  generation: 2
  name: global
  resourceVersion: "655622697"
  uid: 811e26e9-733c-4a88-9c80-2f63f7bd3fb6
spec:
  settings:
    modules:
      https:
      publicDomainTemplate: '%s.test.cluster.test.cloud'
  version: 1
status:
  version: "1"

> kubectl patch --type=merge -p '{"metadata": {"annotations": {"meta.helm.sh/release-name": "cluster-resources", "meta.helm.sh/release-namespace": "cluster-resources"}}}' ModuleConfig/global
moduleconfig.deckhouse.io/global patched
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix absent object error in public domain template validation webhook.
```