### PR TITLE
[docs] Fix zone in volumeTypeMap vk cloud config.yml

### DIFF
--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.ee.inc
@@ -149,7 +149,7 @@ masterNodeGroup:
     # [<ru>] <availability zone>: <volume type>
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    DP1: dp1-high-iops
+    ME1: high-iops
   instanceClass:
     # [<en>] Flavor in use.
     # [<ru>] Используемый flavor.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -165,7 +165,7 @@ masterNodeGroup:
     # [<ru>] <availability zone>: <volume type>
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    DP1: dp1-high-iops
+    ME1: high-iops
   instanceClass:
     # [<en>] Flavor in use.
     # [<ru>] Используемый flavor.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix zone and disk in `volumeTypeMap` vk cloud config.yml from getting started

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
DP1 zone and dp1-high-iops is deprecated and we have error in dhctl bootstrap
```
  on deckhouse/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf line 8, in locals:
   8:   zone                 = element(tolist(setintersection(keys(local.volume_type_map), local.actual_zones)), var.nodeIndex)
    | local.actual_zones is list of string with 3 elements
    | local.volume_type_map is object with 1 attribute "DP1"
    | var.nodeIndex is "0"

Call to function "element" failed: cannot use element function with an empty
list.
```
```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix
impact: fix error in bootstrap in vk cloud from getting started config.yml
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
