### PR TITLE
[dhctl][kube-dns] kube-dns is rarely not created when creating a cluster

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -652,6 +652,7 @@ func (r *RegistryData) Auth() (string, error) {
 }
 
 func getDNSAddress(serviceCIDR string) string {
+	log.InfoF("serviceCIDR: %s", serviceCIDR)
 	ip, ipnet, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
 		log.DebugLn("serviceSubnetCIDR is not valid CIDR (should be validated with openapi scheme)")
@@ -677,6 +678,8 @@ func getDNSAddress(serviceCIDR string) string {
 		}
 		counter++
 	}
+
+	log.InfoF("clusterDNS: %s", clusterDNS)
 
 	return clusterDNS
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -430,25 +430,24 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 	}
 
 	if cfg.KubeDNSAddress != "" {
-		log.InfoF("KubeDNSAddress: %s", cfg.KubeDNSAddress)
-		// tasks = append(tasks, actions.ManifestTask{
-		// 	Name: `Service "kube-dns"`,
-		// 	Manifest: func() interface{} {
-		// 		return manifests.KubeDNSService(cfg.KubeDNSAddress)
-		// 	},
-		// 	CreateFunc: func(manifest interface{}) error {
-		// 		_, err := kubeCl.CoreV1().Services("kube-system").Create(context.TODO(), manifest.(*apiv1.Service), metav1.CreateOptions{})
-		// 		if err != nil && strings.Contains(err.Error(), "provided IP is already allocated") {
-		// 			log.InfoLn("Service for DNS already exists. Skip!")
-		// 			return nil
-		// 		}
-		// 		return err
-		// 	},
-		// 	UpdateFunc: func(manifest interface{}) error {
-		// 		_, err := kubeCl.CoreV1().Services("kube-system").Update(context.TODO(), manifest.(*apiv1.Service), metav1.UpdateOptions{})
-		// 		return err
-		// 	},
-		// })
+		tasks = append(tasks, actions.ManifestTask{
+			Name: `Service "kube-dns"`,
+			Manifest: func() interface{} {
+				return manifests.KubeDNSService(cfg.KubeDNSAddress)
+			},
+			CreateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().Services("kube-system").Create(context.TODO(), manifest.(*apiv1.Service), metav1.CreateOptions{})
+				if err != nil && strings.Contains(err.Error(), "provided IP is already allocated") {
+					log.InfoLn("Service for DNS already exists. Skip!")
+					return nil
+				}
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				_, err := kubeCl.CoreV1().Services("kube-system").Update(context.TODO(), manifest.(*apiv1.Service), metav1.UpdateOptions{})
+				return err
+			},
+		})
 	}
 
 	lockCmTask, err := LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -430,24 +430,25 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 	}
 
 	if cfg.KubeDNSAddress != "" {
-		tasks = append(tasks, actions.ManifestTask{
-			Name: `Service "kube-dns"`,
-			Manifest: func() interface{} {
-				return manifests.KubeDNSService(cfg.KubeDNSAddress)
-			},
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Services("kube-system").Create(context.TODO(), manifest.(*apiv1.Service), metav1.CreateOptions{})
-				if err != nil && strings.Contains(err.Error(), "provided IP is already allocated") {
-					log.InfoLn("Service for DNS already exists. Skip!")
-					return nil
-				}
-				return err
-			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Services("kube-system").Update(context.TODO(), manifest.(*apiv1.Service), metav1.UpdateOptions{})
-				return err
-			},
-		})
+		log.InfoF("KubeDNSAddress: %s", cfg.KubeDNSAddress)
+		// tasks = append(tasks, actions.ManifestTask{
+		// 	Name: `Service "kube-dns"`,
+		// 	Manifest: func() interface{} {
+		// 		return manifests.KubeDNSService(cfg.KubeDNSAddress)
+		// 	},
+		// 	CreateFunc: func(manifest interface{}) error {
+		// 		_, err := kubeCl.CoreV1().Services("kube-system").Create(context.TODO(), manifest.(*apiv1.Service), metav1.CreateOptions{})
+		// 		if err != nil && strings.Contains(err.Error(), "provided IP is already allocated") {
+		// 			log.InfoLn("Service for DNS already exists. Skip!")
+		// 			return nil
+		// 		}
+		// 		return err
+		// 	},
+		// 	UpdateFunc: func(manifest interface{}) error {
+		// 		_, err := kubeCl.CoreV1().Services("kube-system").Update(context.TODO(), manifest.(*apiv1.Service), metav1.UpdateOptions{})
+		// 		return err
+		// 	},
+		// })
 	}
 
 	lockCmTask, err := LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
