### PR TITLE
[local-path-provisioner] remove wildcard from module RBAC

### DIFF
--- a/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
+++ b/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
@@ -13,11 +13,11 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "local-path-provisioner")) | nindent 2 }}
 rules:
 - apiGroups: [ "" ]
-  resources: [ "nodes", "persistentvolumeclaims", "configmaps" ]
+  resources: [ "nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log" ]
   verbs: [ "get", "list", "watch" ]
 - apiGroups: [ "" ]
-  resources: [ "endpoints", "persistentvolumes", "pods" ]
-  verbs: [ "*" ]
+  resources: [ "persistentvolumes" ]
+  verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
 - apiGroups: [ "" ]
   resources: [ "events" ]
   verbs: [ "create", "patch" ]
@@ -38,3 +38,29 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}
   namespace: d8-{{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "local-path-provisioner")) | nindent 2 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "local-path-provisioner")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Chart.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}
+    namespace: d8-{{ .Chart.Name }}

--- a/testing/matrix/linter/rules/roles/placement.go
+++ b/testing/matrix/linter/rules/roles/placement.go
@@ -44,7 +44,8 @@ func isDeckhouseSystemNamespace(actual string) bool {
 		// TODO: remove next lines after RBAC objects naming fixes
 		actual == "d8-admission-policy-engine" ||
 		actual == "d8-operator-trivy" ||
-		actual == "d8-log-shipper"
+		actual == "d8-log-shipper" ||
+		actual == "d8-local-path-provisioner"
 }
 
 func ObjectRBACPlacement(m utils.Module, object storage.StoreObject) errors.LintRuleError {

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -58,9 +58,6 @@ var skipCheckWildcards = map[string][]string{
 	"cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml": {
 		"d8:cloud-provider-yandex:cloud-controller-manager",
 	},
-	"local-path-provisioner/templates/rbac-for-us.yaml": {
-		"d8:local-path-provisioner",
-	},
 	"istio/templates/kiali/rbac-for-us.yaml": {
 		"d8:istio:kiali",
 	},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove wildcard from module RBAC

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to reduce the module's permissions to limit available resources.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This is necessary for some of our customers

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

More secure platform

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: local-path-provisioner
type: chore
summary: Remove wildcard from module RBAC.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
