### PR TITLE
[testing] set centos 9 stream for aws

### DIFF
--- a/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
@@ -24,7 +24,7 @@ fi
 volume_names="$(find /dev | grep -i 'nvme[0-21]n1$' || true)"
 for volume in ${volume_names}
 do
- symlink="$(nvme id-ctrl -v "${volume}" | grep '^0000:' | sed -E 's/.*"(\/dev\/)?([a-z0-9]+)\.+"$/\/dev\/\2/')"
+ symlink="$(nvme id-ctrl -v "${volume}" | ( grep '^0000:' || true ) | sed -E 's/.*"(\/dev\/)?([a-z0-9]+)\.+"$/\/dev\/\2/')"
  if [ ! -z "${symlink}" ] && [ ! -e "${symlink}" ]; then
   ln -s "${volume}" "${symlink}"
  fi

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -24,13 +24,11 @@ git:
 artifact: terraform
 # we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
 # current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
-from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 shell:
-  beforeInstall:
-    - apk add --no-cache make patch git bash
   install:
     - mkdir /src
     - export GOPROXY={{ $.GOPROXY }}

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -29,7 +29,7 @@ masterNodeGroup:
   replicas: 1
   instanceClass:
     instanceType: m5.xlarge
-    ami: ami-0afcbcee3dfbce929 #  Centos 7
+    ami: ami-017299323dfff257b # Centos 9
 nodeNetworkCIDR: "172.16.0.0/22"
 vpcNetworkCIDR: "172.16.0.0/16"
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -29,7 +29,7 @@ masterNodeGroup:
   replicas: 1
   instanceClass:
     instanceType: m5.xlarge
-    ami: ami-017299323dfff257b # Centos 9
+    ami: ami-0022e2e80fa74c5d7 # Centos 9
 nodeNetworkCIDR: "172.16.0.0/22"
 vpcNetworkCIDR: "172.16.0.0/16"
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -292,7 +292,7 @@ function prepare_environment() {
         envsubst '${DECKHOUSE_DOCKERCFG} ${PREFIX} ${DEV_BRANCH} ${KUBERNETES_VERSION} ${CRI} ${AWS_ACCESS_KEY} ${AWS_SECRET_ACCESS_KEY}' \
         <"$cwd/configuration.tpl.yaml" >"$cwd/configuration.yaml"
 
-    ssh_user="centos"
+    ssh_user="ec2-user"
     ;;
 
   "Azure")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Use centos 9 stream image in aws e2e because centos 7 end of life is June 30. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Centos 7 end of life is June 30. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: Use centos 9 stream image in aws e2e. 
impact_level: low
```
```changes
section: terraform-manager
type: fix
summary: Rebuild with dev base-image. 
impact_level: low
```
```changes
section: candi
type: fix
summary: Fix 001_create_nvme_ebs_aliases.sh step for cases without requirements symlinks.
impact_level: low
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
