### PR TITLE
[istio] Inheriting cluster access rules from authenticated user to Kiali (impersonation)

### DIFF
--- a/modules/110-istio/hooks/generate_kiali_signing_key.go
+++ b/modules/110-istio/hooks/generate_kiali_signing_key.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+type kialiSecret struct {
+	SigningKey string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "kiali_signing_key_secret",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			FilterFunc: applyKialiSecretFilter,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"kiali-signing-key"},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+	},
+}, generateKialiSigningKey)
+
+func applyKialiSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert kiali secret object to structured secret: %v", err)
+	}
+
+	signingKey := secret.Data["key"]
+
+	return kialiSecret{
+		SigningKey: string(signingKey),
+	}, nil
+}
+
+func generateKialiSigningKey(input *go_hook.HookInput) error {
+	for _, secretSnapshot := range input.Snapshots["kiali_signing_key_secret"] {
+		secret := secretSnapshot.(kialiSecret)
+		if len(secret.SigningKey) == 32 {
+			input.Values.Set("istio.internal.kialiSigningKey", secret.SigningKey)
+			return nil
+		}
+	}
+	generatedSigningKey := randomString(32)
+	input.Values.Set("istio.internal.kialiSigningKey", generatedSigningKey)
+	return nil
+}
+
+func randomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
+}

--- a/modules/110-istio/hooks/generate_kiali_signing_key.go
+++ b/modules/110-istio/hooks/generate_kiali_signing_key.go
@@ -64,15 +64,15 @@ func applyKialiSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 }
 
 func generateKialiSigningKey(input *go_hook.HookInput) error {
-	for _, secretSnapshot := range input.Snapshots["kiali_signing_key_secret"] {
-		secret := secretSnapshot.(kialiSecret)
-		if len(secret.SigningKey) == 32 {
-			input.Values.Set("istio.internal.kialiSigningKey", secret.SigningKey)
-			return nil
-		}
+	kialiSigningKey := ""
+	if len(input.Snapshots["kiali_signing_key_secret"]) == 1 {
+		secret := input.Snapshots["kiali_signing_key_secret"][0].(kialiSecret)
+		kialiSigningKey = secret.SigningKey
 	}
-	generatedSigningKey := randomString(32)
-	input.Values.Set("istio.internal.kialiSigningKey", generatedSigningKey)
+	if len(kialiSigningKey) != 32 {
+		kialiSigningKey = randomString(32)
+	}
+	input.Values.Set("istio.internal.kialiSigningKey", kialiSigningKey)
 	return nil
 }
 

--- a/modules/110-istio/hooks/generate_kiali_signing_key_test.go
+++ b/modules/110-istio/hooks/generate_kiali_signing_key_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Istio hooks :: generate_kiali_signing_key ::", func() {
+	f := HookExecutionConfigInit(`{"global":{"discovery":{"clusterDomain":"cluster.flomaster"}},"istio":{"internal":{"kialiSigningKey":""}}}`, "")
+
+	Context("Empty cluster; empty value; secret doesn't exist", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Leave the value unchanged, proceed to generate the secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(len(f.ValuesGet("istio.internal.kialiSigningKey").String())).To(Equal(32))
+		})
+	})
+
+	Context("Signing key is in cluster; empty value", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali-signing-key
+  namespace: d8-istio
+type: Opaque
+data:
+  key: "NVo4ZFFlT2l1RkpRTllQa2duMmh1bEE0M3FuRzZ0SGI=" # 5Z8dQeOiuFJQNYPkgn2hulA43qnG6tHb
+`))
+			f.RunHook()
+		})
+		It("Signing key is not changed and copied to value", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("istio.internal.kialiSigningKey").String()).To(Equal("5Z8dQeOiuFJQNYPkgn2hulA43qnG6tHb"))
+		})
+	})
+
+})

--- a/modules/110-istio/hooks/generate_kiali_signing_key_test.go
+++ b/modules/110-istio/hooks/generate_kiali_signing_key_test.go
@@ -63,4 +63,26 @@ data:
 		})
 	})
 
+	Context("Wrong signing key is in cluster; empty value", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali-signing-key
+  namespace: d8-istio
+type: Opaque
+data:
+  key: "d3Jvbmcta2V5" # "wrong-key", not 32 bytes len
+`))
+			f.RunHook()
+		})
+		It("Signing key must be generated anew", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(len(f.ValuesGet("istio.internal.kialiSigningKey").String())).To(Equal(32))
+		})
+	})
 })

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -28,7 +28,7 @@ properties:
               x-examples: [false]
       kialiSigningKey:
         type: string
-        x-examples: "kiali"
+        x-examples: "FD9Q24PwNZkg4pV9cxTOV1Se5R0RD1sT"
       istioToK8sCompatibilityMap:
         type: object
         default:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -28,6 +28,7 @@ properties:
               x-examples: [false]
       kialiSigningKey:
         type: string
+        x-examples: "kiali"
       istioToK8sCompatibilityMap:
         type: object
         default:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -28,7 +28,8 @@ properties:
               x-examples: [false]
       kialiSigningKey:
         type: string
-        x-examples: "FD9Q24PwNZkg4pV9cxTOV1Se5R0RD1sT"
+        x-examples:
+        - "FD9Q24PwNZkg4pV9cxTOV1Se5R0RD1sT"
       istioToK8sCompatibilityMap:
         type: object
         default:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -26,6 +26,8 @@ properties:
             isReady:
               type: boolean
               x-examples: [false]
