### PR TITLE
feat: update shell-operator version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/flant/addon-operator v1.4.1
 	github.com/flant/kube-client v1.1.0
-	github.com/flant/shell-operator v1.4.9
+	github.com/flant/shell-operator v1.4.10
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee h1:evii83J+/6QGNv
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/shell-operator v1.4.9 h1:QHKxtc0Y5lc8OpskvyIuOUEZrNXDSo1PXAiwZ6hjLRY=
 github.com/flant/shell-operator v1.4.9/go.mod h1:pXvO4tnlY4SJJLDpO0F1jAZ1Ni7bndxhC4mSyabmPYM=
+github.com/flant/shell-operator v1.4.10 h1:QuBqx/pp+xuLU8ibZ3uOaYD8Ji5HiWXR1viDm0XeUZA=
+github.com/flant/shell-operator v1.4.10/go.mod h1:pXvO4tnlY4SJJLDpO0F1jAZ1Ni7bndxhC4mSyabmPYM=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "v1.4.7"}}
+{{- $shellOperatorVersion := "v1.4.10"}}
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}

--- a/werf.yaml
+++ b/werf.yaml
@@ -307,7 +307,7 @@ git:
 {{- include "exclude_modules_dir_from_images" .  | nindent 2}}
 {{ .Files.Get (printf "tools/build_includes/modules-excluded-%s.yaml" .Env) | nindent 2}}
 - url: {{ .SOURCE_REPO }}/flant/shell-operator
-  tag: v1.4.5
+  tag: v1.4.10
   add: /frameworks/shell
   to: /deckhouse/shell-operator/frameworks/shell
 {{ .Files.Get (printf "tools/build_includes/modules-with-exclude-%s.yaml" .Env) }}
@@ -1164,18 +1164,18 @@ shell:
     - export GOPROXY={{ $.GOPROXY }}
     - git clone --depth 1 --branch v3.4.3 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-random.git /src-provider-random
     - cd /src-provider-random
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\""
     - git clone --depth 1 --branch v4.0.4 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-tls.git /src-provider-tls
     - cd /src-provider-tls
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\""
     - git clone --depth 1 --branch v2.2.0 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-cloudinit.git /src-provider-cloudinit
     - cd /src-provider-cloudinit
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\""
     - git clone --depth 1 --branch v2.31.0 {{ $.SOURCE_REPO }}/hashicorp/terraform-provider-kubernetes.git /src-provider-kubernetes
     - cd /src-provider-kubernetes
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\"" 
-    - mv /src-provider-random/terraform-provider-random /terraform-provider-random 
-    - mv /src-provider-tls/terraform-provider-tls /terraform-provider-tls 
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -extldflags \"-static\""
+    - mv /src-provider-random/terraform-provider-random /terraform-provider-random
+    - mv /src-provider-tls/terraform-provider-tls /terraform-provider-tls
     - mv /src-provider-cloudinit/terraform-provider-cloudinit /terraform-provider-cloudinit
     - mv /src-provider-kubernetes/terraform-provider-kubernetes /terraform-provider-kubernetes
     - chmod 755 /terraform-provider-*


### PR DESCRIPTION
## Description

We need to change default ports for shell-operator.

We already have a new version of shell-operator with this functionality, and now we need to use it

Closed: #9056

## Why do we need it, and what problem does it solve?

This is necessary to be able to configure the standard ports that are used in the shell-operator.

## What is the expected result?

After changing the version of shell-operator we are using, we have the opportunity to configure standard shell-operator ports through environment variables.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: update shell-operator version
impact_level: low
```
