### PR TITLE
[go_lib] fix: successful confirmation of module installation via annotations

### DIFF
--- a/go_lib/updater/updater.go
+++ b/go_lib/updater/updater.go
@@ -233,7 +233,7 @@ func (du *Updater[R]) checkMinorReleaseConditions(predictedRelease *R, updateWin
 
 		if du.inManualMode {
 			// check: release is approved in Manual mode
-			if !(*predictedRelease).GetApprovedStatus() {
+			if !(*predictedRelease).GetManuallyApproved() {
 				du.logger.Infof("Release %s is waiting for manual approval", (*predictedRelease).GetName())
 				du.metricsUpdater.WaitingManual((*predictedRelease).GetName(), float64(du.totalPendingManualReleases))
 				err := du.updateStatus(predictedRelease, waitingManualApprovalMsg, PhasePending)


### PR DESCRIPTION
## Description

When using manual confirmation of module installation, an error occurred; the confirmation status was reset immediately before the check. As a result, after installing the annotation in Kubernetes on the module, the installation did not proceed.

## Why do we need it, and what problem does it solve?

It is necessary to restore the functionality of confirming the installation of modules in manual mode.

## What is the expected result?

After installing the annotation on the module in Kubernetes, the installation is successful.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: go_lib
type: fix
summary: successful confirmation of module installation via annotations
impact_level: low
```
