### PR TITLE
[operator-trivy] fix: set node.collector.imagePullSecret to deckhouse-registry

### DIFF
--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
   configAuditReports.scanner: "Trivy"
   report.recordFailedChecksOnly: "true"
   node.collector.imageRef: {{ include "helm_lib_module_image" (list . "nodeCollector") }}
+  node.collector.imagePullSecret: deckhouse-registry
   {{- with (include "helm_lib_tolerations" (tuple . "any-node") | fromYaml) }}
   scanJob.tolerations: {{ .tolerations | toJson | quote }}
   {{- end }}


### PR DESCRIPTION
## Description

We are only adding `deckhouse-registry` to the imagePullSecret option in the kubernetes manifest.

## Why do we need it, and what problem does it solve?

Node collector pod fails to pull its image in a KaaS-cluster.

## What is the expected result?

trivy image pull successful

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: fix
summary: set node.collector.imagePullSecret to deckhouse-registry
impact_level: default
```

Closed #8637