### PR TITLE
[prometheus] Fix copying of Grafana v10 custom certificate

### DIFF
--- a/modules/300-prometheus/templates/grafana/authenticator-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/authenticator-v10.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
-  applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
+  applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
   {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   signOutURL: "/logout"

--- a/modules/300-prometheus/templates/grafana/certificate.yaml
+++ b/modules/300-prometheus/templates/grafana/certificate.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.global.modules.publicDomainTemplate }}
   {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/modules/300-prometheus/templates/grafana/certificate.yaml
+++ b/modules/300-prometheus/templates/grafana/certificate.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.modules.publicDomainTemplate }}
+  {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grafana
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "grafana")) | nindent 2 }}
+spec:
+  certificateOwnerRef: false
+  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "grafana") | nindent 2 }}
+  dnsNames:
+    - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
+    - {{ include "helm_lib_module_public_domain" (list . "grafana") }}
+    - {{ include "helm_lib_module_public_domain" (list . "prometheus") }}
+  issuerRef:
+    name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+    kind: ClusterIssuer
+  {{- end }}
+{{- end }}

--- a/modules/300-prometheus/templates/grafana/ingress-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-v10.yaml
@@ -41,7 +41,7 @@ spec:
   tls:
   - hosts:
     - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
-    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
   {{- end }}
   rules:
   - host: {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
@@ -64,7 +64,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "grafana-v10")) | nindent 2 }}
 spec:
   certificateOwnerRef: false
-  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
   {{ include "helm_lib_module_generate_common_name" (list . "grafana-v10") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}

--- a/modules/300-prometheus/templates/grafana/ingress-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-v10.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.modules.publicDomainTemplate }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/modules/300-prometheus/templates/grafana/ingress-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-v10.yaml
@@ -41,7 +41,7 @@ spec:
   tls:
   - hosts:
     - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
-    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
+    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
   {{- end }}
   rules:
   - host: {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
@@ -64,7 +64,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "grafana-v10")) | nindent 2 }}
 spec:
   certificateOwnerRef: false
-  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
+  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
   {{ include "helm_lib_module_generate_common_name" (list . "grafana-v10") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}

--- a/modules/300-prometheus/templates/grafana/ingress-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-v10.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.global.modules.publicDomainTemplate }}
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -41,7 +40,7 @@ spec:
   tls:
   - hosts:
     - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
-    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
+    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
   {{- end }}
   rules:
   - host: {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
@@ -54,22 +53,4 @@ spec:
             name: grafana-v10
             port:
               name: https
-  {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: grafana-v10
-  namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "grafana-v10")) | nindent 2 }}
-spec:
-  certificateOwnerRef: false
-  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-v10") }}
-  {{ include "helm_lib_module_generate_common_name" (list . "grafana-v10") | nindent 2 }}
-  dnsNames:
-  - {{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
-  issuerRef:
-    name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
-    kind: ClusterIssuer
-  {{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/grafana/ingress.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.modules.publicDomainTemplate }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/modules/300-prometheus/templates/grafana/ingress.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.global.modules.publicDomainTemplate }}
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -68,23 +67,4 @@ spec:
               name: grafana
               port:
                 name: https
-  {{- if eq (include "helm_lib_module_https_mode" .) "CertManager" }}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: grafana
-  namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "grafana")) | nindent 2 }}
-spec:
-  certificateOwnerRef: false
-  secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
-  {{ include "helm_lib_module_generate_common_name" (list . "grafana") | nindent 2 }}
-  dnsNames:
-  - {{ include "helm_lib_module_public_domain" (list . "grafana") }}
-  - {{ include "helm_lib_module_public_domain" (list . "prometheus") }}
-  issuerRef:
-    name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
-    kind: ClusterIssuer
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Fix copying of Grafana v10 custom certificate

## Why do we need it, and what problem does it solve?
Closes #8756 

## What is the expected result?
Custom certificate is added for Grafana v10 ingress when https global module mode is CustomCertificate

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: fix
summary: Fix copying of Grafana v10 custom certificate
impact_level: default
```