### PR TITLE
[docs] fix the docs about exec process

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -9,7 +9,7 @@ apiVersions:
       Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -9,7 +9,7 @@ apiVersions:
       Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
@@ -9,7 +9,7 @@ apiVersions:
       Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -9,7 +9,7 @@ apiVersions:
       Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       To change the `ClusterConfiguration` resource in a running cluster, run the following command:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit cluster-configuration
       ```
     additionalProperties: false
     required: [apiVersion, kind, clusterType, kubernetesVersion, podSubnetCIDR, serviceSubnetCIDR, clusterDomain]

--- a/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -10,7 +10,7 @@ apiVersions:
       Чтобы изменить содержимое ресурса `ClusterConfiguration` в работающем кластере, выполните следующую команду:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit cluster-configuration
       ```
     properties:
       apiVersion:

--- a/candi/openapi/doc-ru-static_cluster_configuration.yaml
+++ b/candi/openapi/doc-ru-static_cluster_configuration.yaml
@@ -8,7 +8,7 @@ apiVersions:
       Чтобы изменить содержимое ресурса `StaticClusterConfiguration` в работающем кластере, выполните следующую команду:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit static-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit static-cluster-configuration
       ```
     properties:
       apiVersion:

--- a/candi/openapi/static_cluster_configuration.yaml
+++ b/candi/openapi/static_cluster_configuration.yaml
@@ -9,7 +9,7 @@ apiVersions:
       To change the `StaticClusterConfiguration` resource in a running cluster, run the following command:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit static-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit static-cluster-configuration
       ```
     additionalProperties: false
     required: [apiVersion, kind]

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -257,7 +257,7 @@ Patch releases (e.g., an update from version `1.30.1` to version `1.30.2`) ignor
   Here is how you can retrieve the IP address of the Deckhouse container registry in a pod:
   
   ```shell
-  $ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- getent ahosts registry.deckhouse.io
+  $ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- getent ahosts registry.deckhouse.io
   46.4.145.194    STREAM registry.deckhouse.io
   46.4.145.194    DGRAM  registry.deckhouse.io
   ```
