### PR TITLE
[testing] rewrite controller tests

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -61,12 +61,18 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 }`
 
 	suite.Run("Have new deckhouse image", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{LayersStub: func() ([]v1.Layer, error) {
-			return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.3"}`}}, nil
-		},
-			DigestStub: func() (v1.Hash, error) {
-				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b777")
-			}}, nil)
+		dependency.TestDC.CRClient.ImageMock.Return(
+			&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{
+						FilesContent: map[string]string{`version.json`: `{"version": "v1.25.3"}`}},
+					}, nil
+				},
+				DigestStub: func() (v1.Hash, error) {
+					return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b777")
+				},
+			}, nil,
+		)
 
 		suite.setupController("have-new-deckhouse-image.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
@@ -74,12 +80,19 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Have canary release wave 0", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{LayersStub: func() ([]v1.Layer, error) {
-			return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "6m"}}}`}}, nil
-		},
-			DigestStub: func() (v1.Hash, error) {
-				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-			}}, nil)
+		dependency.TestDC.CRClient.ImageMock.Return(
+			&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{
+						FilesContent: map[string]string{
+							`version.json`: `{"version": "v1.25.0", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "6m"}}}`,
+						}}}, nil
+				},
+				DigestStub: func() (v1.Hash, error) {
+					return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+				},
+			}, nil,
+		)
 
 		suite.setupController("have-canary-release-wave-0.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
@@ -87,9 +100,13 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Have canary release wave 4", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{LayersStub: func() ([]v1.Layer, error) {
-			return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.5", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "15m"}}}`}}, nil
-		},
+		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{
+						`version.json`: `{"version": "v1.25.5", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "15m"}}}`,
+					}}}, nil
+			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666")
 			}}, nil)
