### PR TITLE
chore(dhctl-for-commander): minor logging fixes

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -85,11 +85,12 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 
 	hasUUID, err := stateCache.InCache("uuid")
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to check uuid: %w", err)
 	}
 
 	if !hasUUID {
 		if b.CommanderMode {
+			log.InfoF("No UUID found in the cache, will exit now\n")
 			return nil
 		}
 		return fmt.Errorf("No UUID found in the cache. Perhaps, the cluster was already bootstrapped.")


### PR DESCRIPTION
## Description

Minor logging fixes related to commander-mode operation of dhctl.

## Why do we need it, and what problem does it solve?

This PR improves logging when uuid is not exists in the dhctl cache. And in the case when uuid does not exists in the cache there is a corresponding log message.