### PR TITLE
[cloud-provider-yandex] Fix typo in label key in discoverer

### DIFF
--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
@@ -97,11 +97,6 @@ func (d *Discoverer) DisksMeta(ctx context.Context) ([]v1alpha1.DiskMeta, error)
 	disksMeta := make([]v1alpha1.DiskMeta, 0, len(disks))
 
 	for _, disk := range disks {
-		// skip disks created from another clusters
-		clusterUUID, ok := disk.Labels["clusterUUID"]
-		if ok && clusterUUID != d.clusterUUID {
-			continue
-		}
 		disksMeta = append(disksMeta, v1alpha1.DiskMeta{ID: disk.Id, Name: disk.Name})
 	}
 
@@ -120,7 +115,7 @@ func (d *Discoverer) getDisksCreatedByCSIDriver(ctx context.Context) ([]*compute
 	disksCreatedByCSIDriver := make([]*compute.Disk, 0, len(disks))
 
 	for _, disk := range disks {
-		if disk.Description == "Created by Yandex CSI driver" {
+		if clusterUUID, ok := disk.Labels["cluster_uuid"]; ok && clusterUUID == d.clusterUUID {
 			disksCreatedByCSIDriver = append(disksCreatedByCSIDriver, disk)
 		}
 	}

--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/discoverer.go
@@ -115,7 +115,7 @@ func (d *Discoverer) getDisksCreatedByCSIDriver(ctx context.Context) ([]*compute
 	disksCreatedByCSIDriver := make([]*compute.Disk, 0, len(disks))
 
 	for _, disk := range disks {
-		if clusterUUID, ok := disk.Labels["cluster_uuid"]; ok && clusterUUID == d.clusterUUID {
+		if disk.Labels["cluster_uuid"] == d.clusterUUID {
 			disksCreatedByCSIDriver = append(disksCreatedByCSIDriver, disk)
 		}
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix typo in label key in discoverer.

Also remove the disk description filter, because that was a workaround until the `cluster_uuid` label came up.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We set label in snake_case, not in camelCase:
https://github.com/deckhouse/yandex-csi-driver/pull/19/files#diff-7b46685eeb2e24ed466c2d8f7c64f093cafa2b24e858407b1431c4d9e1576b47R176

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Now it doesn't work.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Fix typo in label key in discoverer.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
