### PR TITLE
[user-authn] feat: validate email and password on user create

### DIFF
--- a/modules/010-user-authn-crd/crds/user.yaml
+++ b/modules/010-user-authn-crd/crds/user.yaml
@@ -35,6 +35,7 @@ spec:
               properties:
                 email:
                   type: string
+                  pattern: '^[\w\-\.]+@(?:[\w-]+\.)+[\w-]{2,}$'
                   description: |
                     User email.
 
@@ -42,6 +43,7 @@ spec:
                   x-doc-examples: ['user@domain.com']
                 password:
                   type: string
+                  minLength: 1
                   description: |
                     User password hash in plaintext or Base64 encoded.
 
@@ -120,6 +122,7 @@ spec:
               properties:
                 email:
                   type: string
+                  pattern: '^[\w\-\.]+@(?:[\w-]+\.)+[\w-]{2,}$'
                   description: |
                     User email.
 
@@ -127,6 +130,7 @@ spec:
                   x-doc-examples: ['user@domain.com']
                 password:
                   type: string
+                  minLength: 1
                   description: |
                     User password hash in plaintext or Base64 encoded.
 


### PR DESCRIPTION
## Description

When creating a user, email and password checks are not performed. You can create a user with empty values ​​or with an incorrect email.

In this regard, a number of errors are possible. And we need to check that the password and email fields are filled in correctly.

## Why do we need it, and what problem does it solve?

The cluster must have users with a correctly specified email and non-empty password fields.

## What is the expected result?

When creating a user, the email and password fields are checked for completion. In this case, the email field is checked for a specific format.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: chore
summary: Validate email and password on user create.
impact_level: default
```
