### PR TITLE
Add missing variable to deprecated-apis dashboard

### DIFF
--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
@@ -590,7 +590,26 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      }
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
     ]
   },
   "time": {

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
@@ -575,7 +575,7 @@
           "uid": "$ds_prometheus"
         },
         "definition": "label_values(apiserver_requested_deprecated_apis, removed_release)",
-        "hide": 0,
+        "hide": 2,
         "includeAll": false,
         "label": "Desired K8s version",
         "multi": false,

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
@@ -609,7 +609,7 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
+      }
     ]
   },
   "time": {

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/grafana-dashboards/kubernetes-cluster/deprecated-resources.json
@@ -575,7 +575,7 @@
           "uid": "$ds_prometheus"
         },
         "definition": "label_values(apiserver_requested_deprecated_apis, removed_release)",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "Desired K8s version",
         "multi": false,
@@ -597,7 +597,7 @@
           "text": "default",
           "value": "default"
         },
-        "hide": 0,
+        "hide": 2,
         "includeAll": false,
         "label": "Prometheus",
         "multi": false,


### PR DESCRIPTION
## Description
A variable was missing in the Kubernetes Cluster/Deprecated APIs dashboard.

## Why do we need it, and what problem does it solve?

Without the variable the dashboard wasn't working. This commit fixes that

## Why do we need it in the patch release (if we do)?
## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes-control-plane
type: fix
summary: Add missing datasource variable to deprecated-apis dashboard
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->