### PR TITLE
[istio][cilium-hubble] Remove wildcard from modules RBAC

### DIFF
--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -60,11 +60,83 @@ rules:
   - patch
 - apiGroups:
   - networking.istio.io
+  resources:
+  - destinationrules
+  - destinationrules/status
+  - envoyfilters
+  - envoyfilters/status
+  - gateways
+  - gateways/status
+  - proxyconfigs
+  - proxyconfigs/status
+  - serviceentries
+  - serviceentries/status
+  - sidecars
+  - sidecars/status
+  - virtualservices
+  - virtualservices/status
+  - workloadentries
+  - workloadentries/status
+  - workloadgroups
+  - workloadgroups/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups:
   - security.istio.io
+  resources:
+  - authorizationpolicies
+  - authorizationpolicies/status
+  - peerauthentications
+  - peerauthentications/status
+  - requestauthentications
+  - requestauthentications/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups:
   - extensions.istio.io
+  resources:
+  - wasmplugins
+  - wasmplugins/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups:
   - telemetry.istio.io
+  resources:
+  - telemetries
+  - telemetries/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups:
   - gateway.networking.k8s.io
-  resources: ["*"]
+  resources:
+  - grpcroutes
+  - grpcroutes/status
+  - gateways
+  - gateways/status
+  - gatewayclasses
+  - gatewayclasses/status
+  - httproutes
+  - httproutes/status
   verbs:
   - get
   - list

--- a/modules/110-istio/templates/operator/rbac-for-us.yaml
+++ b/modules/110-istio/templates/operator/rbac-for-us.yaml
@@ -14,35 +14,64 @@ metadata:
 rules:
 # istio groups
 - apiGroups:
-  - authentication.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - config.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
   - install.istio.io
   resources:
-  - '*'
+  - istiooperators
+  - istiooperators/status
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - networking.istio.io
   resources:
-  - '*'
+  - destinationrules
+  - destinationrules/status
+  - envoyfilters
+  - envoyfilters/status
+  - gateways
+  - gateways/status
+  - proxyconfigs
+  - proxyconfigs/status
+  - serviceentries
+  - serviceentries/status
+  - sidecars
+  - sidecars/status
+  - virtualservices
+  - virtualservices/status
+  - workloadentries
+  - workloadentries/status
+  - workloadgroups
+  - workloadgroups/status
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - security.istio.io
   resources:
-  - '*'
+  - authorizationpolicies
+  - authorizationpolicies/status
+  - peerauthentications
+  - peerauthentications/status
+  - requestauthentications
+  - requestauthentications/status
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 # k8s groups
 - apiGroups:
   - admissionregistration.k8s.io
@@ -50,14 +79,26 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions.apiextensions.k8s.io
   - customresourcedefinitions
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - apps
   - extensions
@@ -69,13 +110,25 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -89,7 +142,13 @@ rules:
   resources:
   - poddisruptionbudgets
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -98,7 +157,13 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - '*'
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -122,8 +187,13 @@ rules:
   - services
   - serviceaccounts
   verbs:
-  - '*'
-
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/500-cilium-hubble/templates/ui/rbac-for-us.yaml
+++ b/modules/500-cilium-hubble/templates/ui/rbac-for-us.yaml
@@ -43,7 +43,40 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - "*"
+      - ciliumbgppeeringpolicies
+      - ciliumbgppeeringpolicies/status
+      - ciliumcidrgroups
+      - ciliumcidrgroups/status
+      - ciliumclusterwideenvoyconfigs
+      - ciliumclusterwideenvoyconfigs/status
+      - ciliumclusterwidenetworkpolicies
+      - ciliumclusterwidenetworkpolicies/status
+      - ciliumegressgatewaypolicies
+      - ciliumegressgatewaypolicies/status
+      - ciliumendpoints
+      - ciliumendpoints/status
+      - ciliumendpointslices
+      - ciliumendpointslices/status
+      - ciliumenvoyconfigs
+      - ciliumenvoyconfigs/status
+      - ciliumexternalworkloads
+      - ciliumexternalworkloads/status
+      - ciliumidentities
+      - ciliumidentities/status
+      - ciliuml2announcementpolicies
+      - ciliuml2announcementpolicies/status
+      - ciliumloadbalancerippools
+      - ciliumloadbalancerippools/status
+      - ciliumlocalredirectpolicies
+      - ciliumlocalredirectpolicies/status
+      - ciliumnetworkpolicies
+      - ciliumnetworkpolicies/status
+      - ciliumnodeconfigs
+      - ciliumnodeconfigs/status
+      - ciliumnodes
+      - ciliumnodes/status
+      - ciliumpodippools
+      - ciliumpodippools/status
     verbs:
       - get
       - list

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -58,12 +58,6 @@ var skipCheckWildcards = map[string][]string{
 	"cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml": {
 		"d8:cloud-provider-yandex:cloud-controller-manager",
 	},
-	"istio/templates/kiali/rbac-for-us.yaml": {
-		"d8:istio:kiali",
-	},
-	"istio/templates/operator/rbac-for-us.yaml": {
-		"d8:istio:operator",
-	},
 	"operator-prometheus/templates/rbac-for-us.yaml": {
 		"d8:operator-prometheus",
 	},

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -70,9 +70,6 @@ var skipCheckWildcards = map[string][]string{
 	"ingress-nginx/templates/kruise/rbac-for-us.yaml": {
 		"d8:ingress-nginx:kruise-role",
 	},
-	"cilium-hubble/templates/ui/rbac-for-us.yaml": {
-		"d8:cilium-hubble:ui:reader",
-	},
 	"okmeter/templates/rbac-for-us.yaml": {
 		"d8:okmeter",
 	},


### PR DESCRIPTION
## Description
Remove wildcard from network modules RBAC

## Why do we need it, and what problem does it solve?
Setting a wildcard for Role/ClusterRole is potentially dangerous. We need to reduce the modules' permissions to to avoid security issues.

## Why do we need it in the patch release (if we do)?
This is necessary for some of our customers

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Remove wildcard from network modules RBAC.
impact_level: low
---
section: cilium-hubble
type: chore
summary: Remove wildcard from network modules RBAC.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
