### PR TITLE
[site] Sort modules in the documentation sidebar

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -361,42 +361,6 @@ entries:
                   url: /modules/030-cloud-provider-vcd/examples.html
                 - title: FAQ
                   url: /modules/030-cloud-provider-vcd/faq.html
-            - title: zVirt
-              d8Revision: ee
-              featureStatus: experimental
-              folders:
-                - title:
-                    en: Description
-                    ru: Описание
-                  url: /modules/030-cloud-provider-zvirt/
-                - title:
-                    en: Installation
-                    ru: Установка
-                  folders:
-                    - title:
-                        en: Preparing environment
-                        ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-zvirt/environment.html
-                    - title:
-                        en: Layouts
-                        ru: Схемы размещения
-                      url: /modules/030-cloud-provider-zvirt/layouts.html
-                    - title:
-                        en: Provider configuration
-                        ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-zvirt/cluster_configuration.html
-                - title:
-                    en: Reference
-                    ru: Справка
-                  folders:
-                    - title:
-                        en: Configuration
-                        ru: Настройки
-                      url: /modules/030-cloud-provider-zvirt/configuration.html
-                    - title: Custom Resources
-                      url: /modules/030-cloud-provider-zvirt/cr.html
-                - title: FAQ
-                  url: /modules/030-cloud-provider-zvirt/faq.html
             - title: Yandex Cloud
               folders:
                 - title:
@@ -435,6 +399,42 @@ entries:
                   url: /modules/030-cloud-provider-yandex/examples.html
                 - title: FAQ
                   url: /modules/030-cloud-provider-yandex/faq.html
+            - title: zVirt
+              d8Revision: ee
+              featureStatus: experimental
+              folders:
+                - title:
+                    en: Description
+                    ru: Описание
+                  url: /modules/030-cloud-provider-zvirt/
+                - title:
+                    en: Installation
+                    ru: Установка
+                  folders:
+                    - title:
+                        en: Preparing environment
+                        ru: Подготовка окружения
+                      url: /modules/030-cloud-provider-zvirt/environment.html
+                    - title:
+                        en: Layouts
+                        ru: Схемы размещения
+                      url: /modules/030-cloud-provider-zvirt/layouts.html
+                    - title:
+                        en: Provider configuration
+                        ru: Настройка провайдера
+                      url: /modules/030-cloud-provider-zvirt/cluster_configuration.html
+                - title:
+                    en: Reference
+                    ru: Справка
+                  folders:
+                    - title:
+                        en: Configuration
+                        ru: Настройки
+                      url: /modules/030-cloud-provider-zvirt/configuration.html
+                    - title: Custom Resources
+                      url: /modules/030-cloud-provider-zvirt/cr.html
+                - title: FAQ
+                  url: /modules/030-cloud-provider-zvirt/faq.html
         - title:
             en: Control plane management
             ru: Управление control plane
@@ -481,6 +481,16 @@ entries:
             en: Other modules
             ru: Другие модули
           folders:
+            - title: cilium-hubble
+              folders:
+                - title:
+                    ru: Описание
+                    en: Description
+                  url: /modules/500-cilium-hubble/
+                - title:
+                    ru: Настройки
+                    en: Configuration
+                  url: /modules/500-cilium-hubble/configuration.html
             - title: cni-cilium
               folders:
                 - title:
@@ -497,16 +507,6 @@ entries:
                     en: Examples
                     ru: Примеры
                   url: /modules/021-cni-cilium/examples.html
-            - title: cilium-hubble
-              folders:
-                - title:
-                    ru: Описание
-                    en: Description
-                  url: /modules/500-cilium-hubble/
-                - title:
-                    ru: Настройки
-                    en: Configuration
-                  url: /modules/500-cilium-hubble/configuration.html
             - title: cni-flannel
               folders:
                 - title:
@@ -523,12 +523,6 @@ entries:
                     en: Description
                     ru: Описание
                   url: /modules/035-cni-simple-bridge/
-            - title: kube-proxy
-              folders:
-                - title:
-                    en: Description
-                    ru: Описание
-                  url: /modules/036-kube-proxy/
             - title: kube-dns
               folders:
                 - title:
@@ -545,6 +539,12 @@ entries:
                   url: /modules/042-kube-dns/examples.html
                 - title: FAQ
                   url: /modules/042-kube-dns/faq.html
+            - title: kube-proxy
+              folders:
+                - title:
+                    en: Description
+                    ru: Описание
+                  url: /modules/036-kube-proxy/
             - title: node-local-dns
               d8Revision: ee
               folders:
@@ -560,16 +560,6 @@ entries:
                     en: Configuration
                     ru: Настройки
                   url: /modules/350-node-local-dns/configuration.html
-            - title: terraform-manager
-              folders:
-                - title:
-                    en: Description
-                    ru: Описание
-                  url: /modules/040-terraform-manager/
-                - title:
-                    en: Configuration
-                    ru: Настройки
-                  url: /modules/040-terraform-manager/configuration.html
             - title: static-routing-manager
               folders:
                 - title:
@@ -590,6 +580,16 @@ entries:
                     en: Examples
                     ru: Примеры
                   url: /modules/025-static-routing-manager/examples.html
+            - title: terraform-manager
+              folders:
+                - title:
+                    en: Description
+                    ru: Описание
+                  url: /modules/040-terraform-manager/
+                - title:
+                    en: Configuration
+                    ru: Настройки
+                  url: /modules/040-terraform-manager/configuration.html
     - title:
         en: Accessing cluster
         ru: Доступ к кластеру
@@ -854,6 +854,18 @@ entries:
                     en: Configuration
                     ru: Настройки
                   url: /modules/600-flant-integration/configuration.html
+            - title: operator-prometheus
+              folders:
+                - title:
+                    en: Description
+                    ru: Описание
+                  url: /modules/200-operator-prometheus/
+                - title:
+                    en: Configuration
+                    ru: Настройки
+                  url: /modules/200-operator-prometheus/configuration.html
+                - title: FAQ
+                  url: /modules/200-operator-prometheus/faq.html
             - title: okmeter
               featureStatus: proprietaryOkmeter
               folders:
@@ -869,18 +881,6 @@ entries:
                     en: Configuration
                     ru: Настройки
                   url: /modules/500-okmeter/configuration.html
-            - title: operator-prometheus
-              folders:
-                - title:
-                    en: Description
-                    ru: Описание
-                  url: /modules/200-operator-prometheus/
-                - title:
-                    en: Configuration
-                    ru: Настройки
-                  url: /modules/200-operator-prometheus/configuration.html
-                - title: FAQ
-                  url: /modules/200-operator-prometheus/faq.html
             - title: prometheus-pushgateway
               folders:
                 - title:
@@ -1152,20 +1152,6 @@ entries:
             en: Other modules
             ru: Другие модули
           folders:
-            - title: network-policy-engine
-              folders:
-                - title:
-                    en: Description
-                    ru: Описание
-                  url: /modules/050-network-policy-engine/
-                - title:
-                    en: Examples
-                    ru: Примеры
-                  url: /modules/050-network-policy-engine/examples.html
-                - title:
-                    en: Configuration
-                    ru: Настройки
-                  url: /modules/050-network-policy-engine/configuration.html
             - title: cert-manager
               folders:
                 - title:
@@ -1188,6 +1174,20 @@ entries:
                       url: /modules/101-cert-manager/cr.html
                 - title: FAQ
                   url: /modules/101-cert-manager/faq.html
+            - title: network-policy-engine
+              folders:
+                - title:
+                    en: Description
+                    ru: Описание
+                  url: /modules/050-network-policy-engine/
+                - title:
+                    en: Examples
+                    ru: Примеры
+                  url: /modules/050-network-policy-engine/examples.html
+                - title:
+                    en: Configuration
+                    ru: Настройки
+                  url: /modules/050-network-policy-engine/configuration.html
             - title: operator-trivy
               d8Revision: ee
               featureStatus: experimental


### PR DESCRIPTION
## Description
Sort modules in the documentation sidebar.

## Why do we need it in the patch release (if we do)?

Not necessary.

## Changelog entries
```changes
section: docs
type: chore
summary: Sort modules in the documentation sidebar.
impact_level: low
```
