### PR TITLE
[cni-cilium] Update internal documentation about cilium connectivity tests

### DIFF
--- a/modules/021-cni-cilium/docs/internal/CONNECTIVITY_TESTS.md
+++ b/modules/021-cni-cilium/docs/internal/CONNECTIVITY_TESTS.md
@@ -1,6 +1,6 @@
 # Cilium connectivity tests
 
-## Create a default clusterrolle with the name `cilium` before run
+## Create a default clusterrole with the name `cilium` before run
 
 ```bash
 kubectl get clusterrole d8:cni-cilium:agent -o yaml | sed -e 's/name: d8:cni-cilium:agent/name: cilium/' | kubectl apply -f -

--- a/modules/021-cni-cilium/docs/internal/CONNECTIVITY_TESTS.md
+++ b/modules/021-cni-cilium/docs/internal/CONNECTIVITY_TESTS.md
@@ -1,6 +1,6 @@
 # Cilium connectivity tests
 
-## Prior to run, clusterrole with default name ```cilium``` should be created
+## Create a default clusterrolle with the name `cilium` before run
 
 ```bash
 kubectl get clusterrole d8:cni-cilium:agent -o yaml | sed -e 's/name: d8:cni-cilium:agent/name: cilium/' | kubectl apply -f -

--- a/modules/021-cni-cilium/docs/internal/CONNECTIVITY_TESTS.md
+++ b/modules/021-cni-cilium/docs/internal/CONNECTIVITY_TESTS.md
@@ -1,5 +1,11 @@
 # Cilium connectivity tests
 
+## Prior to run, clusterrole with default name ```cilium``` should be created
+
+```bash
+kubectl get clusterrole d8:cni-cilium:agent -o yaml | sed -e 's/name: d8:cni-cilium:agent/name: cilium/' | kubectl apply -f -
+```
+
 ## How to run
 
 ```bash


### PR DESCRIPTION
## Description
Added description about clusterrole creation.

## Why do we need it, and what problem does it solve?
For internal cilium connectivity tests

## What is the expected result?
Run cilium connectivity tests without error.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-cilium
type: chore
summary: Add description about clusterrole creation.
impact_level: low
```
