### PR TITLE
[chrony] Optimize permissions and capabilities for chrony and chrony-master

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -56,6 +56,11 @@ groups:
     en: Nodes to masters traffic
     ru: Трафик между любыми узлами и мастер-узлами
   destinations:
+  - ports: "4234"
+    protocol: UDP
+    description:
+      en: NTP for time synchronization between nodes
+      ru: NTP для синхронизации времени между узлами
   - ports: "6443"
     protocol: TCP
     description:
@@ -87,11 +92,6 @@ groups:
     description:
       en: ICMP for node-to-node connectivity monitoring
       ru: ICMP для мониторинга связности между узлами
-  - ports: "123"
-    protocol: UDP
-    description:
-      en: NTP for time synchronization between nodes
-      ru: NTP для синхронизации времени между узлами
   - ports: "7000-7999"
     protocol: TCP
     description:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -77,6 +77,7 @@ spec:
         - '--web.listen-address=127.0.0.1:4206'
         - '--path.rootfs=/host/root'
         - '--collector.ntp'
+        - '--collector.ntp.server-port=4234'
         - '--no-collector.wifi'
         - '--collector.ntp.server-is-local'
         - '--collector.ntp.server=$(HOST_IP)'

--- a/modules/470-chrony/images/chrony/main.go
+++ b/modules/470-chrony/images/chrony/main.go
@@ -29,12 +29,10 @@ import (
 )
 
 const (
-	chronyRuntimeDir    = "/var/run/chrony"
-	chronyConfPath      = "/var/run/chrony/chrony.conf"
-	chronyConfTplPath   = "/var/run/chrony/chrony.conf.tpl"
-	chronyDriftFilePath = "/var/run/chrony/chrony.drift"
-	chronydPidFilePath  = "/var/run/chrony/chronyd.pid"
-	chronydPath         = "/opt/chrony-static/sbin/chronyd"
+	chronyConfPath     = "/etc/chrony/chrony.conf"
+	chronyConfTplPath  = "/etc/chrony/chrony.conf.tpl"
+	chronydPidFilePath = "/var/run/chrony/chronyd.pid"
+	chronydPath        = "/opt/chrony-static/sbin/chronyd"
 )
 
 type ChronyConfigTemplateData struct {
@@ -45,21 +43,6 @@ type ChronyConfigTemplateData struct {
 }
 
 func main() {
-	err := os.Chown(chronyRuntimeDir, 64535, 64535)
-	if err != nil {
-		log.Fatal(errors.Wrapf(err, "failed to chown %s", chronyRuntimeDir))
-	}
-
-	err = os.Chmod(chronyRuntimeDir, 0700)
-	if err != nil {
-		log.Fatal(errors.Wrapf(err, "failed to chmod %s", chronyRuntimeDir))
-	}
-
-	_, err = os.OpenFile(chronyDriftFilePath, os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		log.Fatal(errors.Wrapf(err, "failed to create %s file", chronyDriftFilePath))
-	}
-
 	ntpServers := os.Getenv("NTP_SERVERS")
 
 	var ntpServersList []string
@@ -76,7 +59,7 @@ func main() {
 
 	configBuffer := &bytes.Buffer{}
 
-	err = template.Must(template.New(path.Base(chronyConfTplPath)).ParseFiles(chronyConfTplPath)).Execute(configBuffer, configTemplateData)
+	err := template.Must(template.New(path.Base(chronyConfTplPath)).ParseFiles(chronyConfTplPath)).Execute(configBuffer, configTemplateData)
 	if err != nil {
 		log.Fatal(errors.Wrapf(err, "failed to execute %s template", chronyConfTplPath))
 	}

--- a/modules/470-chrony/images/chrony/werf.inc.yaml
+++ b/modules/470-chrony/images/chrony/werf.inc.yaml
@@ -12,8 +12,8 @@ shell:
     - make -j1
     - make -j1 install
     - chown -R 64535:64535 /opt/chrony-static
-    - chmod 0700 /opt/chrony-static/bin/chronyc
-    - chmod 0700 /opt/chrony-static/sbin/chronyd
+    - chmod +x /opt/chrony-static/bin/chronyc
+    - chmod +x /opt/chrony-static/sbin/chronyd
 ---
 artifact: {{ .ModuleName }}/build-entrypoint-artifact
 from: {{ .Images.BASE_GOLANG_20_ALPINE }}
@@ -37,7 +37,7 @@ shell:
     - cd /src
     - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-extldflags "-static" -s -w' -o entrypoint main.go
     - chown -R 64535:64535 entrypoint
-    - chmod 0700 entrypoint
+    - chmod +x entrypoint
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/470-chrony/templates/configmap.yaml
+++ b/modules/470-chrony/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
     makestep 1.0 -1
     rtcsync
     bindaddress {{ .HostIP }}
+    port 4234
     cmdallow 127/8
 
     {{ if (eq .NTPRole "source") }}
@@ -22,7 +23,7 @@ data:
     local stratum 9
     allow 127/8
     allow {{ .HostIP }}/32
-    pool {{ .ChronyMastersService }} iburst
+    pool {{ .ChronyMastersService }} iburst port 4234
     {{ end }}
 
     {{ range .NTPServers }}

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -96,24 +96,23 @@ spec:
       containers:
       - name: chrony
         securityContext:
-          allowPrivilegeEscalation: true
           capabilities:
             add:
+            # SYS_TIME: Allows a process to modify the system time.
+            # Chrony is designed to adjust system time.
             - SYS_TIME
+            # CHOWN: Allows changing the ownership of files and directories.
+            # Chrony can create /var/run/chrony folfer and change its owner.
             - CHOWN
+            # DAC_OVERRIDE: Allows access to files and directories, even if the process isn't the owner.
+            # /entrypoint can remove /var/run/chrony/chronyd.pid file (UID/GID 64535:64535).
             - DAC_OVERRIDE
-            - FOWNER
-            - FSETID
-            - KILL
+            # SETGID: Make arbitrary manipulations of process GIDs.
+            # Chrony can change its own process GID on the fly.
             - SETGID
+            # SETUID: Make arbitrary manipulations of process UIDs.
+            # Chrony can change its own process UID on the fly.
             - SETUID
-            - SETPCAP
-            - NET_BIND_SERVICE
-            - NET_RAW
-            - SYS_CHROOT
-            - MKNOD
-            - AUDIT_WRITE
-            - SETFCAP
             drop:
             - ALL
           readOnlyRootFilesystem: true
@@ -136,7 +135,7 @@ spec:
               fieldPath: status.hostIP
         ports:
         - name: ntp
-          containerPort: 123
+          containerPort: 4234
           protocol: UDP
         livenessProbe:
           exec:
@@ -153,11 +152,13 @@ spec:
         - name: tzdata-config
           mountPath: /etc/timezone
           readOnly: true
-        - name: chrony
-          mountPath: /var/run/chrony
+        - name: etc-chrony
+          mountPath: /etc/chrony
         - name: config
-          mountPath: /var/run/chrony/chrony.conf.tpl
+          mountPath: /etc/chrony/chrony.conf.tpl
           subPath: chrony.conf.tpl
+        - name: var-run
+          mountPath: /var/run
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
@@ -171,7 +172,9 @@ spec:
       - name: tzdata-config
         hostPath:
           path: /etc/timezone
-      - name: chrony
+      - name: etc-chrony
+        emptyDir: {}
+      - name: var-run
         emptyDir: {}
       - name: config
         configMap:
@@ -214,24 +217,23 @@ spec:
       containers:
       - name: chrony
         securityContext:
-          allowPrivilegeEscalation: true
           capabilities:
             add:
+            # SYS_TIME: Allows a process to modify the system time.
+            # Chrony is designed to adjust system time.
             - SYS_TIME
+            # CHOWN: Allows changing the ownership of files and directories.
+            # Chrony can create /var/run/chrony folfer and change its owner.
             - CHOWN
+            # DAC_OVERRIDE: Allows access to files and directories, even if the process isn't the owner.
+            # /entrypoint can remove /var/run/chrony/chronyd.pid file (UID/GID 64535:64535).
             - DAC_OVERRIDE
-            - FOWNER
-            - FSETID
-            - KILL
+            # SETGID: Make arbitrary manipulations of process GIDs.
+            # Chrony can change its own process GID on the fly.
             - SETGID
+            # SETUID: Make arbitrary manipulations of process UIDs.
+            # Chrony can change its own process UID on the fly.
             - SETUID
-            - SETPCAP
-            - NET_BIND_SERVICE
-            - NET_RAW
-            - SYS_CHROOT
-            - MKNOD
-            - AUDIT_WRITE
-            - SETFCAP
             drop:
             - ALL
           readOnlyRootFilesystem: true
@@ -252,7 +254,7 @@ spec:
               fieldPath: status.hostIP
         ports:
         - name: ntp
-          containerPort: 123
+          containerPort: 4234
           protocol: UDP
         livenessProbe:
           exec:
@@ -269,11 +271,13 @@ spec:
         - name: tzdata-config
           mountPath: /etc/timezone
           readOnly: true
-        - name: chrony
-          mountPath: /var/run/chrony
+        - name: etc-chrony
+          mountPath: /etc/chrony
         - name: config
-          mountPath: /var/run/chrony/chrony.conf.tpl
+          mountPath: /etc/chrony/chrony.conf.tpl
           subPath: chrony.conf.tpl
+        - name: var-run
+          mountPath: /var/run
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
@@ -287,9 +291,10 @@ spec:
       - name: tzdata-config
         hostPath:
           path: /etc/timezone
-      - name: chrony
+      - name: etc-chrony
+        emptyDir: {}
+      - name: var-run
         emptyDir: {}
       - name: config
         configMap:
           name: chrony
-

--- a/modules/470-chrony/templates/service.yaml
+++ b/modules/470-chrony/templates/service.yaml
@@ -10,5 +10,6 @@ spec:
     app: chrony-master
   ports:
     - protocol: UDP
-      port: 123
+      port: 4234
       name: ntp
+      targetPort: ntp

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -567,14 +567,6 @@ func objectSecurityContext(object storage.StoreObject) errors.LintRuleError {
 }
 
 func skipHostNetworkPorts(o *storage.StoreObject, c *v1.Container, p *v1.ContainerPort, hostNetworkUsed bool) bool {
-	// The 123 port is standard one, which is configured on external clients.
-	if o.Unstructured.GetKind() == "DaemonSet" && strings.HasPrefix(o.Unstructured.GetName(), "chrony") &&
-		o.Unstructured.GetNamespace() == "d8-chrony" && c.Name == "chrony" {
-		if (hostNetworkUsed && p.ContainerPort == 123) || p.HostPort == 123 {
-			return true
-		}
-	}
-
 	// The 5416 port is standard one which is already configured on client's side.
 	if o.Unstructured.GetKind() == "StatefulSet" && o.Unstructured.GetName() == "openvpn" &&
 		o.Unstructured.GetNamespace() == "d8-openvpn" && c.Name == "openvpn-tcp" {


### PR DESCRIPTION
## Description
Optimize permissions and capabilities for chrony and chrony-master. Change NTP listen ports.

## Why do we need it, and what problem does it solve?
This will reduce security risks and satisfy our port range policy.

## What is the expected result?
- Chrony listens on port 4234/udp.
- Chrony only run with the necessary permissions.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: chrony
type: chore
summary: Optimized permissions and capabilities for chrony and chrony-master. NTP listen ports changed.
impact_level: default
```