### PR TITLE
[docs][registrypackages] Bump Deckhouse CLI to 0.2.0. Refactor the Deckhouse CLI installation page.

### DIFF
--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -1,0 +1,48 @@
+{% if include.os == "Windows" %}
+1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
+({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase }}.tar.gz).
+{% else %}
+1. {% if page.lang == 'ru' %}Скачайте архив для {{ include.os }} {{ include.arch }}{% else %}Download the archive for {{ include.os }} {{ include.arch }}{% endif %}:
+
+   ```shell
+   curl -LO {%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase }}.tar.gz
+   ```
+{% endif %}
+
+{% if include.os == "Windows" %}
+{%    if page.lang == 'ru' -%}
+1. Распакуйте архив, переместите файл `d8.exe` в выбранный вами каталог и добавьте каталог в переменную `PATH` операционной системы.
+{%-   else -%}
+1. Extract the archive, move the file `d8.exe` to the directory of your choice, and add the directory to the 'PATH' environment variable of the operating system.
+{%-   endif -%}
+{% else %}
+1. {% if page.lang == 'ru' -%}Распакуйте архив{% else %}Extract the archive{% endif %}:
+
+   ```bash
+   tar -xvf "d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase }}.tar.gz" "{{ include.os | downcase }}-{{ include.arch | downcase }}/d8"
+   ```
+
+1. {% if page.lang == 'ru' -%}
+Переместите файл `d8` в каталог, находящийся в списке в переменной окружения `PATH` операционной системы (например, `/usr/local/bin/`)
+{%- else -%}
+Move the file `d8` to the directory listed in the `PATH` system environment variable (for example, `/usr/local/bin/`)
+{%- endif %}:
+
+   ```bash
+   sudo mv "{{ include.os | downcase }}-{{ include.arch | downcase }}/d8" /usr/local/bin/
+   ```
+
+   > {%- if page.lang == 'ru' -%}
+     Переменная окружения `PATH` содержит список каталогов, в которых ОС будет искать исполняемый файл при вызове команды из терминала. Просмотреть ее можно командой `echo $PATH`.
+     {%- else -%}
+     `PATH` is a system environment variable containing a list of directories with executable files. This is where the OS will look for the binary when a command is run in the terminal. You can view this list with the `echo $PATH` command.
+     {%- endif %}
+{% endif %}
+
+1. {% if page.lang == 'ru' -%}Проверьте, что утилита работает{% else %}Check that the CLI is working{% endif %}:
+
+   ```bash
+   d8 help
+   ```
+
+{% if page.lang == 'ru' -%}Готово, вы установили Deckhouse CLI.{% else %}Congrats, you have successfully installed Deckhouse CLI.{% endif %}

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -1,11 +1,11 @@
 {% if include.os == "Windows" %}
 1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
