### PR TITLE
[deckhouse-controller][e2e] do not reveal secrets in logs

### DIFF
--- a/testing/cloud_layouts/script_eks.sh
+++ b/testing/cloud_layouts/script_eks.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
-
 usage=$(cat <<EOF
 Usage:
   ./script.sh [command]
@@ -105,7 +103,7 @@ function prepare_environment() {
 
 
 function bootstrap_eks() {
-  set -x
+  # set -x
 
   >&2 echo "Run terraform to create nodes for EKS cluster ..."
 #  pushd "$cwd"


### PR DESCRIPTION
## Description

During e2e tests, AWS secrets are displayed in our logs. We are making a correction as part of this request.

## Why do we need it, and what problem does it solve?

It is enough to look at the logs of running e2e tests to see the user’s credentials in aws. This data can be used for your own purposes. Including the evil ones.

## Why do we need it in the patch release (if we do)?

A data leak entails both financial losses and can lead to loss of reputation.

## What is the expected result?

Credentials are no longer present in e2e test launch logs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: do not reveal aws secrets in logs
impact_level: low
```
