### PR TITLE
[core] fix work registry-packages-proxy with module sources

### DIFF
--- a/candi/bashible/bashbooster/50_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_registrypackages.sh
@@ -200,18 +200,6 @@ bb-package-fetch() {
   bb-log-info "Packages saved under ${BB_FETCHED_PACKAGES_STORE}"
 }
 
-# Unpack package from module image and run install script
-# bb-package-module-install package:digest registry_auth scheme registry_address registry_path
-bb-package-module-install() {
-  local MODULE_PACKAGE=$1
-  local REGISTRY_AUTH=$2
-  local SCHEME=$3
-  local REGISTRY_ADDRESS=$4
-  local REGISTRY_PATH=$5
-
-  bb-package-install $MODULE_PACKAGE
-}
-
 # run uninstall script from hold dir
 # bb-package-remove package
 bb-package-remove() {

--- a/candi/bashible/bashbooster/50_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_registrypackages.sh
@@ -56,6 +56,9 @@ function check_python() {
 # Fetch a package using python.
 # bb-package-proxy-fetch-blob digest output_file_path
 bb-package-fetch-blob() {
+  local REPOSITORY="${REPOSITORY:-}"
+  local REPOSITORY_PATH="${REPOSITORY_PATH:-}"
+
   check_python
 
   cat - <<EOF | $python_binary

--- a/candi/bashible/bashbooster/50_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_registrypackages.sh
@@ -69,7 +69,7 @@ except ImportError as e:
 endpoints = "${PACKAGES_PROXY_ADDRESSES}".split(",")
 endpoint = random.choice(endpoints)
 ssl._create_default_https_context = ssl._create_unverified_context
-url = 'https://{}/package?digest=$1&repository=${REPOSITORY}'.format(endpoint)
+url = 'https://{}/package?digest=$1&repository=${REPOSITORY}&path=${REPOSITORY_PATH}'.format(endpoint)
 request = Request(url, headers={'Authorization': 'Bearer ${PACKAGES_PROXY_TOKEN}'})
 try:
     response = urlopen(request, timeout=300)
@@ -153,10 +153,12 @@ bb-package-install() {
 }
 
 # Unpack package from module image and run install script
-# bb-package-module-install package:digest repository
+# bb-package-module-install package:digest repository module_name
+# repository is like in appropriate ModuleConfig
 bb-package-module-install() {
   local MODULE_PACKAGE=$1
   local REPOSITORY=$2
+  local REPOSITORY_PATH=$3
 
   bb-package-install $MODULE_PACKAGE
 }

--- a/candi/bashible/bb_package_install.sh.tpl
+++ b/candi/bashible/bb_package_install.sh.tpl
@@ -18,10 +18,9 @@ set -Eeo pipefail
 
 export PATH="/opt/deckhouse/bin:$PATH"
 export LANG=C
-export REPOSITORY=""
 export BB_INSTALLED_PACKAGES_STORE="/var/cache/registrypackages"
-export TMPDIR="/opt/deckhouse/tmp"
 export BB_FETCHED_PACKAGES_STORE="/${TMPDIR}/registrypackages"
+export TMPDIR="/opt/deckhouse/tmp"
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}
 export HTTP_PROXY={{ .proxy.httpProxy | quote }}
@@ -101,6 +100,9 @@ bb-package-fetch-blobs() {
 }
 
 bb-package-fetch-blob() {
+  local REPOSITORY="${REPOSITORY:-}"
+  local REPOSITORY_PATH="${REPOSITORY_PATH:-}"
+
   check_python
 
   cat - <<EOFILE | $python_binary

--- a/candi/bashible/bb_package_install.sh.tpl
+++ b/candi/bashible/bb_package_install.sh.tpl
@@ -93,7 +93,7 @@ bb-package-fetch-blobs() {
     retries=0
     while [ "$retries" -lt 3 ]
     do
-      retries=$(( retries+1 )) 
+      retries=$(( retries+1 ))
       bb-package-fetch-blob "${PACKAGE_DIGEST}" "${PACKAGE_DIR}/${PACKAGE_DIGEST}.tar.gz" && break
 			sleep 2
     done
@@ -115,7 +115,7 @@ endpoints = "${PACKAGES_PROXY_ADDRESSES}".split(",")
 random.shuffle(endpoints)
 ssl._create_default_https_context = ssl._create_unverified_context
 for ep in endpoints:
-  url = 'https://{}/package?digest=$1&repository=${REPOSITORY}'.format(ep)
+  url = 'https://{}/package?digest=$1&repository=${REPOSITORY}&path=${REPOSITORY_PATH}'.format(ep)
   request = Request(url, headers={'Authorization': 'Bearer ${PACKAGES_PROXY_TOKEN}'})
   try:
     response = urlopen(request, timeout=300)

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -144,6 +144,7 @@ func (p *Proxy) Stop() {
 func (p *Proxy) getPackage(ctx context.Context, digest string, repository string) (int64, io.ReadCloser, error) {
 	// if cache is nil, return digest directly from registry
 	if p.cache == nil {
+		p.logger.Infof("cache is not set, trying to fetch package from registry")
 		return p.getPackageFromRegistry(ctx, digest, repository)
 	}
 
@@ -199,7 +200,7 @@ func (p *Proxy) getPackageFromRegistry(ctx context.Context, digest string, repos
 		return 0, nil, err
 	}
 
-	size, registryReader, err := p.registryClient.GetPackage(ctx, registryConfig, digest)
+	size, registryReader, err := p.registryClient.GetPackage(ctx, p.logger, registryConfig, digest)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -67,6 +67,7 @@ func NewProxy(server *http.Server,
 func (p *Proxy) Serve() {
 	http.HandleFunc("/package", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "HEAD" && r.Method != "GET" {
+			p.logger.Error("method not allowed")
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
@@ -89,6 +90,7 @@ func (p *Proxy) Serve() {
 		p.logger.Infof("%s\n", logEntry)
 
 		if digest == "" {
+			p.logger.Error("missing digest")
 			http.Error(w, "missing digest", http.StatusBadRequest)
 			return
 		}
@@ -98,6 +100,7 @@ func (p *Proxy) Serve() {
 			defer packageReader.Close()
 		}
 		if err != nil {
+			p.logger.Error(err)
 			if errors.Is(err, registry.ErrPackageNotFound) {
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return

--- a/go_lib/registry-packages-proxy/registry/client.go
+++ b/go_lib/registry-packages-proxy/registry/client.go
@@ -31,5 +31,5 @@ const (
 var ErrPackageNotFound = errors.New("package not found")
 
 type Client interface {
-	GetPackage(ctx context.Context, log log.Logger, config *ClientConfig, digest string) (int64, io.ReadCloser, error)
+	GetPackage(ctx context.Context, log log.Logger, config *ClientConfig, digest string, path string) (int64, io.ReadCloser, error)
 }

--- a/go_lib/registry-packages-proxy/registry/client.go
+++ b/go_lib/registry-packages-proxy/registry/client.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// defaultRepository is the repository address from deckhouse-registry secret.
-	DefaultRepository = ""
+	DefaultRepository = "__default__"
 )
 
 var ErrPackageNotFound = errors.New("package not found")

--- a/go_lib/registry-packages-proxy/registry/client.go
+++ b/go_lib/registry-packages-proxy/registry/client.go
@@ -19,6 +19,8 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+
+	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/log"
 )
 
 const (
@@ -29,5 +31,5 @@ const (
 var ErrPackageNotFound = errors.New("package not found")
 
 type Client interface {
-	GetPackage(ctx context.Context, config *ClientConfig, digest string) (int64, io.ReadCloser, error)
+	GetPackage(ctx context.Context, log log.Logger, config *ClientConfig, digest string) (int64, io.ReadCloser, error)
 }

--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -53,8 +53,9 @@ func (c *DefaultClient) GetPackage(ctx context.Context, log log.Logger, config *
 	if err != nil {
 		e := &transport.Error{}
 		for _, err := range e.Errors {
-			log.Errorf(err.String())
+			log.Error(err.String())
 		}
+		log.Error(e.Error())
 		if errors.As(err, &e) && e.StatusCode == http.StatusNotFound {
 			return 0, nil, ErrPackageNotFound
 		}

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
@@ -61,6 +61,7 @@ func (c *Cache) Get(digest string) (int64, io.ReadCloser, error) {
 
 	// check if cache entry exists
 	if !c.storageGetOK(digest) {
+		c.logger.Infof("entry with digest %s is not foundd in the cache", digest)
 		return 0, nil, cache.ErrEntryNotFound
 	}
 

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
@@ -61,7 +61,7 @@ func (c *Cache) Get(digest string) (int64, io.ReadCloser, error) {
 
 	// check if cache entry exists
 	if !c.storageGetOK(digest) {
-		c.logger.Infof("entry with digest %s is not foundd in the cache", digest)
+		c.logger.Infof("entry with digest %s is not found in the cache", digest)
 		return 0, nil, cache.ErrEntryNotFound
 	}
 

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/module_source.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/module_source.go
@@ -15,8 +15,6 @@
 package credentials
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -51,19 +49,10 @@ type ModuleSourceSpec struct {
 type ModuleSourceSpecRegistry struct {
 	Scheme    string `json:"scheme,omitempty"`
 	Repo      string `json:"repo"`
-	DockerCFG string `json:"dockerCfg"`
+	DockerCFG []byte `json:"dockerCfg"`
 	CA        string `json:"ca"`
 }
 
 type ModuleSourceStatus struct {
-	SyncTime         time.Time     `json:"syncTime"`
-	ModulesCount     int           `json:"modulesCount"`
-	AvailableModules []string      `json:"availableModules"`
-	Msg              string        `json:"message"`
-	ModuleErrors     []ModuleError `json:"moduleErrors"`
-}
-
-type ModuleError struct {
-	Name  string `json:"name"`
-	Error string `json:"error"`
+	AvailableModules []string `json:"availableModules"`
 }

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/module_source.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/module_source.go
@@ -15,6 +15,8 @@
 package credentials
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -25,20 +27,43 @@ var moduleSourceGVR = schema.GroupVersionResource{
 	Resource: "modulesources",
 }
 
+// copy of the dhctl/pkg/apis/v1alpha1/source.go
+
 type ModuleSource struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// Spec defines the behavior of an ModuleSource.
 	Spec ModuleSourceSpec `json:"spec"`
+
+	// Status of an ModuleSource.
+	Status ModuleSourceStatus `json:"status,omitempty"`
 }
 
 type ModuleSourceSpec struct {
-	Registry ModuleSourceSpecRegistry `json:"registry"`
+	Registry       ModuleSourceSpecRegistry `json:"registry"`
+	ReleaseChannel string                   `json:"releaseChannel"`
 }
 
 type ModuleSourceSpecRegistry struct {
 	Scheme    string `json:"scheme,omitempty"`
 	Repo      string `json:"repo"`
-	DockerCFG []byte `json:"dockerCfg"`
+	DockerCFG string `json:"dockerCfg"`
 	CA        string `json:"ca"`
+}
+
+type ModuleSourceStatus struct {
+	SyncTime         time.Time     `json:"syncTime"`
+	ModulesCount     int           `json:"modulesCount"`
+	AvailableModules []string      `json:"availableModules"`
+	Msg              string        `json:"message"`
+	ModuleErrors     []ModuleError `json:"moduleErrors"`
+}
+
+type ModuleError struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
 }

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/module_source.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/module_source.go
@@ -1,16 +1,20 @@
-// Copyright 2024 Flant JSC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// from https://github.com/deckhouse/deckhouse/blob/f365e32d8662337366d02c001bd058998783eb5a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
 
 package credentials
 
@@ -19,14 +23,30 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var moduleSourceGVR = schema.GroupVersionResource{
-	Group:    "deckhouse.io",
-	Version:  "v1alpha1",
-	Resource: "modulesources",
+var SchemeGroupVersion = schema.GroupVersion{
+	Group:   "deckhouse.io",
+	Version: "v1alpha1",
 }
 
-// copy of the dhctl/pkg/apis/v1alpha1/source.go
+var (
+	ModuleSourceGVR = schema.GroupVersionResource{
+		Group:    SchemeGroupVersion.Group,
+		Version:  SchemeGroupVersion.Version,
+		Resource: "modulesources",
+	}
+	ModuleSourceGVK = schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    "ModuleSource",
+	}
+)
 
+// +genclient
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ModuleSource source
 type ModuleSource struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -49,10 +69,47 @@ type ModuleSourceSpec struct {
 type ModuleSourceSpecRegistry struct {
 	Scheme    string `json:"scheme,omitempty"`
 	Repo      string `json:"repo"`
-	DockerCFG []byte `json:"dockerCfg"`
+	DockerCFG string `json:"dockerCfg"`
 	CA        string `json:"ca"`
 }
 
 type ModuleSourceStatus struct {
-	AvailableModules []string `json:"availableModules"`
+	SyncTime         metav1.Time       `json:"syncTime"`
+	ModulesCount     int               `json:"modulesCount"`
+	AvailableModules []AvailableModule `json:"modules"`
+	Msg              string            `json:"message"`
+	ModuleErrors     []ModuleError     `json:"moduleErrors" patchStrategy:"retainKeys" patchKey:"name"`
+}
+
+type AvailableModule struct {
+	Name       string `json:"name"`
+	Policy     string `json:"policy,omitempty"`
+	Overridden bool   `json:"overridden,omitempty"`
+}
+
+type ModuleError struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+// +k8s:deepcopy-gen=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ModuleSourceList is a list of ModuleSource resources
+type ModuleSourceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []ModuleSource `json:"items"`
+}
+
+type moduleSourceKind struct{}
+
+func (in *ModuleSourceStatus) GetObjectKind() schema.ObjectKind {
+	return &moduleSourceKind{}
+}
+
+func (f *moduleSourceKind) SetGroupVersionKind(_ schema.GroupVersionKind) {}
+func (f *moduleSourceKind) GroupVersionKind() schema.GroupVersionKind {
+	return ModuleSourceGVK
 }

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/secret.go
@@ -28,7 +28,7 @@ type registrySecretData struct {
 	Path         string `json:"path" yaml:"path"`
 	Scheme       string `json:"scheme" yaml:"scheme"`
 	CA           string `json:"ca,omitempty" yaml:"ca,omitempty"`
-	DockerConfig string `json:".dockerconfigjson" yaml:".dockerconfigjson"`
+	DockerConfig []byte `json:".dockerconfigjson" yaml:".dockerconfigjson"`
 }
 
 func (d *registrySecretData) FromSecretData(m map[string][]byte) {
@@ -49,7 +49,7 @@ func (d *registrySecretData) FromSecretData(m map[string][]byte) {
 	}
 
 	if v, ok := m[".dockerconfigjson"]; ok {
-		d.DockerConfig = string(v)
+		d.DockerConfig = v
 	}
 }
 
@@ -82,15 +82,10 @@ type dockerConfig struct {
 	} `json:"auths"`
 }
 
-func dockerConfigToAuth(config string, address string) (string, error) {
+func dockerConfigToAuth(config []byte, address string) (string, error) {
 	var dockerConfig dockerConfig
 
-	auth, err := base64.StdEncoding.DecodeString(config)
-	if err != nil {
-		return "", err
-	}
-
-	err = json.Unmarshal(auth, &dockerConfig)
+	err := json.Unmarshal(config, &dockerConfig)
 	if err != nil {
 		return "", err
 	}

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -191,7 +191,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(moduleSourceEvent.Object.(*unstructured.Unstructured).Object, &moduleSource)
 	if err != nil {
-		return err
+		return fmt.Errorf("unmarshal module source event: %v", err)
 	}
 
 	switch moduleSourceEvent.Type {

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -200,7 +200,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 
 		if len(moduleSource.Spec.Registry.DockerCFG) > 0 {
 			var err error
-			auth, err = dockerConfigToAuth(moduleSource.Spec.Registry.DockerCFG, strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
+			auth, err = dockerConfigToAuth([]byte(moduleSource.Spec.Registry.DockerCFG), strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
 			if err != nil {
 				return err
 			}
@@ -214,7 +214,10 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 		}
 
 		w.Lock()
-		w.registryClientConfigs[moduleSource.Spec.Registry.Repo] = clientConfig
+		for _, module := range moduleSource.Status.AvailableModules {
+			fullPath := strings.Join([]string{moduleSource.Spec.Registry.Repo, module}, "/")
+			w.registryClientConfigs[fullPath] = clientConfig
+		}
 		w.Unlock()
 	case watch.Deleted:
 		w.Lock()

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -90,7 +90,7 @@ func (w *Watcher) Watch(ctx context.Context) {
 
 func (w *Watcher) watchSecret(ctx context.Context) {
 	watchFunc := func(_ metav1.ListOptions) (watch.Interface, error) {
-		timeout := int64((30 * time.Second).Seconds())
+		timeout := int64(30)
 
 		// Get the deckhouse-registry secret
 		return w.k8sClient.CoreV1().Secrets("d8-system").Watch(ctx, metav1.ListOptions{

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -202,7 +202,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 
 		if len(moduleSource.Spec.Registry.DockerCFG) > 0 {
 			var err error
-			auth, err = dockerConfigToAuth([]byte(moduleSource.Spec.Registry.DockerCFG), strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
+			auth, err = dockerConfigToAuth(moduleSource.Spec.Registry.DockerCFG, strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
 			if err != nil {
 				return err
 			}

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -200,7 +200,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 
 		if len(moduleSource.Spec.Registry.DockerCFG) > 0 {
 			var err error
-			auth, err = dockerConfigToAuth([]byte(moduleSource.Spec.Registry.DockerCFG), strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
+			auth, err = dockerConfigToAuth(moduleSource.Spec.Registry.DockerCFG, strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
 			if err != nil {
 				return err
 			}

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -215,13 +215,18 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 
 		w.Lock()
 		for _, module := range moduleSource.Status.AvailableModules {
+			w.logger.Infof("added registry config for repo %s and module %s", moduleSource.Spec.Registry.Repo, module)
 			fullPath := strings.Join([]string{moduleSource.Spec.Registry.Repo, module}, "/")
 			w.registryClientConfigs[fullPath] = clientConfig
 		}
 		w.Unlock()
 	case watch.Deleted:
 		w.Lock()
-		delete(w.registryClientConfigs, moduleSource.Spec.Registry.Repo)
+		for _, module := range moduleSource.Status.AvailableModules {
+			w.logger.Infof("deleted registry config for repo %s and module %s", moduleSource.Spec.Registry.Repo, module)
+			fullPath := strings.Join([]string{moduleSource.Spec.Registry.Repo, module}, "/")
+			delete(w.registryClientConfigs, fullPath)
+		}
 		w.Unlock()
 	}
 

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -16,6 +16,7 @@ package credentials
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"sync"
@@ -203,8 +204,12 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 		var auth string
 
 		if len(moduleSource.Spec.Registry.DockerCFG) > 0 {
-			var err error
-			auth, err = dockerConfigToAuth(moduleSource.Spec.Registry.DockerCFG, strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
+			dc, err := base64.StdEncoding.DecodeString(moduleSource.Spec.Registry.DockerCFG)
+			if err != nil {
+				return err
+			}
+
+			auth, err = dockerConfigToAuth(dc, strings.Split(moduleSource.Spec.Registry.Repo, "/")[0])
 			if err != nil {
 				return err
 			}

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -217,7 +217,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 
 		w.Lock()
 		for _, module := range moduleSource.Status.AvailableModules {
-			w.logger.Infof("added registry config for repo %s and module %s", moduleSource.Spec.Registry.Repo, module)
+			w.logger.Infof("added registry config for repo %s and module %s", moduleSource.Spec.Registry.Repo, module.Name)
 			fullPath := strings.Join([]string{moduleSource.Spec.Registry.Repo, module.Name}, "/")
 			w.registryClientConfigs[fullPath] = clientConfig
 		}
@@ -225,7 +225,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 	case watch.Deleted:
 		w.Lock()
 		for _, module := range moduleSource.Status.AvailableModules {
-			w.logger.Infof("deleted registry config for repo %s and module %s", moduleSource.Spec.Registry.Repo, module)
+			w.logger.Infof("deleted registry config for repo %s and module %s", moduleSource.Spec.Registry.Repo, module.Name)
 			fullPath := strings.Join([]string{moduleSource.Spec.Registry.Repo, module.Name}, "/")
 			delete(w.registryClientConfigs, fullPath)
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix registry packages proxy to work with modules images.
Added additional logging info.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Currently registry packages proxy cannot work properly with registries from module sources.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: fix work registry-packages-proxy with module sources
impact: registry-packages-proxy should be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
