### PR TITLE
[candi] fix(dhctl-for-commander): init configuration openapi spec: allow any init-configuration changes

### DIFF
--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -36,7 +36,6 @@ apiVersions:
         enum: [InitConfiguration]
       deckhouse:
         type: object
-        x-unsafe: true
         description: Initial parameters required to install Deckhouse.
         properties:
           imagesRepo:


### PR DESCRIPTION
## Description

Removed x-unsafe for deckhouse settings in InitConfiguration crd.

## Why do we need it, and what problem does it solve?

Initially x-unsafe was added to InitConfiguration to prevent changes of InitConfiguration settings. This was wrong decision. So we remove any x-unsafe annotations from InitConfiguration CRD, thus allowing changes of InitConfiguration during changes validation. Changes validation now mainly used in the commander, it should allow changing of InitConfiguration for already created clusters without any affect on those clusters.

## Why do we need it in the patch release (if we do)?

This change allows changing of InitConfiguration in created clusters in the commander. Thus it is preferred to include this change into patch release.

## What is the expected result?

It is not expected to change dhctl cli behaviour in any way, only validate-changes procedure which is currently used only in the commander.

