### PR TITLE
[deckhouse-cli] Bump Deckhouse CLI version from 0.2.0 to 0.2.1

### DIFF
--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "0.2.0" }}
+{{- $version := "0.2.1" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_SCRATCH }}


### PR DESCRIPTION
## Description
Bump [Deckhouse CLI](https://deckhouse.io/documentation/v1.62/deckhouse-cli/) version from 0.2.0 to 0.2.1.

## Changelog entries
```changes
section: registrypackages
type: chore
summary: Bump [Deckhouse CLI](https://deckhouse.io/documentation/v1.62/deckhouse-cli/) version 0.2.1.
```
