### PR TITLE
[ingress-nginx] bump controller to 1.10.3

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-10/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_ALT
 ARG BASE_ALT_DEV
 ARG BASE_ALPINE_DEV
-ARG BASE_GOLANG_21_BULLSEYE_DEV
-ARG CONTROLLER_BRANCH=controller-v1.10.1
+ARG BASE_GOLANG_22_ALPINE_DEV
+ARG CONTROLLER_BRANCH=controller-v1.10.3
 
 FROM $BASE_ALT as base-alt
 
@@ -26,7 +26,7 @@ RUN cd / && \
     && luarocks-5.1 install lua-iconv-7-3.src.rock
 
 # Build ingress controller, debug tool and pre-stop hook
-FROM $BASE_GOLANG_21_BULLSEYE_DEV as controller-builder
+FROM $BASE_GOLANG_22_ALPINE_DEV  as controller-builder
 ARG CONTROLLER_BRANCH
 ENV CONTROLLER_BRANCH=${CONTROLLER_BRANCH}
 ARG SOURCE_REPO
@@ -66,10 +66,10 @@ RUN apt-get update && apt-get install -y ninja-build libabseil-cpp-devel build-e
 RUN patch build.sh < nginx-build.patch && /build.sh
 
 # This intermediary image will be used only to copy all the required files to the chroot
-# Based on tag "controller-v1.10.1":
-# - https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/images/nginx-1.25/rootfs/Dockerfile
-# - https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/Dockerfile-chroot
-# - https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.1/rootfs/chroot.sh
+# Based on tag "controller-v1.10.2":
+# - https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.3/images/nginx-1.25/rootfs/Dockerfile
+# - https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.3/rootfs/Dockerfile-chroot
+# - https://github.com/kubernetes/ingress-nginx/blob/controller-v1.10.3/rootfs/chroot.sh
 FROM $BASE_ALT_DEV as chroot
 
 COPY --from=nginx-builder /usr/local /usr/local

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/makefile.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/makefile.patch
@@ -25,7 +25,7 @@ index 8ff0f0ca0..bbed9acee 100644
  .PHONY: build
  build:  ## Build ingress controller, debug tool and pre-stop hook.
 +ifeq ($(USE_DOCKER), true)
- 	E2E_IMAGE=golang:$(GO_VERSION)-alpine3.19 USE_SHELL=/bin/sh build/run-in-docker.sh \
+ 	E2E_IMAGE=golang:$(GO_VERSION)-alpine3.20 USE_SHELL=/bin/sh build/run-in-docker.sh \
  		MAC_OS=$(MAC_OS) \
  		PKG=$(PKG) \
 @@ -118,7 +119,9 @@ build:  ## Build ingress controller, debug tool and pre-stop hook.

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/nginx-build.patch
@@ -1,8 +1,8 @@
 diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.sh
-index 3fe610945..760faafe7 100755
+index 1ebce8efc..8ab932511 100755
 --- a/images/nginx-1.25/rootfs/build.sh
 +++ b/images/nginx-1.25/rootfs/build.sh
-@@ -14,11 +14,14 @@
+@@ -14,6 +14,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  
@@ -12,13 +12,7 @@ index 3fe610945..760faafe7 100755
  set -o errexit
  set -o nounset
  set -o pipefail
- 
--export NGINX_VERSION=1.25.3
-+export NGINX_VERSION=1.25.5
- 
- # Check for recent changes: https://github.com/vision5/ngx_devel_kit/compare/v0.3.3...master
- export NDK_VERSION=v0.3.3
-@@ -110,177 +113,16 @@ export OPENTELEMETRY_CPP_VERSION="v1.11.0"
+@@ -110,79 +113,10 @@ export OPENTELEMETRY_CPP_VERSION="v1.11.0"
  export OPENTELEMETRY_PROTO_VERSION="v1.1.0"
  
  export BUILD_PATH=/tmp/build
@@ -94,16 +88,12 @@ index 3fe610945..760faafe7 100755
 -  c-ares-dev \
 -  re2-dev \
 -  grpc-dev \
--  protobuf-dev 
+-  protobuf-dev
 -
--# apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing opentelemetry-cpp-dev
--
--# There is some bug with some platforms and git, so force HTTP/1.1
--git config --global http.version HTTP/1.1
--git config --global http.postBuffer 157286400
--
- mkdir -p /etc/nginx
+ # apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing opentelemetry-cpp-dev
  
+ # There is some bug with some platforms and git, so force HTTP/1.1
+@@ -194,93 +128,7 @@ mkdir -p /etc/nginx
  mkdir --verbose -p "$BUILD_PATH"
  cd "$BUILD_PATH"
  
@@ -194,11 +184,11 @@ index 3fe610945..760faafe7 100755
 -
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
-+git clone -b "controller-v1.10.1-nginx-1.25.5" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
++git clone -b "controller-v1.10.3" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
  
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
-@@ -304,7 +146,7 @@ cd "$BUILD_PATH/opentelemetry-cpp"
+@@ -304,7 +152,7 @@ cd "$BUILD_PATH/opentelemetry-cpp"
  export CXXFLAGS="-DBENCHMARK_HAS_NO_INLINE_ASSEMBLY"
  cmake -B build -G Ninja -Wno-dev \
          -DOTELCPP_PROTO_PATH="${BUILD_PATH}/opentelemetry-proto/" \
@@ -207,7 +197,7 @@ index 3fe610945..760faafe7 100755
          -DBUILD_SHARED_LIBS=ON \
          -DBUILD_TESTING="OFF" \
          -DBUILD_W3CTRACECONTEXT_TEST="OFF" \
-@@ -327,15 +169,16 @@ git config --global --add core.compression -1
+@@ -327,15 +175,16 @@ git config --global --add core.compression -1
  
  # Get Brotli source and deps
  cd "$BUILD_PATH"
@@ -226,7 +216,7 @@ index 3fe610945..760faafe7 100755
  cd ssdeep/
  
  ./bootstrap
-@@ -346,10 +189,13 @@ make install
+@@ -346,10 +195,13 @@ make install
  
  # build modsecurity library
  cd "$BUILD_PATH"
@@ -241,7 +231,7 @@ index 3fe610945..760faafe7 100755
  git submodule update
  
  sh build.sh
-@@ -379,7 +225,7 @@ echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecuri
+@@ -379,7 +231,7 @@ echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecuri
  # Download owasp modsecurity crs
  cd /etc/nginx/
  
@@ -250,15 +240,7 @@ index 3fe610945..760faafe7 100755
  mv coreruleset owasp-modsecurity-crs
  cd owasp-modsecurity-crs
  
-@@ -447,6 +293,7 @@ WITH_FLAGS="--with-debug \
-   --with-http_gzip_static_module \
-   --with-http_sub_module \
-   --with-http_v2_module \
-+  --with-http_v3_module \
-   --with-stream \
-   --with-stream_ssl_module \
-   --with-stream_realip_module \
-@@ -523,7 +370,7 @@ make install
+@@ -521,7 +373,7 @@ make install
  export OPENTELEMETRY_CONTRIB_COMMIT=aaa51e2297bcb34297f3c7aa44fa790497d2f7f3
  cd "$BUILD_PATH"
  
@@ -267,7 +249,7 @@ index 3fe610945..760faafe7 100755
  
  cd ${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
  git reset --hard ${OPENTELEMETRY_CONTRIB_COMMIT}
-@@ -616,7 +463,7 @@ writeDirs=( \
+@@ -614,7 +466,7 @@ writeDirs=( \
    /var/log/nginx \
  );
  


### PR DESCRIPTION
## Description
It bumps ingress-nginx to 1.10.3

## Why do we need it, and what problem does it solve?
This version contains our patches, security and performance improvements.

## What is the expected result?
Ingress-nginx controller 1.10.3
<img width="644" alt="Screenshot 2024-07-22 at 6 33 19 PM" src="https://github.com/user-attachments/assets/fd778ad2-354f-49bb-8e56-728b5a34915c">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: feature
summary: Bump ingress-nginx to 1.10.3
impact: ingress-nginx controllers' pods will be recreated.
impact_level: default 
```

