### PR TITLE
[node-manager] Re-enable ClusterHasOrphanedDisks alert for yandex

### DIFF
--- a/modules/040-node-manager/monitoring/prometheus-rules/cloud-data-discovery.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/cloud-data-discovery.tpl
@@ -34,10 +34,9 @@
         Cloud data discoverer cannot save data to k8s resource. See cloud data discoverer logs for more information:
         `kubectl -n {{`{{ $labels.namespace }}`}} logs deploy/cloud-data-discoverer`
 
-{{/* TODO remove condition with label namespace after release 1.61 when all yandex clusters applied cloud-migrator in discoverer  */}}
   - alert: ClusterHasOrphanedDisks
     for: 1h
-    expr: max by(job, id, name)(cloud_data_discovery_orphaned_disk_info{namespace!="d8-cloud-provider-yandex"} == 1)
+    expr: max by(job, id, name, namespace)(cloud_data_discovery_orphaned_disk_info == 1)
     labels:
       severity_level: "6"
       d8_module: node-manager


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Re-enable ClusterHasOrphanedDisks alert for yandex.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Related to #8224.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Re-enable ClusterHasOrphanedDisks alert for yandex.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
