### PR TITLE
[docs][prometheus]: Add VictoriaMetrics documentation links for data …

### DIFF
--- a/modules/300-prometheus/docs/USAGE.md
+++ b/modules/300-prometheus/docs/USAGE.md
@@ -34,6 +34,12 @@ spec:
 
 Prometheus supports remote_write'ing data from the local Prometheus to a separate longterm storage (e.g., [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)). In Deckhouse, this mechanism is implemented using the `PrometheusRemoteWrite` custom resource.
 
+{% endraw -%}
+{% alert level="info" %}
+For VictoriaMetrics detailed information about how to send data to vmagent can be found in the VictoriaMetrics [documentation](https://docs.victoriametrics.com/vmagent/index.html#how-to-push-data-to-vmagent).
+{% endalert %}
+{% raw %}
+
 ### Example of the basic PrometheusRemoteWrite
 
 ```yaml

--- a/modules/300-prometheus/docs/USAGE_RU.md
+++ b/modules/300-prometheus/docs/USAGE_RU.md
@@ -34,6 +34,12 @@ spec:
 
 У Prometheus есть поддержка remote_write данных из локального Prometheus в отдельный longterm storage (например, [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)). В Deckhouse поддержка данного механизма реализована с помощью custom resource `PrometheusRemoteWrite`.
 
+{% endraw -%}
+{% alert level="info" %}
+Для VictoriaMetrics подробную информацию о способах передачи данные в vmagent можно получить в [документации](https://docs.victoriametrics.com/vmagent/index.html#how-to-push-data-to-vmagent) VictoriaMetrics.
+{% endalert %}
+{% raw %}
+
 ### Пример минимального PrometheusRemoteWrite
 
 ```yaml


### PR DESCRIPTION
## Description
Add a link to VictoriaMetrics documentation about data push to vmagent.

## Changelog entries

```changes
section: prometheus
type: chore
summary: Add a link to VictoriaMetrics documentation about data push to vmagent.
impact_level: low
```
