### PR TITLE
fix(dhctl-for-commander): enable default preflight checks for dhctl server bootstrap operation

### DIFF
--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -191,8 +191,6 @@ func (s *Service) bootstrap(
 	})
 	app.SanityCheck = true
 	app.UseTfCache = app.UseStateCacheYes
-	app.PreflightSkipDeckhouseVersionCheck = true
-	app.PreflightSkipAll = true
 	app.CacheDir = s.cacheDir
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)


### PR DESCRIPTION
## Description

This PR enables standard preflight checks in dhctl server bootstrap operation, which are used in dhctl bootstrap cli command.

## Why do we need it, and what problem does it solve?

All preflight checks was disabled for dhtll server bootstrap operation just because these checks was initially disabled in dhctl bootstrap operation in the commander. Currently we aim to enable these checks just like in default dhctl cli bootstrap command.

