### PR TITLE
[cloud-provider-vcd] API token support

### DIFF
--- a/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
@@ -93,14 +93,14 @@ apiVersions:
                 placementPolicy:
                   description: |
                     PlacementPolicy is the placement policy to be used on this machine.
-                    
+
                     If no placement policy is specified, default placement policy will be used to create the nodes.
                   type: string
                   example: Hypervisor1
                 sizingPolicy:
                   description: |
                     SizingPolicy is the sizing policy to be used on this machine.
-                    
+
                     If no sizing policy is specified, default sizing policy will be used to create the nodes.
                   type: string
                   example: 4Cpu8Memory
@@ -201,14 +201,14 @@ apiVersions:
                   placementPolicy:
                     description: |
                       PlacementPolicy is the placement policy to be used on this machine.
-                      
+
                       If no placement policy is specified, default placement policy will be used to create the nodes.
                     type: string
                     example: Hypervisor1
                   sizingPolicy:
                     description: |
                       SizingPolicy is the sizing policy to be used on this machine.
-                      
+
                       If no sizing policy is specified, default sizing policy will be used to create the nodes.
                     type: string
                     example: 4Cpu8Memory
@@ -286,18 +286,46 @@ apiVersions:
             password:
               type: string
               description: The user's password.
+            apiToken:
+              type: string
+              description: |
+                The token for authentication.
+
+                > **Caution!** When using `apiToken`, leave `username` and `password` empty.
             insecure:
               type: boolean
               description:  Set to `true` if VCD has a self-signed certificate.
               x-doc-default: false
           required:
             - server
-            - username
-            - password
-      oneOf:
+      allOf:
+      - oneOf:
         - required: [layout]
           properties:
             layout:
               enum:
                 - Standard
               type: string
+      - oneOf:
+        - properties:
+            provider:
+              required: [apiToken]
+              type: object
+              properties:
+                username:
+                  not: {}
+                password:
+                  not: {}
+                apiToken:
+                  type: string
+        - properties:
+            provider:
+              required: [username, password]
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+                apiToken:
+                  not: {}

--- a/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
@@ -147,5 +147,10 @@ apiVersions:
               description: Имя пользователя с полными правами на проект.
             password:
               description: Пароль пользователя.
+            apiToken:
+              description: |
+                Токен для аутентификации.
+
+                > **Внимание!** При использовании `apiToken` необходимо оставить `username` и `password` пустыми.
             insecure:
               description:  Устанавливается в `true`, VCD имеет self-signed-сертификат.

--- a/ee/candi/cloud-providers/vcd/terraform-modules/providers.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/providers.tf
@@ -5,9 +5,10 @@ provider "vcd" {
   url = join("/", [trimsuffix(var.providerClusterConfiguration.provider.server, "/api"), "api"])
   org = var.providerClusterConfiguration.organization
   vdc = var.providerClusterConfiguration.virtualDataCenter
-  user = var.providerClusterConfiguration.provider.username
-  password = var.providerClusterConfiguration.provider.password
-  auth_type = "integrated"
+  user = lookup(var.providerClusterConfiguration.provider, "username", "none")
+  password = lookup(var.providerClusterConfiguration.provider, "password", "none")
+  api_token = lookup(var.providerClusterConfiguration.provider, "apiToken", "")
+  auth_type = lookup(var.providerClusterConfiguration.provider, "apiToken", null) != null ? "api_token" : "integrated"
   allow_unverified_ssl = lookup(var.providerClusterConfiguration.provider, "insecure", false)
   max_retry_timeout = 60
 }

--- a/ee/modules/030-cloud-provider-vcd/capi/cluster.yaml
+++ b/ee/modules/030-cloud-provider-vcd/capi/cluster.yaml
@@ -9,8 +9,15 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capcd-controller-manager")) | nindent 2 }}
 type: Opaque
 data:
+  {{- if $providerClusterConfiguration.username }}
   username: {{ $providerClusterConfiguration.username | b64enc | quote }}
+  {{- end }}
+  {{- if $providerClusterConfiguration.password }}
   password: {{ $providerClusterConfiguration.password | b64enc | quote }}
