### PR TITLE
[dhctl] del name label on d8-node-terraform-state secret

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -516,7 +516,7 @@ func DeckhouseRegistrySecret(registry config.RegistryData) *apiv1.Secret {
 }
 
 func generateSecret(name, namespace string, data map[string][]byte, labels map[string]string) *apiv1.Secret {
-	preparedLabels := map[string]string{"heritage": "deckhouse", "name": name}
+	preparedLabels := map[string]string{"heritage": "deckhouse"}
 	for key, value := range labels {
 		preparedLabels[key] = value
 	}
@@ -596,6 +596,8 @@ func SecretWithNodeTerraformState(nodeName, nodeGroup string, data, settings []b
 		"d8-system",
 		body,
 		map[string]string{
+			"node.deckhouse.io/node-group":      nodeGroup,
+			"node.deckhouse.io/node-name":       nodeName,
 			"node.deckhouse.io/terraform-state": "",
 		},
 	)

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -596,8 +596,6 @@ func SecretWithNodeTerraformState(nodeName, nodeGroup string, data, settings []b
 		"d8-system",
 		body,
 		map[string]string{
-			"node.deckhouse.io/node-group":      nodeGroup,
-			"node.deckhouse.io/node-name":       nodeName,
 			"node.deckhouse.io/terraform-state": "",
 		},
 	)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix creation cloudPermanent nodes with valid length name ( no longer 42 symbols ).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

CloudPermanent ng with correct length name  ( cluster prefix + node group name should be no longer then 42 symbols ) doesn't create.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

 In example used cluster prefix `dev-` and node group name `worker-permanent-to-looooooooooooooong`, that give valid name with 42 symbols. Try apply it:

```
nodeGroups:
- instanceClass:
    configDrive: false
    flavorName: m1.medium
    imageName: redos-standard-7.3.4
    mainNetwork: dev
  name: worker-permanent-to-looooooooooooooong
  replicas: 1
```

Behavior before:
```
...
│ │ │ State path: terraform.tfstate
│ │ │ Terraform runner "static-node" process exited.
│ │ │ Save intermediate state error: timeout while "Save intermediate Terraform state for Node                                             ↵
│ │ │ \"dev-worker-permanent-to-looooooooooooooong-0\"": last error: Create 'Secret                                                        ↵
│ │ │ "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0"': Secret                                                      ↵
│ │ │ "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0" is invalid: metadata.labels: Invalid value:                   ↵
│ │ │ "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0": must be no more than 63 characters
│ │ └ terraform apply ... (453.09 seconds)
│ └ 🌱 ~ Terraform: Pipeline static-node for dev-worker-permanent-to-looooooooooooooong-0 (456.50 seconds)
│
│ ┌ Save Terraform state for Node "dev-worker-permanent-to-looooooooooooooong-0"
│ │ Manifest for Secret "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0"
│ │ ️⛱️️ Attempt #1 of 45 |
│ │ 	Save Terraform state for Node "dev-worker-permanent-to-looooooooooooooong-0" failed, next attempt will be in 10s"
│ │ 	Error: create resource: Secret "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0" is invalid: metadata.labels:    ↵
│ │ Invalid value: "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0": must be no more than 63 characters
...
```

Behavior after:
```
...
│ │ │ State path: terraform.tfstate
│ │ │ Terraform runner "static-node" process exited.
│ │ └ terraform apply ... (82.47 seconds)
│ └ 🌱 ~ Terraform: Pipeline static-node for dev-worker-permanent-to-looooooooooooooong-0 (85.84 seconds)
│
│ ┌ Save Terraform state for Node "dev-worker-permanent-to-looooooooooooooong-0"
│ │ Manifest for Secret "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0"
│ │ Secret "d8-node-terraform-state-dev-worker-permanent-to-looooooooooooooong-0" already exists. Trying to update ... OK!
│ │ 🎉 Succeeded!
│ └ Save Terraform state for Node "dev-worker-permanent-to-looooooooooooooong-0" (0.18 seconds)
│
│ ┌ Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready
│ │ ️⛱️️ Attempt #1 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #2 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #3 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #4 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #5 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #6 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #7 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │
│ │ ️⛱️️ Attempt #8 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │ * dev-worker-permanent-to-looooooooooooooong-0 | NotReady
│ │
│ │ ️⛱️️ Attempt #9 of 100 |
│ │ 	Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready failed, next attempt will be in 20s"
│ │ 	Error: Nodes Ready 0 of 1
│ │ * dev-worker-permanent-to-looooooooooooooong-0 | NotReady
│ │
│ │ Nodes Ready 1 of 1
│ │ * dev-worker-permanent-to-looooooooooooooong-0 | Ready
│ │
│ │ 🎉 Succeeded!
│ └ Waiting for NodeGroup worker-permanent-to-looooooooooooooong to become Ready (180.75 seconds)
└ 🛸 ~ Converge: Add NodeGroup worker-permanent-to-looooooooooooooong (replicas: 1)️ (277.34 seconds)
...
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix creation cloudPermanent nodes with valid length name (no longer 42 symbols).
impact: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
