### PR TITLE
[monitoring] Fix node exporter NTP address

### DIFF
--- a/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_DISTROLESS
-ARG BASE_GOLANG_20_ALPINE_DEV
+ARG BASE_GOLANG_22_ALPINE_DEV
 
-FROM $BASE_GOLANG_20_ALPINE_DEV as artifact
+FROM $BASE_GOLANG_22_ALPINE_DEV as artifact
 
 ARG GOPROXY
 ARG SOURCE_REPO
@@ -12,7 +12,7 @@ ENV GOPROXY=${GOPROXY} \
     GOOS=linux \
     GOARCH=amd64
 
-RUN git clone --depth 1 --branch v1.7.0 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
+RUN git clone --depth 1 --branch v1.8.1 ${SOURCE_REPO}/prometheus/node_exporter.git /node_exporter
 WORKDIR /node_exporter/
 
 RUN go mod tidy

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -79,6 +79,7 @@ spec:
         - '--collector.ntp'
         - '--no-collector.wifi'
         - '--collector.ntp.server-is-local'
+        - '--collector.ntp.server=$(HOST_IP)'
         - '--collector.processes'
         - '--collector.filesystem.mount-points-exclude'
         - '(^/(dev|proc|sys|run)($|/))|(^/var/lib/docker/)|(^/var/lib/containerd/)|(/kubelet/)'
@@ -94,6 +95,11 @@ spec:
         - '/host/textfile*'
         - '--collector.netstat.fields'
         - '^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_.*|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$'
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         volumeMounts:
         - name: root
           readOnly:  true

--- a/modules/470-chrony/templates/configmap.yaml
+++ b/modules/470-chrony/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
     {{ else if (eq .NTPRole "sink") }}
     local stratum 9
     allow 127/8
+    allow {{ .HostIP }}/32
     pool {{ .ChronyMastersService }} iburst
     {{ end }}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix node exporter ntp address.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Node exporter awaits ntp server on localhost, bu our chrony listens on the node ip.
This PR fixes access from node-exporter to the chrony on the node.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: fix
summary: Fix node exporter NTP address.
impact: node-exporter will restart.
impact_level: default
```
