### PR TITLE
[cilium] alert for orphan EgressGatewayPolicy

### DIFF
--- a/ee/modules/021-cni-cilium/.build.yaml
+++ b/ee/modules/021-cni-cilium/.build.yaml
@@ -2,3 +2,4 @@ crds/*
 hooks/*
 images/*
 templates/*
+monitoring/*

--- a/ee/modules/021-cni-cilium/hooks/ee/egressgatewaypolicies_discovery.go
+++ b/ee/modules/021-cni-cilium/hooks/ee/egressgatewaypolicies_discovery.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 12},
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 12}, // to run after egressgateways_discovery.go
 	Queue:        "/modules/cni-cilium/egress-policy-discovery",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{

--- a/ee/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
+++ b/ee/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
@@ -1,0 +1,18 @@
+- name: d8.cni-cilium.egressgatewaypolicies
+  rules:
+    - alert: CniCiliumOrphanEgressGatewayPolicyFound
+      expr: max by (name, egressgateway) (d8_cni_cilium_orphan_egress_gateway_policy == 1)
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: application
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__istio_irrelevant_external_services: ClusterHasCniCiliumOrphanEgressGatewayPolicies,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__istio_irrelevant_external_services: ClusterHasCniCiliumOrphanEgressGatewayPolicies,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        summary: Found orphan EgressGatewayPolicy with irrelevant EgressGateway name
+        description: |
+          There is orphan EgressGatewayPolicy in the cluster: with the name: `{{$labels.name}}` which has irrelevant EgressGateway name.
+
+          It is recommended to check EgressGateway name in EgressGatewayPolicy resource: egress gateway name: `{{$labels.egressgateway}}`

--- a/ee/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
+++ b/ee/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
@@ -15,4 +15,4 @@
         description: |
           There is orphan EgressGatewayPolicy in the cluster: with the name: `{{$labels.name}}` which has irrelevant EgressGateway name.
 
-          It is recommended to check EgressGateway name in EgressGatewayPolicy resource: egress gateway name: `{{$labels.egressgateway}}`
+          It is recommended to check EgressGateway name in EgressGatewayPolicy resource: `{{$labels.egressgateway}}`

--- a/ee/modules/021-cni-cilium/templates/monitoring.yaml
+++ b/ee/modules/021-cni-cilium/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-cni-cilium") }}

--- a/tools/build_includes/modules-EE.yaml
+++ b/tools/build_includes/modules-EE.yaml
@@ -94,6 +94,16 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
+  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
+  to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/025-static-routing-manager
   to: /deckhouse/modules/025-static-routing-manager
   stageDependencies:

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -94,6 +94,16 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
+  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
+  to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/025-static-routing-manager
   to: /deckhouse/modules/025-static-routing-manager
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-EE.yaml
+++ b/tools/build_includes/modules-with-dependencies-EE.yaml
@@ -436,6 +436,52 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
+  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
+  excludePaths:
+    - images
+    - templates
+    - charts
+    - crds
+    - docs
+    - monitoring
+    - openapi
+    - oss.yaml
+    - cloud-instance-manager
+    - values_matrix_test.yaml
+    - values.yaml
+    - .helmignore
+    - candi
+    - Chart.yaml
+    - .namespace
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
+  to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
+  excludePaths:
+    - images
+    - templates
+    - charts
+    - crds
+    - docs
+    - monitoring
+    - openapi
+    - oss.yaml
+    - cloud-instance-manager
+    - values_matrix_test.yaml
+    - values.yaml
+    - .helmignore
+    - candi
+    - Chart.yaml
+    - .namespace
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/025-static-routing-manager
   to: /deckhouse/modules/025-static-routing-manager
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -436,6 +436,52 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
+  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
+  excludePaths:
+    - images
+    - templates
+    - charts
+    - crds
+    - docs
+    - monitoring
+    - openapi
+    - oss.yaml
+    - cloud-instance-manager
+    - values_matrix_test.yaml
+    - values.yaml
+    - .helmignore
+    - candi
+    - Chart.yaml
+    - .namespace
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
+  to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
+  excludePaths:
+    - images
+    - templates
+    - charts
+    - crds
+    - docs
+    - monitoring
+    - openapi
+    - oss.yaml
+    - cloud-instance-manager
+    - values_matrix_test.yaml
+    - values.yaml
+    - .helmignore
+    - candi
+    - Chart.yaml
+    - .namespace
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/025-static-routing-manager
   to: /deckhouse/modules/025-static-routing-manager
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -233,6 +233,32 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
+  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - hooks/*.go
+    - hack
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
+- add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
+  to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - hooks/*.go
+    - hack
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/025-static-routing-manager
   to: /deckhouse/modules/025-static-routing-manager
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -233,6 +233,32 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
+  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - hooks/*.go
+    - hack
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
+- add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
+  to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - hooks/*.go
+    - hack
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/025-static-routing-manager
   to: /deckhouse/modules/025-static-routing-manager
   excludePaths:


### PR DESCRIPTION
## Description
Add alert for orphan EgressGatewayPolicy resources with irrelevant EgressGateway fields.

## Why do we need it, and what problem does it solve?
The alert will help the client quickly respond to a situation where the EgressGatewayPolicy is misconfigured.

## Why do we need it in the patch release (if we do)?
This is an important patch that will help improve the client experience.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: Alert for orphan EgressGatewayPolicy.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
