### PR TITLE
[cloud-provider-vsphere] net-bootstap fix

### DIFF
--- a/ee/candi/cloud-providers/vsphere/bashible/bundles/altlinux/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bundles/altlinux/bootstrap-networks.sh.tpl
@@ -6,10 +6,11 @@
 shopt -s extglob
 
 primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
-primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 
-if [ -z "$primary_ifname" ]; then
-  primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
+if [ -z "$primary_mac" ]; then
+  primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)
+else
+  primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 fi
 
 for i in /sys/class/net/!($primary_ifname); do

--- a/ee/candi/cloud-providers/vsphere/bashible/bundles/astra/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bundles/astra/bootstrap-networks.sh.tpl
@@ -6,10 +6,11 @@
 shopt -s extglob
 
 primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
-primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 
-if [ -z "$primary_ifname" ]; then
-  primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
+if [ -z "$primary_mac" ]; then
+  primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)
+else
+  primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 fi
 
 for i in /sys/class/net/!($primary_ifname); do

--- a/ee/candi/cloud-providers/vsphere/bashible/bundles/debian/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bundles/debian/bootstrap-networks.sh.tpl
@@ -6,10 +6,11 @@
 shopt -s extglob
 
 primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
-primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 
-if [ -z "$primary_ifname" ]; then
-  primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
+if [ -z "$primary_mac" ]; then
+  primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)
+else
+  primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 fi
 
 for i in /sys/class/net/!($primary_ifname); do

--- a/ee/candi/cloud-providers/vsphere/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -6,11 +6,11 @@
 shopt -s extglob
 
 primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
-primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 
-
-if [ -z "$primary_ifname" ]; then
-  primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
+if [ -z "$primary_mac" ]; then
+  primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)
+else
+  primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 fi
 
 for i in /sys/class/net/!($primary_ifname); do

--- a/ee/candi/cloud-providers/vsphere/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bundles/ubuntu-lts/bootstrap-networks.sh.tpl
@@ -8,6 +8,7 @@ shopt -s extglob
 primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml)"
 primary_ifname="$(ip -o link show | grep "link/ether $primary_mac" | cut -d ":" -f2 | tr -d " ")"
 
+
 if [ -z "$primary_ifname" ]; then
   primary_ifname="$(cat /etc/netplan/50-cloud-init.yaml | grep "^ *ens[0-9]*:$" | awk '{sub(/:/,"");print $1}')"
 fi


### PR DESCRIPTION
Signed-off-by: borg-z <me@nikolay-z.top>

## Description

Updated `bootstrap-network` script to determine the primary network interface from the `50-cloud-init.yaml` file. If the file does not contain a MAC address, the script will extract the interface name using a regular expression.

## Why do we need it, and what problem does it solve?

`50-cloud-init.yaml` file sometimes does not contain a MAC address

## Why do we need it in the patch release (if we do)?

## What is the expected result?

The primary network interface will be correctly identified and configured even if the `50-cloud-init.yaml` file does not contain a MAC address. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Updated  `bootstrap-network` script to determine the primary network interface from the `50-cloud-init.yaml` file, with fallback to regex matching if MAC address is missing.
impact: Ensures correct network interface identification and configuration in all scenarios.
impact_level: default
```

