### PR TITLE
[dhctl] feat(dhctl-for-commander): production ready commander mode (1.61.4)

### DIFF
--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -34,7 +34,13 @@ import (
 type DefaultClient struct{}
 
 func (c *DefaultClient) GetPackage(ctx context.Context, config *ClientConfig, digest string) (int64, io.ReadCloser, error) {
-	repository, err := name.NewRepository(config.Repository)
+	var nameOptions []name.Option
+
+	if strings.ToLower(config.Scheme) == "http" {
+		nameOptions = append(nameOptions, name.Insecure)
+	}
+
+	repository, err := name.NewRepository(config.Repository, nameOptions...)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -51,12 +57,6 @@ func (c *DefaultClient) GetPackage(ctx context.Context, config *ClientConfig, di
 
 		httpTransport.TLSClientConfig = &tls.Config{
 			RootCAs: certPool,
-		}
-	}
-
-	if strings.ToLower(config.Scheme) == "http" {
-		httpTransport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR is not intended to merge. PR only needed to build deckhouse images into dev-registry, which is currently needed for commander and this need from commander will be removed soon.