@@ -102,12 +119,12 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Existed release suspended", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0", "suspend": true}`}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0", "suspend": true}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-			},
-		}, nil)
+			}}, nil)
 
 		suite.setupController("existed-release-suspended.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
@@ -117,7 +134,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Deployed release suspended", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0", "suspend": true}`}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0", "suspend": true}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -132,7 +150,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("New release suspended", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0", "suspend": true}`}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0", "suspend": true}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -147,7 +166,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Resume suspended release", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0"}`}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0"}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -162,7 +182,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Image hash not changed", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0"}`}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0"}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f66857")
@@ -178,7 +199,10 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Release has requirements", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.30.0", "requirements": {"k8s": "1.19", "req1": "dep1"}}`}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{
+						`version.json`: `{"version": "v1.30.0", "requirements": {"k8s": "1.19", "req1": "dep1"}}`,
+					}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f66858")
@@ -193,7 +217,9 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Release has canary", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"canary":{"alpha":{"enabled":true,"interval":"5m","waves":2},"beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5},"stable":{"enabled":true,"interval":"30m","waves":6}},"version":"v1.31.0"}`}}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{
+						"version.json": `{"canary":{"alpha":{"enabled":true,"interval":"5m","waves":2}, "beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5},"stable":{"enabled":true,"interval":"30m","waves":6}},"version":"v1.31.0"}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76859")
@@ -218,7 +244,9 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 		}, nil)
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.31.0"}`}}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
+					"version.json": `{"version":"v1.31.0"}`,
+				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76859")
@@ -240,7 +268,9 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Inherit release cooldown", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.31.1"}`}}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
+					"version.json": `{"version":"v1.31.1"}`,
+				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76869")
@@ -262,7 +292,9 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Patch release has own cooldown", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.31.2"}`}}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
+					"version.json": `{"version":"v1.31.2"}`,
+				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
@@ -284,7 +316,9 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	suite.Run("Release has disruptions", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version": "v1.32.0", "disruptions":{"1.32":["ingressNginx"]}}`}}}, nil
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
+					"version.json": `{"version": "v1.32.0", "disruptions":{"1.32":["ingressNginx"]}}`,
+				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f66859")
@@ -402,8 +436,6 @@ global:
 
 type fakeLayer struct {
 	v1.Layer
-	// Deprecated: use FilesContent with specified name instead
-	Body string
 
 	FilesContent map[string]string // pair: filename - file content
 }
@@ -412,11 +444,6 @@ func (fl fakeLayer) Uncompressed() (io.ReadCloser, error) {
 	result := bytes.NewBuffer(nil)
 	if fl.FilesContent == nil {
 		fl.FilesContent = make(map[string]string)
-	}
-
-	if fl.Body != "" && len(fl.FilesContent) == 0 {
-		// backward compatibility for tests
-		fl.FilesContent["version.json"] = fl.Body
 	}
 
 	if len(fl.FilesContent) == 0 {
@@ -441,10 +468,6 @@ func (fl fakeLayer) Uncompressed() (io.ReadCloser, error) {
 }
 
 func (fl fakeLayer) Size() (int64, error) {
-	if len(fl.Body) > 0 {
-		return int64(len(fl.Body)), nil
-	}
-
 	return int64(len(fl.FilesContent)), nil
 }
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deckhouse_release
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/releaseutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+func setupFakeController(
+	t *testing.T,
+	filename, values string,
+	mup *v1alpha1.ModuleUpdatePolicySpec,
+) (*deckhouseReleaseReconciler, client.Client) {
+	ds := &helpers.DeckhouseSettings{
+		ReleaseChannel: mup.ReleaseChannel,
+	}
+	ds.Update.Mode = mup.Update.Mode
+	ds.Update.Windows = mup.Update.Windows
+	ds.Update.DisruptionApprovalMode = "Auto"
+	return setupControllerSettings(t, filename, values, ds)
+}
+
+func setupControllerSettings(
+	t *testing.T,
+	filename,
+	values string,
+	ds *helpers.DeckhouseSettings,
+) (*deckhouseReleaseReconciler, client.Client) {
+	yamlDoc := fetchTestFileData(t, filename, values)
+	manifests := releaseutil.SplitManifests(yamlDoc)
+
+	var initObjects = make([]client.Object, 0, len(manifests))
+	for _, manifest := range manifests {
+		obj := assembleInitObject(t, manifest)
+		initObjects = append(initObjects, obj)
+	}
+
+	sc := runtime.NewScheme()
+	_ = v1alpha1.SchemeBuilder.AddToScheme(sc)
+	_ = appsv1.AddToScheme(sc)
+	_ = corev1.AddToScheme(sc)
+	cl := fake.NewClientBuilder().
+		WithScheme(sc).
+		WithObjects(initObjects...).
+		WithStatusSubresource(&v1alpha1.DeckhouseRelease{}).
+		Build()
+	dc := dependency.NewDependencyContainer()
+
+	rec := &deckhouseReleaseReconciler{
+		client:         cl,
+		dc:             dc,
+		logger:         log.New(),
+		moduleManager:  stubModulesManager{},
+		updateSettings: helpers.NewDeckhouseSettingsContainer(ds),
+	}
+
+	return rec, cl
+}
+
+func assembleInitObject(t *testing.T, obj string) client.Object {
+	var res client.Object
+	var typ runtime.TypeMeta
+
+	err := yaml.Unmarshal([]byte(obj), &typ)
+	require.NoError(t, err)
+
+	switch typ.Kind {
+	case "Secret":
+		res = unmarshalRelease[corev1.Secret](obj, t)
+	case "Pod":
+		res = unmarshalRelease[corev1.Pod](obj, t)
+	case "Deployment":
+		res = unmarshalRelease[appsv1.Deployment](obj, t)
+	case "DeckhouseRelease":
+		res = unmarshalRelease[v1alpha1.DeckhouseRelease](obj, t)
+	case "ConfigMap":
+		res = unmarshalRelease[corev1.ConfigMap](obj, t)
+
+	default:
+		require.Fail(t, "unknown Kind:"+typ.Kind)
+	}
+
+	return res
+}
+
+func fetchTestFileData(t *testing.T, filename, valuesJSON string) string {
+	data := []byte("")
+	if filename != "" {
+		dir := "./testdata"
+		var err error
+		data, err = os.ReadFile(filepath.Join(dir, filename))
+		require.NoError(t, err)
+	}
+
+	deckhouseDiscovery := `---
+apiVersion: v1
+kind: Secret
+metadata:
+ name: deckhouse-discovery
+ namespace: d8-system
+type: Opaque
+data:
+{{- if $.Values.global.discovery.clusterUUID }}
+ clusterUUID: {{ $.Values.global.discovery.clusterUUID | b64enc }}
+{{- end }}
+`
+
+	deckhouseRegistry := `---
+apiVersion: v1
+kind: Secret
+metadata:
+ name: deckhouse-registry
+ namespace: d8-system
+data:
+ clusterIsBootstrapped: {{ .Values.global.clusterIsBootstrapped | quote | b64enc }}
+ imagesRegistry: {{ b64enc .Values.global.modulesImages.registry.base }}
+`
+
+	tmpl, err := template.New("manifest").
+		Funcs(sprig.TxtFuncMap()).
+		Parse(string(data) + deckhouseDiscovery + deckhouseRegistry)
+	require.NoError(t, err)
+
+	var values any
+	err = json.Unmarshal([]byte(valuesJSON), &values)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, map[string]any{"Values": values})
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+func unmarshalRelease[T any](manifest string, t *testing.T) *T {
+	var obj T
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	require.NoError(t, err)
+	return &obj
+}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -1,0 +1,267 @@
+package deckhouse_release
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"text/template"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/Masterminds/sprig/v3"
+	"github.com/google/go-cmp/cmp"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"helm.sh/helm/v3/pkg/releaseutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
+)
+
+func TestReleaseTestSuite(t *testing.T) {
+	suite.Run(t, new(ReleaseTestSuite))
+}
+
+type ReleaseTestSuite struct {
+	suite.Suite
+
+	kubeClient client.Client
+	ctr        *deckhouseReleaseReconciler
+}
+
+func (suite *ReleaseTestSuite) SetupSuite() {
+	suite.T().Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
+	dependency.TestDC.CRClient = cr.NewClientMock(suite.T())
+	dependency.TestDC.HTTPClient.DoMock.
+		Expect(&http.Request{}).
+		Return(&http.Response{
+			StatusCode: http.StatusOK,
+		}, nil)
+}
+
+func (suite *ReleaseTestSuite) setupController(values string, mup *v1alpha1.ModuleUpdatePolicySpec) {
+	ds := &helpers.DeckhouseSettings{
+		ReleaseChannel: mup.ReleaseChannel,
+	}
+	ds.Update.Mode = mup.Update.Mode
+	ds.Update.Windows = mup.Update.Windows
+	ds.Update.DisruptionApprovalMode = "Auto"
+
+	suite.setupControllerSettings(values, ds)
+}
+
+func (suite *ReleaseTestSuite) setupControllerSettings(values string, ds *helpers.DeckhouseSettings) {
+	yamlDoc := suite.fetchTestFileData(values)
+	manifests := releaseutil.SplitManifests(yamlDoc)
+
+	var initObjects = make([]client.Object, 0, len(manifests))
+	for _, manifest := range manifests {
+		obj := suite.assembleInitObject(manifest)
+		initObjects = append(initObjects, obj)
+	}
+
+	sc := runtime.NewScheme()
+	_ = v1alpha1.SchemeBuilder.AddToScheme(sc)
+	_ = appsv1.AddToScheme(sc)
+	_ = corev1.AddToScheme(sc)
+	cl := fake.NewClientBuilder().
+		WithScheme(sc).
+		WithObjects(initObjects...).
+		WithStatusSubresource(&v1alpha1.DeckhouseRelease{}).
+		Build()
+	dc := dependency.NewDependencyContainer()
+
+	rec := &deckhouseReleaseReconciler{
+		client:         cl,
+		dc:             dc,
+		logger:         log.New(),
+		moduleManager:  stubModulesManager{},
+		updateSettings: helpers.NewDeckhouseSettingsContainer(ds),
+	}
+
+	suite.ctr = rec
+	suite.kubeClient = cl
+}
+
+func (suite *ReleaseTestSuite) assembleInitObject(obj string) client.Object {
+	var res client.Object
+	var typ runtime.TypeMeta
+
+	err := yaml.Unmarshal([]byte(obj), &typ)
+	require.NoError(suite.T(), err)
+
+	switch typ.Kind {
+	case "Secret":
+		res = unmarshalRelease[corev1.Secret](obj, suite)
+	case "Pod":
+		res = unmarshalRelease[corev1.Pod](obj, suite)
+	case "Deployment":
+		res = unmarshalRelease[appsv1.Deployment](obj, suite)
+	case "DeckhouseRelease":
+		res = unmarshalRelease[v1alpha1.DeckhouseRelease](obj, suite)
+	case "ConfigMap":
+		res = unmarshalRelease[corev1.ConfigMap](obj, suite)
+
+	default:
+		require.Fail(suite.T(), "unknown Kind:"+typ.Kind)
+	}
+
+	return res
+}
+
+func (suite *ReleaseTestSuite) fetchTestFileData(valuesJSON string) string {
+	deckhouseDiscovery := `---
+apiVersion: v1
+kind: Secret
+metadata:
+ name: deckhouse-discovery
+ namespace: d8-system
+type: Opaque
+data:
+{{- if $.Values.global.discovery.clusterUUID }}
+ clusterUUID: {{ $.Values.global.discovery.clusterUUID | b64enc }}
+{{- end }}
+`
+
+	deckhouseRegistry := `---
+apiVersion: v1
+kind: Secret
+metadata:
+ name: deckhouse-registry
+ namespace: d8-system
+data:
+ clusterIsBootstrapped: {{ .Values.global.clusterIsBootstrapped | quote | b64enc }}
+ imagesRegistry: {{ b64enc .Values.global.modulesImages.registry.base }}
+`
+
+	tmpl, err := template.New("manifest").
+		Funcs(sprig.TxtFuncMap()).
+		Parse(deckhouseDiscovery + deckhouseRegistry)
+	require.NoError(suite.T(), err)
+
+	var values any
+	err = json.Unmarshal([]byte(valuesJSON), &values)
+	require.NoError(suite.T(), err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, map[string]any{"Values": values})
+	require.NoError(suite.T(), err)
+
+	return buf.String()
+}
+
+func unmarshalRelease[T any](manifest string, suite *ReleaseTestSuite) *T {
+	var obj T
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	require.NoError(suite.T(), err)
+	return &obj
+}
+
+func (suite *ReleaseTestSuite) fetchResults() []byte {
+	result := bytes.NewBuffer(nil)
+
+	var releaseList v1alpha1.DeckhouseReleaseList
+	err := suite.kubeClient.List(context.TODO(), &releaseList)
+	require.NoError(suite.T(), err)
+
+	for _, item := range releaseList.Items {
+		got, _ := yaml.Marshal(item)
+		result.WriteString("---\n")
+		result.Write(got)
+	}
+
+	var podsList corev1.PodList
+	err = suite.kubeClient.List(context.TODO(), &podsList)
+	require.NoError(suite.T(), err)
+
+	for _, item := range podsList.Items {
+		got, _ := yaml.Marshal(item)
+		result.WriteString("---\n")
+		result.Write(got)
+	}
+
+	var deploymentList appsv1.DeploymentList
+	err = suite.kubeClient.List(context.TODO(), &deploymentList)
+	require.NoError(suite.T(), err)
+
+	for _, item := range deploymentList.Items {
+		got, _ := yaml.Marshal(item)
+		result.WriteString("---\n")
+		result.Write(got)
+	}
+
+	var cmList corev1.ConfigMapList
+	err = suite.kubeClient.List(context.TODO(), &cmList)
+	require.NoError(suite.T(), err)
+
+	for _, item := range cmList.Items {
+		got, _ := yaml.Marshal(item)
+		result.WriteString("---\n")
+		result.Write(got)
+	}
+
+	return result.Bytes()
+}
+func (suite *ReleaseTestSuite) TestCheckRelease() {
+	var initValues = `{
+ "global": {
+   "modulesImages": {
+     "registry": {
+       "base": "my.registry.com/deckhouse"
+     }
+   },
+   "discovery": {
+     "clusterUUID": "21da7734-77a7-45ad-a795-ea0b629ee930"
+   }
+ },
+ "deckhouse":{
+   "bundle": "Default",
+   "releaseChannel": "Stable",
+   "internal":{
+     "releaseVersionImageHash":"zxczxczxc"
+   }
+ }
+}`
+
+	suite.Run("CheckNextVersion", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.31.0",
+			"v1.31.1",
+			"v1.32.0",
+			"v1.32.1",
+			"v1.32.2",
+			"v1.32.3",
+			"v1.33.0",
+			"v1.33.1",
+		}, nil)
+
+		suite.setupController(initValues, embeddedMUP)
+
+		rc, err := NewDeckhouseReleaseChecker([]cr.Option{}, suite.ctr.logger, suite.ctr.dc,
+			suite.ctr.moduleManager, "", "")
+		require.NoError(suite.T(), err)
+
+		var v *semver.Version
+		actual := semver.New(1, 31, 0, "", "")
+		target := semver.New(1, 31, 1, "", "")
+		v, err = rc.nextVersion(
+			actual,
+			target,
+		)
+		require.NoError(suite.T(), err)
+
+		if !cmp.Equal(v, target) {
+			suite.T().Fatalf("version is not equal: %v", cmp.Diff(v, target))
+		}
+	})
+}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -1,29 +1,31 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deckhouse_release
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
-	"text/template"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/Masterminds/sprig/v3"
 	"github.com/google/go-cmp/cmp"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"helm.sh/helm/v3/pkg/releaseutil"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/yaml"
 
