### PR TITLE
[l2-load-balancer] fixes with LoadBalancerClass

### DIFF
--- a/ee/modules/381-l2-load-balancer/hooks/discovery_l2_load_balancers_test.go
+++ b/ee/modules/381-l2-load-balancer/hooks/discovery_l2_load_balancers_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("l2-load-balancer :: hooks :: discovery_l2_lb ::", func() {
-	f := HookExecutionConfigInit(`{"l2LoadBalancer":{"internal": {"l2lbservices": [{}]}}}`, "")
+	f := HookExecutionConfigInit(`{"l2LoadBalancer":{"loadBalancerClass": "my-lb-class", "internal": {"l2lbservices": [{}]}}}`, "")
 	f.RegisterCRD("network.deckhouse.io", "v1alpha1", "L2LoadBalancer", false)
 
 	Context("Empty Cluster", func() {
@@ -45,6 +45,8 @@ spec:
   - port: 7473
     protocol: TCP
     targetPort: 7473
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster
   selector:
     app: nginx
   type: LoadBalancer
@@ -120,6 +122,8 @@ spec:
                 "targetPort": 7473
               }
             ],
+			"externalTrafficPolicy": "Local",
+            "internalTrafficPolicy": "Cluster",
             "selector": {
               "app": "nginx"
             }
@@ -139,6 +143,8 @@ spec:
                 "targetPort": 7473
               }
             ],
+			"externalTrafficPolicy": "Local",
+            "internalTrafficPolicy": "Cluster",
             "selector": {
               "app": "nginx"
             }
@@ -158,6 +164,8 @@ spec:
                 "targetPort": 7473
               }
             ],
+			"externalTrafficPolicy": "Local",
+            "internalTrafficPolicy": "Cluster",
             "selector": {
               "app": "nginx"
             }

--- a/ee/modules/381-l2-load-balancer/hooks/types.go
+++ b/ee/modules/381-l2-load-balancer/hooks/types.go
@@ -23,15 +23,17 @@ type NodeInfo struct {
 }
 
 type ServiceInfo struct {
-	AnnotationIsMissed bool
-	Name               string
-	Namespace          string
-	L2LoadBalancerName string
-	LoadBalancerClass  string
-	ClusterIP          string
-	ExternalIPsCount   int
-	Ports              []v1.ServicePort
-	Selector           map[string]string
+	AnnotationIsMissed    bool
+	Name                  string
+	Namespace             string
+	L2LoadBalancerName    string
+	LoadBalancerClass     string
+	ClusterIP             string
+	ExternalIPsCount      int
+	Ports                 []v1.ServicePort
+	ExternalTrafficPolicy v1.ServiceExternalTrafficPolicy
+	InternalTrafficPolicy v1.ServiceInternalTrafficPolicy
+	Selector              map[string]string
 }
 
 type L2LBServiceStatusInfo struct {
@@ -41,15 +43,17 @@ type L2LBServiceStatusInfo struct {
 }
 
 type L2LBServiceConfig struct {
-	Name              string            `json:"name"`
-	Namespace         string            `json:"namespace"`
-	ServiceName       string            `json:"serviceName"`
-	ServiceNamespace  string            `json:"serviceNamespace"`
-	PreferredNode     string            `json:"preferredNode,omitempty"`
-	LoadBalancerClass string            `json:"loadBalancerClass"`
-	ClusterIP         string            `json:"clusterIP"`
-	Ports             []v1.ServicePort  `json:"ports"`
-	Selector          map[string]string `json:"selector"`
+	Name                  string                          `json:"name"`
+	Namespace             string                          `json:"namespace"`
+	ServiceName           string                          `json:"serviceName"`
+	ServiceNamespace      string                          `json:"serviceNamespace"`
+	PreferredNode         string                          `json:"preferredNode,omitempty"`
+	LoadBalancerClass     string                          `json:"loadBalancerClass"`
+	ClusterIP             string                          `json:"clusterIP"`
+	Ports                 []v1.ServicePort                `json:"ports"`
+	ExternalTrafficPolicy v1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy"`
+	InternalTrafficPolicy v1.ServiceInternalTrafficPolicy `json:"internalTrafficPolicy"`
+	Selector              map[string]string               `json:"selector"`
 }
 
 type L2LoadBalancerInfo struct {

--- a/ee/modules/381-l2-load-balancer/openapi/values.yaml
+++ b/ee/modules/381-l2-load-balancer/openapi/values.yaml
@@ -49,6 +49,10 @@ properties:
               additionalProperties:
                 type: string
               type: object
+            externalTrafficPolicy:
+              type: string
+            InternalTrafficPolicy:
+              type: string
             ports:
               items:
                 properties:

--- a/ee/modules/381-l2-load-balancer/templates/controller/deployment.yaml
+++ b/ee/modules/381-l2-load-balancer/templates/controller/deployment.yaml
@@ -55,9 +55,7 @@ spec:
         - args:
             - --port=7472
             - --webhook-mode=disabled
-            {{ if .Values.l2LoadBalancer.loadBalancerClass }}
-            - --lb-class={{ .Values.l2LoadBalancer.loadBalancerClass }}
-            {{- end }}
+            - --lb-class="l2-load-balancer-class.network.deckhouse.io"
           env:
           - name: METALLB_ML_SECRET_NAME
             value: memberlist

--- a/ee/modules/381-l2-load-balancer/templates/l2lbservice/l2lbservice.yaml
+++ b/ee/modules/381-l2-load-balancer/templates/l2lbservice/l2lbservice.yaml
@@ -15,10 +15,10 @@ spec:
     namespace: {{ $l2lbservice.serviceNamespace }}
   ports:
     {{ $l2lbservice.ports | toYaml | nindent 4 }}
+  externalTrafficPolicy: {{ $l2lbservice.externalTrafficPolicy }}
+  internalTrafficPolicy: {{ $l2lbservice.internalTrafficPolicy }}
   selector:
     {{ $l2lbservice.selector | toYaml | nindent 4 }}
   type: LoadBalancer
-  {{ if $.Values.l2LoadBalancer.loadBalancerClass }}
-  loadBalancerClass: {{ $.Values.l2LoadBalancer.loadBalancerClass }}
-  {{- end }}
+  loadBalancerClass: "l2-load-balancer-class.network.deckhouse.io"
 {{- end }}

--- a/ee/modules/381-l2-load-balancer/templates/speaker/daemonset.yaml
+++ b/ee/modules/381-l2-load-balancer/templates/speaker/daemonset.yaml
@@ -56,9 +56,7 @@ spec:
             - --host=127.0.0.1
             - --port=7474
             - --ml-bindport=4225
-            {{ if .Values.l2LoadBalancer.loadBalancerClass }}
-            - --lb-class={{ .Values.l2LoadBalancer.loadBalancerClass }}
-            {{- end }}
+            - --lb-class="l2-load-balancer-class.network.deckhouse.io"
           env:
             - name: METALLB_NODE_NAME
               valueFrom:


### PR DESCRIPTION
## Description
Fixes:
* Transition `SDNInternalL2LBService` to use the internal `LoadBalancerClass: 2-load-balancer-class.network.deckhouse.io`
* Inherit fields **externalTrafficPolicy** and **internalTrafficPolicy**  and  from `Service` in `SDNInternalL2LBService`

## Why do we need it, and what problem does it solve?
This will help clients who use services with fields **externalTrafficPolicy** and **internalTrafficPolicy** in the cluster.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: l2-load-balancer
type: fix
summary: fixes with LoadBalancerClass
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
