### PR TITLE
[prometheus] System-independent Probes 

### DIFF
--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -528,6 +528,45 @@ spec:
     - port: web
 ```
 
+## How do I set up a Probe to work with Prometheus?
+
+Add the `prometheus: main` to Probe.
+Add the label `prometheus.deckhouse.io/probe-watcher-enabled: "true"` to the namespace where the Probe was created.
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/probe-watcher-enabled: "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  labels:
+    app: prometheus
+    component: probes
+    prometheus: main
+  name: cdn-is-up
+  namespace: frontend
+spec:
+  interval: 30s
+  jobName: httpGet
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+      - https://{{ .Values.global.cdn.baseURL }}/status
+```
+
 ## How do I set up a PrometheusRules to work with Prometheus?
 
 Add the label `prometheus.deckhouse.io/rules-watcher-enabled: "true"` to the namespace where the PrometheusRules was created.

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -654,4 +654,46 @@ spec:
   metricsPath: '/metrics'
 ```
 
+## How do I add Prometheus Blackbox exporter Probes?
+
+Add the label `prometheus.deckhouse.io/probe-watcher-enabled: "true"` to the namespace where the Probe was created.
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/probe-watcher-enabled: "true"
+```
+
+Add the Probe with the required label `prometheus: main`:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  labels:
+    app: prometheus
+    component: probes
+    prometheus: main
+  name: cdn-is-up
+  namespace: frontend
+spec:
+  interval: 30s
+  jobName: httpGet
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+      - https://{{ .Values.global.cdn.baseURL }}/status
+```
+
 {% endraw %}

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -654,7 +654,7 @@ spec:
   metricsPath: '/metrics'
 ```
 
-## How do I add Prometheus Blackbox exporter Probes?
+## How do I add additional Blackbox exporter Probes?
 
 Add the label `prometheus.deckhouse.io/probe-watcher-enabled: "true"` to the namespace where the Probe was created.
 

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -693,46 +693,4 @@ spec:
   metricsPath: '/metrics'
 ```
 
-## How do I check additional endpoints using Probes?
-
-Add the label `prometheus.deckhouse.io/probe-watcher-enabled: "true"` to the namespace where the Probe was created.
-
-Example:
-
-```yaml
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: frontend
-  labels:
-    prometheus.deckhouse.io/probe-watcher-enabled: "true"
-```
-
-Add the Probe with the required label `prometheus: main`:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  labels:
-    app: prometheus
-    component: probes
-    prometheus: main
-  name: cdn-is-up
-  namespace: frontend
-spec:
-  interval: 30s
-  jobName: httpGet
-  module: http_2xx
-  prober:
-    path: /probe
-    scheme: http
-    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-      - https://{{ .Values.global.cdn.baseURL }}/status
-```
-
 {% endraw %}

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -564,7 +564,7 @@ spec:
   targets:
     staticConfig:
       static:
-      - https://{{ .Values.global.cdn.baseURL }}/status
+      - https://example.com/status
 ```
 
 ## How do I set up a PrometheusRules to work with Prometheus?

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -654,7 +654,7 @@ spec:
   metricsPath: '/metrics'
 ```
 
