### PR TITLE
[candi] fix bootstrap with static binaries

### DIFF
--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -22,7 +22,7 @@ function ip_in_subnet(){
 }
 
 function metadata_request(){
-  cat - <<EOFILE | python3
+  cat - <<EOFILE | python3 2>/dev/null
 from urllib.request import urlopen, Request
 
 request = Request('http://169.254.169.254/computeMetadata/v1/instance/?recursive=true', headers={'Metadata-Flavor': 'Google'})
@@ -38,7 +38,7 @@ if [ -f "/etc/netplan/50-cloud-init.yaml" ]; then
   fi
 fi
 
-if ! metadata="$(metadata_request 2>/dev/null)"; then
+if ! metadata="$(metadata_request)"; then
   echo "Can't get network cidr from metadata"
   exit 1
 fi

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -25,10 +25,12 @@ function metadata_request(){
   cat - <<EOFILE | python3 2>/dev/null
 from urllib.request import urlopen, Request
 
-request = Request('http://169.254.169.254/computeMetadata/v1/instance/?recursive=true', headers={'Metadata-Flavor': 'Google'})
-response = urlopen(request, timeout=10).read()
-
-print(response.decode('utf-8'))
+request = Request(
+  "http://169.254.169.254/computeMetadata/v1/instance/?recursive=true",
+  headers={"Metadata-Flavor": "Google"},
+)
+with urlopen(request, timeout=10) as response:
+  print(response.read().decode())
 EOFILE
 }
 

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -23,10 +23,7 @@ function ip_in_subnet(){
 
 function metadata_request(){
   cat - <<EOFILE | python3
-try:
-  from urllib.request import urlopen, Request
-except ImportError as e:
-  from urllib2 import urlopen, Request
+from urllib.request import urlopen, Request
 
 request = Request('http://169.254.169.254/computeMetadata/v1/instance/?recursive=true', headers={'Metadata-Flavor': 'Google'})
 response = urlopen(request, timeout=10).read()

--- a/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -22,7 +22,7 @@ function ip_in_subnet(){
 }
 
 function metadata_request(){
-  cat - <<EOF | python3
+  cat - <<EOFILE | python3
 try:
   from urllib.request import urlopen, Request
 except ImportError as e:
@@ -32,7 +32,7 @@ request = Request('http://169.254.169.254/computeMetadata/v1/instance/?recursive
 response = urlopen(request, timeout=10).read()
 
 print(response.decode('utf-8'))
-EOF
+EOFILE
 }
 
 if [ -f "/etc/netplan/50-cloud-init.yaml" ]; then

--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -35,16 +35,8 @@ function check_python() {
 
 function isLegacyKernel() {
   check_python
-  cat - <<EOF | $python_binary
-try:
-    from pkg_resources import parse_version as V
-except ImportError as e:
-    from distutils.version import StrictVersion as V 
-# The distutils package is deprecated and slated for removal in Python 3.12.
-exit(0) if V('$CURRENT_KERNEL_VERSION') < V('$NFT_KERNEL_LIMIT') else exit(1)
-EOF
+  $python_binary -c "exit(0) if tuple(map(int, \"$CURRENT_KERNEL_VERSION\".split('.'))) < tuple(map(int, \"$NFT_KERNEL_LIMIT\".split('.')))  else exit(1)"
 }
-
 
 if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]]; then
   iptablesModeBin="xtables-legacy-multi"

--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -19,13 +19,26 @@ cp -f xtables-nft-multi /opt/deckhouse/bin
 
 kubeletChainsRegex='^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)'
 
+function check_python() {
+  for pybin in python3 python2 python; do
+    if command -v "$pybin" >/dev/null 2>&1; then
+      python_binary="$pybin"
+      return 0
+    fi
+  done
+  echo "Python not found, exiting..."
+  return 1
+}
+
+check_python
+
 NFT_KERNEL_LIMIT=3.14 #   nf_tables_ipv6, nf_tables_bridge, nf_tables_arp allow since Linux kernel >= 3.14.
 CURRENT_KERNEL_VERSION=$(uname -r | cut -c1-4)
 IPTABLES_LEGACY_RULE=$( (/opt/deckhouse/bin/xtables-legacy-multi iptables-save || true ) 2>/dev/null | grep  -E ${kubeletChainsRegex} | wc -l )
 
 if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]]; then
   iptablesModeBin="xtables-legacy-multi"
-elif (( $(echo "$CURRENT_KERNEL_VERSION < $NFT_KERNEL_LIMIT" |bc -l) )); then
+elif ( $python_binary -c "exit(0) if $CURRENT_KERNEL_VERSION < 3.14 else exit(1)" ); then
   iptablesModeBin="xtables-legacy-multi"
 else
   # use iptables-nft as default

--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -19,7 +19,7 @@ cp -f xtables-nft-multi /opt/deckhouse/bin
 
 kubeletChainsRegex='^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)'
 NFT_KERNEL_LIMIT=3.14 # nf_tables_ipv6, nf_tables_bridge, nf_tables_arp allow since Linux kernel >= 3.14.
-CURRENT_KERNEL_VERSION=$(uname -r | awk -F"-" '{print $1}') #version kernel view: a.b.c-generic to a.b.c.
+CURRENT_KERNEL_VERSION=$(uname -r | awk -F"-" '{print $1}') #version kernel view format: a.b.c-generic to a.b.c.
 IPTABLES_LEGACY_RULE=$( (/opt/deckhouse/bin/xtables-legacy-multi iptables-save || true ) 2>/dev/null | grep  -E ${kubeletChainsRegex} | wc -l )
 
 function check_python() {

--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -19,9 +19,13 @@ cp -f xtables-nft-multi /opt/deckhouse/bin
 
 kubeletChainsRegex='^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)'
 
+NFT_KERNEL_LIMIT=3.14 #   nf_tables_ipv6, nf_tables_bridge, nf_tables_arp allow since Linux kernel >= 3.14.
+CURRENT_KERNEL_VERSION=$(uname -r | cut -c1-4)
 IPTABLES_LEGACY_RULE=$( (/opt/deckhouse/bin/xtables-legacy-multi iptables-save || true ) 2>/dev/null | grep  -E ${kubeletChainsRegex} | wc -l )
 
 if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]]; then
