### PR TITLE
[deckhouse] patch ValidatingAdmissionPolicy to ignore kubernetes system changes

### DIFF
--- a/ee/modules/160-multitenancy-manager/templates/validating.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/validating.yaml
@@ -23,7 +23,10 @@ spec:
         scope: "*"
   validations:
     - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"'
+      reason: Forbidden
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
       messageExpression: "'This resource is managed by ' + string(object.metadata.namespace) + ' Project. Manual modification is forbidden.'"
+{{- end }}
 ---
 {{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -38,7 +41,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-manager") ) | nindent 2 }}
 spec:
   policyName: {{ $policyName }}
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]
+{{- end }}
   matchResources:
     namespaceSelector:
       matchLabels:

--- a/ee/modules/160-multitenancy-manager/templates/validating.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/validating.yaml
@@ -24,7 +24,7 @@ spec:
   validations:
     - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"'
       reason: Forbidden
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
       messageExpression: "'This resource is managed by ' + string(object.metadata.namespace) + ' Project. Manual modification is forbidden.'"
 {{- end }}
 ---
@@ -41,7 +41,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-manager") ) | nindent 2 }}
 spec:
   policyName: {{ $policyName }}
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]
 {{- end }}
   matchResources:

--- a/ee/modules/160-multitenancy-manager/templates/validating.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/validating.yaml
@@ -1,7 +1,9 @@
 {{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
 {{- $policyName := "d8-multitenancy-manager" }}
 ---
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1alpha1
@@ -23,7 +25,9 @@ spec:
     - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"'
       messageExpression: "'This resource is managed by ' + string(object.metadata.namespace) + ' Project. Manual modification is forbidden.'"
 ---
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1alpha1

--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -46,6 +46,7 @@ clusterConfiguration:
 discovery:
   clusterMasterCount: 3
   prometheusScrapeInterval: 30
+  kubernetesVersion: "1.28.10"
   d8SpecificNodeCountByRole:
     system: 1
 modules:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -24,7 +24,7 @@ spec:
     - expression: '!(request.userInfo.username != "system:serviceaccount:d8-system:deckhouse"
         && (object.metadata.name.startsWith("d8-") || object.metadata.name.startsWith("kube-")))'
       reason: Forbidden
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
       messageExpression: '''Creation of system namespaces is forbidden'''
 {{- end }}
 ---
@@ -39,7 +39,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
   policyName: {{ $policyName }}
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny]
 {{- end }}
 ---
@@ -87,8 +87,8 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
   policyName: "label-objects.deckhouse.io"
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
-  validationActions: [Deny]
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  validationActions: [Deny, Audit]
 {{- end }}
   matchResources:
     objectSelector:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -72,7 +72,7 @@ spec:
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: '(request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username.startsWith("system:node:"))'
+    - expression: '(request.userInfo.username.startsWith("system:serviceaccount:d8-") || "system:nodes" in request.userInfo.groups)'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -1,0 +1,83 @@
+{{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+{{- $policyName := "system-ns.deckhouse.io" }}
+---
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["*"]
+        operations:  ["CREATE"]
+        resources:   ["namespaces"]
+  validations:
+    - expression: '!(request.userInfo.username != ''system:serviceaccount:d8-system:deckhouse''
+        && (object.metadata.name.startsWith(''d8-'') || object.metadata.name.startsWith(''kube-'')))'
+      messageExpression: '''Creation of system namespaces is forbidden'''
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions: [Deny]
+---
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "label-objects.deckhouse.io"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["*"]
+        apiVersions: ["*"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["*"]
+  matchConditions:
+    - name: 'exclude-kube-system'
+      expression: '!("system:nodes" in request.userInfo.groups)' # exclude kubelet and kube-controller requests
+  validations:
+    - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'')'
+      messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "heritage-label-objects.deckhouse.io"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: "label-objects.deckhouse.io"
+  validationActions: [Deny]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        heritage: deckhouse
+{{- end }}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -23,7 +23,10 @@ spec:
   validations:
     - expression: '!(request.userInfo.username != ''system:serviceaccount:d8-system:deckhouse''
         && (object.metadata.name.startsWith(''d8-'') || object.metadata.name.startsWith(''kube-'')))'
+      reason: Forbidden
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
       messageExpression: '''Creation of system namespaces is forbidden'''
+{{- end }}
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -36,7 +39,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
   policyName: {{ $policyName }}
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny]
+{{- end }}
 ---
 {{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -62,7 +67,10 @@ spec:
       expression: '!("system:nodes" in request.userInfo.groups)' # exclude kubelet and kube-controller requests
   validations:
     - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'')'
+      reason: Forbidden
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
+{{- end }}
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -75,7 +83,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
 spec:
   policyName: "label-objects.deckhouse.io"
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny]
+{{- end }}
   matchResources:
     objectSelector:
       matchLabels:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -21,8 +21,8 @@ spec:
         operations:  ["CREATE"]
         resources:   ["namespaces"]
   validations:
-    - expression: '!(request.userInfo.username != ''system:serviceaccount:d8-system:deckhouse''
-        && (object.metadata.name.startsWith(''d8-'') || object.metadata.name.startsWith(''kube-'')))'
+    - expression: '!(request.userInfo.username != "system:serviceaccount:d8-system:deckhouse"
+        && (object.metadata.name.startsWith("d8-") || object.metadata.name.startsWith("kube-")))'
       reason: Forbidden
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
       messageExpression: '''Creation of system namespaces is forbidden'''
@@ -67,12 +67,12 @@ spec:
     - name: 'exclude-kube-system'
       expression: '!("system:nodes" in request.userInfo.groups)' # exclude kubelet and kube-controller requests
   validations:
-    - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'')'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'') || request.userInfo.username.startsWith(''system:node:'')'
+    - expression: '(request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username.startsWith("system:node:"))'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -68,13 +68,17 @@ spec:
       expression: '!("system:nodes" in request.userInfo.groups)'
     - name: 'exclude-kube-system'
       expression: '!("system:serviceaccounts:kube-system" in request.userInfo.groups)'
+    - name: 'rbac' # Skip RBAC requests.
+      expression: 'request.resource.group != "rbac.authorization.k8s.io"'
+    - name: 'exclude-leases'
+      expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || "system:nodes" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || "system:nodes" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups || request.resource.group == "rbac.authorization.k8s.io" || (request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -64,14 +64,10 @@ spec:
         resources:   ["*"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
-    - name: 'exclude-system-node'
-      expression: '!("system:nodes" in request.userInfo.groups)'
-    - name: 'exclude-kube-system'
-      expression: '!("system:serviceaccounts:kube-system" in request.userInfo.groups)'
+    - name: 'exclude-groups'
+      expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups))'
     - name: 'exclude-kube-controller'
       expression: 'request.userInfo.username != "system:kube-controller-manager"'
-    - name: 'rbac' # Skip RBAC requests.
-      expression: 'request.resource.group != "rbac.authorization.k8s.io"'
     - name: 'exclude-leases'
       expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
   validations:
@@ -80,7 +76,7 @@ spec:
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username == "system:kube-controller-manager" || "system:nodes" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups || request.resource.group == "rbac.authorization.k8s.io" || (request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username == "system:kube-controller-manager" || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || (request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -62,7 +62,7 @@ spec:
         apiVersions: ["*"]
         operations:  ["CREATE", "UPDATE"]
         resources:   ["*"]
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'exclude-kube-system'
       expression: '!("system:nodes" in request.userInfo.groups)' # exclude kubelet and kube-controller requests

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -62,14 +62,18 @@ spec:
         apiVersions: ["*"]
         operations:  ["CREATE", "UPDATE"]
         resources:   ["*"]
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'exclude-kube-system'
       expression: '!("system:nodes" in request.userInfo.groups)' # exclude kubelet and kube-controller requests
   validations:
     - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'')'
       reason: Forbidden
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
+{{- else }}
+  validations:
+    - expression: 'request.userInfo.username.startsWith(''system:serviceaccount:d8-'') || request.userInfo.username.startsWith(''system:node:'')'
+      reason: Forbidden
 {{- end }}
 ---
 {{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -68,15 +68,13 @@ spec:
       expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-kube-controller'
       expression: 'request.userInfo.username != "system:kube-controller-manager"'
-    - name: 'exclude-leases'
-      expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username == "system:kube-controller-manager" || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || (request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username == "system:kube-controller-manager" || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups))'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -64,15 +64,17 @@ spec:
         resources:   ["*"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
+    - name: 'exclude-system-node'
+      expression: '!("system:nodes" in request.userInfo.groups)'
     - name: 'exclude-kube-system'
-      expression: '!("system:nodes" in request.userInfo.groups)' # exclude kubelet and kube-controller requests
+      expression: '!("system:serviceaccounts:kube-system" in request.userInfo.groups)'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: '(request.userInfo.username.startsWith("system:serviceaccount:d8-") || "system:nodes" in request.userInfo.groups)'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || "system:nodes" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -68,6 +68,8 @@ spec:
       expression: '!("system:nodes" in request.userInfo.groups)'
     - name: 'exclude-kube-system'
       expression: '!("system:serviceaccounts:kube-system" in request.userInfo.groups)'
+    - name: 'exclude-kube-controller'
+      expression: 'request.userInfo.username != "system:kube-controller-manager"'
     - name: 'rbac' # Skip RBAC requests.
       expression: 'request.resource.group != "rbac.authorization.k8s.io"'
     - name: 'exclude-leases'
@@ -78,7 +80,7 @@ spec:
       messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || "system:nodes" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups || request.resource.group == "rbac.authorization.k8s.io" || (request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username == "system:kube-controller-manager" || "system:nodes" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups || request.resource.group == "rbac.authorization.k8s.io" || (request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -65,7 +65,7 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'exclude-groups'
-      expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups))'
+      expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-kube-controller'
       expression: 'request.userInfo.username != "system:kube-controller-manager"'
     - name: 'exclude-leases'


### PR DESCRIPTION
## Description
Ignore kubernetes system accounts for changing/creating objects with `heritage: deckhouse` label

## Why do we need it, and what problem does it solve?
This Policy can block kube-controller-manager or kubelet requests

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix ValidatingAdmissionPolicy for objects with the label `heritage: deckhouse`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