-## How do I add additional Blackbox exporter Probes?
+## How do I check additional endpoints using Probes?
 
 Add the label `prometheus.deckhouse.io/probe-watcher-enabled: "true"` to the namespace where the Probe was created.
 

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -651,4 +651,46 @@ spec:
   metricsPath: '/metrics'
 ```
 
+## How do I add Prometheus Blackbox exporter Probes?
+
+Добавьте в namespace, в котором находится Probe, лейбл `prometheus.deckhouse.io/probe-watcher-enabled: "true"`.
+
+Example:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/probe-watcher-enabled: "true"
+```
+
+Добавьте Probe, который имеет обязательный лейбл `prometheus: main`:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  labels:
+    app: prometheus
+    component: probes
+    prometheus: main
+  name: cdn-is-up
+  namespace: frontend
+spec:
+  interval: 30s
+  jobName: httpGet
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+      - https://{{ .Values.global.cdn.baseURL }}/status
+```
+
 {% endraw %}

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -561,7 +561,7 @@ spec:
   targets:
     staticConfig:
       static:
-      - https://{{ .Values.global.cdn.baseURL }}/status
+      - https://example.com/status
 ```
 
 ## Как настроить PrometheusRules для работы с Prometheus?

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -525,6 +525,45 @@ spec:
     - port: web
 ```
 
+## Как настроить Probe для работы с Prometheus?
+
+Добавьте лейбл `prometheus: main` к Probe.
+Добавьте в namespace, в котором находится Probe, лейбл `prometheus.deckhouse.io/probe-watcher-enabled: "true"`.
+
+Пример:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/probe-watcher-enabled: "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  labels:
+    app: prometheus
+    component: probes
+    prometheus: main
+  name: cdn-is-up
+  namespace: frontend
+spec:
+  interval: 30s
+  jobName: httpGet
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+      - https://{{ .Values.global.cdn.baseURL }}/status
+```
+
 ## Как настроить PrometheusRules для работы с Prometheus?
 
 Добавьте в namespace, в котором находятся PrometheusRules, лейбл `prometheus.deckhouse.io/rules-watcher-enabled: "true"`.
@@ -649,48 +688,6 @@ spec:
     - targetLabel: job
       replacement: kube-state-metrics
   metricsPath: '/metrics'
-```
-
-## Как опрашивать дополнительные эндпоинты используя Probe?
-
-Добавьте в namespace, в котором находится Probe, лейбл `prometheus.deckhouse.io/probe-watcher-enabled: "true"`.
-
-Example:
-
-```yaml
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: frontend
-  labels:
-    prometheus.deckhouse.io/probe-watcher-enabled: "true"
-```
-
-Добавьте Probe, который имеет обязательный лейбл `prometheus: main`:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  labels:
-    app: prometheus
-    component: probes
-    prometheus: main
-  name: cdn-is-up
-  namespace: frontend
-spec:
-  interval: 30s
-  jobName: httpGet
-  module: http_2xx
-  prober:
-    path: /probe
-    scheme: http
-    url: blackbox-exporter.blackbox-exporter.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-      - https://{{ .Values.global.cdn.baseURL }}/status
 ```
 
 {% endraw %}

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -651,7 +651,7 @@ spec:
   metricsPath: '/metrics'
 ```
 
-## Как добавить дополнительные пробы в Blackbox exporter? 
+## Как опрашивать дополнительные эндпоинты используя Probe?
 
 Добавьте в namespace, в котором находится Probe, лейбл `prometheus.deckhouse.io/probe-watcher-enabled: "true"`.
 

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -651,7 +651,7 @@ spec:
   metricsPath: '/metrics'
 ```
 
-## How do I add Prometheus Blackbox exporter Probes?
+## Как добавить дополнительные пробы в Blackbox exporter? 
 
 Добавьте в namespace, в котором находится Probe, лейбл `prometheus.deckhouse.io/probe-watcher-enabled: "true"`.
 

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -172,7 +172,7 @@ spec:
       prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"
   probeNamespaceSelector:
     matchLabels:
-      heritage: deckhouse
+      prometheus.deckhouse.io/probe-watcher-enabled: "true"
   podMetadata:
     labels:
       threshold.extended-monitoring.deckhouse.io/disk-bytes-warning: "94"


### PR DESCRIPTION
## Description
System-independent Probes

## Why do we need it, and what problem does it solve?
Closes #8777 

## What is the expected result?
Probes must be system-independent and searched by applying label value:

```yaml
prometheus.deckhouse.io/probe-watcher-enabled: "true"
```

to the namespace containing required probes

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: feature
summary: System-independent Probes.
impact_level: default
```
