### PR TITLE
[ingress-nginx] bump nginx to 1.25.5

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/add-http3.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/add-http3.patch
@@ -23,7 +23,7 @@ index 47f2120f1..10ddc5226 100644
  		ProxyStreamTimeout:               "600s",
  		ProxyStreamNextUpstream:          true,
 diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
-index 7cd6a0604..2247127b4 100644
+index 7cd6a0604..f6df09b8b 100644
 --- a/internal/ingress/controller/template/template.go
 +++ b/internal/ingress/controller/template/template.go
 @@ -276,6 +276,7 @@ var funcMap = text_template.FuncMap{
@@ -34,10 +34,29 @@ index 7cd6a0604..2247127b4 100644
  	"buildOpentelemetryForLocation":      buildOpentelemetryForLocation,
  	"shouldLoadOpentelemetryModule":      shouldLoadOpentelemetryModule,
  	"buildModSecurityForLocation":        buildModSecurityForLocation,
-@@ -1436,6 +1437,44 @@ func buildHTTPSListener(t, s interface{}) string {
+@@ -1380,7 +1381,7 @@ func buildHTTPListener(t, s interface{}) string {
+ 		addrV4 = tc.Cfg.BindAddressIpv4
+ 	}
+ 
+-	co := commonListenOptions(&tc, hostname)
++	co := commonListenOptions(&tc, hostname, false)
+ 
+ 	out = append(out, httpListener(addrV4, co, &tc)...)
+ 
+@@ -1413,7 +1414,7 @@ func buildHTTPSListener(t, s interface{}) string {
+ 		return ""
+ 	}
+ 
+-	co := commonListenOptions(&tc, hostname)
++	co := commonListenOptions(&tc, hostname, false)
+ 
+ 	addrV4 := []string{""}
+ 	if len(tc.Cfg.BindAddressIpv4) > 0 {
+@@ -1436,7 +1437,45 @@ func buildHTTPSListener(t, s interface{}) string {
  	return strings.Join(out, "\n")
  }
  
+-func commonListenOptions(template *config.TemplateConfig, hostname string) string {
 +func buildHTTP3Listener(t, s interface{}) string {
 +	var out []string
 +
@@ -53,7 +72,7 @@ index 7cd6a0604..2247127b4 100644
 +		return ""
 +	}
 +
-+	co := commonListenOptions(&tc, hostname)
++	co := commonListenOptions(&tc, hostname, true)
 +
 +	addrV4 := []string{""}
 +	if len(tc.Cfg.BindAddressIpv4) > 0 {
@@ -76,10 +95,24 @@ index 7cd6a0604..2247127b4 100644
 +	return strings.Join(out, "\n")
 +}
 +
- func commonListenOptions(template *config.TemplateConfig, hostname string) string {
++func commonListenOptions(template *config.TemplateConfig, hostname string, useHTTP3 bool) string {
  	var out []string
  
-@@ -1509,6 +1548,24 @@ func httpsListener(addresses []string, co string, tc *config.TemplateConfig) []s
+ 	if template.Cfg.UseProxyProtocol {
+@@ -1455,7 +1494,11 @@ func commonListenOptions(template *config.TemplateConfig, hostname string) strin
+ 		out = append(out, "reuseport")
+ 	}
+ 
+-	out = append(out, fmt.Sprintf("backlog=%v", template.BacklogSize))
++	//filter backlog, due to unavailable to use with quic
++	//https://mailman.nginx.org/pipermail/nginx-devel/2024-January/UM73PXAEESYS36KEQTYMA5HSC2GK2C4L.html
++	if !useHTTP3 {
++		out = append(out, fmt.Sprintf("backlog=%v", template.BacklogSize))
++	}
+ 
+ 	return strings.Join(out, " ")
+ }
+@@ -1509,6 +1552,24 @@ func httpsListener(addresses []string, co string, tc *config.TemplateConfig) []s
  	return out
  }
  

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-build.patch
@@ -194,7 +194,7 @@ index 3fe610945..760faafe7 100755
 -
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
-+git clone -b "bump-nginx-to-1.25.5" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
++git clone -b "controller-v1.10.1-nginx-1.25.5" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
  
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-build.patch
@@ -1,8 +1,8 @@
 diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.sh
-index 3fe610945..e7ffcdf42 100755
+index 3fe610945..760faafe7 100755
 --- a/images/nginx-1.25/rootfs/build.sh
 +++ b/images/nginx-1.25/rootfs/build.sh
-@@ -14,6 +14,9 @@
+@@ -14,11 +14,14 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  
@@ -12,6 +12,12 @@ index 3fe610945..e7ffcdf42 100755
  set -o errexit
  set -o nounset
  set -o pipefail
+ 
+-export NGINX_VERSION=1.25.3
++export NGINX_VERSION=1.25.5
+ 
+ # Check for recent changes: https://github.com/vision5/ngx_devel_kit/compare/v0.3.3...master
+ export NDK_VERSION=v0.3.3
 @@ -110,177 +113,16 @@ export OPENTELEMETRY_CPP_VERSION="v1.11.0"
  export OPENTELEMETRY_PROTO_VERSION="v1.1.0"
  
@@ -188,7 +194,7 @@ index 3fe610945..e7ffcdf42 100755
 -
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
-+git clone -b "$CONTROLLER_BRANCH" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
++git clone -b "bump-nginx-to-1.25.5" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
  
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))


### PR DESCRIPTION
## Description
It provides updates for ingress-nginx, it bumps version of nginx to 1.25.5.

## What is the expected result?
Ingress-controller 1.10 has nginx 1.25.5

```
bash-4.4$ nginx -v
nginx version: nginx/1.25.5
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: feature 
summary: bump nginx to 1.25.5
```