+  iptablesModeBin="xtables-legacy-multi"
+elif (( $(echo "$CURRENT_KERNEL_VERSION < $NFT_KERNEL_LIMIT" |bc -l) )); then
   iptablesModeBin="xtables-legacy-multi"
 else
   # use iptables-nft as default

--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -35,7 +35,7 @@ function check_python() {
 
 function isLegacyKernel() {
   check_python
-  $python_binary -c "exit(0) if tuple(map(int, \"$CURRENT_KERNEL_VERSION\".split('.'))) < tuple(map(int, \"$NFT_KERNEL_LIMIT\".split('.')))  else exit(1)"
+  $python_binary -c "exit(0) if tuple(map(int, '$CURRENT_KERNEL_VERSION'.split('.'))) < tuple(map(int, '$NFT_KERNEL_LIMIT'.split('.')))  else exit(1)"
 }
 
 if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]]; then

--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -18,6 +18,9 @@ cp -f xtables-legacy-multi /opt/deckhouse/bin
 cp -f xtables-nft-multi /opt/deckhouse/bin
 
 kubeletChainsRegex='^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)'
+NFT_KERNEL_LIMIT=3.14 # nf_tables_ipv6, nf_tables_bridge, nf_tables_arp allow since Linux kernel >= 3.14.
+CURRENT_KERNEL_VERSION=$(uname -r | awk -F"-" '{print $1}') #version kernel view: a.b.c-generic to a.b.c.
+IPTABLES_LEGACY_RULE=$( (/opt/deckhouse/bin/xtables-legacy-multi iptables-save || true ) 2>/dev/null | grep  -E ${kubeletChainsRegex} | wc -l )
 
 function check_python() {
   for pybin in python3 python2 python; do
@@ -30,15 +33,22 @@ function check_python() {
   return 1
 }
 
-check_python
+function isLegacyKernel() {
+  check_python
+  cat - <<EOF | $python_binary
+try:
+    from pkg_resources import parse_version as V
+except ImportError as e:
+    from distutils.version import StrictVersion as V 
+# The distutils package is deprecated and slated for removal in Python 3.12.
+exit(0) if V('$CURRENT_KERNEL_VERSION') < V('$NFT_KERNEL_LIMIT') else exit(1)
+EOF
+}
 
-NFT_KERNEL_LIMIT=3.14 #   nf_tables_ipv6, nf_tables_bridge, nf_tables_arp allow since Linux kernel >= 3.14.
-CURRENT_KERNEL_VERSION=$(uname -r | cut -c1-4)
-IPTABLES_LEGACY_RULE=$( (/opt/deckhouse/bin/xtables-legacy-multi iptables-save || true ) 2>/dev/null | grep  -E ${kubeletChainsRegex} | wc -l )
 
 if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]]; then
   iptablesModeBin="xtables-legacy-multi"
-elif ( $python_binary -c "exit(0) if $CURRENT_KERNEL_VERSION < 3.14 else exit(1)" ); then
+elif (isLegacyKernel); then
   iptablesModeBin="xtables-legacy-multi"
 else
   # use iptables-nft as default


### PR DESCRIPTION
## Description

Fix bootstrap steps with static binaries.

## Why do we need it, and what problem does it solve?

1.  Replacing d8-curl on python, because `bootstrap-networks.sh.tpl` step is running before d8-binaries are available on the node.
2. We should use xtables-legacy-multi for OS with kernel version older then 3.14.

## What is the expected result?

Succesful bootstrap.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix bootstrap steps with static binaries.
impact: low
```
```changes
section: registrypackages
type: fix
summary: Fix install binary iptables for OS with kernel older then 3.14.
impact: low
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