-	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
-	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
 )
@@ -37,231 +39,58 @@ type ReleaseTestSuite struct {
 
 	kubeClient client.Client
 	ctr        *deckhouseReleaseReconciler
+	rc         *DeckhouseReleaseChecker
 }
 
 func (suite *ReleaseTestSuite) SetupSuite() {
 	suite.T().Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
+}
+
+func (suite *ReleaseTestSuite) SetupSubTest() {
 	dependency.TestDC.CRClient = cr.NewClientMock(suite.T())
 	dependency.TestDC.HTTPClient.DoMock.
 		Expect(&http.Request{}).
 		Return(&http.Response{
 			StatusCode: http.StatusOK,
 		}, nil)
+
+	dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+		"v1.31.0",
+		"v1.31.1",
+		"v1.32.0",
+		"v1.32.1",
+		"v1.32.2",
+		"v1.32.3",
+		"v1.33.0",
+		"v1.33.1",
+	}, nil)
+
+	suite.ctr, suite.kubeClient = setupFakeController(suite.T(), "", initValues, embeddedMUP)
+	var err error
+	suite.rc, err = NewDeckhouseReleaseChecker([]cr.Option{}, suite.ctr.logger, suite.ctr.dc,
+		suite.ctr.moduleManager, "", "")
+	require.NoError(suite.T(), err)
 }
 
