### PR TITLE
[deckhouse] feat: restrict creating system namespaces

### DIFF
--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -46,6 +46,7 @@ clusterConfiguration:
 discovery:
   clusterMasterCount: 3
   prometheusScrapeInterval: 30
+  kubernetesVersion: "1.28.10"
   d8SpecificNodeCountByRole:
     system: 1
 modules:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -21,7 +21,7 @@ spec:
   validations:
     - expression: '!(request.userInfo.username != ''system:serviceaccount:d8-system:deckhouse''
         && (object.metadata.name.startsWith(''d8-'') || object.metadata.name.startsWith(''kube-'')))'
-      messageExpression: '''Restricts create system namespaces'''
+      messageExpression: '''Creation of system namespaces is forbidden'''
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -1,0 +1,40 @@
+{{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+{{- $policyName := "d8-create-namespace-validator" }}
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConditions:
+    - expression: (request.userInfo.username != "system:serviceaccount:d8-system:deckhouse")
+      name: exclude-system-user
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["*"]
+        apiVersions: ["*"]
+        operations:  ["CREATE"]
+        resources:   ["namespaces"]
+  validations:
+    - expression: (!object.metadata.name.startsWith('d8-') && (!object.metadata.name.startsWith('kube-')))
+      messageExpression: '''Restrics create system namespaces'''
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions: [Deny]
+{{- end }}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -12,9 +12,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
   failurePolicy: Fail
-  matchConditions:
-    - expression: (request.userInfo.username != "system:serviceaccount:d8-system:deckhouse")
-      name: exclude-system-user
   matchConstraints:
     resourceRules:
       - apiGroups:   ["*"]
@@ -22,8 +19,9 @@ spec:
         operations:  ["CREATE"]
         resources:   ["namespaces"]
   validations:
-    - expression: (!object.metadata.name.startsWith('d8-') && (!object.metadata.name.startsWith('kube-')))
-      messageExpression: '''Restrics create system namespaces'''
+    - expression: '!(request.userInfo.username != ''system:serviceaccount:d8-system:deckhouse''
+        && (object.metadata.name.startsWith(''d8-'') || object.metadata.name.startsWith(''kube-'')))'
+      messageExpression: '''Restricts create system namespaces'''
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -1,5 +1,5 @@
 {{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
-{{- $policyName := "d8-create-namespace-validator" }}
+{{- $policyName := "system-ns.deckhouse.io" }}
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -14,7 +14,7 @@ spec:
   failurePolicy: Fail
   matchConstraints:
     resourceRules:
-      - apiGroups:   ["*"]
+      - apiGroups:   [""]
         apiVersions: ["*"]
         operations:  ["CREATE"]
         resources:   ["namespaces"]
@@ -43,7 +43,7 @@ apiVersion: admissionregistration.k8s.io/v1alpha1
 {{- end }}
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: "d8-create-heritage-deckhouse-objects"
+  name: "label-objects.deckhouse.io"
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
   failurePolicy: Fail
@@ -55,7 +55,7 @@ spec:
         resources:   ["*"]
   validations:
     - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'')'
-      messageExpression: '''Restricts create object as NOT service account'''
+      messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -64,10 +64,10 @@ apiVersion: admissionregistration.k8s.io/v1alpha1
 {{- end }}
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: "d8-create-heritage-deckhouse-objects"
+  name: "heritage-label-objects.deckhouse.io"
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
-  policyName: "d8-create-heritage-deckhouse-objects"
+  policyName: "label-objects.deckhouse.io"
   validationActions: [Deny]
   matchResources:
     objectSelector:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -35,4 +35,42 @@ metadata:
 spec:
   policyName: {{ $policyName }}
   validationActions: [Deny]
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "d8-create-heritage-deckhouse-objects"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["*"]
+        apiVersions: ["*"]
+        operations:  ["CREATE"]
+        resources:   ["*"]
+  validations:
+    - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'')'
+      messageExpression: '''Restricts create object as NOT service account'''
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "d8-create-heritage-deckhouse-objects"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: "d8-create-heritage-deckhouse-objects"
+  validationActions: [Deny]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        heritage: deckhouse
 {{- end }}


### PR DESCRIPTION
## Description

We need to prohibit the creation of namespaces with names that begin with `kube-` and `d8-`

Only the deckhouse system user should be able to do this

## Why do we need it, and what problem does it solve?

Regular users, including the administrator, should not be able to create system namespaces so as not to affect important settings.

## What is the expected result?

Any user, with the exception of deckhouse, should receive an error for such an attempt when trying to create a namespace whose name begins with `d8-` or `kube-`.

## Checklist
- [X] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: restrict creating system namespaces
impact_level: default
```
