### PR TITLE
[testing][e2e] Add basic tests for network modules

### DIFF
--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -71,3 +71,12 @@ spec:
   settings:
     ebpfExporterEnabled: false
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
@@ -74,3 +74,12 @@ spec:
   settings:
     ebpfExporterEnabled: false
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -98,3 +98,12 @@ metadata:
   name: vertical-pod-autoscaler
 spec:
   enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
@@ -56,3 +56,12 @@ spec:
   tolerations:
     - effect: NoSchedule
       operator: Exists
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -52,3 +52,12 @@ masterNodeGroup:
     imageName: "redos-STD-MINIMAL-8.0.0"
   volumeTypeMap:
     ru-3a: "fast.ru-3a"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -35,8 +35,9 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
-  name: cni-flannel
+  name: cni-cilium
 spec:
+  version: 1
   enabled: true
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -68,3 +69,21 @@ spec:
   enabled: true
   settings:
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: static-routing-manager
+spec:
+  version: 1
+  enabled: true
+  settings:
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -62,3 +62,68 @@ spec:
     dedicated.worker: ""
   addressPool:
     - 192.168.2.100-192.168.2.150
+---
+apiVersion: network.deckhouse.io/v1alpha1
+kind: RoutingTable
+metadata:
+  name: myrt-main
+spec:
+  ipRoutingTableID: 254 # main routing table id is 254
+  routes:
+    - destination: 10.1.1.0/8
+      gateway: 192.168.21.1
+  nodeSelector:
+    dedicated.worker: ""
+---
+apiVersion: network.deckhouse.io/v1alpha1
+kind: IPRuleSet
+metadata:
+  name: myiprule
+spec:
+  rules:
+    - selectors:
+        from:
+          - 192.168.111.0/24
+          - 192.168.222.0/24
+        to:
+          - 8.8.8.8/32
+          - 172.16.8.0/21
+        sportRange:
+          start: 100
+          end: 200
+        dportRange:
+          start: 300
+          end: 400
+        ipProto: 6
+      actions:
+        lookup:
+          routingTableName: myrt-main
+      priority: 50
+  nodeSelector:
+    dedicated.worker: ""
+---
+apiVersion: network.deckhouse.io/v1alpha1
+kind: EgressGateway
+metadata:
+  name: my-egressgw
+spec:
+  nodeSelector:
+    dedicated.worker: ""
+  sourceIP:
+    mode: VirtualIPAddress
+    virtualIPAddress:
+      ip: 172.18.18.242
+---
+apiVersion: network.deckhouse.io/v1alpha1
+kind: EgressGatewayPolicy
+metadata:
+  name: my-egressgw-policy
+spec:
+  destinationCIDRs:
+    - 0.0.0.0/0
+  egressGatewayName: my-egressgw
+  selectors:
+    - podSelector:
+        matchLabels:
+          app: backend
+          io.kubernetes.pod.namespace: my-ns

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -53,3 +53,12 @@ spec:
     modules:
       publicDomainTemplate: "%s.k8s.smoke.flant.com"
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
@@ -149,7 +149,17 @@ Ingress $ingress_inlet check: $([ "$ingress" == "ok" ] && echo "success" || echo
 EOF
   fi
 
-  if [[ "$availability:$ingress" == "ok:ok" ]]; then
+  if [ "$(kubectl -n d8-istio get po | grep istiod | wc -l)" -gt 0 ]; then
+    istio="ok"
+  else
+    istio=""
+  fi
+
+  cat <<EOF
+Istio operator check: $([ "$istio" == "ok" ] && echo "success" || echo "failed")
+EOF
+
+  if [[ "$availability:$ingress:$istio" == "ok:ok:ok" ]]; then
     exit 0
   fi
 done

--- a/testing/cloud_layouts/vCloudDirector/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/configuration.tpl.yaml
@@ -43,7 +43,7 @@ layout: Standard
 internalNetworkCIDR: 192.168.254.0/23 # 192.168.254.0/24 - dhctp, 192.168.255.0/24 - metalb
 masterNodeGroup:
   instanceClass:
-    storageProfile: Fast vHDD 
+    storageProfile: Fast vHDD
     sizingPolicy: ${VCD_ORG}-MSK
     etcdDiskSizeGb: 10
     rootDiskSizeGb: 40
@@ -51,7 +51,7 @@ masterNodeGroup:
   replicas: 1
 nodeGroups:
 - instanceClass:
-    storageProfile:  Fast vHDD 
+    storageProfile:  Fast vHDD
     sizingPolicy: ${VCD_ORG}-MSK
     rootDiskSizeGb: 40
     template: private-templates/Ubuntu 24.04 Server (20240628)
@@ -70,7 +70,7 @@ provider:
   username: ${VCD_USERNAME}
   insecure: true
 organization: ${VCD_ORG}
-virtualApplicationName: deckhouse-e2e 
+virtualApplicationName: deckhouse-e2e
 virtualDataCenter: ${VCD_ORG}-MSK1-S1-vDC2
 mainNetwork:  deckhouse-e2e
 sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU=
@@ -82,3 +82,12 @@ metadata:
   name: flant-integration
 spec:
   enabled: false
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
@@ -98,3 +98,12 @@ spec:
     modules:
       publicDomainTemplate: "%s.k8s.smoke.flant.com"
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true
+  settings:


### PR DESCRIPTION
## Description
Basic e2e-tests for modules:
* istio
* static-routing-manager
* cilium (EgressGateway and EgressGatewayPolicy)

## Why do we need it, and what problem does it solve?
Tests will help to detect modules deployment errors at an early stage.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: basic e2e tests for network modules
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
