### PR TITLE
[global] improve documentation permissions

### DIFF
--- a/modules/810-documentation/templates/rbac-for-us.yaml
+++ b/modules/810-documentation/templates/rbac-for-us.yaml
@@ -15,7 +15,14 @@ metadata:
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["*"]
+    verbs:
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -96,9 +96,6 @@ var skipCheckWildcards = map[string][]string{
 	"upmeter/templates/upmeter/rbac-for-us.yaml": {
 		"d8:upmeter:upmeter",
 	},
-	"documentation/templates/rbac-for-us.yaml": {
-		"documentation:leases-edit",
-	},
 	"delivery/templates/argocd/application-controller/rbac-for-us.yaml": {
 		"d8:delivery:argocd:application-controller",
 	},


### PR DESCRIPTION
## Description

Replace wildcards to specific resources in dex

## Why do we need it, and what problem does it solve?

Setting a wildcard for Role/ClusterRole is potentially dangerous. We have to review them and replace with specific resources.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Improve documentation rbac permissions.
impact_level: low
```
