### PR TITLE
Revert "[ci] Run build tasks closer to the registry. Reduce matrix test cpu usage (#8717)"

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -47,7 +47,7 @@ steps:
 {!{- $ctx := index . 0 -}!}
 {!{- $buildType := index . 1 -}!}
 # <template: build_template>
-runs-on: [self-hosted, regular, selectel]
+runs-on: [self-hosted, regular]
 outputs:
   tests_image_name: ${{ steps.build.outputs.tests_image_name }}
 steps:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -543,7 +543,7 @@ jobs:
     env:
       WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -257,7 +257,7 @@ jobs:
     env:
       WERF_ENV: "FE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -371,7 +371,7 @@ jobs:
     env:
       WERF_ENV: "FE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -677,7 +677,7 @@ jobs:
     env:
       WERF_ENV: "EE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -983,7 +983,7 @@ jobs:
     env:
       WERF_ENV: "SE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -1289,7 +1289,7 @@ jobs:
     env:
       WERF_ENV: "BE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -1595,7 +1595,7 @@ jobs:
     env:
       WERF_ENV: "CE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, regular]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:

--- a/testing/matrix/linter/controller.go
+++ b/testing/matrix/linter/controller.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	workersQuantity = runtime.NumCPU() * 8
+	workersQuantity = runtime.NumCPU() * 32
 
 	renderedTemplatesHash = sync.Map{}
 )


### PR DESCRIPTION
## Description
This reverts commit 5039f3f064d67425b6809d2a4817c27a57da2a39.

#8717

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Revert "[ci] Run build tasks closer to the registry. Reduce matrix test cpu usage (#8717)"
impact_level: low
```