-({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase }}.tar.gz).
+({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz).
 {% else %}
 1. {% if page.lang == 'ru' %}Скачайте архив для {{ include.os }} {{ include.arch }}{% else %}Download the archive for {{ include.os }} {{ include.arch }}{% endif %}:
 
    ```shell
-   curl -LO {%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase }}.tar.gz
+   curl -LO {%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
    ```
 {% endif %}
 
@@ -19,7 +19,7 @@
 1. {% if page.lang == 'ru' -%}Распакуйте архив{% else %}Extract the archive{% endif %}:
 
    ```bash
-   tar -xvf "d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase }}.tar.gz" "{{ include.os | downcase }}-{{ include.arch | downcase }}/d8"
+   tar -xvf "d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8"
    ```
 
 1. {% if page.lang == 'ru' -%}
@@ -29,7 +29,7 @@ Move the file `d8` to the directory listed in the `PATH` system environment vari
 {%- endif %}:
 
    ```bash
-   sudo mv "{{ include.os | downcase }}-{{ include.arch | downcase }}/d8" /usr/local/bin/
+   sudo mv "{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8" /usr/local/bin/
    ```
 
    > {%- if page.lang == 'ru' -%}

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -12,8 +12,18 @@
 {% if include.os == "Windows" %}
 {%    if page.lang == 'ru' -%}
 1. Распакуйте архив, переместите файл `d8.exe` в выбранный вами каталог и добавьте каталог в переменную `PATH` операционной системы.
+1. Разблокируйте файл `d8.exe`, например, следующим способом:
+   - Щелкните правой кнопкой мыши на файле и выберите *Свойства* в контекстном меню.
+   - В окне *Свойства* убедитесь, что находитесь на вкладке *Общие*.
+   - Внизу вкладки *Общие* вы можете увидеть раздел *Безопасность* с сообщением о блокировке файла.
+   - Установите флажок *Разблокировать* или нажмите кнопку *Разблокировать*, затем нажмите *Применить* и *ОК*, чтобы сохранить изменения.
 {%-   else -%}
 1. Extract the archive, move the file `d8.exe` to the directory of your choice, and add the directory to the 'PATH' environment variable of the operating system.
+1. Unlock the file `d8.exe`, for example, in the following way:
+   - Right-click on the file and select *Properties* from the context menu.
+   - In the Properties window, make sure you are on the *General* tab.
+   - At the bottom of the General tab, you may see a section that says *Security* with a message like *This file came from another computer and might be blocked to help protect this computer.* If this message is displayed, there will be an *Unblock* button or checkbox next to it.
+   - Check the *Unblock* checkbox or click the *Unblock* button, then click *Apply* and *OK* to save the changes.
 {%-   endif -%}
 {% else %}
 1. {% if page.lang == 'ru' -%}Распакуйте архив{% else %}Extract the archive{% endif %}:
@@ -44,5 +54,13 @@ Move the file `d8` to the directory listed in the `PATH` system environment vari
    ```bash
    d8 help
    ```
+
+{% if include.os == "Windows" %}
+1. {% if page.lang == 'ru' %}Включите автодополнение в PowerShell, выполнив следующую команду{% else %}Enable auto-completion in PowerShell by running the following command{% endif %}:
+
+   ```shell
+   d8 completion powershell >> $PROFILE
+   ```
+{% endif %}
 
 {% if page.lang == 'ru' -%}Готово, вы установили Deckhouse CLI.{% else %}Congrats, you have successfully installed Deckhouse CLI.{% endif %}

--- a/docs/documentation/_includes/d8-cli-install/main.liquid
+++ b/docs/documentation/_includes/d8-cli-install/main.liquid
@@ -1,0 +1,32 @@
+<a id='tab_installer_linux_x86-64' href="javascript:void(0)" class="tabs__btn tabs__btn_installer active"
+   onclick="openTabAndSaveStatus(event, 'tabs__btn_installer', 'tabs__content_installer', 'block_installer_linux_x86-64');" >
+  Linux x86-64
+</a>
+<a id='tab_installer_macos_x86-64' href="javascript:void(0)" class="tabs__btn tabs__btn_installer"
+   onclick="openTabAndSaveStatus(event, 'tabs__btn_installer', 'tabs__content_installer', 'block_installer_macos_x86-64');" >
+  macOS x86-64
+</a>
+<a id='tab_installer_macos_arm64' href="javascript:void(0)" class="tabs__btn tabs__btn_installer"
+   onclick="openTabAndSaveStatus(event, 'tabs__btn_installer', 'tabs__content_installer', 'block_installer_macos_arm64');" >
+  macOS ARM64
+</a>
+<a id='tab_installer_windows' href="javascript:void(0)" class="tabs__btn tabs__btn_installer"
+   onclick="openTabAndSaveStatus(event, 'tabs__btn_installer', 'tabs__content_installer', 'block_installer_windows');" >
+  Windows
+</a>
+
+<div id='block_installer_linux_x86-64' class="tabs__content tabs__content_installer active" markdown="1">
+  {%  include d8-cli-install/content.liquid os="Linux" arch="x86-64" %}
+</div>
+
+<div id='block_installer_macos_x86-64' class="tabs__content tabs__content_installer" markdown="1">
+  {%  include d8-cli-install/content.liquid os="macOS" arch="x86-64" %}
+</div>
+
+<div id='block_installer_macos_arm64' class="tabs__content tabs__content_installer" markdown="1">
+  {%  include d8-cli-install/content.liquid os="macOS" arch="ARM64" %}
+</div>
+
+<div id='block_installer_windows' class="tabs__content tabs__content_installer" markdown="1">
+  {%  include d8-cli-install/content.liquid os="Windows" arch="ARM64"%}
+</div>

--- a/docs/documentation/_includes/d8-cli-install/main.liquid
+++ b/docs/documentation/_includes/d8-cli-install/main.liquid
@@ -20,7 +20,7 @@
 </div>
 
 <div id='block_installer_macos_x86-64' class="tabs__content tabs__content_installer" markdown="1">
-  {%  include d8-cli-install/content.liquid os="macOS" arch="x86-64" %}
+  {%  include d8-cli-install/content.liquid os="macOS" arch="x86-64 " %}
 </div>
 
 <div id='block_installer_macos_arm64' class="tabs__content tabs__content_installer" markdown="1">

--- a/docs/documentation/pages/DECKHOUSE-CLI.md
+++ b/docs/documentation/pages/DECKHOUSE-CLI.md
@@ -33,33 +33,4 @@ On the command line, the utility can be invoked using the `d8` alias. All the co
 
 ## How do I install Deckhouse CLI?
 
-1. Download the archive for your OS/architecture:
-   * [Linux x86-64]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-linux-amd64.tar.gz)
-   * [macOS x86-64]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-darwin-amd64.tar.gz)
-   * [macOS ARM64]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-darwin-arm64.tar.gz)
-
-1. Extract the archive:
-
-   ```bash
-   tar -xvf "d8-v${RELEASE_VERSION}-${OS}-${ARCH}.tar.gz" "${OS}-${ARCH}/d8"
-   ```
-
-   > For example, for an archive named `d8-v0.1.2-linux-amd64.tar.gz`, the command would look as follows: `tar -xvf "d8-v0.1.2-linux-amd64.tar.gz" "linux-amd64/d8"`.
-
-1. Copy the `d8` file to a directory at the `PATH` variable on your system:
-
-   ```bash
-   sudo mv "${OS}-${ARCH}/d8" /usr/local/bin/
-   ```
-
-   > For example, for an extracted file named `linux-amd64/d8`, the command would look as follows: `sudo mv "linux-amd64/d8" /usr/local/bin/`.
-   >
-   > `PATH` is a system variable containing a list of directories with executable files. This is where the OS will look for the binary when a command is run in the terminal. You can view this list with the `echo $PATH` command.
-
-1. Check that the CLI is working:
-
-   ```bash
-   d8 help
-   ```
-
-Congrats, you have successfully installed Deckhouse CLI!
+{% include d8-cli-install/main.liquid %}

