### PR TITLE
[deckhouse] fix overwriting embedded modules' images tags

### DIFF
--- a/global-hooks/discovery/modules_images_tags.go
+++ b/global-hooks/discovery/modules_images_tags.go
@@ -58,7 +58,10 @@ func discoveryModulesImagesDigests(input *go_hook.HookInput) error {
 
 	modulesDigestsObj := readModulesImagesDigests(input, externalModulesDir)
 	for k, v := range modulesDigestsObj {
-		digestsObj[k] = v
+		// under no circumstances do we overwrite existing digests
+		if _, found := digestsObj[k]; !found {
+			digestsObj[k] = v
+		}
 	}
 
 	input.Values.Set("global.modulesImages.digests", digestsObj)

--- a/global-hooks/discovery/modules_images_tags_test.go
+++ b/global-hooks/discovery/modules_images_tags_test.go
@@ -56,6 +56,9 @@ var _ = Describe("Global hooks :: discovery :: modules_images_tags ", func() {
 	"basicAuth": {
 	  "nginx": "valid-digest"
 	},
+	"double": {
+          "srv": "sourced-module-digest"
+        },
 	"testLocal": {
 	  "test": "valid-digest"
 	},
@@ -108,6 +111,34 @@ var _ = Describe("Global hooks :: discovery :: modules_images_tags ", func() {
 
 			It("Should return error", func() {
 				Expect(f).NotTo(ExecuteSuccessfully())
+			})
+		})
+
+		Context("Should save the embedded module's digest, not the sourced one", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.GenerateOnStartupContext())
+
+				const content = `{"double": {"srv": "embedded-module-digest"}}`
+				err := writeTagsTMPFile(content)
+				Expect(err).To(BeNil())
+				f.RunHook()
+			})
+
+			It("Should set tags files content as object into 'global.modulesImages.digests'", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				tag := f.ValuesGet("global.modulesImages.digests").String()
+				Expect(tag).To(MatchJSON(`
+{
+	"double": {
+          "srv": "embedded-module-digest"
+        },
+	"testLocal": {
+	  "test": "valid-digest"
+	},
+	"testTest": {
+	  "test": "valid-digest"
+	}
+}`))
 			})
 		})
 

--- a/global-hooks/discovery/testdata/modules-images-tags/external-modules-source/998-double/images_digests.json
+++ b/global-hooks/discovery/testdata/modules-images-tags/external-modules-source/998-double/images_digests.json
@@ -1,0 +1,3 @@
+{
+  "srv": "sourced-module-digest"
+}

--- a/global-hooks/discovery/testdata/modules-images-tags/external-modules/998-double
+++ b/global-hooks/discovery/testdata/modules-images-tags/external-modules/998-double
@@ -1,0 +1,1 @@
+../external-modules-source/998-double


### PR DESCRIPTION
## Description
This PR updates `modules_images_tags` discovery hook's logic so that if there are two modules in the cluster with the same name, images tags of first one (supposedly, an embedded module) will make their way into resulting images_digests.json file.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Closes #8480 
We need it because in opposite case images digests of an embedded module get overwritten with values of its namesake sourced module.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Embedded modules have priority in terms of charts and images digests over source modules.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Fix overwriting embedded modules' images tags.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
