### PR TITLE
[dhctl] add preflight checks for sudo access

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -28,6 +28,7 @@ var (
 	PreflightSkipRegistryCredentials       = false
 	PreflightSkipContainerdExistCheck      = false
 	PreflightSkipPythonChecks              = false
+	PreflightSkipSudoIsAllowedForUserCheck = false
 )
 
 const (
@@ -41,6 +42,7 @@ const (
 	RegistryCredentialsCheckArgName  = "preflight-skip-registry-credential"
 	ContainerdExistCheckArgName      = "preflight-skip-containerd-exist"
 	PythonChecksArgName              = "preflight-skip-python-checks"
+	SudoAllowedCheckArgName          = "preflight-skip-sudo-allowed"
 )
 
 func DefinePreflight(cmd *kingpin.CmdClause) {
@@ -77,4 +79,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(PythonChecksArgName, "Skip verifying python installation").
 		Envar(configEnvName("PREFLIGHT_SKIP_PYTHON_CHECKS")).
 		BoolVar(&PreflightSkipPythonChecks)
+	cmd.Flag(SudoAllowedCheckArgName, "Skip verifying sudo is allowed for user").
+		Envar(configEnvName("PREFLIGHT_SKIP_SUDO_ALLOWED_CHECK")).
+		BoolVar(&PreflightSkipSudoIsAllowedForUserCheck)
 }

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -87,6 +87,11 @@ func (pc *Checker) Static() error {
 			successMessage: "resolve the localhost domain",
 			skipFlag:       app.RegistryCredentialsCheckArgName,
 		},
+		{
+			fun:            pc.CheckSudoIsAllowedForUser,
+			successMessage: "sudo is allowed for user",
+			skipFlag:       app.SudoAllowedCheckArgName,
+		},
 	})
 }
 

--- a/dhctl/pkg/preflight/sudoers.go
+++ b/dhctl/pkg/preflight/sudoers.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+)
+
+func (pc *Checker) CheckSudoIsAllowedForUser() error {
+	if app.PreflightSkipSudoIsAllowedForUserCheck {
+		log.DebugLn("sudoers preflight check is skipped")
+		return nil
+	}
+
+	if app.AskBecomePass {
+		return callSudo(pc.sshClient, app.BecomePass)
+	}
+
+	return callSudo(pc.sshClient, "")
+
+}
+
+func callSudo(sshCl *ssh.Client, password string) error {
+	args := []string{"-Sv", "<<<", password}
+	if password == "" {
+		args = []string{"-n", "echo", "-n"}
+	}
+
+	err := sshCl.Command("sudo", args...).Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() != 255 {
+			return errors.New("Provided SSH user is not allowed to sudo, please check that your password is correct and that this user is in the sudoers file.")
+		}
+		return fmt.Errorf("Unexpected error when checking sudoers permissions for SSH user: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a preflight check to validate that bootstrapping user as able to run elevate priviliges using sudo

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We hit a case where root was not in sudoers file some time ago and it was not obvious what is wrong nad how to fix the problem


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No change in happy path, error message if user cannot use sudo due to lack of privileges or incorrect password

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: added a preflight check for sudo permissions
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
