### PR TITLE
[deckhouse] fix: registry-packages-proxy revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
-	github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy v0.0.0-00010101000000-000000000000 // indirect
+	github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy v0.0.0-20240625153005-47bb472a1a1d // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v24.0.6+incompatible // indirect
 	github.com/docker/docker v24.0.9+incompatible // indirect


### PR DESCRIPTION
## Description

When running the go list command, we get an error like:

```plain
go: github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

The module is placed in a local directory, but for correct use it is necessary to correctly specify the revision in which it can be found.

## Why do we need it, and what problem does it solve?

Correct operation of the go list command

## What is the expected result?

The go list command runs without errors

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: registry-packages-proxy revision
impact_level: default
```
