### PR TITLE
[docs][gs] Change the owner of the home directory in bare metal installation

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -151,8 +151,8 @@ useradd -m -s /bin/bash caps
 usermod -aG sudo caps
 echo 'caps ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 mkdir /home/caps/.ssh
-chown -R caps:caps /home/caps
 echo $KEY >> /home/caps/.ssh/authorized_keys
+chown -R caps:caps /home/caps
 chmod 700 /home/caps/.ssh
 chmod 600 /home/caps/.ssh/authorized_keys
 ```

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -152,8 +152,8 @@ useradd -m -s /bin/bash caps
 usermod -aG sudo caps
 echo 'caps ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 mkdir /home/caps/.ssh
-chown -R caps:caps /home/caps
 echo $KEY >> /home/caps/.ssh/authorized_keys
+chown -R caps:caps /home/caps
 chmod 700 /home/caps/.ssh
 chmod 600 /home/caps/.ssh/authorized_keys
 ```


### PR DESCRIPTION
## Description
  It contains a fix for the correct caps-controller-manager log in.

## Why do we need it, and what problem does it solve?
  Changing the owner of the caps user's home directory so that the caps-controller-manager can log in without errors

When adding a key with the command echo `$KEY >> /home/caps/.ssh/authorized_keys` without changing the owner of the caps home directory, caps-controller-manager shows a failure in the logs:
```
.x-k8s.io" controllerKind="StaticMachine" StaticMachine="d8-cloud-instance-manager/worker-vv8qc" namespace="d8-cloud-instance-manager" name="worker-vv8qc" reconcileID="ccf86311-ae9e-4993-b802-f97da13b6eff" line=38 output="ssh: caps@158.160.121.206: Permission denied (publickey)."
E0514 11:03:58.349054       1 bootstrap.go:144] "Failed to bootstrap StaticInstance: failed to exec ssh command" err="failed to run ssh command: exit status 255" controller="staticmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="StaticMachine" StaticMachine="d8-cloud-instance-manager/worker-vv8qc" namespace="d8-cloud-instance-manager" name="worker-vv8qc" reconcileID="ccf86311-ae9e-4993-b802-f97da13b6eff"
```


## What is the expected result?

Сaps-controller-manager will log in without failures.



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: With the changed owner of home directory of caps'es user caps-controller-manager can do log in without failure.
impact_level: low