### PR TITLE
[candi] fix dir permission for NodeUser

### DIFF
--- a/candi/bashible/common-steps/all/003_create_deckhouse_user.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_deckhouse_user.sh.tpl
@@ -19,11 +19,13 @@ create_user_and_group() {
     local userid="$2"
     local groupname="$3"
     local groupid="$4"
+		local shell="$5"
 
     uid="$(id -u "${username}" 2>/dev/null || true)"
     gid="$(getent group "${groupname}" | cut -d: -f3 || true)"
 
     if [ "$uid" == "$userid" ] && [ "$gid" == "$groupid" ]; then
+				usermod -s "$shell" "$username"
         return
     fi
 
@@ -33,7 +35,7 @@ create_user_and_group() {
     fi
 
     groupadd -g "$groupid" "$groupname"
-    useradd -u "$userid" -g "$groupname" "$username"
+    useradd -M -s "$shell" -u "$userid" -g "$groupname" "$username"
 }
 
-create_user_and_group deckhouse 64535 deckhouse 64535
+create_user_and_group deckhouse 64535 deckhouse 64535 /sbin/nologin

--- a/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
@@ -184,7 +184,12 @@ function main() {
   default_shell="/bin/bash"
   comment="created by deckhouse"
 
-  mkdir -p $home_base_path
+	if [ -d "$home_base_path" ]; then
+		chmod -c 755  $home_base_path 
+		chown -c root:root $home_base_path 
+	else
+		mkdir -p $home_base_path
+	fi
 
   for uid in $(jq -rc '.[].spec.uid' <<< "$node_users_json"); do
     user_name="$(jq --arg uid $uid -rc '.[] | select(.spec.uid==($uid | tonumber)) | .name' <<< "$node_users_json")"


### PR DESCRIPTION
## Description

Don't create deckhouse user's home directory and check right permissions for NodeUser home dir.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Step `003_create_deckhouse_user.sh` creates `/home/deckhouse` with default permission 700, that denies access to the NodeUsers ssh key.

## Why do we need it in the patch release (if we do)?

Without these changes NodeUser can't connect via ssh-key.

## What is the expected result?

Repair ability to connect via ssh for NodeUser.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix home directory permission for NodeUser.
impact: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
