### PR TITLE
[user-authn] fix crowd basic auth proxy migration

### DIFF
--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
@@ -31,10 +31,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue:        "/modules/user-authn/delete-crowd-proxy-ingress",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:                "crowd-proxy-ingress",
-			ApiVersion:          "networking.k8s.io/v1",
-			Kind:                "Ingress",
-			ExecuteHookOnEvents: pointer.Bool(false),
+			Name:                         "crowd-proxy-ingress",
+			ApiVersion:                   "networking.k8s.io/v1",
+			Kind:                         "Ingress",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"crowd-basic-auth-proxy"},
 			},

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
@@ -33,9 +33,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Name:       "crowd-proxy-ingress",
 			ApiVersion: "networking.k8s.io/v1",
 			Kind:       "Ingress",
-			NameSelector: &types.NameSelector{
-				MatchNames: []string{"crowd-basic-auth-proxy"},
-			},
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
 					MatchNames: []string{"d8-user-authn"},
@@ -50,6 +47,9 @@ func filterIngressName(obj *unstructured.Unstructured) (go_hook.FilterResult, er
 	var ingress v1.Ingress
 	if err := sdk.FromUnstructured(obj, &ingress); err != nil {
 		return nil, err
+	}
+	if ingress.Name != "crowd-basic-auth-proxy" {
+		return nil, nil
 	}
 	return ingress.Name, nil
 }

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// TODO(ipaqsa): can be deleted after 1.65
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
 	Queue:        "/modules/user-authn/delete-crowd-proxy-ingress",

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
+	Queue:        "/modules/user-authn/delete-crowd-proxy-ingress",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "crowd-proxy-ingress",
+			ApiVersion: "networking.k8s.io/v1",
+			Kind:       "Ingress",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"crowd-basic-auth-proxy"},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-user-authn"},
+				},
+			},
+			FilterFunc: filterIngressName,
+		},
+	},
+}, deleteCrowdIngress)
+
+func filterIngressName(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var ingress v1.Ingress
+	if err := sdk.FromUnstructured(obj, &ingress); err != nil {
+		return nil, err
+	}
+	return ingress.Name, nil
+}
+
+func deleteCrowdIngress(input *go_hook.HookInput) (err error) {
+	for _, snap := range input.Snapshots["crowd-proxy-ingress"] {
+		if snap == nil {
+			continue
+		}
+		input.PatchCollector.Delete("networking.k8s.io/v1", "Ingress", "d8-user-authn", snap.(string))
+	}
+	return nil
+}

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
@@ -47,47 +47,12 @@ spec:
         path: /basic-auth(\/?)(.*)
 `
 			f.BindingContexts.Set(f.KubeStateSet(crowdIngress))
+			f.RunHook()
 		})
 		It("Should delete the crowd-basic-auth-proxy ingress", func() {
-			f.RunHook()
 			Expect(f).To(ExecuteSuccessfully())
 			ingress := f.KubernetesResource("Ingress", "d8-user-authn", "crowd-basic-auth-proxy")
 			Expect(ingress).To(BeEmpty())
-		})
-		It("Should not delete the crowd-basic-auth-proxy ingress", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			ingress := f.KubernetesResource("Ingress", "d8-user-authn", "crowd-basic-auth-proxy")
-			Expect(ingress.Field("metadata.name").Str).To(Equal("crowd-basic-auth-proxy"))
-		})
-	})
-	Context("There's the basic-auth-proxy ingress", func() {
-		BeforeEach(func() {
-			basicIngress := `
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: basic-auth-proxy
-  namespace: d8-user-authn
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: api.dev.hf.flant.com
-    http:
-      paths:
-      - backend:
-          service:
-            name: basic-auth-proxy
-            port:
-              number: 7332
-        path: /basic-auth(\/?)(.*)
-`
-			f.BindingContexts.Set(f.KubeStateSet(basicIngress))
-			f.RunHook()
-		})
-		It("Should not delete the basic-auth-proxy ingress", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			ingress := f.KubernetesResource("Ingress", "d8-user-authn", "basic-auth-proxy")
-			Expect(ingress.Field("metadata.name").Str).To(Equal("basic-auth-proxy"))
 		})
 	})
 })

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package hooks
 
 import (
-	. "github.com/deckhouse/deckhouse/testing/hooks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("User Authn hooks :: delete the crowd-basic-auth-proxy ingress::", func() {

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
@@ -46,7 +46,7 @@ spec:
               number: 7332
         path: /basic-auth(\/?)(.*)
 `
-			f.BindingContexts.Set(f.KubeStateSet(crowdIngress))
+			f.BindingContexts.Set(f.KubeStateSet(crowdIngress), f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
 		It("Should delete the crowd-basic-auth-proxy ingress", func() {

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("User Authn hooks :: delete the crowd-basic-auth-proxy ingress::", func() {
+	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
+	Context("There's the crowd-basic-auth-proxy ingress", func() {
+		BeforeEach(func() {
+			crowdIngress := `
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: crowd-basic-auth-proxy
+  namespace: d8-user-authn
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api.dev.hf.flant.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: basic-auth-proxy
+            port:
+              number: 7332
+        path: /basic-auth(\/?)(.*)
+`
+			f.BindingContexts.Set(f.KubeStateSet(crowdIngress))
+		})
+		It("Should delete the crowd-basic-auth-proxy ingress", func() {
+			f.RunHook()
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesResource("Ingress", "d8-user-authn", "crowd-basic-auth-proxy")
+			Expect(ingress).To(BeEmpty())
+		})
+		It("Should not delete the crowd-basic-auth-proxy ingress", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesResource("Ingress", "d8-user-authn", "crowd-basic-auth-proxy")
+			Expect(ingress.Field("metadata.name").Str).To(Equal("crowd-basic-auth-proxy"))
+		})
+	})
+	Context("There's the basic-auth-proxy ingress", func() {
+		BeforeEach(func() {
+			basicIngress := `
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: basic-auth-proxy
+  namespace: d8-user-authn
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api.dev.hf.flant.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: basic-auth-proxy
+            port:
+              number: 7332
+        path: /basic-auth(\/?)(.*)
+`
+			f.BindingContexts.Set(f.KubeStateSet(basicIngress))
+			f.RunHook()
+		})
+		It("Should not delete the basic-auth-proxy ingress", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingress := f.KubernetesResource("Ingress", "d8-user-authn", "basic-auth-proxy")
+			Expect(ingress.Field("metadata.name").Str).To(Equal("basic-auth-proxy"))
+		})
+	})
+})


### PR DESCRIPTION
## Description
It provides fix for crowd-basic-auth-proxy to avoid ingress problems during migration to basic-auth-proxy

## Why do we need it, and what problem does it solve?
It helps to avoid migration problems. We have renamed the crowd-basic-auth-proxy ingress, and it causes conflicts during migration from crowd-basic-auth-proxy to basic-auth-proxy.

## Why do we need it in the patch release (if we do)?
```
Queue 'main': length 43, status: 'run first task'

 1. ModuleRun:main:user-authn:doStartup:OperatorStartup:failures 3:helm upgrade failed: failed to create resource: admission webhook "main.validate.d8-ingress-nginx-deckhouse" denied the request: host "api.dev.hf.flant.com" and path "/basic-auth(\/?)(.*)" is already defined in ingress d8-user-authn/crowd-basic-auth-proxy
```
To avoid migration problems.

## What is the expected result?
Succeful migration from crowd-auth-basic-proxy(v1.60) to basic-auth-proxy(v1.61)

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: fix crowd basic auth proxy migration
```

