### PR TITLE
[docs] Add FAQ to chrony section in sidebar

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1278,6 +1278,8 @@ entries:
                 en: Configuration
                 ru: Настройки
               url: /modules/470-chrony/configuration.html
+            - title: FAQ
+              url: /modules/470-chrony/faq.html
         - title: namespace-configurator
           folders:
             - title:


### PR DESCRIPTION
## Description

Add the FAQ section to the side menu for the _chrony_ module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Add the FAQ section to the side menu for the chrony module.
impact_level: low
```
