### PR TITLE
[dhctl] feat(dhctl-for-commander): server refactoring

### DIFF
--- a/dhctl/pkg/server/pkg/interceptors/interceptors.go
+++ b/dhctl/pkg/server/pkg/interceptors/interceptors.go
@@ -45,14 +45,14 @@ func PanicRecoveryHandler() func(ctx context.Context, p any) error {
 
 func UnaryLogger(log *slog.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
-		return handler(logger.ToContext(ctx, log), req)
+		return handler(logger.ToContext(ctx, log, logger.AttrFromGRPCCtx(ctx)...), req)
 	}
 }
 
 func StreamLogger(log *slog.Logger) grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		wss := newStreamContextWrapper(ss)
-		wss.SetContext(logger.ToContext(ss.Context(), log))
+		wss.SetContext(logger.ToContext(ss.Context(), log, logger.AttrFromGRPCCtx(ss.Context())...))
 		return handler(srv, wss)
 	}
 }

--- a/dhctl/pkg/server/pkg/logger/logger.go
+++ b/dhctl/pkg/server/pkg/logger/logger.go
@@ -66,21 +66,7 @@ func Err(err error) slog.Attr {
 	return slog.Attr{Key: errKey, Value: slog.StringValue(err.Error())}
 }
 
-func ToContext(ctx context.Context, log *slog.Logger) context.Context {
-	return context.WithValue(ctx, loggerCtxKey{}, log.With(attrFromCtx(ctx)...))
-}
-
-func L(ctx context.Context) *slog.Logger {
-	l := ctx.Value(loggerCtxKey{})
-	if l == nil {
-		logger := NewLogger(&slog.LevelVar{}).With(slog.String("UNINITIALIZED", "UNINITIALIZED"))
-		return logger
-	}
-
-	return l.(*slog.Logger)
-}
-
-func attrFromCtx(ctx context.Context) []any {
+func AttrFromGRPCCtx(ctx context.Context) []any {
 	attrs := make([]any, 0, 1)
 
 	md, ok := metadata.FromIncomingContext(ctx)
@@ -94,4 +80,18 @@ func attrFromCtx(ctx context.Context) []any {
 	}
 
 	return attrs
+}
+
+func ToContext(ctx context.Context, log *slog.Logger, args ...any) context.Context {
+	return context.WithValue(ctx, loggerCtxKey{}, log.With(args...))
+}
+
+func L(ctx context.Context) *slog.Logger {
+	l := ctx.Value(loggerCtxKey{})
+	if l == nil {
+		logger := NewLogger(&slog.LevelVar{}).With(slog.String("UNINITIALIZED", "UNINITIALIZED"))
+		return logger
+	}
+
+	return l.(*slog.Logger)
 }

--- a/dhctl/pkg/server/pkg/logger/writer.go
+++ b/dhctl/pkg/server/pkg/logger/writer.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"log/slog"
+	"sync"
+)
+
+type LogWriter[T any] struct {
+	l      *slog.Logger
+	sendCh chan T
+	f      func([]string) T
+
+	m    sync.Mutex
+	prev []byte
+}
+
+func NewLogWriter[T any](l *slog.Logger, sendCh chan T, f func(lines []string) T) *LogWriter[T] {
+	return &LogWriter[T]{
+		l:      l,
+		sendCh: sendCh,
+		f:      f,
+	}
+}
+
+func (w *LogWriter[T]) Write(p []byte) (n int, err error) {
+	w.m.Lock()
+	defer w.m.Unlock()
+
+	var lines []string
+
+	for _, b := range p {
+		switch b {
+		case '\n', '\r':
+			s := string(w.prev)
+			if s != "" {
+				lines = append(lines, s)
+			}
+			w.prev = []byte{}
+		default:
+			w.prev = append(w.prev, b)
+		}
+	}
+
+	if len(lines) > 0 {
+		for _, line := range lines {
+			w.l.Info(line)
+		}
+		w.sendCh <- w.f(lines)
+	}
+
+	return len(p), nil
+}

--- a/dhctl/pkg/server/pkg/logger/writer_test.go
+++ b/dhctl/pkg/server/pkg/logger/writer_test.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input [][]byte
+		lines [][]string
+		f     func([]string) []string
+	}{
+		"one line of text": {
+			input: [][]byte{
+				[]byte("one line of text\n"),
+			},
+			lines: [][]string{
+				{"one line of text"},
+			},
+			f: func(lines []string) []string { return lines },
+		},
+		"one line of text, multiple writes": {
+			input: [][]byte{
+				[]byte("one line o"), []byte("f text"), []byte("\n"),
+			},
+			lines: [][]string{
+				{"one line of text"},
+			},
+			f: func(lines []string) []string { return lines },
+		},
+		"multiple lines of text, multiple writes": {
+			input: [][]byte{
+				[]byte("first line o"), []byte("f text"), []byte("\n"),
+				[]byte("second line of text\nthird line of text\n"),
+			},
+			lines: [][]string{
+				{"first line of text"},
+				{"second line of text", "third line of text"},
+			},
+			f: func(lines []string) []string { return lines },
+		},
+		"mutate data": {
+			input: [][]byte{
+				[]byte("first line of text\n"),
+				[]byte("second line of text\n"),
+				[]byte("third line of text\n"),
+			},
+			lines: [][]string{
+				{"FIRST LINE OF TEXT"},
+				{"SECOND LINE OF TEXT"},
+				{"THIRD LINE OF TEXT"},
+			},
+			f: func(lines []string) []string {
+				result := make([]string, 0, len(lines))
+				for _, line := range lines {
+					result = append(result, strings.ToUpper(line))
+				}
+				return result
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			sendCh := make(chan []string)
+			defer close(sendCh)
+
+			var logBuff bytes.Buffer
+			log := slog.New(slog.NewTextHandler(io.Writer(&logBuff), &slog.HandlerOptions{
+				ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+					if attr.Key == slog.TimeKey {
+						return slog.Attr{}
+					}
+					return attr
+				},
+			})).With(slog.String("key", "value"))
+
+			w := logger.NewLogWriter(log, sendCh, tt.f)
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				var writes int
+				for writes < len(tt.lines) {
+					lines := <-sendCh
+					assert.Equal(t, tt.lines[writes], lines)
+					writes++
+				}
+			}()
+
+			for _, input := range tt.input {
+				n, err := w.Write(input)
+				require.NoError(t, err)
+				assert.EqualValues(t, len(input), n)
+			}
+
+			wg.Wait()
+
+			expectedLogLines := make([]string, 0)
+			for _, lines := range tt.lines {
+				for _, line := range lines {
+					lohLine := fmt.Sprintf("level=INFO msg=\"%s\" key=value", strings.ToLower(line))
+					expectedLogLines = append(expectedLogLines, lohLine)
+				}
+			}
+
+			logLines := strings.Split(strings.TrimSpace(logBuff.String()), "\n")
+			assert.Equal(t, expectedLogLines, logLines)
+		})
+	}
+}

