### PR TITLE
[dhctl] add mirror deprecation notice

### DIFF
--- a/dhctl/cmd/dhctl/commands/mirror.go
+++ b/dhctl/cmd/dhctl/commands/mirror.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -43,6 +44,8 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	app.DefineMirrorFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
+		printMirrorDeprecationNotice()
+
 		if app.MirrorRegistry != "" {
 			return log.Process("mirror", "Push mirrored Deckhouse images from local filesystem to private registry", func() error {
 				return mirrorPushDeckhouseToPrivateRegistry()
@@ -55,6 +58,16 @@ func DefineMirrorCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	})
 
 	return cmd
+}
+
+func printMirrorDeprecationNotice() {
+	log.ErrorF(
+		"%sWARNING: dhctl mirror is deprecated and will be removed in Deckhouse Kubernetes Platform v1.64.\n"+
+			"All of it's functions are now moved into the Deckhouse CLI\n"+
+			"https://deckhouse.io/documentation/v1/deckhouse-cli/%s\n",
+		strings.Repeat("=", 80)+strings.Repeat("\n", 6),
+		strings.Repeat("\n", 6)+strings.Repeat("=", 80),
+	)
 }
 
 func mirrorPushDeckhouseToPrivateRegistry() error {

--- a/dhctl/cmd/dhctl/commands/mirror_modules.go
+++ b/dhctl/cmd/dhctl/commands/mirror_modules.go
@@ -28,6 +28,8 @@ func DefineMirrorModulesCommand(parent *kingpin.Application) *kingpin.CmdClause 
 	app.DefineMirrorModulesFlags(cmd)
 
 	cmd.Action(func(context *kingpin.ParseContext) error {
+		printMirrorDeprecationNotice()
+
 		if app.MirrorRegistry != "" {
 			var authProvider authn.Authenticator = nil
 			if app.MirrorRegistryUsername != "" {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a message to inform dhctl mirror users of it's deprecation

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We moved all mirroring functions to d8-cli, `dhctl mirror` this is no longer supported

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: dhctl mirror is deprecated in favour of Deckhouse CLI.
impact: dhctl mirror is deprecated. All mirroring-related functionality has been moved into the Deckhouse CLI and will be completely removed from dhctl in Deckhouse Kubernetes Platform v1.64.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
