### PR TITLE
[cilium] fix trouble with empty excludedCIDRs in EgressGatewayPolicy

### DIFF
--- a/ee/modules/021-cni-cilium/hooks/ee/egressgatewaypolicies_discovery.go
+++ b/ee/modules/021-cni-cilium/hooks/ee/egressgatewaypolicies_discovery.go
@@ -34,12 +34,17 @@ func applyEgressGatewayPolicyFilter(obj *unstructured.Unstructured) (go_hook.Fil
 		return nil, err
 	}
 
+	excludeCIDRs := []string{}
+	if len(egp.Spec.ExcludedCIDRs) > 0 {
+		excludeCIDRs = egp.Spec.ExcludedCIDRs
+	}
+
 	return EgressGatewayPolicyInfo{
 		Name:              egp.Name,
 		EgressGatewayName: egp.Spec.EgressGatewayName,
 		Selectors:         egp.Spec.Selectors,
 		DestinationCIDRs:  egp.Spec.DestinationCIDRs,
-		ExcludedCIDRs:     egp.Spec.ExcludedCIDRs,
+		ExcludedCIDRs:     excludeCIDRs,
 	}, err
 }
 

--- a/ee/modules/021-cni-cilium/hooks/ee/egressgatewaypolicies_discovery_test.go
+++ b/ee/modules/021-cni-cilium/hooks/ee/egressgatewaypolicies_discovery_test.go
@@ -111,5 +111,83 @@ spec:
 `))
 			})
 		})
+
+		Context("Adding EgressGatewayPolicies without excludedCIDRs", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: network.deckhouse.io/v1alpha1
+kind: EgressGatewayPolicy
+metadata:
+  name: egp-dev
+spec:
+  selectors:
+  - podSelector:
+      matchLabels:
+        role: worker
+  destinationCIDRs:
+  - "192.168.0.0/16"
+  egressGatewayName: egfg-dev
+---
+apiVersion: network.deckhouse.io/v1alpha1
+kind: EgressGatewayPolicy
+metadata:
+  name: egp-prod
+spec:
+  selectors:
+  - podSelector:
+      matchLabels:
+        role: master
+  destinationCIDRs:
+  - "172.16.0.0/16"
+  egressGatewayName: egfg-prod
+`))
+				f.RunHook()
+			})
+
+			It("EgressGatewayPolicies must be present in internal values", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+				Expect(f.ValuesGet("cniCilium.internal.egressGatewayPolicies").String()).To(MatchJSON(`
+[
+	{
+		"name": "egp-dev",
+		"egressGatewayName": "egfg-dev",
+		"selectors": [
+                {
+                  "podSelector": {
+                    "matchLabels": {
+                      "role": "worker"
+                    }
+                  }
+                }
+		],
+		"destinationCIDRs": [
+			"192.168.0.0/16"
+		],
+		"excludedCIDRs": []
+	},
+	{
+		"name": "egp-prod",
+		"egressGatewayName": "egfg-prod",
+		"selectors": [
+                {
+                  "podSelector":{
+                    "matchLabels": {
+                      "role": "master"
+                    }
+                  }
+                }
+		],
+		"destinationCIDRs": [
+			"172.16.0.0/16"
+		],
+		"excludedCIDRs": []
+	}
+]
+`))
+			})
+		})
 	})
 })

--- a/modules/021-cni-cilium/docs/EXAMPLES.md
+++ b/modules/021-cni-cilium/docs/EXAMPLES.md
@@ -79,5 +79,5 @@ spec:
   - podSelector:
       matchLabels:
         app: backend
-        io.kubernetes.pod.namespace: myns
+        io.kubernetes.pod.namespace: my-ns
 ```

--- a/modules/021-cni-cilium/docs/EXAMPLES_RU.md
+++ b/modules/021-cni-cilium/docs/EXAMPLES_RU.md
@@ -70,7 +70,7 @@ spec:
 apiVersion: network.deckhouse.io/v1alpha1
 kind: EgressGatewayPolicy
 metadata:
-  name: 
+  name: my-egressgw-policy
 spec:
   destinationCIDRs:
   - 0.0.0.0/0

--- a/modules/021-cni-cilium/docs/EXAMPLES_RU.md
+++ b/modules/021-cni-cilium/docs/EXAMPLES_RU.md
@@ -74,10 +74,10 @@ metadata:
 spec:
   destinationCIDRs:
   - 0.0.0.0/0
-  egressGatewayName: myegressgw
+  egressGatewayName: my-egressgw
   selectors:
   - podSelector:
       matchLabels:
         app: backend
-        io.kubernetes.pod.namespace: myns
+        io.kubernetes.pod.namespace: my-ns
 ```


### PR DESCRIPTION
## Description
* Fix trouble with empty excludedCIDRs in EgressGatewayPolicy
* Fix EgressGatewayPolicy example in documentation

## Why do we need it, and what problem does it solve?
If the _EgressGatewayPolicy_ resource is created with an empty `excludedCIDRs` field, the DH logs will contain an error:
```
ModuleRun:main:cni-cilium:Kubernetes-Change-ModuleValues:failures 6:2 errors occurred:
        * cannot apply values patch for module values
        * cniCilium.internal.egressGatewayPolicies.excludedCIDRs must be of type array: "null"
```

## Why do we need it in the patch release (if we do)?
Fix as soon as posible

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cilium
type: fix
summary: Fix trouble with empty `excludedCIDRs` field in `EgressGatewayPolicy`.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
