### PR TITLE
[network-policy-engine] Using the same iptables from registrypackages as in the host

### DIFF
--- a/modules/007-registrypackages/images/iptables/werf.inc.yaml
+++ b/modules/007-registrypackages/images/iptables/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{/* Important! The iptables binaries from artifact are also used in kube-router image of network-policy-engine module. */}}
 {{- $version := "1.8.10" }}
 {{- $image_version := $version | replace "." "-" }}
 ---

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -1,4 +1,6 @@
-{{- $binaries := "/sbin/xtables-nft-multi /sbin/ip6tables-nft /sbin/ip6tables-nft-restore /sbin/ip6tables-nft-save /sbin/iptables-nft /sbin/iptables-nft-restore /sbin/iptables-nft-save /sbin/xtables-legacy-multi /sbin/iptables /sbin/iptables-restore /sbin/iptables-save /sbin/iptables-legacy /sbin/iptables-legacy-restore /sbin/iptables-legacy-save /sbin/ip6tables /sbin/ip6tables-restore /sbin/ip6tables-save /sbin/ip6tables-legacy /sbin/ip6tables-legacy-restore /sbin/ip6tables-legacy-save /usr/lib64/libnetfilter_conntrack.so* /sbin/ipset /sbin/ip /usr/sbin/conntrack" }}
+{{- $binaries := "/usr/lib64/libnetfilter_conntrack.so* /sbin/ipset /sbin/ip /usr/sbin/conntrack" }}
+{{- $iptables_version := "1.8.10" }}
+{{- $iptables_image_version := $version | replace "." "-" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ .Images.BASE_ALT_DEV }}
@@ -35,12 +37,12 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- artifact: registryPackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin/
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
   before: setup
 - image: common/iptables-wrapper
   add: /iptables-wrapper

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -1,6 +1,6 @@
 {{- $binaries := "/usr/lib64/libnetfilter_conntrack.so* /sbin/ipset /sbin/ip /usr/sbin/conntrack" }}
 {{- $iptables_version := "1.8.10" }}
-{{- $iptables_image_version := $version | replace "." "-" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ .Images.BASE_ALT_DEV }}

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -37,7 +37,7 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: registryPackages/iptables-artifact-{{ $iptables_image_version }}
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin/
   includePaths:


### PR DESCRIPTION
## Description
Using the same iptables from registrypackages as in the host.

## Why do we need it, and what problem does it solve?
There is a [conflict](https://github.com/cloudnativelabs/kube-router/issues/1370) between kubelet and kube-router which leads to DROPping all the input and output traffic. They both work with the KUBE-FIREWALL iptables chain and kubelet creates the rule:
```
-A KUBE-FIREWALL -m comment --comment "kubernetes firewall for dropping marked packets" -m mark --mark 0x8000/0x8000 -j DROP
```
Meanwhile, the kube-router uses iptables-save/iptables-restore flow to sync his own rules and during restore, the `-m mark --mark 0x8000/0x8000` part is being lost. The result is lost connectivity between Nodes!

Fix is using the same iptables versions both in kubelet (host) and kube-router (image).

Also, the only affected and supported by d8 kubernetes version is v1.26, because there is `IPTablesOwnershipCleanup`  FeatureGate [disabled by default](https://github.com/kubernetes/kubernetes/blob/840d9bfe2ee5a9ca6d54435c598c2dc563f9cb70/pkg/features/kube_features.go#L1036C2-L1036C26). After v1.27 it is [enabled](https://github.com/kubernetes/kubernetes/blob/e596f2e471096ef7711b2f38529cbffb30801f14/pkg/features/kube_features.go#L1028) and [the DROP rules aren't being deployed](https://github.com/kubernetes/kubernetes/blob/e596f2e471096ef7711b2f38529cbffb30801f14/pkg/kubelet/kubelet_network_linux.go#L122).

## Why do we need it in the patch release (if we do)?
Losing connectivity between Nodes is a great disaster. It is extremely important fix for network-policy-engine users.


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: network-policy-engine
type: fix
summary: The kube-router image now use the same iptables binaries as on the host to prevent incompatibility.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
