### PR TITLE
[global] rbac fix

### DIFF
--- a/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
@@ -19,7 +19,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "update"]
 - apiGroups: ["deckhouse.io"]
-  resources: ["*"]
+  resources: ["*"] # We want to read all resources from the deckhouse.io group
   verbs: ["get","list","watch"]
 - apiGroups: [""]
   resources: ["secrets","endpoints","configmaps","namespaces"]

--- a/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
+++ b/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
@@ -49,7 +49,7 @@ metadata:
   name: "d8:admission-policy-engine:gatekeeper"
 rules:
   - apiGroups:
-      - '*'
+      - '*' # Gatekeeper have to have read access to all resources because of audit periodical checks
     resources:
       - '*'
     verbs:
@@ -103,7 +103,7 @@ rules:
   - apiGroups:
       - constraints.gatekeeper.sh
     resources:
-      - '*'
+      - '*' # We couldn't use explicit set of resources because they are created dynamically (see Gatekeeper ConstraintTemplate)
     verbs:
       - create
       - delete
@@ -127,7 +127,10 @@ rules:
   - apiGroups:
       - mutations.gatekeeper.sh
     resources:
-      - '*'
+      - assign
+      - assignimage
+      - assignmetadata
+      - modifyset
     verbs:
       - create
       - delete
@@ -147,7 +150,10 @@ rules:
   - apiGroups:
       - status.gatekeeper.sh
     resources:
-      - '*'
+      - constraintpodstatuses
+      - constrainttemplatepodstatuses
+      - expansiontemplatepodstatuses
+      - mutatorpodstatuses
     verbs:
       - create
       - delete

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -39,11 +39,13 @@ var skipCheckWildcards = map[string][]string{
 		// Some resources are created dynamically from CR. See more details in the target file
 		"d8:admission-policy-engine:gatekeeper",
 	},
-
-	// Have to be reviewed
 	"deckhouse/templates/webhook-handler/rbac-for-us.yaml": {
+		// We read all resources from the `deckhouse.io` api group
 		"d8:deckhouse:webhook-handler",
 	},
+
+	// Have to be reviewed
+
 	"cloud-provider-aws/templates/cloud-controller-manager/rbac-for-us.yaml": {
 		"d8:cloud-provider-aws:cloud-controller-manager",
 	},

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -34,9 +34,13 @@ import (
 //
 // !!IMPORTANT NOTE!!: will be fixed by separated issues
 var skipCheckWildcards = map[string][]string{
+	// Confirmed excludes
 	"admission-policy-engine/templates/rbac-for-us.yaml": {
+		// Some resources are created dynamically from CR. See more details in the target file
 		"d8:admission-policy-engine:gatekeeper",
 	},
+
+	// Have to be reviewed
 	"deckhouse/templates/webhook-handler/rbac-for-us.yaml": {
 		"d8:deckhouse:webhook-handler",
 	},


### PR DESCRIPTION
## Description
Add comments for wildcard rbac permissions

## Why do we need it, and what problem does it solve?
Setting a wildcard for Role/ClusterRole is potentially dangerous. We have to review them and 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: Add comments for wildcard rbac permissions.
impact_level: low
```
```changes
section: deckhouse
type: chore
summary: Add comments for wildcard rbac permissions.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
