### PR TITLE
[deckhouse-controller] fix: ModuleRelease with absent ModuleReleasePolicy

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -443,6 +443,9 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 					UpdatePolicyLabel: policy.Name,
 				},
 			},
+			"status": map[string]any{
+				"message": "",
+			},
 		})
 		p := client.RawPatch(types.MergePatchType, patch)
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -415,7 +415,7 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 			if e := c.updateModuleReleaseStatusMessage(ctx, mr, disabledByIgnorePolicy); e != nil {
 				return ctrl.Result{Requeue: true}, e
 			}
-			return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
+			return ctrl.Result{RequeueAfter: defaultCheckInterval * 4}, nil
 		}
 	} else {
 		// get all policies regardless of their labels

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -52,11 +52,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
-	addonutils "github.com/flant/addon-operator/pkg/utils"
-	"github.com/flant/addon-operator/pkg/utils/logger"
-	"github.com/flant/shell-operator/pkg/metric_storage"
-
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/models"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -437,10 +437,18 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 					UpdatePolicyLabel: policy.Name,
 				},
 			},
+			"status": map[string]string{
+				"message": "",
+			},
 		})
 		p := client.RawPatch(types.MergePatchType, patch)
 
 		err = c.client.Patch(ctx, mr, p)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
+		}
+		// also patch status field
+		err = c.client.Status().Patch(ctx, mr, p)
 		if err != nil {
 			return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 		}

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -437,14 +437,12 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 			}
 			return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 		}
+		mr.Status.Message = ""
 		patch, _ := json.Marshal(map[string]any{
 			"metadata": map[string]any{
 				"labels": map[string]any{
 					UpdatePolicyLabel: policy.Name,
 				},
-			},
-			"status": map[string]any{
-				"message": "",
 			},
 		})
 		p := client.RawPatch(types.MergePatchType, patch)
@@ -526,7 +524,6 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 		//TODO: create custom error type with additional fields like reason end requeueAfter
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 	}
-
 	if err != nil {
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, fmt.Errorf("apply predicted release: %w", err)
 	}

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -450,7 +450,7 @@ alerts:
       description: |
         Module update policy not found for {{ $labels.module_release }}
 
-        You need to remove label from MR: `kubectl label mr {{ $labels.module }} modules.deckhouse.io/update-policy-`.
+        You need to remove label from MR: `kubectl label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-`.
         A new suitable policy will be detected automatically.
       summary: |
         Module update policy not found for {{ $labels.module_release }}

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -442,6 +442,20 @@ alerts:
         The {{ $labels.module }}/{{ $labels.hook }} Deckhouse hook crashes way too often.
       severity: "9"
       markupFormat: markdown
+    - name: D8DeckhouseModuleUpdatePolicyNotFound
+      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+      moduleUrl: 340-monitoring-deckhouse
+      module: monitoring-deckhouse
+      edition: ce
+      description: |
+        Module update policy not found for {{ $labels.module_release }}
+
+        You need to remove label from MR: `kubectl label mr {{ $labels.module }} modules.deckhouse.io/update-policy-`.
+        A new suitable policy will be detected automatically.
+      summary: |
+        Module update policy not found for {{ $labels.module_release }}
+      severity: "5"
+      markupFormat: markdown
     - name: D8DeckhousePodIsNotReady
       sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
       moduleUrl: 340-monitoring-deckhouse

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -108,6 +108,50 @@ spec:
         heritage: deckhouse
 {{- end }}
 ---
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "update-policy-label-objects.deckhouse.io"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["deckhouse.io"]
+        apiVersions: ["*"]
+        operations:  ["UPDATE"]
+        resources:   ["modulereleases"]
+  validations:
+    - expression: request.userInfo.username.startsWith("system:serviceaccount:d8-")
+        || ! ("modules.deckhouse.io/update-policy" in object.metadata.labels)
+        || ! ("modules.deckhouse.io/update-policy" in oldObject.metadata.labels)
+        || object.metadata.labels["modules.deckhouse.io/update-policy"] == oldObject.metadata.labels["modules.deckhouse.io/update-policy"]
+      reason: Forbidden
+      {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+      messageExpression: "'Manual update-policy change is forbidden. Please, remove the update-policy label to automatically find a new suitable policy'"
+      {{- end }}
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "update-policy-label-objects.deckhouse.io"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: "update-policy-label-objects.deckhouse.io"
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  validationActions: [Deny]
+{{- end }}
+---
 {{- $policyName := "moduleconfigs-settings.deckhouse.io" }}
 {{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -431,5 +431,5 @@
       description: |
         Module update policy not found for {{ $labels.module_release }}
 
-        You need to remove label from MR: `kubectl label mr {{ $labels.module }} modules.deckhouse.io/update-policy-`.
+        You need to remove label from MR: `kubectl label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-`.
         A new suitable policy will be detected automatically.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -415,3 +415,21 @@
       description: |
         The deckhouse configmap is no longer used.
         You need to remove configmap "d8-system/deckhouse" from ArgoCD
+
+  - alert: D8DeckhouseModuleUpdatePolicyNotFound
+    expr: |
+      increase(deckhouse_module_update_policy_not_found[__SCRAPE_INTERVAL_X_2__]) > 0
+    for: 3m
+    labels:
+      tier: cluster
+      d8_module: "{{ $labels.module }}"
+      severity_level: "5"
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary: Module update policy not found for {{ $labels.module_release }}
+      description: |
+        Module update policy not found for {{ $labels.module_release }}
+
+        You need to remove label from MR: `kubectl label mr {{ $labels.module }} modules.deckhouse.io/update-policy-`.
+        A new suitable policy will be detected automatically.


### PR DESCRIPTION
## Description

If you create a _ModuleRelease_ resource with a _ModuleUpdatePolicy_ and then remove the _ModuleUpdatePolicy_, the module stops updating.

Instead of errors in the logs, a module should get update settings from the default _ModuleUpdatePolicy_.

## Why do we need it, and what problem does it solve?

Removing ModuleUpdatePolicy should not block module updates.

## What is the expected result?

ModuleRelease should find new matching ModuleUpdatePolicy or fallback to the embedded one (the default _ModuleUpdatePolicy_)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Use the default _ModuleUpdatePolicy_ if the _ModuleUpdatePolicy_, referenced in _ModuleRelease_, has been deleted.
impact_level: default
```

Fixed: #8988