### PR TITLE
[testing] Add linter for checking if service target port is symbolic

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/service.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - port: 443
       protocol: TCP
-      targetPort: 4201
+      targetPort: webhook-server
   selector:
     app: "capcd-controller-manager"

--- a/ee/modules/500-operator-trivy/templates/trivy-server.yaml
+++ b/ee/modules/500-operator-trivy/templates/trivy-server.yaml
@@ -45,7 +45,7 @@ spec:
     - name: trivy-http
       protocol: TCP
       port: 4954
-      targetPort: 4954
+      targetPort: trivy-http
   sessionAffinity: ClientIP
 
 ---

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -149,6 +149,9 @@ spec:
         - name: DEBUG
           value: "true"
         {{- end }}
+        ports:
+        - name: webhook
+          containerPort: 9680
         livenessProbe:
           httpGet:
             path: /sidekick/ping

--- a/ee/modules/650-runtime-audit-engine/templates/webhook-service.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/webhook-service.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - name: webhook
       port: 443
-      targetPort: 9680
+      targetPort: webhook
       protocol: TCP
   selector:
     app: {{ $.Chart.Name }}

--- a/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-application-controller-statefulset.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-application-controller-statefulset.yaml
@@ -194,6 +194,7 @@ spec:
           name: argocd-application-controller
           ports:
             - containerPort: 8082
+              name: metrics-port
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-application-controller-statefulset.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-application-controller-statefulset.yaml
@@ -194,7 +194,7 @@ spec:
           name: argocd-application-controller
           ports:
             - containerPort: 8082
-              name: metrics-port
+              name: metrics
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 8082
       protocol: TCP
-      targetPort: 8082
+      targetPort: metrics-port
   selector:
     app.kubernetes.io/name: argocd-application-controller

--- a/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/application-controller/argocd-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 8082
       protocol: TCP
-      targetPort: metrics-port
+      targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-application-controller

--- a/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           image: {{ include "helm_lib_module_image" (list . "argocd") }}
           imagePullPolicy: IfNotPresent
           ports:
-          - name: notifications
+          - name: metrics
             containerPort: 9001
           livenessProbe:
             tcpSocket:

--- a/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           image: {{ include "helm_lib_module_image" (list . "argocd") }}
           imagePullPolicy: IfNotPresent
           ports:
-          - name: argocd-notifications-port
+          - name: notifications
             containerPort: 9001
           livenessProbe:
             tcpSocket:

--- a/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-deployment.yaml
@@ -71,6 +71,9 @@ spec:
             - argocd-notifications
           image: {{ include "helm_lib_module_image" (list . "argocd") }}
           imagePullPolicy: IfNotPresent
+          ports:
+          - name: argocd-notifications-port
+            containerPort: 9001
           livenessProbe:
             tcpSocket:
               port: 9001

--- a/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 9001
       protocol: TCP
-      targetPort: argocd-notifications-port
+      targetPort: notifications
   selector:
     app.kubernetes.io/name: argocd-notifications-controller

--- a/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 9001
       protocol: TCP
-      targetPort: 9001
+      targetPort: argocd-notifications-port
   selector:
     app.kubernetes.io/name: argocd-notifications-controller

--- a/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/notifications-controller/argocd-notifications-controller-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 9001
       protocol: TCP
-      targetPort: notifications
+      targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-notifications-controller

--- a/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
-              name: redis-port
+              name: redis
           resources:
             requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-deployment.yaml
@@ -73,6 +73,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              name: redis-port
           resources:
             requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
     - name: tcp-redis
       port: 6379
-      targetPort: 6379
+      targetPort: redis-port
   selector:
     app.kubernetes.io/name: argocd-redis

--- a/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/redis/argocd-redis-service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
     - name: tcp-redis
       port: 6379
-      targetPort: redis-port
+      targetPort: redis
   selector:
     app.kubernetes.io/name: argocd-redis

--- a/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
@@ -231,7 +231,9 @@ spec:
           name: argocd-repo-server
           ports:
             - containerPort: 8081
+              name: server-port
             - containerPort: 8084
+              name: metrics-port
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
@@ -231,9 +231,9 @@ spec:
           name: argocd-repo-server
           ports:
             - containerPort: 8081
-              name: server-port
+              name: server
             - containerPort: 8084
-              name: metrics-port
+              name: metrics
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
@@ -9,10 +9,10 @@ spec:
     - name: server
       port: 8081
       protocol: TCP
