### PR TITLE
[deckhouse] feat: set clusterDomain from global.clusterConfiguration.clusterDomain

### DIFF
--- a/global-hooks/discovery/cluster_domain.go
+++ b/global-hooks/discovery/cluster_domain.go
@@ -70,6 +70,20 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			FilterFunc: applyClusterDomainFromDNSPodFilter,
 		},
+		{
+			Name:       "clusterConfiguration",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-cluster-configuration"},
+			},
+			FilterFunc: applyClusterConfigurationYamlFilter,
+		},
 	},
 }, discoveryClusterDomain)
 
@@ -99,9 +113,6 @@ func applyClusterDomainFromDNSPodFilter(obj *unstructured.Unstructured) (go_hook
 }
 
 func discoveryClusterDomain(input *go_hook.HookInput) error {
-	clusterDomainCoreCMSnap := input.Snapshots[clusterDomainCoreCMSnapName]
-	clusterDomainDNSPodsSnap := input.Snapshots[clusterDomainDNSPodsSnapName]
-
 	// We have a hook for handling clusterConfiguration.
 	// During the operation of this hook, there is a blocking check for filling in the clusterDomain field.
 	// So now we just need to check that the `clusterConfiguration` is present in the secrets.
@@ -117,6 +128,9 @@ func discoveryClusterDomain(input *go_hook.HookInput) error {
 	}
 
 	clusterDomain := "cluster.local"
+
+	clusterDomainCoreCMSnap := input.Snapshots[clusterDomainCoreCMSnapName]
+	clusterDomainDNSPodsSnap := input.Snapshots[clusterDomainDNSPodsSnapName]
 
 	if len(clusterDomainCoreCMSnap) > 0 {
 		domain := clusterDomainCoreCMSnap[0].(string)

--- a/global-hooks/discovery/cluster_domain.go
+++ b/global-hooks/discovery/cluster_domain.go
@@ -24,6 +24,7 @@ import (
 	v1core "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 
 	"github.com/deckhouse/deckhouse/go_lib/filter"
 )
@@ -82,7 +83,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"d8-cluster-configuration"},
 			},
-			FilterFunc: applyClusterConfigurationYamlFilter,
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			FilterFunc:                   applyClusterConfigurationYamlFilter,
 		},
 	},
 }, discoveryClusterDomain)

--- a/global-hooks/discovery/cluster_domain.go
+++ b/global-hooks/discovery/cluster_domain.go
@@ -102,8 +102,16 @@ func discoveryClusterDomain(input *go_hook.HookInput) error {
 	clusterDomainCoreCMSnap := input.Snapshots[clusterDomainCoreCMSnapName]
 	clusterDomainDNSPodsSnap := input.Snapshots[clusterDomainDNSPodsSnapName]
 
-	const clusterDomainPath = "global.discovery.clusterDomain"
+	// We have a hook for handling clusterConfiguration.
+	// During the operation of this hook, there is a blocking check for filling in the clusterDomain field.
+	// So now we just need to check that the `clusterConfiguration` is present in the secrets.
+	// And if this is the case, then the `global.discovery.clusterDomain` will be filled.
+	currentConfig, ok := input.Snapshots["clusterConfiguration"]
+	if ok && len(currentConfig) > 0 {
+		return nil
+	}
 
+	const clusterDomainPath = "global.discovery.clusterDomain"
 	if input.Values.Exists(clusterDomainPath) {
 		return nil
 	}

--- a/global-hooks/discovery/cluster_domain_test.go
+++ b/global-hooks/discovery/cluster_domain_test.go
@@ -166,8 +166,6 @@ spec:
 	})
 
 	Context("Cluster with clusterDomain in clusterConfiguration", func() {
-		f := HookExecutionConfigInit(`{"global": {"discovery": {"clusterDomain": "test.local"}}}`, initConfigValuesString)
-
 		BeforeEach(func() {
 			var (
 				stateAClusterConfiguration = `
@@ -197,10 +195,10 @@ data:
 			f.RunHook()
 		})
 
-		It("`global.discovery.clusterDomain` must be not set", func() {
+		It("`global.discovery.clusterDomain` must not be set", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("global.discovery.clusterDomain").String()).
-				To(Equal("test.local"))
+				To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
## Description

If the domain field is filled in in the cluster configuration, we need to use it in the work of the hook to determine the domain name.

## Why do we need it, and what problem does it solve?

Sometimes it can be quite difficult to determine a domain name based on dynamic variables. And if the cluster configuration is defined, we just use it.

## What is the expected result?

If the domain name is defined in the cluster configuration, it will be used in the `global.discovery.clusterDomain` field.

## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: set clusterDomain from global.clusterConfiguration.clusterDomain
impact_level: default
```
