### PR TITLE
[core] fix working with registries on non-standard ports

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -199,10 +198,8 @@ func newRegistryClientConfigGetter(config config.RegistryData) (*registryClientC
 		return nil, fmt.Errorf("registry auth: %v", err)
 	}
 
-	repo, err := url.JoinPath(config.Address, config.Path)
-	if err != nil {
-		return nil, fmt.Errorf("registry repo: %v", err)
-	}
+	repo := fmt.Sprintf("%s/%s", strings.Trim(config.Address, "/"), strings.Trim(config.Path, "/"))
+
 	return &registryClientConfigGetter{
 		ClientConfig: registry.ClientConfig{
 			Repository: repo,

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -53,6 +53,26 @@ func TestNewRegistryClientConfigGetter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, getter.Repository, "registry.deckhouse.io/deckhouse/ee")
 	})
+	t.Run("Host with port, path with leading slash", func(t *testing.T) {
+		config := config.RegistryData{
+			Address:   "registry.deckhouse.io:30000",
+			Path:      "/deckhouse/ee",
+			DockerCfg: "eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5pbzozMDAwMCI6IHt9fX0=", // {"auths": { "registry.deckhouse.io:30000": {}}}
+		}
+		getter, err := newRegistryClientConfigGetter(config)
+		require.NoError(t, err)
+		require.Equal(t, getter.Repository, "registry.deckhouse.io:30000/deckhouse/ee")
+	})
+	t.Run("Host with port, path without leading slash", func(t *testing.T) {
+		config := config.RegistryData{
+			Address:   "registry.deckhouse.io:30000",
+			Path:      "deckhouse/ee",
+			DockerCfg: "eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5pbzozMDAwMCI6IHt9fX0=", // {"auths": { "registry.deckhouse.io:30000	": {}}}
+		}
+		getter, err := newRegistryClientConfigGetter(config)
+		require.NoError(t, err)
+		require.Equal(t, getter.Repository, "registry.deckhouse.io:30000/deckhouse/ee")
+	})
 }
 
 func TestBootstrapGetNodesFromCache(t *testing.T) {

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/url"
+	"strings"
 
 	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/registry"
 )
@@ -64,10 +64,7 @@ func (d registrySecretData) toClientConfig() (*registry.ClientConfig, error) {
 		}
 	}
 
-	repo, err := url.JoinPath(d.Address, d.Path)
-	if err != nil {
-		return nil, err
-	}
+	repo := fmt.Sprintf("%s/%s", strings.Trim(d.Address, "/"), strings.Trim(d.Path, "/"))
 
 	return &registry.ClientConfig{
 		Repository: repo,

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret_test.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret_test.go
@@ -39,4 +39,23 @@ func TestToClientConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, c.Repository, "registry.deckhouse.io/deckhouse/ee")
 	})
+	t.Run("Host with port, path with leading slash", func(t *testing.T) {
+		sd := registrySecretData{
+			Address: "registry.deckhouse.io:30000",
+			Path:    "deckhouse/ee",
+		}
+		c, err := sd.toClientConfig()
+		require.NoError(t, err)
+		require.Equal(t, c.Repository, "registry.deckhouse.io:30000/deckhouse/ee")
+	})
+	t.Run("Host with port, path without leading slash", func(t *testing.T) {
+		sd := registrySecretData{
+			Address: "registry.deckhouse.io:30000",
+			Path:    "deckhouse/ee",
+		}
+		c, err := sd.toClientConfig()
+		require.NoError(t, err)
+		require.Equal(t, c.Repository, "registry.deckhouse.io:30000/deckhouse/ee")
+	})
+
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix working with registries on non-standard ports.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Due to wrong calculate a path to registry with non-standard port in url, registry-packages-proxy cannot work with this registries, affecting new installs and upgrade.
Symthoms:
```
bashible.sh[164163]: Failed to execute step /var/lib/bashible/bundle_steps/062_install_kubelet_and_his_friends.sh ... retry in 10 seconds.
bashible.sh[164163]: ===
bashible.sh[164163]: === Step: /var/lib/bashible/bundle_steps/062_install_kubelet_and_his_friends.sh
bashible.sh[164163]: ===
bashible.sh[164163]: error: error parsing STDIN: error converting YAML to JSON: yaml: line 9: did not find expected key
...
bashible.sh[164163]: bb-package [INFO] Fetching packages: d8
bashible.sh[164163]: ++ trap 'bb-log-error "Failed to fetch packages"' ERR
bashible.sh[164163]: ++ bb-package-fetch-blobs PACKAGES_MAP
bashible.sh[164163]: ++ local PACKAGE_DIGEST
bashible.sh[164163]: ++ for PACKAGE_DIGEST in "${!PACKAGES_MAP[@]}"
bashible.sh[164163]: ++ local PACKAGE_DIR=/opt/deckhouse/tmp/registrypackages/d8
bashible.sh[164163]: ++ mkdir -p /opt/deckhouse/tmp/registrypackages/d8
bashible.sh[164163]: ++ bb-package-fetch-blob sha256:7f9dd986818d7c9bb8cd60dd3dee61cae563c4ae7f08a1752509399f1663a0b5 /opt/deckhouse/tmp/registrypackages/d8/sha256:7f9dd986818d7c9bb8cd60dd3dee61cae563c4ae7f08a1752509399f1663a0b5.tar.gz
bashible.sh[164163]: ++ check_python
bashible.sh[164163]: ++ for pybin in python3 python2 python
bashible.sh[164163]: ++ command -v python3
bashible.sh[164163]: ++ python_binary=python3
bashible.sh[164163]: ++ return 0
bashible.sh[164163]: ++ cat -
bashible.sh[164163]: ++ python3
bashible.sh[164163]: HTTP Error 500: b'repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: registry.local:48123\n'
bashible.sh[164163]: ++ trap - ERR
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: fix working with registries on non-standard ports
impact: registry-packages-proxy should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