-      targetPort: 8081
+      targetPort: server-port
     - name: metrics
       port: 8084
       protocol: TCP
-      targetPort: 8084
+      targetPort: metrics-port
   selector:
     app.kubernetes.io/name: argocd-repo-server

--- a/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
@@ -9,10 +9,10 @@ spec:
     - name: server
       port: 8081
       protocol: TCP
-      targetPort: server-port
+      targetPort: server
     - name: metrics
       port: 8084
       protocol: TCP
-      targetPort: metrics-port
+      targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-repo-server

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-deployment.yaml
@@ -267,9 +267,9 @@ spec:
           name: argocd-server
           ports:
             - containerPort: 8080
-              name: argocd-server-port
+              name: server
             - containerPort: 8083
-              name: argocd-metrics-port
+              name: metrics
           resources:
             requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-deployment.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-deployment.yaml
@@ -267,7 +267,9 @@ spec:
           name: argocd-server
           ports:
             - containerPort: 8080
+              name: argocd-server-port
             - containerPort: 8083
+              name: argocd-metrics-port
           resources:
             requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 8083
       protocol: TCP
-      targetPort: argocd-metrics-port
+      targetPort: metrics
   selector:
     app.kubernetes.io/name: argocd-server

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-metrics-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-metrics-service.yaml
@@ -9,6 +9,6 @@ spec:
     - name: metrics
       port: 8083
       protocol: TCP
-      targetPort: 8083
+      targetPort: argocd-metrics-port
   selector:
     app.kubernetes.io/name: argocd-server

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
@@ -9,10 +9,10 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: argocd-server-port
+      targetPort: server
     - name: https
       port: 443
       protocol: TCP
-      targetPort: argocd-server-port
+      targetPort: server
   selector:
     app.kubernetes.io/name: argocd-server

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
@@ -9,10 +9,10 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8080
+      targetPort: argocd-server-port
     - name: https
       port: 443
       protocol: TCP
-      targetPort: 8080
+      targetPort: argocd-server-port
   selector:
     app.kubernetes.io/name: argocd-server

--- a/modules/002-deckhouse/templates/deckhouse-leader-service.yaml
+++ b/modules/002-deckhouse/templates/deckhouse-leader-service.yaml
@@ -13,9 +13,9 @@ spec:
   ports:
     - name: self
       port: 8080
-      targetPort: 9650
+      targetPort: self
       protocol: TCP
     - name: webhook
-      port: 9651
-      targetPort: 9651
+      port: 4223
+      targetPort: webhook
       protocol: TCP

--- a/modules/002-deckhouse/templates/service.yaml
+++ b/modules/002-deckhouse/templates/service.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
     - name: self
       port: 8080
-      targetPort: 4222
+      targetPort: self
       protocol: TCP
     - name: webhook
       port: 4223
-      targetPort: 4223
+      targetPort: webhook
       protocol: TCP

--- a/modules/002-deckhouse/templates/webhook-handler/service.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/service.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - name: validating-webhook
       port: 443
-      targetPort: 9680
+      targetPort: validating-http
       protocol: TCP
   selector:
     app: webhook-handler
@@ -24,7 +24,7 @@ spec:
   ports:
     - name: conversion-webhook
       port: 443
-      targetPort: 9681
+      targetPort: conversion-http
       protocol: TCP
   selector:
     app: webhook-handler

--- a/modules/040-node-manager/templates/bashible-apiserver/service.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 4221
+    targetPort: https
   selector:
     app: "bashible-apiserver"

--- a/modules/042-kube-dns/templates/service.yaml
+++ b/modules/042-kube-dns/templates/service.yaml
@@ -13,11 +13,11 @@ spec:
   ports:
   - name: dns
     port: 53
-    targetPort: 5353
+    targetPort: dns
     protocol: UDP
   - name: dns-tcp
     port: 53
-    targetPort: 5353
+    targetPort: dns-tcp
     protocol: TCP
 ---
 apiVersion: v1
@@ -33,11 +33,11 @@ spec:
   ports:
   - name: dns
     port: 53
-    targetPort: 5353
+    targetPort: dns
     protocol: UDP
   - name: dns-tcp
     port: 53
-    targetPort: 5353
+    targetPort: dns-tcp
     protocol: TCP
 ---
 apiVersion: v1

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
@@ -77,7 +77,8 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "snapshotValidationWebhook") }}
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 4443
+        - name: tcp-webhook
+          containerPort: 4443
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "snapshotValidationWebhook") }}
         imagePullPolicy: IfNotPresent
         ports:
-        - name: tcp-webhook
+        - name: webhook
           containerPort: 4443
         resources:
           requests:

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/service.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/service.yaml
@@ -10,4 +10,4 @@ spec:
   ports:
     - protocol: TCP
       port: 4443
-      targetPort: 4443
+      targetPort: tcp-webhook

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/service.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/service.yaml
@@ -10,4 +10,4 @@ spec:
   ports:
     - protocol: TCP
       port: 4443
-      targetPort: tcp-webhook
+      targetPort: webhook

--- a/modules/101-cert-manager/templates/webhook/deployment.yaml
+++ b/modules/101-cert-manager/templates/webhook/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         - --secure-port=6443
         - --tls-cert-file=/certs/tls.crt
         - --tls-private-key-file=/certs/tls.key
+        ports:
+        - name: webhook
+          containerPort: 6443
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/modules/101-cert-manager/templates/webhook/service.yaml
+++ b/modules/101-cert-manager/templates/webhook/service.yaml
@@ -10,6 +10,6 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 6443
+    targetPort: webhook
   selector:
     app: webhook

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -64,21 +64,21 @@ spec:
         - "-config"
         - "/kiali-configuration/config.yaml"
         ports:
-        - name: api-port
+        - name: api
           containerPort: 20001
         - name: http-metrics
           containerPort: 9090
         readinessProbe:
           httpGet:
             path: /kiali/healthz
-            port: api-port
+            port: api
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
         livenessProbe:
           httpGet:
             path: /kiali/healthz
-            port: api-port
+            port: api
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/modules/110-istio/templates/kiali/service.yaml
+++ b/modules/110-istio/templates/kiali/service.yaml
@@ -10,8 +10,10 @@ spec:
   - name: http
     protocol: TCP
     port: 20001
+    targetPort: api-port
   - name: http-metrics
     protocol: TCP
     port: 9090
+    targetPort: http-metrics
   selector:
     app: kiali

--- a/modules/110-istio/templates/kiali/service.yaml
+++ b/modules/110-istio/templates/kiali/service.yaml
@@ -10,7 +10,7 @@ spec:
   - name: http
     protocol: TCP
     port: 20001
-    targetPort: api-port
+    targetPort: api
   - name: http-metrics
     protocol: TCP
     port: 9090

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -200,7 +200,8 @@ spec:
             {{- include "dex_authenticator_resources" . | nindent 12 }}
   {{- end }}
         ports:
-        - containerPort: 8443
+        - name: dex-https
+          containerPort: 8443
           protocol: TCP
       - name: redis
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -11,7 +11,7 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8443
+    targetPort: dex-https
   selector:
     app: dex-authenticator
     name: {{ $crd.name }}

--- a/modules/300-prometheus/templates/aggregating-proxy/service.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/service.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
     - port: 443
       name: https
-      targetPort: 8443
+      targetPort: https
   selector:
     app: aggregating-proxy

--- a/modules/300-prometheus/templates/memcached/service.yaml
+++ b/modules/300-prometheus/templates/memcached/service.yaml
@@ -10,9 +10,9 @@ spec:
   ports:
     - name: memcached
       port: 11211
-      targetPort: 11211
+      targetPort: memcached
     - name: http-metrics
       port: 9150
-      targetPort: 9150
+      targetPort: http-metrics
   selector:
     app: memcached

--- a/modules/300-prometheus/templates/trickster/service.yaml
+++ b/modules/300-prometheus/templates/trickster/service.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - port: 443
     name: https
-    targetPort: 8443
+    targetPort: https
   selector:
     app: trickster

--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --client-ca-file=/var/run/apiserver-proxy-client/ca.crt
         ports:
-        - name: metrics
+        - name: https-metrics
           containerPort: 6443
         livenessProbe:
           httpGet:

--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -82,8 +82,8 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --client-ca-file=/var/run/apiserver-proxy-client/ca.crt
         ports:
-          - name: metrics
-            containerPort: 6443
+        - name: metrics
+          containerPort: 6443
         livenessProbe:
           httpGet:
             path: /healthz

--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --client-ca-file=/var/run/apiserver-proxy-client/ca.crt
         ports:
-          - name: metrics-adapter-port
+          - name: metrics
             containerPort: 6443
         livenessProbe:
           httpGet:

--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -82,7 +82,8 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --client-ca-file=/var/run/apiserver-proxy-client/ca.crt
         ports:
-        - containerPort: 6443
+          - name: metrics-adapter-port
+            containerPort: 6443
         livenessProbe:
           httpGet:
             path: /healthz

--- a/modules/301-prometheus-metrics-adapter/templates/service.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/service.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: metrics
+    targetPort: https-metrics
   selector:
     app: prometheus-metrics-adapter

--- a/modules/301-prometheus-metrics-adapter/templates/service.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/service.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: metrics-adapter-port
+    targetPort: metrics
   selector:
     app: prometheus-metrics-adapter

--- a/modules/301-prometheus-metrics-adapter/templates/service.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/service.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 6443
+    targetPort: metrics-adapter-port
   selector:
     app: prometheus-metrics-adapter

--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -77,8 +77,8 @@ spec:
             mountPath: "/etc/tls-certs"
             readOnly: true
         ports:
-          - name: controller
-            containerPort: 8000
+        - name: controller
+          containerPort: 8000
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -77,7 +77,8 @@ spec:
             mountPath: "/etc/tls-certs"
             readOnly: true
         ports:
-        - containerPort: 8000
+          - name: admission-controller-port
+            containerPort: 8000
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
@@ -98,6 +99,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 8000
+      targetPort: admission-controller-port
   selector:
     app: vpa-admission-controller

--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             mountPath: "/etc/tls-certs"
             readOnly: true
         ports:
-          - name: admission-controller-port
+          - name: controller
             containerPort: 8000
         resources:
           requests:
@@ -99,6 +99,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: admission-controller-port
+      targetPort: controller
   selector:
     app: vpa-admission-controller

--- a/modules/303-prometheus-pushgateway/templates/service.yaml
+++ b/modules/303-prometheus-pushgateway/templates/service.yaml
@@ -12,6 +12,7 @@ spec:
   ports:
   - name: http-metrics
     port: 9091
+    targetPort: http-metrics
   selector:
     app: {{ $instance }}
 {{- end }}

--- a/modules/402-ingress-nginx/templates/kruise/service.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 9876
+      targetPort: webhook-server
   selector:
     control-plane: controller-manager
     app: kruise
@@ -24,7 +24,7 @@ metadata:
 spec:
   ports:
     - port: 8443
-      targetPort: 10354
+      targetPort: https-metrics
   selector:
     control-plane: controller-manager
     app: kruise

--- a/modules/462-loki/templates/service.yaml
+++ b/modules/462-loki/templates/service.yaml
@@ -11,6 +11,6 @@ spec:
   - name: loki
     port: 3100
     protocol: TCP
-    targetPort: 3100
+    targetPort: https-metrics
   selector:
     app: {{ .Chart.Name }}

--- a/modules/470-chrony/templates/service.yaml
+++ b/modules/470-chrony/templates/service.yaml
@@ -12,3 +12,4 @@ spec:
     - protocol: UDP
       port: 123
       name: ntp
+      targetPort: ntp

--- a/modules/500-cilium-hubble/templates/relay/service.yaml
+++ b/modules/500-cilium-hubble/templates/relay/service.yaml
@@ -11,4 +11,4 @@ spec:
   ports:
   - protocol: TCP
     port: 443
-    targetPort: 4245
+    targetPort: grpc

--- a/modules/500-cilium-hubble/templates/ui/service.yaml
+++ b/modules/500-cilium-hubble/templates/ui/service.yaml
@@ -11,4 +11,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 8081
+      targetPort: http

--- a/modules/500-openvpn/templates/openvpn/service.yaml
+++ b/modules/500-openvpn/templates/openvpn/service.yaml
@@ -11,6 +11,6 @@ spec:
   - name: https
     port: 443
     protocol: TCP
-    targetPort: 8443
+    targetPort: https
   selector:
     app: {{ .Chart.Name }}

--- a/modules/500-upmeter/templates/smoke-mini/services.yaml
+++ b/modules/500-upmeter/templates/smoke-mini/services.yaml
@@ -33,6 +33,7 @@ spec:
   - name: http
     port: 8080
     protocol: TCP
+    targetPort: http
   selector:
     app: smoke-mini
 ---
@@ -48,6 +49,7 @@ spec:
   - name: http
     port: 8080
     protocol: TCP
+    targetPort: http
   selector:
     app: smoke-mini
 {{- end }}

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             value: {{ $.Values.global.discovery.clusterDomain | quote }}
         ports:
           - containerPort: 8081