--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -242,7 +242,7 @@ func (s *Service) abort(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -40,7 +38,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func (s *Service) Abort(server pb.DHCTL_AbortServer) error {
@@ -54,14 +51,17 @@ func (s *Service) Abort(server pb.DHCTL_AbortServer) error {
 	internalErrCh := make(chan error)
 	receiveCh := make(chan *pb.AbortRequest)
 	sendCh := make(chan *pb.AbortResponse)
-	phaseSwitcher := &abortPhaseSwitcher{
-		sendCh: sendCh,
-		f:      f,
-		next:   make(chan error),
+	phaseSwitcher := &fsmPhaseSwitcher[*pb.AbortResponse, any]{
+		f: f, dataFunc: s.abortSwitchPhaseData, sendCh: sendCh, next: make(chan error),
 	}
+	logWriter := logger.NewLogWriter(logger.L(ctx).With(logTypeDHCTL), sendCh,
+		func(lines []string) *pb.AbortResponse {
+			return &pb.AbortResponse{Message: &pb.AbortResponse_Logs{Logs: &pb.Logs{Logs: lines}}}
+		},
+	)
 
-	s.startAborterReceiver(server, receiveCh, doneCh, internalErrCh)
-	s.startAborterSender(server, sendCh, internalErrCh)
+	startReceiver[*pb.AbortRequest, *pb.AbortResponse](server, receiveCh, doneCh, internalErrCh)
+	startSender[*pb.AbortRequest, *pb.AbortResponse](server, sendCh, internalErrCh)
 
 connectionProcessor:
 	for {
@@ -87,9 +87,10 @@ connectionProcessor:
 						logger.Err(err), slog.String("message", fmt.Sprintf("%T", message)))
 					continue connectionProcessor
 				}
-				s.startAbort(
-					ctx, message.Start, phaseSwitcher, &abortLogWriter{l: logger.L(ctx), sendCh: sendCh}, sendCh,
-				)
+				go func() {
+					result := s.abort(ctx, message.Start, phaseSwitcher.switchPhase, logWriter)
+					sendCh <- &pb.AbortResponse{Message: &pb.AbortResponse_Result{Result: result}}
+				}()
 
 			case *pb.AbortRequest_Continue:
 				err := f.Event("toNextPhase")
@@ -118,68 +119,10 @@ connectionProcessor:
 	}
 }
 
-func (s *Service) startAborterReceiver(
-	server pb.DHCTL_AbortServer,
-	receiveCh chan *pb.AbortRequest,
-	doneCh chan struct{},
-	internalErrCh chan error,
-) {
-	go func() {
-		for {
-			request, err := server.Recv()
-			if errors.Is(err, io.EOF) {
-				close(doneCh)
-				return
-			}
-			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
-				return
-			}
-			receiveCh <- request
-		}
-	}()
-}
-
-func (s *Service) startAborterSender(
-	server pb.DHCTL_AbortServer,
-	sendCh chan *pb.AbortResponse,
-	internalErrCh chan error,
-) {
-	go func() {
-		for response := range sendCh {
-			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
-			err := loop.Run(func() error {
-				return server.Send(response)
-			})
-			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startAbort(
-	ctx context.Context,
-	request *pb.AbortStart,
-	phaseSwitcher *abortPhaseSwitcher,
-	logWriter *abortLogWriter,
-	sendCh chan *pb.AbortResponse,
-) {
-	go func() {
-		result := s.abort(ctx, request, phaseSwitcher, logWriter)
-		sendCh <- &pb.AbortResponse{
-			Message: &pb.AbortResponse_Result{
-				Result: result,
-			},
-		}
-	}()
-}
-
 func (s *Service) abort(
 	_ context.Context,
 	request *pb.AbortStart,
-	phaseSwitcher *abortPhaseSwitcher,
+	switchPhase phases.DefaultOnPhaseFunc,
 	logWriter io.Writer,
 ) *pb.AbortResult {
 	var err error
@@ -281,7 +224,7 @@ func (s *Service) abort(
 		DeckhouseTimeout: request.Options.DeckhouseTimeout.AsDuration(),
 
 		ResetInitialState: true,
-		OnPhaseFunc:       phaseSwitcher.switchPhase,
+		OnPhaseFunc:       switchPhase,
 		CommanderMode:     request.Options.CommanderMode,
 		CommanderUUID:     commanderUUID,
 		TerraformContext:  terraform.NewTerraformContext(),
@@ -315,64 +258,14 @@ func (s *Service) abortServerTransitions() []fsm.Transition {
 	}
 }
 
-type abortLogWriter struct {
-	l      *slog.Logger
-	sendCh chan *pb.AbortResponse
-
-	m    sync.Mutex
-	prev []byte
-}
-
-func (w *abortLogWriter) Write(p []byte) (n int, err error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-
-	var r []string
-
-	for _, b := range p {
-		switch b {
-		case '\n', '\r':
-			s := string(w.prev)
-			if s != "" {
-				r = append(r, s)
-			}
-			w.prev = []byte{}
-		default:
-			w.prev = append(w.prev, b)
-		}
-	}
-
-	if len(r) > 0 {
-		for _, line := range r {
-			w.l.Info(line, logTypeDHCTL)
-		}
-		w.sendCh <- &pb.AbortResponse{
-			Message: &pb.AbortResponse_Logs{Logs: &pb.Logs{Logs: r}},
-		}
-	}
-
-	return len(p), nil
-}
-
-type abortPhaseSwitcher struct {
-	sendCh chan *pb.AbortResponse
-	f      *fsm.FiniteStateMachine
-	next   chan error
-}
-
-func (b *abortPhaseSwitcher) switchPhase(
+func (s *Service) abortSwitchPhaseData(
 	completedPhase phases.OperationPhase,
 	completedPhaseState phases.DhctlState,
-	_ interface{},
+	_ any,
 	nextPhase phases.OperationPhase,
 	nextPhaseCritical bool,
-) error {
-	err := b.f.Event("wait")
-	if err != nil {
-		return fmt.Errorf("changing state to waiting: %w", err)
-	}
-
-	b.sendCh <- &pb.AbortResponse{
+) (*pb.AbortResponse, error) {
+	return &pb.AbortResponse{
 		Message: &pb.AbortResponse_PhaseEnd{
 			PhaseEnd: &pb.AbortPhaseEnd{
 				CompletedPhase:      string(completedPhase),
@@ -381,11 +274,5 @@ func (b *abortPhaseSwitcher) switchPhase(
 				NextPhaseCritical:   nextPhaseCritical,
 			},
 		},
-	}
-
-	switchErr, ok := <-b.next
-	if !ok {
-		return fmt.Errorf("server stopped, cancel task")
-	}
-	return switchErr
+	}, nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -22,8 +22,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -41,7 +39,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func (s *Service) Bootstrap(server pb.DHCTL_BootstrapServer) error {
@@ -55,14 +52,17 @@ func (s *Service) Bootstrap(server pb.DHCTL_BootstrapServer) error {
 	internalErrCh := make(chan error)
 	receiveCh := make(chan *pb.BootstrapRequest)
 	sendCh := make(chan *pb.BootstrapResponse)
-	phaseSwitcher := &bootstrapPhaseSwitcher{
-		sendCh: sendCh,
-		f:      f,
-		next:   make(chan error),
+	phaseSwitcher := &fsmPhaseSwitcher[*pb.BootstrapResponse, any]{
+		f: f, dataFunc: s.bootstrapSwitchPhaseData, sendCh: sendCh, next: make(chan error),
 	}
+	logWriter := logger.NewLogWriter(logger.L(ctx).With(logTypeDHCTL), sendCh,
+		func(lines []string) *pb.BootstrapResponse {
+			return &pb.BootstrapResponse{Message: &pb.BootstrapResponse_Logs{Logs: &pb.Logs{Logs: lines}}}
+		},
+	)
 
-	s.startBootstrapperReceiver(server, receiveCh, doneCh, internalErrCh)
-	s.startBootstrapperSender(server, sendCh, internalErrCh)
+	startReceiver[*pb.BootstrapRequest, *pb.BootstrapResponse](server, receiveCh, doneCh, internalErrCh)
+	startSender[*pb.BootstrapRequest, *pb.BootstrapResponse](server, sendCh, internalErrCh)
 
 connectionProcessor:
 	for {
@@ -88,9 +88,10 @@ connectionProcessor:
 						logger.Err(err), slog.String("message", fmt.Sprintf("%T", message)))
 					continue connectionProcessor
 				}
-				s.startBootstrap(
-					ctx, message.Start, phaseSwitcher, &bootstrapLogWriter{l: logger.L(ctx), sendCh: sendCh}, sendCh,
-				)
+				go func() {
+					result := s.bootstrap(ctx, message.Start, phaseSwitcher.switchPhase, logWriter)
+					sendCh <- &pb.BootstrapResponse{Message: &pb.BootstrapResponse_Result{Result: result}}
+				}()
 
 			case *pb.BootstrapRequest_Continue:
 				err := f.Event("toNextPhase")
@@ -119,68 +120,10 @@ connectionProcessor:
 	}
 }
 
-func (s *Service) startBootstrapperReceiver(
-	server pb.DHCTL_BootstrapServer,
-	receiveCh chan *pb.BootstrapRequest,
-	doneCh chan struct{},
-	internalErrCh chan error,
-) {
-	go func() {
-		for {
-			request, err := server.Recv()
-			if errors.Is(err, io.EOF) {
-				close(doneCh)
-				return
-			}
-			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
-				return
-			}
-			receiveCh <- request
-		}
-	}()
-}
-
-func (s *Service) startBootstrapperSender(
-	server pb.DHCTL_BootstrapServer,
-	sendCh chan *pb.BootstrapResponse,
-	internalErrCh chan error,
-) {
-	go func() {
-		for response := range sendCh {
-			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
-			err := loop.Run(func() error {
-				return server.Send(response)
-			})
-			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startBootstrap(
-	ctx context.Context,
-	request *pb.BootstrapStart,
-	phaseSwitcher *bootstrapPhaseSwitcher,
-	logWriter *bootstrapLogWriter,
-	sendCh chan *pb.BootstrapResponse,
-) {
-	go func() {
-		result := s.bootstrap(ctx, request, phaseSwitcher, logWriter)
-		sendCh <- &pb.BootstrapResponse{
-			Message: &pb.BootstrapResponse_Result{
-				Result: result,
-			},
-		}
-	}()
-}
-
 func (s *Service) bootstrap(
 	_ context.Context,
 	request *pb.BootstrapStart,
-	phaseSwitcher *bootstrapPhaseSwitcher,
+	switchPhase phases.DefaultOnPhaseFunc,
 	logWriter io.Writer,
 ) *pb.BootstrapResult {
 	var err error
@@ -288,7 +231,7 @@ func (s *Service) bootstrap(
 		InitialState:               initialState,
 		ResetInitialState:          true,
 		DisableBootstrapClearCache: true,
-		OnPhaseFunc:                phaseSwitcher.switchPhase,
+		OnPhaseFunc:                switchPhase,
 		CommanderMode:              request.Options.CommanderMode,
 		CommanderUUID:              commanderUUID,
 		TerraformContext:           terraform.NewTerraformContext(),
@@ -330,64 +273,14 @@ func (s *Service) bootstrapServerTransitions() []fsm.Transition {
 	}
 }
 
-type bootstrapLogWriter struct {
-	l      *slog.Logger
-	sendCh chan *pb.BootstrapResponse
-
-	m    sync.Mutex
-	prev []byte
-}
-
-func (w *bootstrapLogWriter) Write(p []byte) (n int, err error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-
-	var r []string
-
-	for _, b := range p {
-		switch b {
-		case '\n', '\r':
-			s := string(w.prev)
-			if s != "" {
-				r = append(r, s)
-			}
-			w.prev = []byte{}
-		default:
-			w.prev = append(w.prev, b)
-		}
-	}
-
-	if len(r) > 0 {
-		for _, line := range r {
-			w.l.Info(line, logTypeDHCTL)
-		}
-		w.sendCh <- &pb.BootstrapResponse{
-			Message: &pb.BootstrapResponse_Logs{Logs: &pb.Logs{Logs: r}},
-		}
-	}
-
-	return len(p), nil
-}
-
-type bootstrapPhaseSwitcher struct {
-	sendCh chan *pb.BootstrapResponse
-	f      *fsm.FiniteStateMachine
-	next   chan error
-}
-
-func (b *bootstrapPhaseSwitcher) switchPhase(
+func (s *Service) bootstrapSwitchPhaseData(
 	completedPhase phases.OperationPhase,
 	completedPhaseState phases.DhctlState,
-	_ interface{},
+	_ any,
 	nextPhase phases.OperationPhase,
 	nextPhaseCritical bool,
-) error {
-	err := b.f.Event("wait")
-	if err != nil {
-		return fmt.Errorf("changing state to waiting: %w", err)
-	}
-
-	b.sendCh <- &pb.BootstrapResponse{
+) (*pb.BootstrapResponse, error) {
+	return &pb.BootstrapResponse{
 		Message: &pb.BootstrapResponse_PhaseEnd{
 			PhaseEnd: &pb.BootstrapPhaseEnd{
 				CompletedPhase:      string(completedPhase),
@@ -396,11 +289,5 @@ func (b *bootstrapPhaseSwitcher) switchPhase(
 				NextPhaseCritical:   nextPhaseCritical,
 			},
 		},
-	}
-
-	switchErr, ok := <-b.next
-	if !ok {
-		return fmt.Errorf("server stopped, cancel task")
-	}
-	return switchErr
+	}, nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -255,7 +255,7 @@ func (s *Service) bootstrap(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -218,7 +218,7 @@ func (s *Service) check(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -41,7 +39,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func (s *Service) Check(server pb.DHCTL_CheckServer) error {
@@ -54,10 +51,15 @@ func (s *Service) Check(server pb.DHCTL_CheckServer) error {
 	doneCh := make(chan struct{})
 	internalErrCh := make(chan error)
 	receiveCh := make(chan *pb.CheckRequest)
-	sendCh := make(chan *pb.CheckResponse, 100)
+	sendCh := make(chan *pb.CheckResponse)
+	logWriter := logger.NewLogWriter(logger.L(ctx).With(logTypeDHCTL), sendCh,
+		func(lines []string) *pb.CheckResponse {
+			return &pb.CheckResponse{Message: &pb.CheckResponse_Logs{Logs: &pb.Logs{Logs: lines}}}
+		},
+	)
 
-	s.startCheckerReceiver(server, receiveCh, doneCh, internalErrCh)
-	s.startCheckerSender(server, sendCh, internalErrCh)
+	startReceiver[*pb.CheckRequest, *pb.CheckResponse](server, receiveCh, doneCh, internalErrCh)
+	startSender[*pb.CheckRequest, *pb.CheckResponse](server, sendCh, internalErrCh)
 
 connectionProcessor:
 	for {
@@ -83,9 +85,10 @@ connectionProcessor:
 						logger.Err(err), slog.String("message", fmt.Sprintf("%T", message)))
 					continue connectionProcessor
 				}
-				s.startChecker(
-					ctx, message.Start, &checkLogWriter{l: logger.L(ctx), sendCh: sendCh}, sendCh,
-				)
+				go func() {
+					result := s.check(ctx, message.Start, logWriter)
+					sendCh <- &pb.CheckResponse{Message: &pb.CheckResponse_Result{Result: result}}
+				}()
 
 			default:
 				logger.L(ctx).Error("got unprocessable message",
@@ -94,63 +97,6 @@ connectionProcessor:
 			}
 		}
 	}
-}
-
-func (s *Service) startCheckerReceiver(
-	server pb.DHCTL_CheckServer,
-	receiveCh chan *pb.CheckRequest,
-	doneCh chan struct{},
-	internalErrCh chan error,
-) {
-	go func() {
-		for {
-			request, err := server.Recv()
-			if errors.Is(err, io.EOF) {
-				close(doneCh)
-				return
-			}
-			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
-				return
-			}
-			receiveCh <- request
-		}
-	}()
-}
-
-func (s *Service) startCheckerSender(
-	server pb.DHCTL_CheckServer,
-	sendCh chan *pb.CheckResponse,
-	internalErrCh chan error,
-) {
-	go func() {
-		for response := range sendCh {
-			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
-			err := loop.Run(func() error {
-				return server.Send(response)
-			})
-			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startChecker(
-	ctx context.Context,
-	request *pb.CheckStart,
-	logWriter *checkLogWriter,
-	sendCh chan *pb.CheckResponse,
-) {
-	go func() {
-		result := s.check(ctx, request, logWriter)
-		sendCh <- &pb.CheckResponse{
-			Message: &pb.CheckResponse_Result{
-				Result: result,
-			},
-		}
-	}()
 }
 
 func (s *Service) check(
@@ -285,43 +231,4 @@ func (s *Service) checkServerTransitions() []fsm.Transition {
 			Destination: "running",
 		},
 	}
-}
-
-type checkLogWriter struct {
-	l      *slog.Logger
-	sendCh chan *pb.CheckResponse
-
-	m    sync.Mutex
-	prev []byte
-}
-
-func (w *checkLogWriter) Write(p []byte) (n int, err error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-
-	var r []string
-
-	for _, b := range p {
-		switch b {
-		case '\n', '\r':
-			s := string(w.prev)
-			if s != "" {
-				r = append(r, s)
-			}
-			w.prev = []byte{}
-		default:
-			w.prev = append(w.prev, b)
-		}
-	}
-
-	if len(r) > 0 {
-		for _, line := range r {
-			w.l.Info(line, logTypeDHCTL)
-		}
-		w.sendCh <- &pb.CheckResponse{
-			Message: &pb.CheckResponse_Logs{Logs: &pb.Logs{Logs: r}},
-		}
-	}
-
-	return len(p), nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -202,7 +202,7 @@ func (s *Service) CommanderAttachCluster(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -38,7 +36,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/logger"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func (s *Service) CommanderAttach(server pb.DHCTL_CommanderAttachServer) error {
@@ -46,21 +43,23 @@ func (s *Service) CommanderAttach(server pb.DHCTL_CommanderAttachServer) error {
 
 	logger.L(ctx).Info("started")
 
-	f := fsm.New("initial", s.CommanderAttachServerTransitions())
+	f := fsm.New("initial", s.commanderAttachServerTransitions())
 
 	doneCh := make(chan struct{})
 	internalErrCh := make(chan error)
 	receiveCh := make(chan *pb.CommanderAttachRequest)
 	sendCh := make(chan *pb.CommanderAttachResponse)
-
-	phaseSwitcher := &CommanderAttachPhaseSwitcher{
-		sendCh: sendCh,
-		f:      f,
-		next:   make(chan error),
+	phaseSwitcher := &fsmPhaseSwitcher[*pb.CommanderAttachResponse, attach.PhaseData]{
+		f: f, dataFunc: s.attachSwitchPhaseData, sendCh: sendCh, next: make(chan error),
 	}
+	logWriter := logger.NewLogWriter(logger.L(ctx).With(logTypeDHCTL), sendCh,
+		func(lines []string) *pb.CommanderAttachResponse {
+			return &pb.CommanderAttachResponse{Message: &pb.CommanderAttachResponse_Logs{Logs: &pb.Logs{Logs: lines}}}
+		},
+	)
 
-	s.startattacherReceiver(server, receiveCh, doneCh, internalErrCh)
-	s.startattacherSender(server, sendCh, internalErrCh)
+	startReceiver[*pb.CommanderAttachRequest, *pb.CommanderAttachResponse](server, receiveCh, doneCh, internalErrCh)
+	startSender[*pb.CommanderAttachRequest, *pb.CommanderAttachResponse](server, sendCh, internalErrCh)
 
 connectionProcessor:
 	for {
@@ -86,9 +85,10 @@ connectionProcessor:
 						logger.Err(err), slog.String("message", fmt.Sprintf("%T", message)))
 					continue connectionProcessor
 				}
-				s.startCommanderAttach(
-					ctx, message.Start, phaseSwitcher, &CommanderAttachLogWriter{l: logger.L(ctx), sendCh: sendCh}, sendCh,
-				)
+				go func() {
+					result := s.commanderAttach(ctx, message.Start, phaseSwitcher.switchPhase, logWriter)
+					sendCh <- &pb.CommanderAttachResponse{Message: &pb.CommanderAttachResponse_Result{Result: result}}
+				}()
 
 			case *pb.CommanderAttachRequest_Continue:
 				err := f.Event("toNextPhase")
@@ -117,68 +117,10 @@ connectionProcessor:
 	}
 }
 
-func (s *Service) startattacherReceiver(
-	server pb.DHCTL_CommanderAttachServer,
-	receiveCh chan *pb.CommanderAttachRequest,
-	doneCh chan struct{},
-	internalErrCh chan error,
-) {
-	go func() {
-		for {
-			request, err := server.Recv()
-			if errors.Is(err, io.EOF) {
-				close(doneCh)
-				return
-			}
-			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
-				return
-			}
-			receiveCh <- request
-		}
-	}()
-}
-
-func (s *Service) startattacherSender(
-	server pb.DHCTL_CommanderAttachServer,
-	sendCh chan *pb.CommanderAttachResponse,
-	internalErrCh chan error,
-) {
-	go func() {
-		for response := range sendCh {
-			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
-			err := loop.Run(func() error {
-				return server.Send(response)
-			})
-			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startCommanderAttach(
+func (s *Service) commanderAttach(
 	ctx context.Context,
 	request *pb.CommanderAttachStart,
-	phaseSwitcher *CommanderAttachPhaseSwitcher,
-	logWriter *CommanderAttachLogWriter,
-	sendCh chan *pb.CommanderAttachResponse,
-) {
-	go func() {
-		result := s.CommanderAttachCluster(ctx, request, phaseSwitcher, logWriter)
-		sendCh <- &pb.CommanderAttachResponse{
-			Message: &pb.CommanderAttachResponse_Result{
-				Result: result,
-			},
-		}
-	}()
-}
-
-func (s *Service) CommanderAttachCluster(
-	ctx context.Context,
-	request *pb.CommanderAttachStart,
-	phaseSwitcher *CommanderAttachPhaseSwitcher,
+	switchPhase phases.OnPhaseFunc[attach.PhaseData],
 	logWriter io.Writer,
 ) *pb.CommanderAttachResult {
 	var err error
@@ -236,7 +178,7 @@ func (s *Service) CommanderAttachCluster(
 		SSHClient:        sshClient,
 		OnCheckResult:    onCheckResult,
 		TerraformContext: terraform.NewTerraformContext(),
-		OnPhaseFunc:      phaseSwitcher.switchPhase,
+		OnPhaseFunc:      switchPhase,
 		AttachResources: attach.AttachResources{
 			Template: request.ResourcesTemplate,
 			Values:   request.ResourcesValues.AsMap(),
@@ -253,7 +195,7 @@ func (s *Service) CommanderAttachCluster(
 	return &pb.CommanderAttachResult{State: string(stateData), Result: string(resultString), Err: errToString(err)}
 }
 
-func (s *Service) CommanderAttachServerTransitions() []fsm.Transition {
+func (s *Service) commanderAttachServerTransitions() []fsm.Transition {
 	return []fsm.Transition{
 		{
 			Event:       "start",
@@ -273,69 +215,19 @@ func (s *Service) CommanderAttachServerTransitions() []fsm.Transition {
 	}
 }
 
-type CommanderAttachLogWriter struct {
-	l      *slog.Logger
-	sendCh chan *pb.CommanderAttachResponse
-
-	m    sync.Mutex
-	prev []byte
-}
-
-func (w *CommanderAttachLogWriter) Write(p []byte) (n int, err error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-
-	var r []string
-
-	for _, b := range p {
-		switch b {
-		case '\n', '\r':
-			s := string(w.prev)
-			if s != "" {
-				r = append(r, s)
-			}
-			w.prev = []byte{}
-		default:
-			w.prev = append(w.prev, b)
-		}
-	}
-
-	if len(r) > 0 {
-		for _, line := range r {
-			w.l.Info(line, logTypeDHCTL)
-		}
-		w.sendCh <- &pb.CommanderAttachResponse{
-			Message: &pb.CommanderAttachResponse_Logs{Logs: &pb.Logs{Logs: r}},
-		}
-	}
-
-	return len(p), nil
-}
-
-type CommanderAttachPhaseSwitcher struct {
-	sendCh chan *pb.CommanderAttachResponse
-	f      *fsm.FiniteStateMachine
-	next   chan error
-}
-
-func (b *CommanderAttachPhaseSwitcher) switchPhase(
+func (s *Service) attachSwitchPhaseData(
 	completedPhase phases.OperationPhase,
 	completedPhaseState phases.DhctlState,
 	phaseData attach.PhaseData,
 	nextPhase phases.OperationPhase,
 	nextPhaseCritical bool,
-) error {
-	err := b.f.Event("wait")
-	if err != nil {
-		return fmt.Errorf("changing state to waiting: %w", err)
-	}
-
+) (*pb.CommanderAttachResponse, error) {
 	phaseDataBytes, err := json.Marshal(phaseData)
 	if err != nil {
-		return fmt.Errorf("changing state to waiting: %w", err)
+		return nil, err
 	}
 
-	b.sendCh <- &pb.CommanderAttachResponse{
+	return &pb.CommanderAttachResponse{
 		Message: &pb.CommanderAttachResponse_PhaseEnd{
 			PhaseEnd: &pb.CommanderAttachPhaseEnd{
 				CompletedPhase:      string(completedPhase),
@@ -345,11 +237,5 @@ func (b *CommanderAttachPhaseSwitcher) switchPhase(
 				NextPhaseCritical:   nextPhaseCritical,
 			},
 		},
-	}
-
-	switchErr, ok := <-b.next
-	if !ok {
-		return fmt.Errorf("server stopped, cancel task")
-	}
-	return switchErr
+	}, nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -219,7 +219,7 @@ func (s *Service) CommanderDetachCluster(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -42,7 +40,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func (s *Service) CommanderDetach(server pb.DHCTL_CommanderDetachServer) error {
@@ -50,15 +47,20 @@ func (s *Service) CommanderDetach(server pb.DHCTL_CommanderDetachServer) error {
 
 	logger.L(ctx).Info("started")
 
-	f := fsm.New("initial", s.CommanderDetachServerTransitions())
+	f := fsm.New("initial", s.commanderDetachServerTransitions())
 
 	doneCh := make(chan struct{})
 	internalErrCh := make(chan error)
 	receiveCh := make(chan *pb.CommanderDetachRequest)
 	sendCh := make(chan *pb.CommanderDetachResponse)
+	logWriter := logger.NewLogWriter(logger.L(ctx).With(logTypeDHCTL), sendCh,
+		func(lines []string) *pb.CommanderDetachResponse {
+			return &pb.CommanderDetachResponse{Message: &pb.CommanderDetachResponse_Logs{Logs: &pb.Logs{Logs: lines}}}
+		},
+	)
 
-	s.startdetacherReceiver(server, receiveCh, doneCh, internalErrCh)
-	s.startdetacherSender(server, sendCh, internalErrCh)
+	startReceiver[*pb.CommanderDetachRequest, *pb.CommanderDetachResponse](server, receiveCh, doneCh, internalErrCh)
+	startSender[*pb.CommanderDetachRequest, *pb.CommanderDetachResponse](server, sendCh, internalErrCh)
 
 connectionProcessor:
 	for {
@@ -84,9 +86,10 @@ connectionProcessor:
 						logger.Err(err), slog.String("message", fmt.Sprintf("%T", message)))
 					continue connectionProcessor
 				}
-				s.startCommanderDetach(
-					ctx, message.Start, &CommanderDetachLogWriter{l: logger.L(ctx), sendCh: sendCh}, sendCh,
-				)
+				go func() {
+					result := s.commanderDetach(ctx, message.Start, logWriter)
+					sendCh <- &pb.CommanderDetachResponse{Message: &pb.CommanderDetachResponse_Result{Result: result}}
+				}()
 
 			default:
 				logger.L(ctx).Error("got unprocessable message",
@@ -97,64 +100,7 @@ connectionProcessor:
 	}
 }
 
-func (s *Service) startdetacherReceiver(
-	server pb.DHCTL_CommanderDetachServer,
-	receiveCh chan *pb.CommanderDetachRequest,
-	doneCh chan struct{},
-	internalErrCh chan error,
-) {
-	go func() {
-		for {
-			request, err := server.Recv()
-			if errors.Is(err, io.EOF) {
-				close(doneCh)
-				return
-			}
-			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
-				return
-			}
-			receiveCh <- request
-		}
-	}()
-}
-
-func (s *Service) startdetacherSender(
-	server pb.DHCTL_CommanderDetachServer,
-	sendCh chan *pb.CommanderDetachResponse,
-	internalErrCh chan error,
-) {
-	go func() {
-		for response := range sendCh {
-			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
-			err := loop.Run(func() error {
-				return server.Send(response)
-			})
-			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startCommanderDetach(
-	ctx context.Context,
-	request *pb.CommanderDetachStart,
-	logWriter *CommanderDetachLogWriter,
-	sendCh chan *pb.CommanderDetachResponse,
-) {
-	go func() {
-		result := s.CommanderDetachCluster(ctx, request, logWriter)
-		sendCh <- &pb.CommanderDetachResponse{
-			Message: &pb.CommanderDetachResponse_Result{
-				Result: result,
-			},
-		}
-	}()
-}
-
-func (s *Service) CommanderDetachCluster(
+func (s *Service) commanderDetach(
 	ctx context.Context,
 	request *pb.CommanderDetachStart,
 	logWriter io.Writer,
@@ -292,7 +238,7 @@ func (s *Service) CommanderDetachCluster(
 	return &pb.CommanderDetachResult{State: resState, Err: errToString(errors.Join(resErrs...))}
 }
 
-func (s *Service) CommanderDetachServerTransitions() []fsm.Transition {
+func (s *Service) commanderDetachServerTransitions() []fsm.Transition {
 	return []fsm.Transition{
 		{
 			Event:       "start",
@@ -300,43 +246,4 @@ func (s *Service) CommanderDetachServerTransitions() []fsm.Transition {
 			Destination: "running",
 		},
 	}
-}
-
-type CommanderDetachLogWriter struct {
-	l      *slog.Logger
-	sendCh chan *pb.CommanderDetachResponse
-
-	m    sync.Mutex
-	prev []byte
-}
-
-func (w *CommanderDetachLogWriter) Write(p []byte) (n int, err error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-
-	var r []string
-
-	for _, b := range p {
-		switch b {
-		case '\n', '\r':
-			s := string(w.prev)
-			if s != "" {
-				r = append(r, s)
-			}
-			w.prev = []byte{}
-		default:
-			w.prev = append(w.prev, b)
-		}
-	}
-
-	if len(r) > 0 {
-		for _, line := range r {
-			w.l.Info(line, logTypeDHCTL)
-		}
-		w.sendCh <- &pb.CommanderDetachResponse{
-			Message: &pb.CommanderDetachResponse_Logs{Logs: &pb.Logs{Logs: r}},
-		}
-	}
-
-	return len(p), nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -244,7 +244,7 @@ func (s *Service) converge(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -41,7 +39,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func (s *Service) Destroy(server pb.DHCTL_DestroyServer) error {
@@ -55,14 +52,17 @@ func (s *Service) Destroy(server pb.DHCTL_DestroyServer) error {
 	internalErrCh := make(chan error)
 	receiveCh := make(chan *pb.DestroyRequest)
 	sendCh := make(chan *pb.DestroyResponse)
-	phaseSwitcher := &destroyPhaseSwitcher{
-		sendCh: sendCh,
-		f:      f,
-		next:   make(chan error),
+	phaseSwitcher := &fsmPhaseSwitcher[*pb.DestroyResponse, any]{
+		f: f, dataFunc: s.destroySwitchPhaseData, sendCh: sendCh, next: make(chan error),
 	}
+	logWriter := logger.NewLogWriter(logger.L(ctx).With(logTypeDHCTL), sendCh,
+		func(lines []string) *pb.DestroyResponse {
+			return &pb.DestroyResponse{Message: &pb.DestroyResponse_Logs{Logs: &pb.Logs{Logs: lines}}}
+		},
+	)
 
-	s.startDestroyerReceiver(server, receiveCh, doneCh, internalErrCh)
-	s.startDestroyerSender(server, sendCh, internalErrCh)
+	startReceiver[*pb.DestroyRequest, *pb.DestroyResponse](server, receiveCh, doneCh, internalErrCh)
+	startSender[*pb.DestroyRequest, *pb.DestroyResponse](server, sendCh, internalErrCh)
 
 connectionProcessor:
 	for {
@@ -88,9 +88,10 @@ connectionProcessor:
 						logger.Err(err), slog.String("message", fmt.Sprintf("%T", message)))
 					continue connectionProcessor
 				}
-				s.startDestroy(
-					ctx, message.Start, phaseSwitcher, &destroyLogWriter{l: logger.L(ctx), sendCh: sendCh}, sendCh,
-				)
+				go func() {
+					result := s.destroy(ctx, message.Start, phaseSwitcher.switchPhase, logWriter)
+					sendCh <- &pb.DestroyResponse{Message: &pb.DestroyResponse_Result{Result: result}}
+				}()
 
 			case *pb.DestroyRequest_Continue:
 				err := f.Event("toNextPhase")
@@ -119,68 +120,10 @@ connectionProcessor:
 	}
 }
 
-func (s *Service) startDestroyerReceiver(
-	server pb.DHCTL_DestroyServer,
-	receiveCh chan *pb.DestroyRequest,
-	doneCh chan struct{},
-	internalErrCh chan error,
-) {
-	go func() {
-		for {
-			request, err := server.Recv()
-			if errors.Is(err, io.EOF) {
-				close(doneCh)
-				return
-			}
-			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
-				return
-			}
-			receiveCh <- request
-		}
-	}()
-}
-
-func (s *Service) startDestroyerSender(
-	server pb.DHCTL_DestroyServer,
-	sendCh chan *pb.DestroyResponse,
-	internalErrCh chan error,
-) {
-	go func() {
-		for response := range sendCh {
-			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
-			err := loop.Run(func() error {
-				return server.Send(response)
-			})
-			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startDestroy(
-	ctx context.Context,
-	request *pb.DestroyStart,
-	phaseSwitcher *destroyPhaseSwitcher,
-	logWriter *destroyLogWriter,
-	sendCh chan *pb.DestroyResponse,
-) {
-	go func() {
-		result := s.destroy(ctx, request, phaseSwitcher, logWriter)
-		sendCh <- &pb.DestroyResponse{
-			Message: &pb.DestroyResponse_Result{
-				Result: result,
-			},
-		}
-	}()
-}
-
 func (s *Service) destroy(
 	_ context.Context,
 	request *pb.DestroyStart,
-	phaseSwitcher *destroyPhaseSwitcher,
+	switchPhase phases.DefaultOnPhaseFunc,
 	logWriter io.Writer,
 ) *pb.DestroyResult {
 	var err error
@@ -274,7 +217,7 @@ func (s *Service) destroy(
 	destroyer, err := destroy.NewClusterDestroyer(&destroy.Params{
 		NodeInterface: ssh.NewNodeInterfaceWrapper(sshClient),
 		StateCache:    cache.Global(),
-		OnPhaseFunc:   phaseSwitcher.switchPhase,
+		OnPhaseFunc:   switchPhase,
 		CommanderMode: true,
 		CommanderUUID: commanderUUID,
 		CommanderModeParams: commander.NewCommanderModeParams(
@@ -315,64 +258,14 @@ func (s *Service) destroyServerTransitions() []fsm.Transition {
 	}
 }
 
-type destroyLogWriter struct {
-	l      *slog.Logger
-	sendCh chan *pb.DestroyResponse
-
-	m    sync.Mutex
-	prev []byte
-}
-
-func (w *destroyLogWriter) Write(p []byte) (n int, err error) {
-	w.m.Lock()
-	defer w.m.Unlock()
-
-	var r []string
-
-	for _, b := range p {
-		switch b {
-		case '\n', '\r':
-			s := string(w.prev)
-			if s != "" {
-				r = append(r, s)
-			}
-			w.prev = []byte{}
-		default:
-			w.prev = append(w.prev, b)
-		}
-	}
-
-	if len(r) > 0 {
-		for _, line := range r {
-			w.l.Info(line, logTypeDHCTL)
-		}
-		w.sendCh <- &pb.DestroyResponse{
-			Message: &pb.DestroyResponse_Logs{Logs: &pb.Logs{Logs: r}},
-		}
-	}
-
-	return len(p), nil
-}
-
-type destroyPhaseSwitcher struct {
-	sendCh chan *pb.DestroyResponse
-	f      *fsm.FiniteStateMachine
-	next   chan error
-}
-
-func (b *destroyPhaseSwitcher) switchPhase(
+func (s *Service) destroySwitchPhaseData(
 	completedPhase phases.OperationPhase,
 	completedPhaseState phases.DhctlState,
-	_ interface{},
+	_ any,
 	nextPhase phases.OperationPhase,
 	nextPhaseCritical bool,
-) error {
-	err := b.f.Event("wait")
-	if err != nil {
-		return fmt.Errorf("changing state to waiting: %w", err)
-	}
-
-	b.sendCh <- &pb.DestroyResponse{
+) (*pb.DestroyResponse, error) {
+	return &pb.DestroyResponse{
 		Message: &pb.DestroyResponse_PhaseEnd{
 			PhaseEnd: &pb.DestroyPhaseEnd{
 				CompletedPhase:      string(completedPhase),
@@ -381,11 +274,5 @@ func (b *destroyPhaseSwitcher) switchPhase(
 				NextPhaseCritical:   nextPhaseCritical,
 			},
 		},
-	}
-
-	switchErr, ok := <-b.next
-	if !ok {
-		return fmt.Errorf("server stopped, cancel task")
-	}
-	return switchErr
+	}, nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -243,7 +243,7 @@ func (s *Service) destroy(
 	err = log.Process("default", "Preparing SSH client", func() error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			request.ConnectionConfig,
-			config.NewSchemaStore(),
+			s.schemaStore,
 			config.ValidateOptionCommanderMode(request.Options.CommanderMode),
 			config.ValidateOptionStrictUnmarshal(request.Options.CommanderMode),
 			config.ValidateOptionValidateExtensions(request.Options.CommanderMode),

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -44,12 +44,15 @@ type Service struct {
 
 	podName  string
 	cacheDir string
+
+	schemaStore *config.SchemaStore
 }
 
-func New(podName, cacheDir string) *Service {
+func New(podName, cacheDir string, schemaStore *config.SchemaStore) *Service {
 	return &Service{
-		podName:  podName,
-		cacheDir: cacheDir,
+		podName:     podName,
+		cacheDir:    cacheDir,
+		schemaStore: schemaStore,
 	}
 }
 

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -38,11 +38,9 @@ import (
 	pb "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/fsm"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/logger"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh/session"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 

--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -73,6 +73,9 @@ func (d *StreamDirector) Director() proxy.StreamDirector {
 			fmt.Sprintf("--server-address=%s", address),
 		)
 
+		// Add parent envs to child envs
+		cmd.Env = append(cmd.Env, os.Environ()...)
+
 		// Launch new process group so that signals (ex: SIGINT) are not sent also to the child process.
 		// https://stackoverflow.com/a/66261096
 		// Child process will start own child process e.g. terraform. We want them to finish normally.

--- a/dhctl/pkg/server/server/singlethreaded/server.go
+++ b/dhctl/pkg/server/server/singlethreaded/server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
@@ -102,7 +103,7 @@ func Serve(network, address string) error {
 	reflection.Register(s)
 
 	// init services
-	dhctlService := dhctl.New(podName, cacheDir)
+	dhctlService := dhctl.New(podName, cacheDir, config.NewSchemaStore())
 
 	// register services
 	pbdhctl.RegisterDHCTLServer(s, dhctlService)


### PR DESCRIPTION
## Description

- Reduced code duplication in the gRPC server message handler
- Reduced code duplication in the log sender
- Refactored the graceful shutdown mechanism
- Added support for proper log output for multiple parallel instances of the dhctl server

## What is the expected result?

It is not expected to change behaviour of any dhctl operation not in commander-mode. 

```changes
section: dhctl
type: feature
summary: Reduces code duplication in the gRPC server message handler and log sender, refactors the graceful shutdown mechanism, and adds support for proper log output for multiple parallel instances of the dhctl server.
impact_level: default
```
