### PR TITLE
[candi] fix aws identity ebs device

### DIFF
--- a/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
@@ -24,9 +24,13 @@ fi
 volume_names="$(find /dev | grep -i 'nvme[0-21]n1$' || true)"
 for volume in ${volume_names}
 do
- symlink="$(nvme id-ctrl -v "${volume}" | ( grep '^0000:' || true ) | sed -E 's/.*"(\/dev\/)?([a-z0-9]+)\.+"$/\/dev\/\2/')"
- if [ ! -z "${symlink}" ] && [ ! -e "${symlink}" ]; then
-  ln -s "${volume}" "${symlink}"
- fi
+  symlink="$(nvme id-ctrl -v "${volume}" | ( grep '^0000:' || true ) | sed -E 's/.*"(\/dev\/)?([a-z0-9]+)\.+"$/\/dev\/\2/')"
+  if [ -z "${symlink}" ]; then
+    symlink="$(nvme id-ctrl  --output binary "${volume}" | tr -d '\0' |grep -aoP '/dev/.*')"
+  fi
+  
+  if [ ! -z "${symlink}" ] && [ ! -e "${symlink}" ]; then
+    ln -s "${volume}" "${symlink}"
+  fi
 done
 {{- end }}

--- a/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
@@ -26,7 +26,7 @@ for volume in ${volume_names}
 do
   symlink="$(nvme id-ctrl -v "${volume}" | ( grep '^0000:' || true ) | sed -E 's/.*"(\/dev\/)?([a-z0-9]+)\.+"$/\/dev\/\2/')"
   if [ -z "${symlink}" ]; then
-    symlink="$(nvme id-ctrl  --output binary "${volume}" | tr -d '\0' |grep -aoP '/dev/.*')"
+    symlink="$(nvme id-ctrl  --output binary "${volume}" | tr -d '\0' |grep -aoP '/dev/\S*')"
   fi
   
   if [ ! -z "${symlink}" ] && [ ! -e "${symlink}" ]; then

--- a/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
@@ -23,7 +23,7 @@ fi
 
 volume_names="$(find /dev | grep -i 'nvme[0-21]n1$' || true)"
 
-if [ ! -z "${volume_names}" ]
+if [ ! -z "${volume_names}" ]; then
   bb-rp-install "ebsnvme-id:{{ .images.registrypackages.amazonEc2Utils220 }}"
 fi
 

--- a/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/node-group/001_create_nvme_ebs_aliases.sh.tpl
@@ -24,7 +24,7 @@ fi
 volume_names="$(find /dev | grep -i 'nvme[0-21]n1$' || true)"
 
 if [ ! -z "${volume_names}" ]; then
-  bb-rp-install "ebsnvme-id:{{ .images.registrypackages.amazonEc2Utils220 }}"
+  bb-package-install "ebsnvme-id:{{ .images.registrypackages.amazonEc2Utils220 }}"
 fi
 
 for volume in ${volume_names}

--- a/modules/007-registrypackages/images/amazon-ec2-utils/scripts/install
+++ b/modules/007-registrypackages/images/amazon-ec2-utils/scripts/install
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+mkdir -p /opt/deckhouse/bin
+cp -f ebsnvme-id /opt/deckhouse/bin

--- a/modules/007-registrypackages/images/amazon-ec2-utils/scripts/uninstall
+++ b/modules/007-registrypackages/images/amazon-ec2-utils/scripts/uninstall
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+rm -f /opt/deckhouse/bin/ebsnvme-id

--- a/modules/007-registrypackages/images/amazon-ec2-utils/werf.inc.yaml
+++ b/modules/007-registrypackages/images/amazon-ec2-utils/werf.inc.yaml
@@ -1,0 +1,33 @@
+{{- $version := "2.2.0" }}
+{{- $image_version := $version | replace "." "-" }}
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+from: {{ $.Images.BASE_SCRATCH }}
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+  add: /
+  to: /
+  includePaths:
+  - ebsnvme-id
+  - install
+  - uninstall
+  before: setup
+docker:
+  LABEL:
+    distro: all
+    version: all
+    growpart: {{ $version }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+from: {{ $.Images.BASE_ALPINE_DEV }}
+git:
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+    to: /
+    stageDependencies:
+      setup:
+      - '**/*'
+shell:
+  setup:
+    - git clone -b v{{ $version }} --depth 1 {{ $.SOURCE_REPO }}/amazonlinux/amazon-ec2-utils.git  /src
+    - mv /src/ebsnvme-id /ebsnvme-id
+    - chmod +x /ebsnvme-id /install /uninstall

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -368,6 +368,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"registryPackagesProxy": "imageHash-registryPackagesProxy-registryPackagesProxy",
 	},
 	"registrypackages": map[string]interface{}{
+		"amazonEc2Utils220":        "imageHash-registrypackages-amazonEc2Utils220",
 		"containerd1713":           "imageHash-registrypackages-containerd1713",
 		"crictl126":                "imageHash-registrypackages-crictl126",
 		"crictl127":                "imageHash-registrypackages-crictl127",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix aws identity ebs device in step `001_create_nvme_ebs_aliases.sh`.

## Why do we need it, and what problem does it solve?

Sometime (e.g. centos 9 stream), step 001_create_nvme_ebs_aliases.sh may fail to determine the EBS device name:
```
[root@9838403433-1-con-1-26-master-0 ~]# nvme id-ctrl -v /dev/nvme1n1 | grep ^0000:
[root@9838403433-1-con-1-26-master-0 ~]#
```
In such cases we can try to get ebs device name as follows:
```
[root@9838403433-1-con-1-26-master-0 ~]# /opt/deckhouse/bin/ebsnvme-id /dev/nvme1n1
Volume ID: vol-0e33e15c451c2c12d
/dev/xvdf
```

## What is the expected result?

Correct identification of EBS device.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix AWS identity EBS device.
impact: low
```
