### PR TITLE
[testing] feat: matrix tests to check roles for wildcards

### DIFF
--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -168,7 +168,7 @@ func checkRoles(object storage.StoreObject) errors.LintRuleError {
 				"WILDCARD001",
 				object.Identity(),
 				object.Path,
-				strings.Join(objs, ", ")+" contains a wildcards",
+				strings.Join(objs, ", ")+" contains a wildcards. Replace them with an explicit list of resources",
 			)
 		}
 	}

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"strings"
+
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules/errors"
+	"github.com/deckhouse/deckhouse/testing/matrix/linter/storage"
+)
+
+func ObjectRolesWildcard(object storage.StoreObject) errors.LintRuleError {
+	// check only `rbac-for-us.yaml` files
+	if !strings.HasSuffix(object.ShortPath(), "rbac-for-us.yaml") {
+		return errors.EmptyRuleError
+	}
+
+	// check Role and ClusterRole for wildcards
+	objectKind := object.Unstructured.GetKind()
+	switch objectKind {
+	case "Role", "ClusterRole":
+		return checkRoles(object)
+	default:
+		return errors.EmptyRuleError
+	}
+}
+
+func checkRoles(object storage.StoreObject) errors.LintRuleError {
+	converter := runtime.DefaultUnstructuredConverter
+
+	role := new(rbac.Role)
+	err := converter.FromUnstructured(object.Unstructured.UnstructuredContent(), role)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rule := range role.Rules {
+		if slices.Contains(rule.APIGroups, "*") {
+			return newWildCardError(object, "apiGroups contained a wildcard rule")
+		}
+		if slices.Contains(rule.Resources, "*") {
+			return newWildCardError(object, "resources contained a wildcard rule")
+		}
+		if slices.Contains(rule.Verbs, "*") {
+			return newWildCardError(object, "verbs contained a wildcard rule")
+		}
+	}
+
+	return errors.EmptyRuleError
+}
+
+func newWildCardError(object storage.StoreObject, message string) errors.LintRuleError {
+	return errors.NewLintRuleError(
+		"WILDCARD001",
+		object.Identity(),
+		object.Path,
+		message,
+	)
+}

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -31,9 +31,88 @@ import (
 //
 // the key is the file name
 // value is an array of rule names that allow wildcards
+//
+// !!IMPORTANT NOTE!!: will be fixed by separated issues
 var skipCheckWildcards = map[string][]string{
 	"admission-policy-engine/templates/rbac-for-us.yaml": {
 		"d8:admission-policy-engine:gatekeeper",
+	},
+	"deckhouse/templates/webhook-handler/rbac-for-us.yaml": {
+		"d8:deckhouse:webhook-handler",
+	},
+	"cloud-provider-aws/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-aws:cloud-controller-manager",
+	},
+	"cloud-provider-azure/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-azure:cloud-controller-manager",
+	},
+	"cloud-provider-gcp/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-gcp:cloud-controller-manager",
+	},
+	"cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-yandex:cloud-controller-manager",
+	},
+	"local-path-provisioner/templates/rbac-for-us.yaml": {
+		"d8:local-path-provisioner",
+	},
+	"istio/templates/kiali/rbac-for-us.yaml": {
+		"d8:istio:kiali",
+	},
+	"istio/templates/operator/rbac-for-us.yaml": {
+		"d8:istio:operator",
+	},
+	"user-authn/templates/dex/rbac-for-us.yaml": {
+		"d8:user-authn:dex:crd",
+		"dex",
+	},
+	"operator-prometheus/templates/rbac-for-us.yaml": {
+		"d8:operator-prometheus",
+	},
+	"prometheus-metrics-adapter/templates/rbac-for-us.yaml": {
+		"d8:prometheus-metrics-adapter:horizontal-pod-autoscaler-external-metrics",
+	},
+	"vertical-pod-autoscaler/templates/rbac-for-us.yaml": {
+		"d8:vertical-pod-autoscaler:controllers-reader",
+	},
+	"ingress-nginx/templates/kruise/rbac-for-us.yaml": {
+		"d8:ingress-nginx:kruise-role",
+	},
+	"cilium-hubble/templates/ui/rbac-for-us.yaml": {
+		"d8:cilium-hubble:ui:reader",
+	},
+	"okmeter/templates/rbac-for-us.yaml": {
+		"d8:okmeter",
+	},
+	"openvpn/templates/openvpn/rbac-for-us.yaml": {
+		"openvpn",
+	},
+	"upmeter/templates/upmeter-agent/rbac-for-us.yaml": {
+		"upmeter-agent",
+		"d8:upmeter:upmeter-agent",
+	},
+	"upmeter/templates/upmeter/rbac-for-us.yaml": {
+		"d8:upmeter:upmeter",
+	},
+	"documentation/templates/rbac-for-us.yaml": {
+		"documentation:leases-edit",
+	},
+	"delivery/templates/argocd/application-controller/rbac-for-us.yaml": {
+		"d8:delivery:argocd:application-controller",
+	},
+	"delivery/templates/argocd/server/rbac-for-us.yaml": {
+		"d8:delivery:argocd:server",
+	},
+	"cloud-provider-openstack/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-openstack:cloud-controller-manager",
+	},
+	"cloud-provider-vcd/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-vcd:cloud-controller-manager",
+	},
+	"cloud-provider-vsphere/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-vsphere:cloud-controller-manager",
+	},
+	"cloud-provider-zvirt/templates/cloud-controller-manager/rbac-for-us.yaml": {
+		"d8:cloud-provider-zvirt:cloud-controller-manager",
 	},
 }
 

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -85,16 +85,6 @@ func skipObjectContainerIfNeeded(o *storage.StoreObject, c *v1.Container) bool {
 	return false
 }
 
