### PR TITLE
[dhctl] add preflight check for python and his friends

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -27,6 +27,7 @@ var (
 	PreflightSkipSSHCredentialsCheck       = false
 	PreflightSkipRegistryCredentials       = false
 	PreflightSkipContainerdExistCheck      = false
+	PreflightSkipPythonChecks              = false
 )
 
 const (
@@ -39,6 +40,7 @@ const (
 	SSHCredentialsCheckArgName       = "preflight-skip-ssh-credentials-check"
 	RegistryCredentialsCheckArgName  = "preflight-skip-registry-credential"
 	ContainerdExistCheckArgName      = "preflight-skip-containerd-exist"
+	PythonChecksArgName              = "preflight-skip-python-checks"
 )
 
 func DefinePreflight(cmd *kingpin.CmdClause) {
@@ -72,4 +74,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(ContainerdExistCheckArgName, "Skip verifying contanerd exist").
 		Envar(configEnvName("PREFLIGHT_SKIP_CONTAINERD_EXIST")).
 		BoolVar(&PreflightSkipContainerdExistCheck)
+	cmd.Flag(PythonChecksArgName, "Skip verifying python installation").
+		Envar(configEnvName("PREFLIGHT_SKIP_PYTHON_CHECKS")).
+		BoolVar(&PreflightSkipPythonChecks)
 }

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -68,6 +68,11 @@ func (pc *Checker) Static() error {
 			skipFlag:       app.SSHForwardArgName,
 		},
 		{
+			fun:            pc.CheckPythonAndItsModules,
+			successMessage: "python and required modules are installed",
+			skipFlag:       app.PythonChecksArgName,
+		},
+		{
 			fun:            pc.CheckRegistryAccessThroughProxy,
 			successMessage: "registry access through proxy",
 			skipFlag:       app.RegistryThroughProxyCheckArgName,

--- a/dhctl/pkg/preflight/python.go
+++ b/dhctl/pkg/preflight/python.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func (pc *Checker) CheckPythonAndItsModules() error {
+	if app.PreflightSkipPythonChecks {
+		log.InfoLn("Python installation preflight check was skipped")
+		return nil
+	}
+
+	// Each subslice is a Python 3 module name and a python 2 fallback for it
+	requiredPythonModules := [][]string{
+		{"urllib.request", "urllib2"},
+		{"urllib.error", "urllib2"},
+		{"configparser", "ConfigParser"},
+		{"http.server", "SimpleHTTPServer"},
+		{"http.server", "SocketServer"},
+	}
+
+	for _, moduleSet := range requiredPythonModules {
+		atLeastOneModuleFoundForSet := false
+		for _, moduleName := range moduleSet {
+			cmd := pc.sshClient.Command("python", "-c", "import "+moduleName)
+			err := cmd.Run()
+			if err != nil {
+				var ee *exec.ExitError
+				if errors.As(err, &ee) && ee.ExitCode() != 255 {
+					log.InfoF("Module %q is not installed\n", moduleName)
+					continue
+				}
+				return fmt.Errorf("Unexpected error during python modules validation: %w", err)
+			}
+
+			atLeastOneModuleFoundForSet = true
+			log.InfoF("Module %q is installed\n", moduleName)
+			break
+		}
+
+		if !atLeastOneModuleFoundForSet {
+			return fmt.Errorf(
+				"Please install at least one of the following python modules on the node to continue: %s",
+				strings.Join(moduleSet, ", "),
+			)
+		}
+	}
+
+	return nil
+}

--- a/dhctl/pkg/preflight/python.go
+++ b/dhctl/pkg/preflight/python.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Flant JSC
+// Copyright 2024 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dhctl/pkg/system/ssh/frontend/command.go
+++ b/dhctl/pkg/system/ssh/frontend/command.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,10 +46,21 @@ type Command struct {
 }
 
 func NewCommand(sess *session.Session, name string, arg ...string) *Command {
+	args := make([]string, len(arg))
+	copy(args, arg)
+	for i := range args {
+		if !strings.HasPrefix(args[i], `"`) &&
+			!strings.HasSuffix(args[i], `"`) &&
+			strings.Contains(args[i], " ") {
+			args[i] = strconv.Quote(args[i])
+		}
+	}
+
 	return &Command{
-		Session: sess,
-		Name:    name,
-		Args:    arg,
+		Executor: process.NewDefaultExecutor(cmd.NewSSH(sess).WithCommand(name, args...).Cmd()),
+		Session:  sess,
+		Name:     name,
+		Args:     args,
 	}
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a preflight check to validate that required python modules are installed on the node

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Installer will not begin bootstrapping nodes without required python modules

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: dhctl will now check if required python modules are installed on the node before bootstrapping it
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