@@ -757,7 +757,7 @@ The general cluster parameters are stored in the [ClusterConfiguration](installi
 To change the general cluster parameters, run the command:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
+kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
 After saving the changes, Deckhouse will bring the cluster configuration to the state according to the changed configuration. Depending on the size of the cluster, this may take some time.
@@ -769,7 +769,7 @@ Cloud provider setting of a cloud of hybrid cluster are stored in the `<PROVIDER
 Regardless of the cloud provider used, its settings can be changed using the following command:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit provider-cluster-configuration
+kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit provider-cluster-configuration
 ```
 
 ### How do I change the configuration of a static cluster?
@@ -779,7 +779,7 @@ Settings of a static cluster are stored in the [StaticClusterConfiguration](inst
 To change the settings of a static cluster, run the command:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit static-cluster-configuration
+kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit static-cluster-configuration
 ```
 
 ### How to switch Deckhouse EE to CE?
@@ -957,7 +957,7 @@ To upgrade the Kubernetes version in a cluster change the [kubernetesVersion](in
 1. Run the command:
 
    ```shell
-   kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
+   kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit cluster-configuration
    ```
 
 1. Change the `kubernetesVersion` field.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -258,7 +258,7 @@ Patch-релизы (например, обновление на версию `1.
   Пример получения IP-адреса хранилища образов Deckhouse в поде Deckhouse:
   
   ```shell
-  $ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- getent ahosts registry.deckhouse.ru
+  $ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- getent ahosts registry.deckhouse.ru
   185.193.90.38    STREAM registry.deckhouse.ru
   185.193.90.38    DGRAM  registry.deckhouse.ru
   ```
@@ -759,7 +759,7 @@ proxy:
 Чтобы изменить общие параметры кластера, выполните команду:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
+kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
 После сохранения изменений Deckhouse приведет конфигурацию кластера к измененному состоянию. В зависимости от размеров кластера это может занять какое-то время.
@@ -771,7 +771,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 Независимо от используемого облачного провайдера его настройки можно изменить с помощью следующей команды:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit provider-cluster-configuration
+kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit provider-cluster-configuration
 ```
 
 ### Как изменить конфигурацию статического кластера?
@@ -781,7 +781,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-control
 Чтобы изменить параметры статического кластера, выполните команду:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit static-cluster-configuration
+kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit static-cluster-configuration
 ```
 
 ### Как переключить Deckhouse EE на CE?
@@ -959,7 +959,7 @@ kubectl -n d8-system exec -it $(kubectl -n d8-system get leases.coordination.k8s
 1. Выполните команду:
 
    ```shell
-   kubectl -n d8-system exec -ti deploy/deckhouse -c deckhouse -- deckhouse-controller edit cluster-configuration
+   kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller edit cluster-configuration
    ```
 
 1. Измените параметр `kubernetesVersion`.

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -10,7 +10,7 @@ apiVersions:
       Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
@@ -12,7 +12,7 @@ apiVersions:
         Run the following command to change the configuration in a running cluster:
 
         ```shell
-        kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+        kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
         ```
       x-doc-search: |
         ProviderClusterConfiguration

--- a/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
@@ -10,7 +10,7 @@ apiVersions:
         Выполните следующую команду, чтобы изменить конфигурацию в запущенном кластере:
 
         ```shell
-        kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+        kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
         ```
       properties:
         masterNodeGroup:

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -12,7 +12,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
@@ -10,7 +10,7 @@ apiVersions:
         Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
         ```shell
-        kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+        kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
         ```
       x-doc-search: |
         ProviderClusterConfiguration

--- a/ee/candi/cloud-providers/zvirt/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/zvirt/openapi/cluster_configuration.yaml
@@ -12,7 +12,7 @@ apiVersions:
       Run the following command to change the configuration in a running cluster:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     x-doc-search: |
       ProviderClusterConfiguration

--- a/ee/candi/cloud-providers/zvirt/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/zvirt/openapi/doc-ru-cluster_configuration.yaml
@@ -12,7 +12,7 @@ apiVersions:
       Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
 
       ```shell
-      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
       ```
     doc-search: |
       ProviderClusterConfiguration

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -21,7 +21,7 @@ properties:
           Run the following command to change the configuration in a running cluster:
 
           ```shell
-          kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+          kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
           ```
         x-examples:
           - apiVersion: deckhouse.io/v1

--- a/ee/modules/030-cloud-provider-zvirt/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/openapi/values.yaml
@@ -19,7 +19,7 @@ properties:
           Run the following command to change the configuration in a running cluster:
 
           ```shell
-          kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+          kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration
           ```
         x-doc-search: |
           ProviderClusterConfiguration

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -7,7 +7,7 @@ title: "The deckhouse module: FAQ"
 First, you have to exec in Deckhouse Pod:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- bash
+kubectl -n d8-system exec -ti svc/deckhouse-leader -- bash
 ```
 
 Then you have to select which node you want to run kube-bench.

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -7,7 +7,7 @@ title: "Модуль deckhouse: FAQ"
 Вначале необходимо зайти внутрь пода Deckhouse:
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- bash
+kubectl -n d8-system exec -ti svc/deckhouse-leader -- bash
 ```
 
 Далее необходимо выбрать, на каком узле запустить kube-bench.

--- a/modules/500-upmeter/scripts/fix_server_db/README.md
+++ b/modules/500-upmeter/scripts/fix_server_db/README.md
@@ -20,7 +20,7 @@ time="2021-05-20T10:22:50Z" level=fatal msg="cannot start server: database not c
 ### 1. Migrate
 
 ```shell
-kubectl -n d8-system exec -ti deploy/deckhouse -- /modules/500-upmeter/scripts/fix_server_db/migrate.sh
+kubectl -n d8-system exec -ti svc/deckhouse-leader -- /modules/500-upmeter/scripts/fix_server_db/migrate.sh
 ```
 
 ### 2. Optionally observe the state


### PR DESCRIPTION
## Description

In the docs everywhere we have a command like:

```sh
kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
```

which could not work for HA installations

We should replace `kubectl -n d8-system exec -ti deploy/deckhouse` with `kubectl -n d8-system exec -ti svc/deckhouse-leader`

## Why do we need it, and what problem does it solve?

related #8994

## What is the expected result?

Documentation is up to date

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Use `svc/deckhouse-leader` in kubectl exec command (more convenient, especially when Deckhouse works in HA mode).
impact_level: low
```
