### PR TITLE
[docs] Change weight for GPU runtime NGC

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -608,7 +608,7 @@ spec:
     EOF
   nodeGroups:
   - gpu
-  weight: 49
+  weight: 31
 ```
 
 Create NodeGroupConfiguration for Nvidia drivers setup on NodeGroup `gpu`.

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -615,7 +615,7 @@ spec:
     EOF
   nodeGroups:
   - gpu
-  weight: 49
+  weight: 31
 ```
 
 Далее необходимо добавить NodeGroupConfiguration для установки драйверов Nvidia для NodeGroup `gpu`.


### PR DESCRIPTION
## Description
Change weight from 49 to 31 for better behaviour then bashible doesn't see new script and wait 4 hours.
We use 31 weight for others containerd NGC, like docker mirror.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Change weight for GPU runtime in NodeGroupConfiguration example.
impact_level: low
```
