### PR TITLE
[candi] Disable systemd-gpt-auto-generator 

### DIFF
--- a/candi/bashible/common-steps/all/003_disable_swap.sh.tpl
+++ b/candi/bashible/common-steps/all/003_disable_swap.sh.tpl
@@ -19,8 +19,8 @@ done
 
 # systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it     
 if [ -f /lib/systemd/system-generators/systemd-gpt-auto-generator ]; then 
-  mkdir /etc/systemd/system-generators
-  ln -s /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
+  mkdir -p /etc/systemd/system-generators
+  ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 fi
 
 swapoff -a

--- a/candi/bashible/common-steps/all/003_disable_swap.sh.tpl
+++ b/candi/bashible/common-steps/all/003_disable_swap.sh.tpl
@@ -17,6 +17,12 @@ for swapunit in $(systemctl list-units --no-legend --plain --no-pager --type swa
   systemctl mask "$swapunit"
 done
 
+# systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it     
+if [ -f /lib/systemd/system-generators/systemd-gpt-auto-generator ]; then 
+  mkdir /etc/systemd/system-generators
+  ln -s /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
+fi
+
 swapoff -a
 
 if grep -q "swap" /etc/fstab; then


### PR DESCRIPTION
## Description

Disable `systemd-gpt-auto-generator`, which automatically detects swap partition in GPT  and activates it.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

If system has a swap partition in the GUID Partition Table, systemd-gpt-auto-generator will automatically enable swap after finishing `003_disable_swap.sh.tpl` and rebooting. 
Closes #8644 

## What is the expected result?

Successful bootstrap cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Disable `systemd-gpt-auto-generator`, which automatically detects swap partition in GPT and activates it.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