+      kialiSigningKey:
+        type: string
       istioToK8sCompatibilityMap:
         type: object
         default:

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -78,6 +78,7 @@ const istioValues = `
           revision: "v1x16x2"
           fullVersion: "1.16.2"
           imageSuffix: "V1x16x2"
+      kialiSigningKey: "kiali"
       operatorVersionsToInstall:  []
       versionsToInstall: []
       federations: []

--- a/modules/110-istio/templates/kiali/configmap.yaml
+++ b/modules/110-istio/templates/kiali/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   config.yaml: |
     auth:
-      strategy: anonymous
+      strategy: header
     deployment:
       namespace: d8-{{ $.Chart.Name }}
       accessible_namespaces:

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -100,7 +100,17 @@ spec:
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
+        - name: kiali-signing-key
+          mountPath: "/kiali-override-secrets/login-token-signing-key"
+
       volumes:
       - name: kiali-configuration
         configMap:
           name: kiali
+      - name: kiali-signing-key
+        secret:
+          secretName: kiali-signing-key
+          items:
+          - key: key
+            path: value.txt
+          optional: false

--- a/modules/110-istio/templates/kiali/ingress.yaml
+++ b/modules/110-istio/templates/kiali/ingress.yaml
@@ -54,6 +54,7 @@ metadata:
     web.deckhouse.io/export-name: "istio"
     web.deckhouse.io/export-icon: "/public/img/istio.ico"
   {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.istio.auth.externalAuthentication }}
+    nginx.ingress.kubernetes.io/auth-response-headers: Authorization
     nginx.ingress.kubernetes.io/auth-signin: {{ .Values.istio.auth.externalAuthentication.authSignInURL | quote }}
     nginx.ingress.kubernetes.io/auth-url: {{ .Values.istio.auth.externalAuthentication.authURL | quote }}
   {{- else }}

--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -12,7 +12,8 @@ metadata:
   name: d8:istio:kiali
   {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - configmaps
   - endpoints
@@ -21,7 +22,8 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - namespaces
   - pods
@@ -31,14 +33,16 @@ rules:
   - get
   - list
   - watch
-  - patch
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - pods/portforward
   verbs:
   - create
   - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups:
+  - extensions
+  - apps
   resources:
   - daemonsets
   - deployments
@@ -48,8 +52,8 @@ rules:
   - get
   - list
   - watch
-  - patch
-- apiGroups: ["batch"]
+- apiGroups:
+  - batch
   resources:
   - cronjobs
   - jobs
@@ -57,7 +61,6 @@ rules:
   - get
   - list
   - watch
-  - patch
 - apiGroups:
   - networking.istio.io
   resources:
@@ -83,9 +86,6 @@ rules:
   - get
   - list
   - watch
-  - create
-  - delete
-  - patch
 - apiGroups:
   - security.istio.io
   resources:
@@ -99,9 +99,6 @@ rules:
   - get
   - list
   - watch
-  - create
-  - delete
-  - patch
 - apiGroups:
   - extensions.istio.io
   resources:
@@ -111,9 +108,6 @@ rules:
   - get
   - list
   - watch
-  - create
-  - delete
-  - patch
 - apiGroups:
   - telemetry.istio.io
   resources:
@@ -123,9 +117,6 @@ rules:
   - get
   - list
   - watch
-  - create
-  - delete
-  - patch
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -141,44 +132,27 @@ rules:
   - get
   - list
   - watch
-  - create
-  - delete
-  - patch
-- apiGroups: ["apps.openshift.io"]
-  resources:
-  - deploymentconfigs
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups: ["project.openshift.io"]
-  resources:
-  - projects
-  verbs:
-  - get
-- apiGroups: ["route.openshift.io"]
-  resources:
-  - routes
-  verbs:
-  - get
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups:
+  - authentication.k8s.io
   resources:
   - tokenreviews
   verbs:
   - create
-- apiGroups: ["apps"]
-  resources: ["deployments/http"]
-  resourceNames: ["trickster"]
-  verbs: ["get", "create", "update", "patch", "delete"]
 - apiGroups:
-    - monitoring.coreos.com
+  - apps
+  resourceNames:
+  - trickster
   resources:
-    - prometheuses
-    - prometheuses/http
+  - deployments/http"
   verbs:
-    - create
-    - get
+  - get
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheuses
+  - prometheuses/http
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/110-istio/templates/kiali/secret.yaml
+++ b/modules/110-istio/templates/kiali/secret.yaml
@@ -10,3 +10,13 @@ type: Opaque
 data:
   auth: {{ print "admin:{PLAIN}" .Values.istio.internal.auth.password | b64enc | quote }}
 {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali-signing-key
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
+type: Opaque
+data:
+  key: {{ .Values.istio.internal.kialiSigningKey | b64enc | quote }}


### PR DESCRIPTION
## Description
Inheriting cluster access rules from authenticated user to Kiali (impersonation). The logged in user will be authorized to do everything according to his RBAC.

## Why do we need it, and what problem does it solve?
Before the PR, Kiali used to identify any authenticated user as anonymous and gave him enormous privileges.

## What is the expected result?
After logging in, the kiali shows your name in the UI and you can't do anything you wasn't allowed to.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: chore
summary: Kiali inherits cluster access rules from an authenticated user (impersonate him), not considering him as anonymous and not provides unwanted privileges.
impact_level: default
```