### PR TITLE
[operator-trivy] fix service url

### DIFF
--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ $trivyServerURL := printf "http://trivy-server.d8-%s:4954" .Chart.Name | quote }}
+{{ $trivyServerURL := printf "http://trivy-server.d8-%s.svc.%s:4954" .Chart.Name .Values.global.discovery.clusterDomain | quote }}
 {{ $dbRepository := printf "%s/security/trivy-db" .Values.global.modulesImages.registry.base | quote }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description
It provides fix for trivy service url to avoid unavailability of trivy-server in env where HTTP_PROXY/HTTPS_PROXY is set.

## Why do we need it, and what problem does it solve?
When the HTTP_PROXY or HTTPS_PROXY is set, the NO_PROXY must be configured to add the trivy service URL. Without this, the operator-trivy will not be able to access the trivy server. But using url with cluster domain fixes this problem, because the cluster domain exists in NO_RPOXY.

## What is the expected result?
Trivy works in env where HTTP_PROXY/HTTPS_PROXY is set.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: fix
summary: Fix service URL to work in env where HTTP_PROXY/HTTPS_PROXY is set.
```