--- a/docs/documentation/pages/DECKHOUSE-CLI_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-CLI_RU.md
@@ -34,33 +34,4 @@ Deckhouse CLI — это интерфейс командной строки дл
 
 ## Как установить Deckhouse CLI?
 
-1. Скачайте архив для вашей ОС:
-   * [Linux x86-64]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-linux-amd64.tar.gz)
-   * [macOS x86-64]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-darwin-amd64.tar.gz)
-   * [macOS ARM64]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-darwin-arm64.tar.gz)
-
-1. Распакуйте архив:
-
-   ```bash
-   tar -xvf "d8-v${RELEASE_VERSION}-${OS}-${ARCH}.tar.gz" "${OS}-${ARCH}/d8"
-   ```
-
-   > Например, для архива с названием `d8-v0.1.2-linux-amd64.tar.gz` команда будет выглядеть так: `tar -xvf "d8-v0.1.2-linux-amd64.tar.gz" "linux-amd64/d8"`.
-
-1. Переместите файл `d8` в каталог в переменной `PATH` вашей системы:
-
-   ```bash
-   sudo mv "${OS}-${ARCH}/d8" /usr/local/bin/
-   ```
-
-   > Например, для распакованного файла `linux-amd64/d8` команда будет выглядеть так: `sudo mv "linux-amd64/d8" /usr/local/bin/`.
-   >
-   > `PATH` — это системная переменная, содержащая список каталогов, в которых ОС будет искать исполняемый файл при вызове команды из терминала. Просмотреть этот список можно командой `echo $PATH`.
-
-1. Проверьте, что утилита работает:
-
-   ```bash
-   d8 help
-   ```
-
-Готово, вы установили Deckhouse CLI.
+{% include d8-cli-install/main.liquid %}

--- a/docs/site/.werf/nginx.conf
+++ b/docs/site/.werf/nginx.conf
@@ -82,7 +82,7 @@ http {
             return 301 https://$host/documentation/v1/$1;
         }
 
-        location ~* ^/downloads/deckhouse-cli/v[0-9]+\.[0-9]+\.[0-9]+/d8-v[0-9]+\.[0-9]+\.[0-9]+-(darwin|linux)-(amd|arm)64.tar.gz$   {
+        location ~* ^/downloads/deckhouse-cli/v[0-9]+\.[0-9]+\.[0-9]+/d8-v[0-9]+\.[0-9]+\.[0-9]+-(darwin|linux|windows)-(amd|arm)64.tar.gz$   {
             rewrite ^/downloads/deckhouse-cli/([^/]+/[^/]+\.gz)$ /deckhouse/deckhouse-cli/releases/download/$1/  break;
 
             proxy_cache             dcache;

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "0.1.2" }}
+{{- $version := "0.2.0" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_SCRATCH }}


### PR DESCRIPTION
## Description

- Update the Deckhouse CLI version from `0.1.2` to `0.2.0`.
- Refactor Deckhouse CLI installation documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: registrypackages
type: chore
summary: Bump Deckhnouse CLI to `0.2.0`. Refactor the Deckhouse CLI installation page.
```
