### PR TITLE
[cni-cilium] Adding maintenance command to the documentation

### DIFF
--- a/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
+++ b/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
@@ -1,6 +1,7 @@
 # Maintenance
 
 ## Rollout restarting of the cilium agent pods
+
 Previously, a mechanism was added to safely update pods with cilium agents. Because of this, the simple `rollout restart ds agent` command no longer functions.
 
 This command allows you to restart all pods of the cilium agent sequentially, if necessary.

--- a/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
+++ b/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
@@ -1,0 +1,7 @@
+# Maintenance
+
+## Rollout restarting of the cilium agent pods
+
+```bash
+kubectl -n d8-cni-cilium annotate pod -l app=agent safe-agent-updater-daemonset-generation- && kubectl -n d8-cni-cilium rollout restart ds safe-agent-updater
+```

--- a/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
+++ b/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
@@ -1,6 +1,9 @@
 # Maintenance
 
 ## Rollout restarting of the cilium agent pods
+Previously, a mechanism was added to safely update pods with cilium agents. Because of this, the simple `rollout restart ds agent` command no longer functions.
+
+This command allows you to restart all pods of the cilium agent sequentially, if necessary.
 
 ```bash
 kubectl -n d8-cni-cilium annotate pod -l app=agent safe-agent-updater-daemonset-generation- && kubectl -n d8-cni-cilium rollout restart ds safe-agent-updater

--- a/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
+++ b/modules/021-cni-cilium/docs/internal/MAINTENANCE.md
@@ -4,7 +4,7 @@
 
 Previously, a mechanism was added to safely update pods with cilium agents. Because of this, the simple `rollout restart ds agent` command no longer functions.
 
-This command allows you to restart all pods of the cilium agent sequentially, if necessary.
+The following command restarts all pods of the cilium agent sequentially, if necessary:
 
 ```bash
 kubectl -n d8-cni-cilium annotate pod -l app=agent safe-agent-updater-daemonset-generation- && kubectl -n d8-cni-cilium rollout restart ds safe-agent-updater


### PR DESCRIPTION
## Description
Adding maintenance command to the documentation

## Why do we need it, and what problem does it solve?
Previously, a mechanism was added to safely update pods with cilium agents. Because of this, the simple `rollout restart ds agent` command no longer functions. 


## What is the expected result?
A new command has been added to the documentation that, if necessary, allows for a sequential restart of all cilium agent pods.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: Add maintenance command to the documentation.
impact_level: low
```