### PR TITLE
[cloud-provider-*] Minimize RBAC permissions in the ClusterRole

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,7 +62,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,7 +62,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/ee/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,7 +62,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/ee/modules/030-cloud-provider-zvirt/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -48,7 +55,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/modules/030-cloud-provider-aws/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,7 +62,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/modules/030-cloud-provider-azure/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,7 +62,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/modules/030-cloud-provider-gcp/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -55,7 +62,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -25,7 +25,14 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -48,7 +55,10 @@ rules:
   resources:
   - persistentvolumes
   verbs:
-  - '*'
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes #8517

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-vsphere
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-azure
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-gcp
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-vcd
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-yandex
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-openstack
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

```changes
section: cloud-provider-zvirt
type: fix
summary: Minimize RBAC permissions by removing the wildcard("*") from ClusterRole rules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
