### PR TITLE
[docs] Improvements in Cloud provider — OpenStack. Fixed objects examples

### DIFF
--- a/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/instance_class.yaml
@@ -97,9 +97,8 @@ spec:
                     Paths to networks that VirtualMachines' secondary NICs will connect to.
 
                     **By default:** the value from `OpenStackCloudDiscoveryData` is used.
-                  x-doc-examples:
-                    - "BGP-network-VLAN-3894"
-                    - "External-VLAN-3699"
+                  x-doc-examples: 
+                  - ['BGP-network-VLAN-3894', 'External-VLAN-3699']
                   type: array
                   items:
                     type: string
@@ -110,9 +109,8 @@ spec:
                     They allow you to set firewall rules for provisioned instances.
 
                     The `SecurityGroups` may not be supported by the cloud provider.
-                  x-doc-examples:
-                  - "security-group-1"
-                  - "security-group-2"
+                  x-doc-examples: 
+                    - ["security-group-1", "security-group-2"]
                   type: array
                   items:
                     type: string


### PR DESCRIPTION
## Description
Fixed examples of filling objects for the "OpenStack: Custom Resources" page.  
The arrays were displayed as multiple single lines:  
- [additionalnetworks](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cr.html#openstackinstanceclass-v1-spec-additionalnetworks)
- [additionalsecuritygroups](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-openstack/cr.html#openstackinstanceclass-v1-spec-additionalsecuritygroups)

## Why do we need it, and what problem does it solve?

The improvement will help clients fill in the module parameters correctly

## Why do we need it in the patch release (if we do)?

Not necessarily

## What is the expected result?

Improve the quality of documentation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Fixed objects examples on page "Cloud provider — OpenStack"
impact_level: low
```