### PR TITLE
[runtime-audit-engine] Move the webhook-handler port to the range 4200-4299

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -45,11 +45,11 @@ groups:
     description:
       en: "*bashible apiserver* for delivering node configurations"
       ru: "*apiserver bashible* для доставки конфигурации на узлы"
-  - ports: "9680"
+  - ports: "4227"
     protocol: TCP
     description:
-      en: runtime-audit-engine webhook
-      ru: webhook компонента runtime-audit-engine
+      en: "runtime-audit-engine webhook handler"
+      ru: "Webhook-обработчик компонента runtime-audit-engine"
 
 - group: NodesToMasters
   description:

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -185,6 +185,8 @@ spec:
           value: d8-runtime-audit-engine.deckhouse.io
         - name: VALIDATING_WEBHOOK_SERVICE_NAME
           value: {{ .Chart.Name }}-webhook
+        - name: VALIDATING_WEBHOOK_LISTEN_PORT
+          value: "4227"
         - name: DEBUG_UNIX_SOCKET
           value: /tmp/shell-operator-debug.socket
         resources:

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -151,7 +151,7 @@ spec:
         {{- end }}
         ports:
         - name: webhook
-          containerPort: 9680
+          containerPort: 4227
         livenessProbe:
           httpGet:
             path: /sidekick/ping

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -632,14 +632,6 @@ func skipHostNetworkPorts(o *storage.StoreObject, c *v1.Container, p *v1.Contain
 		}
 	}
 
-	// Temporary exception on port 9680/tcp of the runtime-audit-engine module .
-	if o.Unstructured.GetKind() == "DaemonSet" && o.Unstructured.GetName() == "runtime-audit-engine" &&
-		o.Unstructured.GetNamespace() == "d8-runtime-audit-engine" && c.Name == "falcosidekick" {
-		if (hostNetworkUsed && p.ContainerPort == 9680) || p.HostPort == 9680 {
-			return true
-		}
-	}
-
 	return false
 }
 


### PR DESCRIPTION
## Description
Moving the webhook-handler port (9680/tcp) that listens on nodes to the range 4200-4299.

## Why do we need it, and what problem does it solve?
This will make it easier for administrators to create network policies on firewalls within the corporate infrastructure. They will be able to add a single range to the policy.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: runtime-audit-engine
type: chore
summary: The webhook-handler port moved to the range 4200-4299.
impact: Note that you will need to change the access policies on the underlying firewalls before upgrading the cluster.
impact_level: high
```