### PR TITLE
[docs] Added documentation improvements in getting started for AWS

### DIFF
--- a/candi/cloud-providers/aws/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/aws/docs/ENVIRONMENT.md
@@ -198,7 +198,7 @@ EOF
 Create a new Policy based on the specification created above with `D8CloudProviderAWS` as a policy name and the ARN identifier:
 
 ```shell
-aws iam create-policy --policy-name D8Policy --policy-document file://policy.json
+aws iam create-policy --policy-name D8CloudProviderAWS --policy-document file://policy.json
 ```
 
 You will see the following:
@@ -206,9 +206,9 @@ You will see the following:
 ```yaml
 {
     "Policy": {
-        "PolicyName": "D8Policy",
+        "PolicyName": "D8CloudProviderAWS",
         "PolicyId": "AAA",
-        "Arn": "arn:aws:iam::123:policy/D8Policy",
+        "Arn": "arn:aws:iam::123:policy/D8CloudProviderAWS",
         "Path": "/",
         "DefaultVersionId": "v1",
         "AttachmentCount": 0,
@@ -263,7 +263,7 @@ You will see the following:
 Attach the specified `Policy` to the specified `User`:
 
 ```shell
-aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8Policy
+aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8CloudProviderAWS
 ```
 
 ## Configuring IAM via Terraform
@@ -280,7 +280,7 @@ resource "aws_iam_access_key" "user" {
 }
 
 resource "aws_iam_policy" "policy" {
-  name        = "D8Policy"
+  name        = "D8CloudProviderAWS"
   path        = "/"
   description = "Deckhouse policy"
 

--- a/candi/cloud-providers/aws/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/aws/docs/ENVIRONMENT_RU.md
@@ -201,7 +201,7 @@ EOF
 Затем создайте новую Policy с именем `D8CloudProviderAWS` и примечанием `ARN`, используя JSON-спецификацию из файла `policy.json`:
 
 ```shell
