### PR TITLE
[cloud-provider-openstack] Add ConfigDrive support for mcm and SimpleWithInternalNetwork layout

### DIFF
--- a/candi/bashible/common-steps/node-group/004_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/node-group/004_integrate_kubernetes_data_device.sh.tpl
@@ -50,6 +50,37 @@ else
   DATA_DEVICE="$(get_data_device_secret | jq -re --arg hostname "$HOSTNAME" '.data[$hostname]' | base64 -d)"
 fi
 
+{{- /*
+# Sometimes the `device_path` output from terraform points to a non-existent device.
+# In such situation we want to find an unpartitioned unused disk
+# with no file system, assuming it is the correct one.
+#
+# Example of this situation (lsblk -o path,type,mountpoint,fstype --tree --json):
+#         {
+#          "path": "/dev/vda",
+#          "type": "disk",
+#          "mountpoint": null,
+#          "fstype": null,
+#          "children": [
+#             {
+#                "path": "/dev/vda1",
+#                "type": "part",
+#                "mountpoint": "/",
+#                "fstype": "ext4"
+#             },{
+#                "path": "/dev/vda15",
+#                "type": "part",
+#                "mountpoint": "/boot/efi",
+#                "fstype": "vfat"
+#             }
+#          ]
+#       },{
+#          "path": "/dev/vdb",
+#          "type": "disk",
+#          "mountpoint": null,
+#          "fstype": null
+#       }
+*/}}
 if ! [ -b "$DATA_DEVICE" ]; then
   >&2 echo "failed to find $DATA_DEVICE disk. Trying to detect the correct one"
   DATA_DEVICE=$(lsblk -o path,type,mountpoint,fstype --tree --json | jq -r '.blockdevices[] | select (.type == "disk" and .mountpoint == null and .children == null) | .path')