-func skipObjectWithWildCardIfNeeded(o *storage.StoreObject) bool {
-	// skip file with object `d8:admission-policy-engine:gatekeeper`
-	if o.Path == "admission-policy-engine/templates/rbac-for-us.yaml" &&
-		o.Unstructured.GetName() == "d8:admission-policy-engine:gatekeeper" {
-		return true
-	}
-
-	return false
-}
-
 type ObjectLinter struct {
 	ObjectStore    *storage.UnstructuredObjectStore
 	ErrorsList     *errors.LintRuleErrorsList
@@ -313,10 +303,7 @@ func (l *ObjectLinter) ApplyObjectRules(object storage.StoreObject) {
 
 	l.ErrorsList.Add(modules.PromtoolRuleCheck(l.Module, object))
 
-	if !skipObjectWithWildCardIfNeeded(&object) {
-		l.ErrorsList.Add(roles.ObjectRolesWildcard(object))
-	}
-
+	l.ErrorsList.Add(roles.ObjectRolesWildcard(object))
 }
 
 func objectRecommendedLabels(object storage.StoreObject) errors.LintRuleError {

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -296,6 +296,7 @@ func (l *ObjectLinter) ApplyObjectRules(object storage.StoreObject) {
 
 	if !skipObjectIfNeeded(&object) {
 		l.ErrorsList.Add(objectSecurityContext(object))
+		l.ErrorsList.Add(roles.ObjectRolesWildcard(object))
 	}
 
 	l.ErrorsList.Add(objectRevisionHistoryLimit(object))


### PR DESCRIPTION
## Description

It is necessary to check for the presence of wildcards in Roles and ClusterRoles in the rbac-for-us.yaml files.

## Why do we need it, and what problem does it solve?

Kubernetes CIS [we recommend not using wildcard rights in Role/ClusterRole](https://github.com/aquasecurity/kube-bench/blob/0f8dfaf1156652b556c913aa8e78fccbb1dfd186/cfg/rke-cis-1.24/policies.yaml#L29-L35).

## What is the expected result?

With each commit, template files are checked for the presence of wildcards. If no exception rule has been added, a validation error is generated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: feature
summary: matrix tests to check roles for wildcards
impact_level: default
```

Closed #8517