### PR TITLE
[e2e] fix path terraform binary for eks

### DIFF
--- a/testing/cloud_layouts/EKS/WithoutNAT/infra.tf.tpl
+++ b/testing/cloud_layouts/EKS/WithoutNAT/infra.tf.tpl
@@ -13,7 +13,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.4.3"
+      version = "~> 3.6.2"
     }
 
     tls = {

--- a/testing/cloud_layouts/EKS/WithoutNAT/infra.tf.tpl
+++ b/testing/cloud_layouts/EKS/WithoutNAT/infra.tf.tpl
@@ -13,7 +13,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6.2"
+      version = "~> 3.4.3"
     }
 
     tls = {

--- a/testing/cloud_layouts/EKS/WithoutNAT/infra.tf.tpl
+++ b/testing/cloud_layouts/EKS/WithoutNAT/infra.tf.tpl
@@ -7,8 +7,8 @@ variable "region" {
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.47.0"
+      source = "hashicorp/aws"
+      version = "4.50.0"
     }
 
     random = {
@@ -27,7 +27,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.3"
+  required_version = ">= 0.13"
 }
 
 provider "aws" {

--- a/testing/cloud_layouts/script_eks.sh
+++ b/testing/cloud_layouts/script_eks.sh
@@ -108,8 +108,8 @@ function bootstrap_eks() {
   >&2 echo "Run terraform to create nodes for EKS cluster ..."
 #  pushd "$cwd"
   cd $cwd
-  terraform init -input=false -plugin-dir=/usr/local/share/terraform/plugins || return $?
-  terraform apply -state="${terraform_state_file}" -auto-approve -no-color | tee "$cwd/terraform.log" || return $?
+  /image/bin/terraform init -input=false -plugin-dir=/usr/local/share/terraform/plugins || return $?
+  /image/bin/terraform apply -state="${terraform_state_file}" -auto-approve -no-color | tee "$cwd/terraform.log" || return $?
 #  popd
 
   if ! cluster_endpoint="$(tail -n5 "$cwd/terraform.log" | grep "cluster_endpoint" | cut -d "=" -f2 | tr -d " \"")" ; then
@@ -255,8 +255,8 @@ function destroy_eks_infra() {
 
 #  pushd "$cwd"
   cd $cwd
-  terraform init -input=false -plugin-dir=/plugins || return $?
-  terraform destroy -state="${terraform_state_file}" -auto-approve -no-color | tee "$cwd/terraform.log" || return $?
+  /image/bin/terraform init -input=false -plugin-dir=/usr/local/share/terraform/plugins || return $?
+  /image/bin/terraform destroy -state="${terraform_state_file}" -auto-approve -no-color | tee "$cwd/terraform.log" || return $?
 #  popd
 
   return $exitCode

--- a/werf.yaml
+++ b/werf.yaml
@@ -1127,13 +1127,13 @@ shell:
   - |
     mkdir /terraform
     mkdir -p /usr/local/share/terraform/plugins
-    cat << EOD > /root/.terraformrc
-    provider_installation {
-      filesystem_mirror {
-        path    = "/usr/local/share/terraform/plugins"
-        include = ["*/*/*"]
-      }
-    }
-    EOD
+    # cat << EOD > /root/.terraformrc
+    # provider_installation {
+    #   filesystem_mirror {
+    #     path    = "/usr/local/share/terraform/plugins"
+    #     include = ["*/*/*"]
+    #   }
+    # }
+    # EOD
     touch /terraform.log
     chmod 755 /terraform.log

--- a/werf.yaml
+++ b/werf.yaml
@@ -1121,15 +1121,19 @@ import:
   {{- end }}
   - artifact: e2e-eks-terraform-plugins
     add: /terraform-provider-random
-    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/ramdom/3.6.2/linux_amd64/terraform-provider-random_v3.6.2_x5
+    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/random/3.6.2/linux_amd64/terraform-provider-random_v3.6.2_x5
     before: setup
   - artifact: e2e-eks-terraform-plugins
     add: /terraform-provider-tls
-    to: /usr/local/share/terraform/plugins/registry.terraform.io//hashicorp/tls/4.0.5/linux_amd64/terraform-provider-tls_v4.0.5_x5
+    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/tls/4.0.5/linux_amd64/terraform-provider-tls_v4.0.5_x5
     before: setup
   - artifact: e2e-eks-terraform-plugins
     add: /terraform-provider-cloudinit
-    to: /usr/local/share/terraform/plugins/registry.terraform.io//hashicorp/cloudinit/2.2.0/linux_amd64/terraform-provider-cloudinit_v2.2.0_x5
+    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/cloudinit/2.2.0/linux_amd64/terraform-provider-cloudinit_v2.2.0_x5
+    before: setup
+  - artifact: e2e-eks-terraform-plugins
+    add: /terraform-provider-kubernetes
+    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/kubernetes/2.31.0/linux_amd64/terraform-provider-kubernetes_v2.31.0_x5
     before: setup
 shell:
   beforeInstall:
@@ -1167,8 +1171,12 @@ shell:
     - git clone --depth 1 --branch v2.2.0 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-cloudinit.git /src-provider-cloudinit
     - cd /src-provider-cloudinit
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - git clone --depth 1 --branch v2.31.0 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-kubernetes.git /src-provider-kubernetes
+    - cd /src-provider-kubernetes
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
     - mv /src-provider-random/terraform-provider-random /terraform-provider-random 
     - mv /src-provider-tls/terraform-provider-tls /terraform-provider-tls 
     - mv /src-provider-cloudinit/terraform-provider-cloudinit /terraform-provider-cloudinit
+    - mv /src-provider-kubernetes/terraform-provider-kubernetes /terraform-provider-kubernetes
     - chmod 755 /terraform-provider-*
     - chown 64535:64535 /terraform-provider-*

--- a/werf.yaml
+++ b/werf.yaml
@@ -1121,7 +1121,7 @@ import:
   {{- end }}
   - artifact: e2e-eks-terraform-plugins
     add: /terraform-provider-random
-    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/random/3.6.2/linux_amd64/terraform-provider-random_v3.6.2_x5
+    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/random/3.4.3/linux_amd64/terraform-provider-random_v3.4.3_x5
     before: setup
   - artifact: e2e-eks-terraform-plugins
     add: /terraform-provider-tls

--- a/werf.yaml
+++ b/werf.yaml
@@ -1167,7 +1167,6 @@ shell:
     - git clone --depth 1 --branch v2.2.0 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-cloudinit.git /src-provider-cloudinit
     - cd /src-provider-cloudinit
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
-    - chown 64535:64535 /terraform-provider-aws
     - mv /src-provider-random/terraform-provider-random /terraform-provider-random 
     - mv /src-provider-tls/terraform-provider-tls /terraform-provider-tls 
     - mv /src-provider-cloudinit/terraform-provider-cloudinit /terraform-provider-cloudinit

--- a/werf.yaml
+++ b/werf.yaml
@@ -1119,6 +1119,18 @@ import:
       {{- break -}}
     {{- end }}
   {{- end }}
+  - artifact: e2e-eks-terraform-plugins
+    add: /terraform-provider-random
+    to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/ramdom/3.6.2/linux_amd64/terraform-provider-random_v3.6.2_x5
+    before: setup
+  - artifact: e2e-eks-terraform-plugins
+    add: /terraform-provider-tls
+    to: /usr/local/share/terraform/plugins/registry.terraform.io//hashicorp/tls/4.0.5/linux_amd64/terraform-provider-tls_v4.0.5_x5
+    before: setup
+  - artifact: e2e-eks-terraform-plugins
+    add: /terraform-provider-cloudinit
+    to: /usr/local/share/terraform/plugins/registry.terraform.io//hashicorp/cloudinit/2.2.0/linux_amd64/terraform-provider-cloudinit_v2.2.0_x5
+    before: setup
 shell:
   beforeInstall:
   - apt-get update
@@ -1127,13 +1139,37 @@ shell:
   - |
     mkdir /terraform
     mkdir -p /usr/local/share/terraform/plugins
-    # cat << EOD > /root/.terraformrc
-    # provider_installation {
-    #   filesystem_mirror {
-    #     path    = "/usr/local/share/terraform/plugins"
-    #     include = ["*/*/*"]
-    #   }
-    # }
-    # EOD
+    cat << EOD > /root/.terraformrc
+    provider_installation {
+      filesystem_mirror {
+        path    = "/usr/local/share/terraform/plugins"
+        include = ["*/*/*"]
+      }
+    }
+    EOD
     touch /terraform.log
     chmod 755 /terraform.log
+---
+artifact: e2e-eks-terraform-plugins
+from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
+mount:
+  - fromPath: ~/go-pkg-cache
+    to: /go/pkg
+shell:
+  install:
+    - export GOPROXY={{ $.GOPROXY }}
+    - git clone --depth 1 --branch v3.4.3 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-random.git /src-provider-random
+    - cd /src-provider-random
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - git clone --depth 1 --branch v4.0.4 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-tls.git /src-provider-tls
+    - cd /src-provider-tls
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - git clone --depth 1 --branch v2.2.0 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-cloudinit.git /src-provider-cloudinit
+    - cd /src-provider-cloudinit
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - chown 64535:64535 /terraform-provider-aws
+    - mv /src-provider-random/terraform-provider-random /terraform-provider-random 
+    - mv /src-provider-tls/terraform-provider-tls /terraform-provider-tls 
+    - mv /src-provider-cloudinit/terraform-provider-cloudinit /terraform-provider-cloudinit
+    - chmod 755 /terraform-provider-*
+    - chown 64535:64535 /terraform-provider-*


### PR DESCRIPTION
## Description

Fix path terraform binary for e2e eks.

## Why do we need it, and what problem does it solve?

Success run e2e eks.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: e2e
type: fix
summary: Fix path for e2e eks.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
