### PR TITLE
[docs][deckhouse-cli] Fix URLs on the Deckhouse CLI installation page.

### DIFF
--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -2,10 +2,11 @@
 1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
 ({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz).
 {% else %}
-1. {% if page.lang == 'ru' %}Скачайте архив для {{ include.os }} {{ include.arch }}{% else %}Download the archive for {{ include.os }} {{ include.arch }}{% endif %}:
+1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
+({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz):
 
    ```shell
-   curl -LO {%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
+   curl -LO {{ site.urls[page.lang] }}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
    ```
 {% endif %}
 

--- a/docs/documentation/_includes/d8-cli-install/main.liquid
+++ b/docs/documentation/_includes/d8-cli-install/main.liquid
@@ -28,5 +28,5 @@
 </div>
 
 <div id='block_installer_windows' class="tabs__content tabs__content_installer" markdown="1">
-  {%  include d8-cli-install/content.liquid os="Windows" arch="ARM64"%}
+  {%  include d8-cli-install/content.liquid os="Windows" arch="x86-64"%}
 </div>


### PR DESCRIPTION
## Description
Fix URLs on the Deckhouse CLI installation page.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix URLs on the Deckhouse CLI installation page.
impact_level: low
```
