### PR TITLE
[node-manager] discover_packages_proxy_addresses hook fix

### DIFF
--- a/modules/039-registry-packages-proxy/templates/deployment.yaml
+++ b/modules/039-registry-packages-proxy/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "uninitialized")  | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-no-csi")  | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "registry-packages-proxy")) | nindent 6 }}

--- a/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
+++ b/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
@@ -81,10 +81,10 @@ func handlePackagesProxyEndpoints(input *go_hook.HookInput) error {
 	endpointsList := endpointsSet.Slice() // sorted
 
 	if len(endpointsList) == 0 {
-		return fmt.Errorf("No packages proxy endpoints found")
+		return fmt.Errorf("no packages proxy endpoints found")
 	}
 
-	input.LogEntry.Infof("Found packages proxy endpoints: %v", endpointsList)
+	input.LogEntry.Infof("found packages proxy endpoints: %v", endpointsList)
 	input.Values.Set("nodeManager.internal.packagesProxy.addresses", endpointsList)
 
 	return nil

--- a/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
+++ b/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
@@ -34,7 +34,7 @@ const (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
 	Queue:        "/modules/node-manager",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
@@ -81,10 +81,10 @@ func handlePackagesProxyEndpoints(input *go_hook.HookInput) error {
 	endpointsList := endpointsSet.Slice() // sorted
 
 	if len(endpointsList) == 0 {
-		return fmt.Errorf("no kubernetes packages proxy endpoints host:port specified")
+		return fmt.Errorf("No packages proxy endpoints found")
 	}
 
-	input.LogEntry.Infof("Found kubernetes packages proxy endpoints: %v", endpointsList)
+	input.LogEntry.Infof("Found packages proxy endpoints: %v", endpointsList)
 	input.Values.Set("nodeManager.internal.packagesProxy.addresses", endpointsList)
 
 	return nil

--- a/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
+++ b/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
@@ -81,10 +81,10 @@ func handlePackagesProxyEndpoints(input *go_hook.HookInput) error {
 	endpointsList := endpointsSet.Slice() // sorted
 
 	if len(endpointsList) == 0 {
-		input.LogEntry.Warn("no kubernetes packages proxy endpoints host:port specified")
-		return nil
+		return fmt.Errorf("no kubernetes packages proxy endpoints host:port specified")
 	}
 
+	input.LogEntry.Infof("Found kubernetes packages proxy endpoints: %v", endpointsList)
 	input.Values.Set("nodeManager.internal.packagesProxy.addresses", endpointsList)
 
 	return nil

--- a/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
+++ b/modules/040-node-manager/hooks/discover_packages_proxy_addresses.go
@@ -34,7 +34,8 @@ const (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue: "/modules/node-manager",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
+	Queue:        "/modules/node-manager",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "packages_proxy",

--- a/modules/040-node-manager/hooks/discover_packages_proxy_addresses_test.go
+++ b/modules/040-node-manager/hooks/discover_packages_proxy_addresses_test.go
@@ -81,7 +81,7 @@ status:
 		})
 
 		It("Hook should execute successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
+			Expect(f).NotTo(ExecuteSuccessfully())
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: borg-z <me@nikolay-z.top>

## Description

Fixed the behavior of the discover_packages_proxy_addresses hook that caused a static node to be created with an empty PACKAGES_PROXY_ADDRESSES variable, resulting in a bootstrap error.

## Why do we need it, and what problem does it solve?

This change resolves an issue where nodes would fail to bootstrap due to missing package proxy addresses

## Why do we need it in the patch release (if we do)?


## What is the expected result?

After applying these changes, nodes should bootstrap successfully without errors related to missing package proxy addresses.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager, registry-packages-proxy
type: fix
summary: Fixed issue causing static nodes to be created with empty package proxy addresses, leading to bootstrap errors.
impact: Nodes will now bootstrap successfully without errors related to missing package proxy addresses.)
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