--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
@@ -35,6 +35,7 @@ module "master" {
   network_port_ids = list(local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id)
   internal_network_cidr = data.openstack_networking_subnet_v2.internal.cidr
   floating_ip_network = local.external_network_floating_ip ? local.external_network_name : ""
+  config_drive = !local.external_network_dhcp
   tags = local.tags
   zone = local.zone
   volume_type = local.volume_type

--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
@@ -28,6 +28,7 @@ locals {
   pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR
   internal_subnet_name  = var.providerClusterConfiguration.simpleWithInternalNetwork.internalSubnetName
   external_network_name = lookup(var.providerClusterConfiguration.simpleWithInternalNetwork, "externalNetworkName", "")
+  external_network_dhcp = lookup(var.providerClusterConfiguration.simpleWithInternalNetwork, "externalNetworkDHCP", true)
   pod_network_mode      = lookup(var.providerClusterConfiguration.simpleWithInternalNetwork, "podNetworkMode", "DirectRoutingWithPortSecurityEnabled")
   image_name            = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
   tags                  = lookup(var.providerClusterConfiguration, "tags", {})

--- a/ee/candi/cloud-providers/openstack/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cloud_discovery_data.yaml
@@ -27,7 +27,6 @@ apiVersions:
         items:
           type: string
           minLength: 1
-        minItems: 1
         uniqueItems: true
       podNetworkMode:
         type: string
@@ -43,7 +42,6 @@ apiVersions:
         type: object
       loadBalancer:
         type: object
-        required: [subnetID, floatingNetworkID]
         additionalProperties: false
         properties:
           subnetID:
@@ -58,6 +56,8 @@ apiVersions:
         layout:
           enum: [Standard]
           type: string
+        externalNetworkNames:
+          minItems: 1
         instances:
           type: object
           required: [sshKeyPairName, imageName, mainNetwork, securityGroups]
@@ -76,11 +76,15 @@ apiVersions:
               type: array
               items:
                 type: string
+        loadBalancer:
+          required: [subnetID, floatingNetworkID]
     - required: [externalNetworkNames]
       properties:
         layout:
           enum: [StandardWithNoRouter]
           type: string
+        externalNetworkNames:
+          minItems: 1
         instances:
           type: object
           required: [sshKeyPairName, imageName, mainNetwork, additionalNetworks, securityGroups]

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -541,6 +541,8 @@ apiVersions:
             default: DirectRoutingWithPortSecurityEnabled
           externalNetworkName:
             <<: *externalNetworkName
+          externalNetworkDHCP:
+            <<: *externalNetworkDHCP
           masterWithExternalFloatingIP:
             description: |
               Defines if Floating IP must be assigned to master nodes.

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -304,6 +304,8 @@ apiVersions:
               > **Внимание!** После переключения с/на VXLAN требуется перезагрузка всех узлов кластера.
           externalNetworkName:
             <<: *externalNetworkName_ru
+          externalNetworkDHCP:
+            <<: *externalNetworkDHCP_ru
           masterWithExternalFloatingIP:
             description: |
               Флаг, который указывает, создавать ли Floating IP на master-узлах.

--- a/ee/modules/030-cloud-provider-openstack/cloud-instance-manager/machine-class.yaml
+++ b/ee/modules/030-cloud-provider-openstack/cloud-instance-manager/machine-class.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   region: {{ .Values.nodeManager.internal.cloudProvider.openstack.connection.region | quote }}
   availabilityZone: {{ .zoneName }}
+  {{- if not .Values.nodeManager.internal.cloudProvider.openstack.externalNetworkDHCP }}
+    useConfigDrive: true
+  {{- end }}
   flavorName: {{ .nodeGroup.instanceClass.flavorName }}
   {{- if hasKey .nodeGroup.instanceClass "imageName" }}
   imageName: {{ .nodeGroup.instanceClass.imageName }}

--- a/ee/modules/030-cloud-provider-openstack/cloud-instance-manager/machine-class.yaml
+++ b/ee/modules/030-cloud-provider-openstack/cloud-instance-manager/machine-class.yaml
@@ -8,7 +8,7 @@ spec:
   region: {{ .Values.nodeManager.internal.cloudProvider.openstack.connection.region | quote }}
   availabilityZone: {{ .zoneName }}
   {{- if not .Values.nodeManager.internal.cloudProvider.openstack.externalNetworkDHCP }}
-    useConfigDrive: true
+  useConfigDrive: true
   {{- end }}
   flavorName: {{ .nodeGroup.instanceClass.flavorName }}
   {{- if hasKey .nodeGroup.instanceClass "imageName" }}

--- a/ee/modules/030-cloud-provider-openstack/hooks/internal/v1/provider_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/internal/v1/provider_cluster_configuration.go
@@ -38,17 +38,18 @@ type OpenstackProviderClusterConfiguration struct {
 		InternalNetworkCIDR     string `json:"internalNetworkCIDR,omitempty" yaml:"internalNetworkCIDR,omitempty"`
 		InternalNetworkSecurity bool   `json:"internalNetworkSecurity,omitempty" yaml:"internalNetworkSecurity,omitempty"`
 		ExternalNetworkName     string `json:"externalNetworkName,omitempty" yaml:"externalNetworkName,omitempty"`
-		ExternalNetworkDHCP     bool   `json:"externalNetworkDHCP,omitempty" yaml:"externalNetworkDHCP,omitempty"`
+		ExternalNetworkDHCP     *bool  `json:"externalNetworkDHCP,omitempty" yaml:"externalNetworkDHCP,omitempty"`
 	} `json:"standardWithNoRouter,omitempty" yaml:"standardWithNoRouter,omitempty"`
 	Simple struct {
 		ExternalNetworkName string `json:"externalNetworkName,omitempty" yaml:"externalNetworkName,omitempty"`
-		ExternalNetworkDHCP bool   `json:"externalNetworkDHCP,omitempty" yaml:"externalNetworkDHCP,omitempty"`
+		ExternalNetworkDHCP *bool  `json:"externalNetworkDHCP,omitempty" yaml:"externalNetworkDHCP,omitempty"`
 		PodNetworkMode      string `json:"podNetworkMode,omitempty" yaml:"podNetworkMode,omitempty"`
 	} `json:"simple,omitempty" yaml:"simple,omitempty"`
 	SimpleWithInternalNetwork struct {
 		InternalSubnetName           string `json:"internalSubnetName,omitempty" yaml:"internalSubnetName,omitempty"`
 		PodNetworkMode               string `json:"podNetworkMode,omitempty" yaml:"podNetworkMode,omitempty"`
 		ExternalNetworkName          string `json:"externalNetworkName,omitempty" yaml:"externalNetworkName,omitempty"`
+		ExternalNetworkDHCP          *bool  `json:"externalNetworkDHCP,omitempty" yaml:"externalNetworkDHCP,omitempty"`
 		MasterWithExternalFloatingIP bool   `json:"masterWithExternalFloatingIP,omitempty" yaml:"masterWithExternalFloatingIP,omitempty"`
 	} `json:"simpleWithInternalNetwork,omitempty" yaml:"simpleWithInternalNetwork,omitempty"`
 

--- a/ee/modules/030-cloud-provider-openstack/hooks/openstack_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/openstack_cluster_configuration.go
@@ -45,9 +45,26 @@ var _ = cluster_configuration.RegisterHook(func(input *go_hook.HookInput, metaCf
 	providerClusterConfiguration.PatchWithModuleConfig(moduleConfiguration)
 	discoveryData.PathWithDiscoveryData(moduleConfiguration)
 
+	externalNetworkDHCP := true
+	switch providerClusterConfiguration.Layout {
+	case "Simple":
+		if v := providerClusterConfiguration.Simple.ExternalNetworkDHCP; v != nil {
+			externalNetworkDHCP = *v
+		}
+	case "SimpleWithInternalNetwork":
+		if v := providerClusterConfiguration.SimpleWithInternalNetwork.ExternalNetworkDHCP; v != nil {
+			externalNetworkDHCP = *v
+		}
+	case "StandardWithNoRouter":
+		if v := providerClusterConfiguration.StandardWithNoRouter.ExternalNetworkDHCP; v != nil {
+			externalNetworkDHCP = *v
+		}
+	}
+
 	input.Values.Set("cloudProviderOpenstack.internal.connection", providerClusterConfiguration.Provider)
 	input.Values.Set("cloudProviderOpenstack.internal.internalNetworkNames", discoveryData.InternalNetworkNames)
 	input.Values.Set("cloudProviderOpenstack.internal.externalNetworkNames", discoveryData.ExternalNetworkNames)
+	input.Values.Set("cloudProviderOpenstack.internal.externalNetworkDHCP", externalNetworkDHCP)
 	input.Values.Set("cloudProviderOpenstack.internal.zones", discoveryData.Zones)
 	input.Values.Set("cloudProviderOpenstack.internal.instances", discoveryData.Instances)
 	input.Values.Set("cloudProviderOpenstack.internal.podNetworkMode", discoveryData.PodNetworkMode)

--- a/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
@@ -45,6 +45,8 @@ properties:
         default: []
         items:
           type: string
+      externalNetworkDHCP:
+        type: boolean
       zones:
         type: array
         default: []

--- a/ee/modules/030-cloud-provider-openstack/templates/registration.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/registration.yaml
@@ -60,6 +60,9 @@ data:
   {{- if hasKey $internal "externalNetworkNames" }}
     {{- $_ := set $openstackValues "externalNetworkNames" $internal.externalNetworkNames }}
   {{- end }}
+  {{- if hasKey $internal "externalNetworkDHCP" }}
+    {{- $_ := set $openstackValues "externalNetworkDHCP" $internal.externalNetworkDHCP }}
+  {{- end }}
   {{- if hasKey $internal "internalNetworkNames" }}
     {{- $_ := set $openstackValues "internalNetworkNames" $internal.internalNetworkNames }}
   {{- else }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add ConfigDrive support for mcm and SimpleWithInternalNetwork layout

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Closes #3060.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: feature
summary: Add support for the `ConfigDrive` parameter in mcm and `SimpleWithInternalNetwork` layout.
impact_level: default
```