-            name: http-probe
+            name: builder-http
             protocol: TCP
         livenessProbe:
           httpGet:

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             value: {{ $.Values.global.discovery.clusterDomain | quote }}
         ports:
           - containerPort: 8081
-            name: http
+            name: http-probe
             protocol: TCP
         livenessProbe:
           httpGet:

--- a/modules/810-documentation/templates/service.yaml
+++ b/modules/810-documentation/templates/service.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
     - name: builder-http
       port: 8081
-      targetPort: http-probe
+      targetPort: builder-http
       protocol: TCP
   selector:
     app: documentation

--- a/modules/810-documentation/templates/service.yaml
+++ b/modules/810-documentation/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
   - name: http
     port: 80
-    targetPort: 8080
+    targetPort: http
     protocol: TCP
   selector:
     app: documentation
@@ -26,7 +26,7 @@ spec:
   ports:
     - name: builder-http
       port: 8081
-      targetPort: 8081
+      targetPort: http-probe
       protocol: TCP
   selector:
     app: documentation

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -569,7 +569,7 @@ func objectSecurityContext(object storage.StoreObject) errors.LintRuleError {
 }
 
 func skipServiceTargetPort(o *storage.StoreObject, port int32) bool {
-	// Deployment istiod is defined by its developers so there is no way to specify a named Target Port.
+	// istiod is being deployed by istio-operator and ports are hardcoded.
 	if o.Unstructured.GetName() == "istiod" && o.Unstructured.GetNamespace() == "d8-istio" &&
 		(port == 15010 || port == 15012 || port == 15014 || port == 15017) {
 		return true

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules/errors"
@@ -300,6 +301,7 @@ func (l *ObjectLinter) ApplyObjectRules(object storage.StoreObject) {
 
 	l.ErrorsList.Add(objectRevisionHistoryLimit(object))
 	l.ErrorsList.Add(objectHostNetworkPorts(object))
+	l.ErrorsList.Add(objectServiceTargetPort(object))
 
 	l.ErrorsList.Add(modules.PromtoolRuleCheck(l.Module, object))
 
@@ -563,6 +565,53 @@ func objectSecurityContext(object storage.StoreObject) errors.LintRuleError {
 		}
 	}
 
+	return errors.EmptyRuleError
+}
+
+func skipServiceTargetPort(o *storage.StoreObject, port int32) bool {
+	// Deployment istiod is defined by its developers so there is no way to specify a named Target Port.
+	if o.Unstructured.GetName() == "istiod" && o.Unstructured.GetNamespace() == "d8-istio" &&
+		(port == 15010 || port == 15012 || port == 15014 || port == 15017) {
+		return true
+	}
+	return false
+}
+
+func objectServiceTargetPort(object storage.StoreObject) errors.LintRuleError {
+	switch object.Unstructured.GetKind() {
+	case "Service":
+	default:
+		return errors.EmptyRuleError
+	}
+
+	converter := runtime.DefaultUnstructuredConverter
+	service := new(v1.Service)
+	err := converter.FromUnstructured(object.Unstructured.UnstructuredContent(), service)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, port := range service.Spec.Ports {
+		if port.TargetPort.Type == intstr.Int {
+			if port.TargetPort.IntVal == 0 {
+				return errors.NewLintRuleError(
+					"MANIFEST004",
+					object.Identity(),
+					nil,
+					"Service port must use an explicit named (non-numeric) target port",
+				)
+			}
+			if skipServiceTargetPort(&object, port.TargetPort.IntVal) {
+				continue
+			}
+			return errors.NewLintRuleError(
+				"MANIFEST004",
+				object.Identity(),
+				port.TargetPort.IntVal,
+				"Service port must use a named (non-numeric) target port",
+			)
+		}
+	}
 	return errors.EmptyRuleError
 }
 

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -640,6 +640,14 @@ func skipHostNetworkPorts(o *storage.StoreObject, c *v1.Container, p *v1.Contain
 		}
 	}
 
+	// Temporary exception on port 9680/tcp of the runtime-audit-engine module .
+	if o.Unstructured.GetKind() == "DaemonSet" && o.Unstructured.GetName() == "runtime-audit-engine" &&
+		o.Unstructured.GetNamespace() == "d8-runtime-audit-engine" && c.Name == "falcosidekick" {
+		if (hostNetworkUsed && p.ContainerPort == 9680) || p.HostPort == 9680 {
+			return true
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## Description
Linter verifies that the service port uses an explicit and named (non-numeric) target port.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: chore
summary: Add linter for checking if service target port is symbolic.
impact_level: low
```