### PR TITLE
[prometheus] Expose Grafana v10 metrics

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
@@ -767,7 +767,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max by (version, namespace) (grafana_build_info{service=\"grafana\", namespace=\"d8-monitoring\"})",
+          "expr": "max by (version, namespace) (grafana_build_info{service=\"grafana-v10\", namespace=\"d8-monitoring\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "{{ version }} {{ edition }}",

--- a/modules/300-prometheus/templates/grafana/servicemonitor-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/servicemonitor-v10.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana-v10-module
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
+spec:
+  jobLabel: app
+  sampleLimit: 5000
+  endpoints:
+  - port: https
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true
+    honorLabels: true
+    relabelings:
+    - targetLabel: tier
+      replacement: cluster
+  selector:
+    matchLabels:
+      app: grafana-v10
+  namespaceSelector:
+    matchNames:
+    - d8-monitoring


### PR DESCRIPTION
## Description

Grafana v10 metrics should be exposed
Currently it takes at least to have `grafana_build_info` exposed to show the actual version of Grafana on home dashboard

## Why do we need it, and what problem does it solve?
Closes #8724 

## What is the expected result?
Grafana v10 metrics are exposed and home dashboard for Grafana v10 contains the actual value for installed version

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Expose Grafana v10 metrics
impact_level: default
```