-aws iam create-policy --policy-name D8Policy --policy-document file://policy.json
+aws iam create-policy --policy-name D8CloudProviderAWS --policy-document file://policy.json
 ```
 
 В ответ отобразится следующий текст:
@@ -209,9 +209,9 @@ aws iam create-policy --policy-name D8Policy --policy-document file://policy.jso
 ```yaml
 {
     "Policy": {
-        "PolicyName": "D8Policy",
+        "PolicyName": "D8CloudProviderAWS",
         "PolicyId": "AAA",
-        "Arn": "arn:aws:iam::123:policy/D8Policy",
+        "Arn": "arn:aws:iam::123:policy/D8CloudProviderAWS",
         "Path": "/",
         "DefaultVersionId": "v1",
         "AttachmentCount": 0,
@@ -266,7 +266,7 @@ aws iam create-access-key --user-name deckhouse
 Объедините `User` и `Policy`:
 
 ```shell
-aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8Policy
+aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8CloudProviderAWS
 ```
 
 ## Настройка IAM через Terraform
@@ -283,7 +283,7 @@ resource "aws_iam_access_key" "user" {
 }
 
 resource "aws_iam_policy" "policy" {
-  name        = "D8Policy"
+  name        = "D8CloudProviderAWS"
   path        = "/"
   description = "Deckhouse policy"
 

--- a/docs/site/_includes/getting_started/aws/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/aws/STEP_ENV.md
@@ -146,7 +146,7 @@ EOF
 Create a new Policy based on the specification created above with `D8CloudProviderAWS` as a policy name:
 {% snippetcut %}
 ```shell
-aws iam create-policy --policy-name D8Policy --policy-document file://policy.json
+aws iam create-policy --policy-name D8CloudProviderAWS --policy-document file://policy.json
 ```
 {% endsnippetcut %}
 
@@ -154,9 +154,9 @@ aws iam create-policy --policy-name D8Policy --policy-document file://policy.jso
 > ```yaml
   {
       "Policy": {
-          "PolicyName": "D8Policy",
+          "PolicyName": "D8CloudProviderAWS",
           "PolicyId": "AAA",
-          "Arn": "arn:aws:iam::123:policy/D8Policy",
+          "Arn": "arn:aws:iam::123:policy/D8CloudProviderAWS",
           "Path": "/",
           "DefaultVersionId": "v1",
           "AttachmentCount": 0,
@@ -211,6 +211,6 @@ aws iam create-access-key --user-name deckhouse
 Attach the specified `Policy` to the specified `User`:
 {% snippetcut %}
 ```shell
-aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8Policy
+aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8CloudProviderAWS
 ```
 {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/aws/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/aws/STEP_ENV_RU.md
@@ -146,7 +146,7 @@ EOF
 Создайте на основе ранее созданной спецификации новую Policy с именем `D8CloudProviderAWS` и примечанием ARN, используя JSON-спецификацию из файла `policy.json`:
 {% snippetcut %}
 ```shell
-aws iam create-policy --policy-name D8Policy --policy-document file://policy.json
+aws iam create-policy --policy-name D8CloudProviderAWS --policy-document file://policy.json
 ```
 {% endsnippetcut %}
 
@@ -154,9 +154,9 @@ aws iam create-policy --policy-name D8Policy --policy-document file://policy.jso
 > ```yaml
   {
       "Policy": {
-          "PolicyName": "D8Policy",
+          "PolicyName": "D8CloudProviderAWS",
           "PolicyId": "AAA",
-          "Arn": "arn:aws:iam::123:policy/D8Policy",
+          "Arn": "arn:aws:iam::123:policy/D8CloudProviderAWS",
           "Path": "/",
           "DefaultVersionId": "v1",
           "AttachmentCount": 0,
@@ -211,6 +211,6 @@ aws iam create-access-key --user-name deckhouse
 Объедините `User` и `Policy`:
 {% snippetcut %}
 ```shell
-aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8Policy
+aws iam attach-user-policy --user-name username --policy-arn arn:aws:iam::123:policy/D8CloudProviderAWS
 ```
 {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
@@ -102,26 +102,6 @@ spec:
         global:
           kubeconfigGeneratorMasterCA: ""
 ---
-# [<en>] cni-cilium module settings.
-# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-# [<ru>] Настройки модуля cni-cilium.
-# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-cilium
-spec:
-  version: 1
-  # [<en>] Enable cni-cilium module
-  # [<ru>] Включить модуль cni-cilium
-  enabled: true
-  settings:
-    # [<en>] cni-cilium module settings
-    # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-    # [<ru>] Настройки модуля cni-cilium
-    # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-    tunnelMode: VXLAN
----
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html
 # [<ru>] Настройки облачного провайдера..

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
@@ -99,26 +99,7 @@ spec:
         mode: Global
         global:
           kubeconfigGeneratorMasterCA: ""
----
-# [<en>] cni-cilium module settings.
-# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-# [<ru>] Настройки модуля cni-cilium.
-# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-cilium
-spec:
-  version: 1
-  # [<en>] Enable cni-cilium module
-  # [<ru>] Включить модуль cni-cilium
-  enabled: true
-  settings:
-    # [<en>] cni-cilium module settings
-    # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-    # [<ru>] Настройки модуля cni-cilium
-    # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-    tunnelMode: VXLAN
+
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ee.inc
@@ -99,7 +99,6 @@ spec:
         mode: Global
         global:
           kubeconfigGeneratorMasterCA: ""
-
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -91,26 +91,7 @@ spec:
         mode: Global
         global:
           kubeconfigGeneratorMasterCA: ""
----
-# [<en>] cni-cilium module settings.
-# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-# [<ru>] Настройки модуля cni-cilium.
-# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-cilium
-spec:
-  version: 1
-  # [<en>] Enable cni-cilium module
-  # [<ru>] Включить модуль cni-cilium
-  enabled: true
-  settings:
-    # [<en>] cni-cilium module settings
-    # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-    # [<ru>] Настройки модуля cni-cilium
-    # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-    tunnelMode: VXLAN
+
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -91,7 +91,6 @@ spec:
         mode: Global
         global:
           kubeconfigGeneratorMasterCA: ""
-
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -99,26 +99,7 @@ spec:
         mode: Global
         global:
           kubeconfigGeneratorMasterCA: ""
----
-# [<en>] cni-cilium module settings.
-# [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-# [<ru>] Настройки модуля cni-cilium.
-# [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-cilium
-spec:
-  version: 1
-  # [<en>] Enable cni-cilium module
-  # [<ru>] Включить модуль cni-cilium
-  enabled: true
-  settings:
-    # [<en>] cni-cilium module settings
-    # [<en>] https://deckhouse.io/documentation/v1/modules/021-cni-cilium/configuration.html
-    # [<ru>] Настройки модуля cni-cilium
-    # [<ru>] https://deckhouse.ru/documentation/v1/modules/021-cni-cilium/configuration.html
-    tunnelMode: VXLAN
+
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -99,7 +99,6 @@ spec:
         mode: Global
         global:
           kubeconfigGeneratorMasterCA: ""
-
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-aws/cluster_configuration.html


### PR DESCRIPTION
## Description

The getting started section has been edited:

* Fixed typo in D8CloudProviderAWS policy name in examples
* Removed enabling the Cillium module for AWS cloud provider. The reason for deletion is that the module is not currently ready for production use in AWS.

## What is the expected result?

Changes in allow you to more correctly deploy Deckhouse in AWS according to the instructions from the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Removed cillium module configuration, fixed typos in the getting started section for the AWS cloud.
impact_level: low
```