+  {{- end }}
+  {{- if $providerClusterConfiguration.apiToken }}
+  refreshToken: {{ $providerClusterConfiguration.apiToken | b64enc | quote }}
+  {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster

--- a/ee/modules/030-cloud-provider-vcd/docs/EXAMPLES.md
+++ b/ee/modules/030-cloud-provider-vcd/docs/EXAMPLES.md
@@ -7,7 +7,7 @@ Below is an example configuration for a VMware Cloud Director cloud provider.
 ## An example of the `VCDInstanceClass` custom resource
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha1
+apiVersion: deckhouse.io/v1
 kind: VCDInstanceClass
 metadata:
   name: test

--- a/ee/modules/030-cloud-provider-vcd/docs/EXAMPLES_RU.md
+++ b/ee/modules/030-cloud-provider-vcd/docs/EXAMPLES_RU.md
@@ -7,7 +7,7 @@ title: "Cloud provider — VMware Cloud Director: Примеры"
 ## Пример custom resource `VCDInstanceClass`
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha1
+apiVersion: deckhouse.io/v1
 kind: VCDInstanceClass
 metadata:
   name: test

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -284,14 +284,15 @@ properties:
               password:
                 type: string
                 description: The user's password.
+              apiToken:
+                type: string
+                description: The user's API token.
               insecure:
                 type: boolean
                 description: Set to `true` if VCD has a self-signed certificate.
                 x-doc-default: false
             required:
               - server
-              - username
-              - password
       capcdControllerManagerWebhookCert:
         type: object
         default: { }

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/deployment.yaml
@@ -104,11 +104,19 @@ spec:
             secretKeyRef:
               key: username
               name: vcd-credentials
+              optional: true
         - name: VCD_PASSWORD
           valueFrom:
             secretKeyRef:
               key: password
               name: vcd-credentials
+              optional: true
+        - name: VCD_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: refreshToken
+              name: vcd-credentials
+              optional: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
@@ -32,6 +32,7 @@ data:
   {{- $_ := set $vcdValues "server" $providerClusterConfiguration.provider.server }}
   {{- $_ := set $vcdValues "username" $providerClusterConfiguration.provider.username }}
   {{- $_ := set $vcdValues "password" $providerClusterConfiguration.provider.password }}
+  {{- $_ := set $vcdValues "apiToken" $providerClusterConfiguration.provider.apiToken }}
   {{- $_ := set $vcdValues "insecure" $providerClusterConfiguration.provider.insecure }}
 
   vcd: {{ $vcdValues | toJson | b64enc | quote }}

--- a/ee/modules/030-cloud-provider-vcd/templates/secret.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/secret.yaml
@@ -7,5 +7,12 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "vcd-cloud-controller")) | nindent 2 }}
   name: vcd-credentials
 data:
-  username: {{ $providerClusterConfiguration.provider.username | toString | b64enc | quote }}
-  password: {{ $providerClusterConfiguration.provider.password | toString | b64enc | quote }}
+  {{- if $providerClusterConfiguration.provider.username }}
+  username: {{ $providerClusterConfiguration.provider.username | b64enc | quote }}
+  {{- end }}
+  {{- if $providerClusterConfiguration.provider.password }}
+  password: {{ $providerClusterConfiguration.provider.password | b64enc | quote }}
+  {{- end }}
+  {{- if $providerClusterConfiguration.provider.apiToken }}
+  refreshToken: {{ $providerClusterConfiguration.provider.apiToken | b64enc | quote }}
+  {{- end }}

--- a/modules/040-node-manager/templates/node-group/_capi_bootstrap_secret.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_bootstrap_secret.tpl
@@ -10,6 +10,10 @@ metadata:
   name: {{ $bootstrap_secret_name }}
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
+  annotations:
+    # todo using for keep machine template after rollout
+    # see this https://github.com/kubernetes-sigs/cluster-api/issues/6588#issuecomment-1925433449
+    helm.sh/resource-policy: keep
 type: Opaque
 data:
   format: {{ "cloud-config" | b64enc}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add support for token-based authentication to the VCD cloud provider.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to add a more secure authentication type than password-based authentication.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: feature
summary: Add support for token-based authentication.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
