### PR TITLE
[e2e] redos 8 image upd

### DIFF
--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -49,6 +49,6 @@ masterNodeGroup:
   instanceClass:
     rootDiskSize: 30
     flavorName: m1.large
-    imageName: "redos-STD-MINIMAL-8.0.0"
+    imageName: "redos-STD-MINIMAL-8.0.0-20240617"
   volumeTypeMap:
     ru-3a: "fast.ru-3a"

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -123,7 +123,7 @@ data "openstack_images_image_v2" "alt_image" {
 data "openstack_images_image_v2" "redos_image" {
   most_recent = true
   visibility  = "shared"
-  name        = "redos-STD-MINIMAL-8.0.0"
+  name        = "redos-STD-MINIMAL-8.0.0-20240617"
 }
 
 resource "openstack_blockstorage_volume_v3" "master" {

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -28,7 +28,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: 'fd86ciomm61qk3o1rta5' #RED OS 8.0.0
+    imageID: 'fd828lkoi88htvvb12uc' #RED OS 8.0.0
     externalIPAddresses:
     - Auto
 provider:


### PR DESCRIPTION
## Description

Update redos 8.0 images for e2e tests

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

