### PR TITLE
[user-authn] improve dex permissions

### DIFF
--- a/modules/150-user-authn/templates/dex/rbac-for-us.yaml
+++ b/modules/150-user-authn/templates/dex/rbac-for-us.yaml
@@ -14,10 +14,34 @@ metadata:
 rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
-  verbs: ["*"]
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups: ["dex.coreos.com"]
-  resources: ["*"]
-  verbs: ["*"]
+  resources:
+  - authcodes
+  - authrequests 
+  - connectors   
+  - devicerequests
+  - devicetokens
+  - oauth2clients
+  - offlinesessionses
+  - passwords
+  - refreshtokens
+  - signingkeies
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -50,7 +74,14 @@ rules:
   - passwords
   - refreshtokens
   - signingkeies
-  verbs: ["*"]
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -67,10 +67,6 @@ var skipCheckWildcards = map[string][]string{
 	"istio/templates/operator/rbac-for-us.yaml": {
 		"d8:istio:operator",
 	},
-	"user-authn/templates/dex/rbac-for-us.yaml": {
-		"d8:user-authn:dex:crd",
-		"dex",
-	},
 	"operator-prometheus/templates/rbac-for-us.yaml": {
 		"d8:operator-prometheus",
 	},


### PR DESCRIPTION
## Description

Replace wildcards to specific resources in dex

## Why do we need it, and what problem does it solve?

Setting a wildcard for Role/ClusterRole is potentially dangerous. We have to review them and replace with specific resources.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: chore
summary: improve dex rbac permissions
impact_level: low
```
