### PR TITLE
[dhctl] Add --config flag and add deprecation warning abour --resources flag for `bootstrap-phase create-resources` command

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -78,7 +78,8 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 	cmd := parent.Command("create-resources", "Create resources in Kubernetes cluster.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
-	app.DefineResourcesFlags(cmd, true)
+	app.DefineConfigsForResourcesPhaseFlags(cmd)
+	app.DefineResourcesFlags(cmd, false)
 	app.DefineKubeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/pkg/app/bootstrap.go
+++ b/dhctl/pkg/app/bootstrap.go
@@ -112,3 +112,11 @@ func DefineDeckhouseInstallFlags(cmd *kingpin.CmdClause) {
 		Default("false").
 		BoolVar(&MasterNodeSelector)
 }
+
+func DefineConfigsForResourcesPhaseFlags(cmd *kingpin.CmdClause) {
+	// we need another flag for dhctl bootstrap-phase create-resources for backward compatibility
+	// because in another cases --config flag is required, and we do not want to add another flag in DefineConfigFlags
+	cmd.Flag("config", `Path to a file with bootstrap configuration and declared Kubernetes resources in YAML format.`).
+		Envar(configEnvName("CONFIG")).
+		StringsVar(&ConfigPaths)
+}

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/fs"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
@@ -45,18 +45,8 @@ var (
 	DefaultKubernetesVersion = "1.27"
 )
 
-func revealWildcardPaths(paths []string) []string {
-	for _, path := range paths {
-		if strings.Contains(path, "*") {
-			revealPaths, _ := filepath.Glob(path)
-			paths = append(paths, revealPaths...)
-		}
-	}
-	return paths
-}
-
 func LoadConfigFromFile(paths []string, opts ...ValidateOption) (*MetaConfig, error) {
-	metaConfig, err := ParseConfig(revealWildcardPaths(paths), opts...)
+	metaConfig, err := ParseConfig(fs.RevealWildcardPaths(paths), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/template/resources.go
+++ b/dhctl/pkg/template/resources.go
@@ -168,6 +168,15 @@ func ParseResourcesContent(content string, data map[string]interface{}) (Resourc
 	return resources, nil
 }
 
+func (r Resources) String() string {
+	s := make([]string, 0)
+	for _, rr := range r {
+		s = append(s, fmt.Sprintf("%v", rr.Object.Object))
+	}
+
+	return strings.Join(s, ";")
+}
+
 func loadResources(path string, data map[string]interface{}) (Resources, error) {
 	fileContent, err := os.ReadFile(path)
 	if err != nil {

--- a/dhctl/pkg/util/fs/path.go
+++ b/dhctl/pkg/util/fs/path.go
@@ -1,0 +1,16 @@
+package fs
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func RevealWildcardPaths(paths []string) []string {
+	for _, path := range paths {
+		if strings.Contains(path, "*") {
+			revealPaths, _ := filepath.Glob(path)
+			paths = append(paths, revealPaths...)
+		}
+	}
+	return paths
+}

--- a/dhctl/pkg/util/fs/path.go
+++ b/dhctl/pkg/util/fs/path.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fs
 
 import (


### PR DESCRIPTION
## Description
Add --config flag and add deprecation warning abour --resources flag for bootstrap-phase create-resources command

## Why do we need it, and what problem does it solve?
`--resources` flag is deprecated. We need use `--config` in all places

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add --config flag and add deprecation warning abour --resources flag for bootstrap-phase create-resources command
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
