### PR TITLE
bashible-apiserver openapi v2 endpoint

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
@@ -115,11 +115,11 @@ func (o *BashibleServerOptions) Config(stopCh <-chan struct{}) (*apiserver.Confi
 		return nil, err
 	}
 
-	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
-		bashibleopenapi.GetOpenAPIDefinitions,
-		openapi.NewDefinitionNamer(apiserver.Scheme))
-	serverConfig.OpenAPIConfig.Info.Title = "Bashible"
-	serverConfig.OpenAPIConfig.Info.Version = "0.1"
+	// serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
+	// 	bashibleopenapi.GetOpenAPIDefinitions,
+	// 	openapi.NewDefinitionNamer(apiserver.Scheme))
+	// serverConfig.OpenAPIConfig.Info.Title = "Bashible"
+	// serverConfig.OpenAPIConfig.Info.Version = "0.1"
 
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
 		return nil, err

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
@@ -115,14 +115,14 @@ func (o *BashibleServerOptions) Config(stopCh <-chan struct{}) (*apiserver.Confi
 		return nil, err
 	}
 
-	// serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
-	// 	bashibleopenapi.GetOpenAPIDefinitions,
-	// 	openapi.NewDefinitionNamer(apiserver.Scheme))
-	// serverConfig.OpenAPIConfig.Info.Title = "Bashible"
-	// serverConfig.OpenAPIConfig.Info.Version = "0.1"
-	// if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
-	// 	return nil, err
-	// }
+	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(
+		bashibleopenapi.GetOpenAPIDefinitions,
+		openapi.NewDefinitionNamer(apiserver.Scheme))
+	serverConfig.OpenAPIConfig.Info.Title = "Bashible"
+	serverConfig.OpenAPIConfig.Info.Version = "0.1"
+	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
+		return nil, err
+	}
 
 	deployInformer := serverConfig.SharedInformerFactory.Apps().V1().Deployments().Informer()
 	deployHealthChecker, err := readyz.NewDeploymentReadinessCheck(stopCh, deployInformer, "d8-system", "deckhouse")

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
@@ -120,10 +120,9 @@ func (o *BashibleServerOptions) Config(stopCh <-chan struct{}) (*apiserver.Confi
 	// 	openapi.NewDefinitionNamer(apiserver.Scheme))
 	// serverConfig.OpenAPIConfig.Info.Title = "Bashible"
 	// serverConfig.OpenAPIConfig.Info.Version = "0.1"
-
-	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
-		return nil, err
-	}
+	// if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
+	// 	return nil, err
+	// }
 
 	deployInformer := serverConfig.SharedInformerFactory.Apps().V1().Deployments().Informer()
 	deployHealthChecker, err := readyz.NewDeploymentReadinessCheck(stopCh, deployInformer, "d8-system", "deckhouse")

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/cmd/server/start.go
@@ -20,11 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
-	"net/http/httputil"
-	"time"
 
-	"github.com/emicklei/go-restful/v3"
 	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
@@ -143,20 +139,6 @@ func (o *BashibleServerOptions) Config(stopCh <-chan struct{}) (*apiserver.Confi
 	return config, nil
 }
 
-func loggingMiddleware(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-	now := time.Now()
-
-	reqBytes, err := httputil.DumpRequest(req.Request, true)
-	if err != nil {
-		_ = resp.WriteError(http.StatusInternalServerError, err)
-		return
-	}
-
-	fmt.Printf("raw http request:\n%s", reqBytes)
-	chain.ProcessFilter(req, resp)
-	fmt.Printf("%s %s %v", req.Request.Method, req.Request.URL, time.Since(now))
-}
-
 // RunBashibleServer starts a new BashibleServer given BashibleServerOptions
 func (o BashibleServerOptions) RunBashibleServer(stopCh <-chan struct{}) error {
 	config, err := o.Config(stopCh)
@@ -176,7 +158,6 @@ func (o BashibleServerOptions) RunBashibleServer(stopCh <-chan struct{}) error {
 			return nil
 		},
 	)
-	server.GenericAPIServer.Handler.GoRestfulContainer.Filter(loggingMiddleware)
 
 	return server.GenericAPIServer.PrepareRun().Run(stopCh)
 }


### PR DESCRIPTION
Signed-off-by: borg-z <me@nikolay-z.top>

## Description

Adding /openapi/v2 endpoint for bashible-apiserver. 

## Why do we need it, and what problem does it solve?


There is a non-stop spam of logs in the kube-apiserver logs:

```
E0724 07:02:08.686694       1 controller.go:116] loading OpenAPI spec for "v1alpha1.bashible.deckhouse.io" failed with: OpenAPI spec does not exist
E0724 07:03:08.690288       1 controller.go:116] loading OpenAPI spec for "v1alpha1.bashible.deckhouse.io" failed with: OpenAPI spec does not exist
E0724 07:05:08.694440       1 controller.go:116] loading OpenAPI spec for "v1alpha1.bashible.deckhouse.io" failed with: OpenAPI spec does not exist
```

The issue arises because the kube-apiserver is unable to[fetch an OpenAPI spec](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go#L137-L147) from the [/openapi/v2 endpoint](https://godoc.org/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator#Downloader.Download). 

see also https://github.com/kubernetes-sigs/prometheus-adapter/issues/254

## Why do we need it in the patch release (if we do)?


## What is the expected result?

The bashible-apiserver will have an `openapi/v2` endpoint, `kube-apiserver` will not spam the error logs

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Reducing unnecessary kube-apiserver logs
impact:  Reducing unnecessary kube-apiserver logs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