-func (suite *ReleaseTestSuite) setupController(values string, mup *v1alpha1.ModuleUpdatePolicySpec) {
-	ds := &helpers.DeckhouseSettings{
-		ReleaseChannel: mup.ReleaseChannel,
-	}
-	ds.Update.Mode = mup.Update.Mode
-	ds.Update.Windows = mup.Update.Windows
-	ds.Update.DisruptionApprovalMode = "Auto"
-
-	suite.setupControllerSettings(values, ds)
-}
-
-func (suite *ReleaseTestSuite) setupControllerSettings(values string, ds *helpers.DeckhouseSettings) {
-	yamlDoc := suite.fetchTestFileData(values)
-	manifests := releaseutil.SplitManifests(yamlDoc)
-
-	var initObjects = make([]client.Object, 0, len(manifests))
-	for _, manifest := range manifests {
-		obj := suite.assembleInitObject(manifest)
-		initObjects = append(initObjects, obj)
-	}
-
-	sc := runtime.NewScheme()
-	_ = v1alpha1.SchemeBuilder.AddToScheme(sc)
-	_ = appsv1.AddToScheme(sc)
-	_ = corev1.AddToScheme(sc)
-	cl := fake.NewClientBuilder().
-		WithScheme(sc).
-		WithObjects(initObjects...).
-		WithStatusSubresource(&v1alpha1.DeckhouseRelease{}).
-		Build()
-	dc := dependency.NewDependencyContainer()
-
-	rec := &deckhouseReleaseReconciler{
-		client:         cl,
-		dc:             dc,
-		logger:         log.New(),
-		moduleManager:  stubModulesManager{},
-		updateSettings: helpers.NewDeckhouseSettingsContainer(ds),
-	}
-
-	suite.ctr = rec
-	suite.kubeClient = cl
-}
-
-func (suite *ReleaseTestSuite) assembleInitObject(obj string) client.Object {
-	var res client.Object
-	var typ runtime.TypeMeta
-
-	err := yaml.Unmarshal([]byte(obj), &typ)
-	require.NoError(suite.T(), err)
-
-	switch typ.Kind {
-	case "Secret":
-		res = unmarshalRelease[corev1.Secret](obj, suite)
-	case "Pod":
-		res = unmarshalRelease[corev1.Pod](obj, suite)
-	case "Deployment":
-		res = unmarshalRelease[appsv1.Deployment](obj, suite)
-	case "DeckhouseRelease":
-		res = unmarshalRelease[v1alpha1.DeckhouseRelease](obj, suite)
-	case "ConfigMap":
-		res = unmarshalRelease[corev1.ConfigMap](obj, suite)
-
-	default:
-		require.Fail(suite.T(), "unknown Kind:"+typ.Kind)
-	}
-
-	return res
-}
-
-func (suite *ReleaseTestSuite) fetchTestFileData(valuesJSON string) string {
-	deckhouseDiscovery := `---
-apiVersion: v1
-kind: Secret
-metadata:
- name: deckhouse-discovery
- namespace: d8-system
-type: Opaque
-data:
-{{- if $.Values.global.discovery.clusterUUID }}
- clusterUUID: {{ $.Values.global.discovery.clusterUUID | b64enc }}
-{{- end }}
-`
-
-	deckhouseRegistry := `---
-apiVersion: v1
-kind: Secret
-metadata:
- name: deckhouse-registry
- namespace: d8-system
-data:
- clusterIsBootstrapped: {{ .Values.global.clusterIsBootstrapped | quote | b64enc }}
- imagesRegistry: {{ b64enc .Values.global.modulesImages.registry.base }}
-`
-
-	tmpl, err := template.New("manifest").
-		Funcs(sprig.TxtFuncMap()).
-		Parse(deckhouseDiscovery + deckhouseRegistry)
-	require.NoError(suite.T(), err)
-
-	var values any
-	err = json.Unmarshal([]byte(valuesJSON), &values)
-	require.NoError(suite.T(), err)
-
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, map[string]any{"Values": values})
-	require.NoError(suite.T(), err)
-
-	return buf.String()
-}
-
-func unmarshalRelease[T any](manifest string, suite *ReleaseTestSuite) *T {
-	var obj T
-	err := yaml.Unmarshal([]byte(manifest), &obj)
-	require.NoError(suite.T(), err)
-	return &obj
-}
-
-func (suite *ReleaseTestSuite) fetchResults() []byte {
-	result := bytes.NewBuffer(nil)
-
-	var releaseList v1alpha1.DeckhouseReleaseList
-	err := suite.kubeClient.List(context.TODO(), &releaseList)
-	require.NoError(suite.T(), err)
-
-	for _, item := range releaseList.Items {
-		got, _ := yaml.Marshal(item)
-		result.WriteString("---\n")
-		result.Write(got)
-	}
-
-	var podsList corev1.PodList
-	err = suite.kubeClient.List(context.TODO(), &podsList)
-	require.NoError(suite.T(), err)
-
-	for _, item := range podsList.Items {
-		got, _ := yaml.Marshal(item)
-		result.WriteString("---\n")
-		result.Write(got)
-	}
-
-	var deploymentList appsv1.DeploymentList
-	err = suite.kubeClient.List(context.TODO(), &deploymentList)
-	require.NoError(suite.T(), err)
-
-	for _, item := range deploymentList.Items {
-		got, _ := yaml.Marshal(item)
-		result.WriteString("---\n")
-		result.Write(got)
-	}
-
-	var cmList corev1.ConfigMapList
-	err = suite.kubeClient.List(context.TODO(), &cmList)
-	require.NoError(suite.T(), err)
-
-	for _, item := range cmList.Items {
-		got, _ := yaml.Marshal(item)
-		result.WriteString("---\n")
-		result.Write(got)
-	}
-
-	return result.Bytes()
-}
 func (suite *ReleaseTestSuite) TestCheckRelease() {
-	var initValues = `{
- "global": {
-   "modulesImages": {
-     "registry": {
-       "base": "my.registry.com/deckhouse"
-     }
-   },
-   "discovery": {
-     "clusterUUID": "21da7734-77a7-45ad-a795-ea0b629ee930"
-   }
- },
- "deckhouse":{
-   "bundle": "Default",
-   "releaseChannel": "Stable",
-   "internal":{
-     "releaseVersionImageHash":"zxczxczxc"
-   }
- }
-}`
+	check := func(name string, actual, target string, fail bool) {
+		suite.Run(name, func() {
+			actual, _ := semver.NewVersion(actual)
+			target, _ := semver.NewVersion(target)
+			v, err := suite.rc.nextVersion(
+				actual,
+				target,
+			)
+			require.NoError(suite.T(), err)
 
-	suite.Run("CheckNextVersion", func() {
-		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
-			"v1.31.0",
-			"v1.31.1",
-			"v1.32.0",
-			"v1.32.1",
-			"v1.32.2",
-			"v1.32.3",
-			"v1.33.0",
-			"v1.33.1",
-		}, nil)
+			if !cmp.Equal(v, target) && !fail {
+				suite.T().Fatalf("version is not equal: %v", cmp.Diff(v, target))
+			}
+		})
+	}
 
-		suite.setupController(initValues, embeddedMUP)
-
-		rc, err := NewDeckhouseReleaseChecker([]cr.Option{}, suite.ctr.logger, suite.ctr.dc,
-			suite.ctr.moduleManager, "", "")
-		require.NoError(suite.T(), err)
-
-		var v *semver.Version
-		actual := semver.New(1, 31, 0, "", "")
-		target := semver.New(1, 31, 1, "", "")
-		v, err = rc.nextVersion(
-			actual,
-			target,
-		)
-		require.NoError(suite.T(), err)
-
-		if !cmp.Equal(v, target) {
-			suite.T().Fatalf("version is not equal: %v", cmp.Diff(v, target))
-		}
-	})
+	check("Patch", "1.31.0", "1.31.1", false)
+	check("Minor", "1.31.0", "1.32.0", false)
+	check("Last Minor", "1.31.0", "1.32.3", false)
+	check("Fail Update", "1.31.0", "1.33.0", true)
 }


### PR DESCRIPTION
## Description

At the current time, we have a suite that is configured strictly for certain behavior and that matches files. This makes it difficult to write tests that don't require this.

## Why do we need it, and what problem does it solve?

We have a number of functions that need to be tested, but which do not require matching with golden files to test.

In these tests we also need to initialize the controller with certain settings.

## What is the expected result?

Once we have separated the controller initialization into separate functions, we can easily use them in new suites. And for each set of tests we can now create a separate suite.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: chore
summary: Rewrite controller tests.
impact_level: low
```
