### PR TITLE
[candi](yandex) Fix external IP addresses index overflow

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -55,7 +55,7 @@ data "yandex_vpc_subnet" "kube_d" {
 }
 
 resource "yandex_vpc_address" "addr" {
-  count = length(local.external_ip_addresses) > 0 ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? 1 : 0 : 0
+  count = var.nodeIndex < length(local.external_ip_addresses) ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? 1 : 0 : 0
   name  = join("-", [local.prefix, "master", var.nodeIndex])
 
   external_ipv4_address {
@@ -64,10 +64,10 @@ resource "yandex_vpc_address" "addr" {
 }
 
 locals {
-  # null if local.external_ip_addresses is empty
+  # null if var.nodeIndex < length(local.external_ip_addresses)
   # yandex_vpc_address.addr[0].external_ipv4_address[0].address if local.external_ip_addresses == Auto
   # local.external_ip_addresses[var.nodeIndex] if local.external_ip_addresses contain IP-addresses
-  external_ip_address = length(local.external_ip_addresses) > 0 ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? yandex_vpc_address.addr[0].external_ipv4_address[0].address : local.external_ip_addresses[var.nodeIndex] : null
+  external_ip_address = var.nodeIndex < length(local.external_ip_addresses) ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? yandex_vpc_address.addr[0].external_ipv4_address[0].address : local.external_ip_addresses[var.nodeIndex] : null
 }
 
 resource "yandex_compute_disk" "kubernetes_data" {

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -54,7 +54,7 @@ data "yandex_vpc_subnet" "kube_d" {
 }
 
 resource "yandex_vpc_address" "addr" {
-  count = length(local.external_ip_addresses) > 0 ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? 1 : 0 : 0
+  count = var.nodeIndex < length(local.external_ip_addresses) ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? 1 : 0 : 0
   name  = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
 
   external_ipv4_address {
@@ -63,10 +63,10 @@ resource "yandex_vpc_address" "addr" {
 }
 
 locals {
-  # null if local.external_ip_addresses is empty
+  # null if var.nodeIndex < length(local.external_ip_addresses)
   # yandex_vpc_address.addr[0].external_ipv4_address[0].address if local.external_ip_addresses == Auto
   # local.external_ip_addresses[var.nodeIndex] if local.external_ip_addresses contain IP-addresses
-  external_ip = length(local.external_ip_addresses) > 0 ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? yandex_vpc_address.addr[0].external_ipv4_address[0].address : local.external_ip_addresses[var.nodeIndex] : null
+  external_ip = var.nodeIndex < length(local.external_ip_addresses) ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? yandex_vpc_address.addr[0].external_ipv4_address[0].address : local.external_ip_addresses[var.nodeIndex] : null
 }
 
 resource "yandex_compute_instance" "static" {

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -122,6 +122,17 @@ masterNodeGroup:
     diskSizeGB: 50
     externalIPAddresses:
       - Auto
+nodeGroups:
+  - name: node-group-1
+    replicas: 2
+    instanceClass:
+      cores: 4
+      memory: 8192
+      imageID: id
+      diskSizeGB: 50
+      externalIPAddresses:
+        - Auto
+        - Auto
 sshPublicKey: ssh-rsa AAAA
 nodeNetworkCIDR: 10.100.0.0/21
 provider:

--- a/dhctl/pkg/config/types.go
+++ b/dhctl/pkg/config/types.go
@@ -53,6 +53,21 @@ type MasterNodeGroupSpec struct {
 	Replicas int `json:"replicas"`
 }
 
+type YandexMasterNodeGroupSpec struct {
+	Replicas      int `json:"replicas"`
+	InstanceClass struct {
+		ExternalIPAddresses []string `json:"externalIPAddresses"`
+	} `json:"instanceClass"`
+}
+
+type YandexNodeGroupSpec struct {
+	Name          string `json:"name"`
+	Replicas      int    `json:"replicas"`
+	InstanceClass struct {
+		ExternalIPAddresses []string `json:"externalIPAddresses"`
+	} `json:"instanceClass"`
+}
+
 type TerraNodeGroupSpec struct {
 	Replicas     int                    `json:"replicas"`
 	Name         string                 `json:"name"`


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Fix index overflow when retrieving values from the list of external IP addresses
- Validate the length of the list of external IP addresses in the `YandexClusterConfiguration`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix index overflow when retrieving values from the list of external IP addresses.
impact_level: default
```

```changes
section: dhctl
type: fix
summary: Validate the length of the list of external IP addresses in the `YandexClusterConfiguration`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
