### PR TITLE
[site] Add redirect for the /platform location

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -20,7 +20,8 @@ metadata:
       proxy_set_header X-Original-URI         $request_uri;
       ssi on;
       ssi_silent_errors on;
-      rewrite ^/source/modules/(.*)$ /modules/$1 permanent;
+      rewrite ^/source/modules/(.*)$ /modules/$1 redirect;
+      rewrite ^/platform/(.*)$ /documentation/v1/$1 redirect;
       rewrite ^/documentation/v1/modules/490-virtualization/(examples|configuration|cr|faq).html(.*)$ /modules/virtualization/stable/$1.html$2 permanent;
       rewrite ^/documentation/v1/modules/490-virtualization/.*$ /modules/virtualization/stable/ permanent;
       rewrite ^/modules/([^./]+)/?$ /modules/$1/stable/ permanent;
@@ -96,6 +97,13 @@ spec:
             port:
               name: http
       - path: /modules
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              name: http
+      - path: /platform
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
## Description

Add temporary HTTP redirect for `/platform` location on the website to the stable documentation.

So, the _https://deckhouse.io/platform/modules/500-dashboard/examples.html_ will redirect to _https://deckhouse.io/documentation/v1/modules/500-dashboard/examples.html_.



## Why do we need it, and what problem does it solve?
There is a problem when creating links in modules. We agreed to create **relative** links to DKP documentation and other modules. But DKP documentation inside the cluster (in the documentation module) is located at the same nesting level relative to the modules. For example:
- /en/platform/URL (for DKP documentation and documentation of internal modules)
- /en/modules/URL (for DKP modules)

At the same time, the documentation on the public website has a different structure. For example:
- https://deckhouse.io/documentation/v1/URL (for DKP documentation and documentation of internal modules)
- https://deckhouse.io/modules (for DKP modules)

We need a solution that will allow us to have one type of relative URL in module documentation that will work both on the site and within the cluster documentation.

## What is the expected result?
```
$ curl https://deckhouse.io/platform/modules/500-dashboard/examples.html -I
HTTP/2 302 
...
location: https://deckhouse.io/documentation/v1/modules/500-dashboard/examples.html
...
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Add redirect for the /platform location on the website.
impact_level: low
```
