### PR TITLE
[istio] release requirements checker fix

### DIFF
--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -64,13 +64,13 @@ func init() {
 
 		currentMinIstioVersionRaw, exists := getter.Get(minVersionValuesKey)
 		if !exists {
-			return false, fmt.Errorf("%s key is not registred", minVersionValuesKey)
+			return true, nil
 		}
 		currentMinIstioVersionStr := currentMinIstioVersionRaw.(string)
 
 		isAtomaticK8sVerRaw, exists := getter.Get(isK8sVersionAutomaticKey)
 		if !exists {
-			return false, fmt.Errorf("%s key is not registred", isK8sVersionAutomaticKey)
+			return true, nil
 		}
 		isAtomaticK8sVer := isAtomaticK8sVerRaw.(bool)
 		// Only if k8s version is set to Automatic in cluster
@@ -80,7 +80,7 @@ func init() {
 
 		compatibilityMapRaw, exists := getter.Get(istioToK8sCompatibilityMapKey)
 		if !exists {
-			return false, fmt.Errorf("%s key is not registred", istioToK8sCompatibilityMapKey)
+			return true, nil
 		}
 		compatibilityMap, ok := compatibilityMapRaw.(map[string][]string)
 		if !ok {


### PR DESCRIPTION
## Description
Fixing istio module release requirements checker.

## Why do we need it, and what problem does it solve?
Even though the module is turned off, the checker runs and throw the error:
```
"k8s" requirement for DeckhouseRelease "1.61.0" not met: istio:minimalVersion key is not registred.
```

## Why do we need it in the patch release (if we do)?
It blocks deckhouse upgrades.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fixed istio module release requirements checker.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
