### PR TITLE
[docs] Delete cdi-uploadproxy domain from GS

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -276,7 +276,6 @@ sudo /opt/deckhouse/bin/kubectl create -f user.yml
 <pre class="highlight">
 <code example-hosts>api.example.com
 argocd.example.com
-cdi-uploadproxy.example.com
 dashboard.example.com
 documentation.example.com
 dex.example.com
@@ -301,7 +300,6 @@ export PUBLIC_IP="<PUT_PUBLIC_IP_HERE>"
 sudo -E bash -c "cat <<EOF >> /etc/hosts
 $PUBLIC_IP api.example.com
 $PUBLIC_IP argocd.example.com
-$PUBLIC_IP cdi-uploadproxy.example.com
 $PUBLIC_IP dashboard.example.com
 $PUBLIC_IP documentation.example.com
 $PUBLIC_IP dex.example.com

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -282,7 +282,6 @@ sudo /opt/deckhouse/bin/kubectl create -f user.yml
 <pre class="highlight">
 <code example-hosts>api.example.com
 argocd.example.com
-cdi-uploadproxy.example.com
 dashboard.example.com
 documentation.example.com
 dex.example.com
@@ -308,7 +307,6 @@ export PUBLIC_IP="<PUBLIC_IP>"
 sudo -E bash -c "cat <<EOF >> /etc/hosts
 $PUBLIC_IP api.example.com
 $PUBLIC_IP argocd.example.com
-$PUBLIC_IP cdi-uploadproxy.example.com
 $PUBLIC_IP dashboard.example.com
 $PUBLIC_IP documentation.example.com
 $PUBLIC_IP dex.example.com

--- a/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS.liquid
+++ b/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS.liquid
@@ -19,7 +19,6 @@
         <ul>
           <li><b title="E.g., <em>&quot;api-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">api</b></li>
           <li><b title="E.g., <em>&quot;argocd-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">argocd</b></li>
-          <li><b title="E.g., <em>&quot;cdi-uploadproxy-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">cdi-uploadproxy</b></li>
           <li><b title="E.g.,  <em>&quot;dashboard-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">dashboard</b></li>
           <li><b title="E.g., <em>&quot;documentation-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">documentation</b></li>
           <li><b title="E.g.,  <em>&quot;dex-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">dex</b></li>
@@ -69,7 +68,7 @@ BALANCER_IP='<BALANCER_IP>'
 <li><p>{% if page.platform_code != 'existing' %}<b>[On the PC]</b>{% endif %} Add records to the <code>/etc/hosts</code> file:</p>
 {% snippetcut %}
 ```shell
-for i in api argocd cdi-uploadproxy dashboard documentation dex grafana hubble istio istio-api-proxy kubeconfig openvpn-admin prometheus status upmeter; do echo "${BALANCER_IP}  ${DOMAIN_TEMPLATE} "| sed "s/%s/$i/"; done  | sudo bash -c "cat >>/etc/hosts"
+for i in api argocd dashboard documentation dex grafana hubble istio istio-api-proxy kubeconfig openvpn-admin prometheus status upmeter; do echo "${BALANCER_IP}  ${DOMAIN_TEMPLATE} "| sed "s/%s/$i/"; done  | sudo bash -c "cat >>/etc/hosts"
 ```
 {% endsnippetcut %}
 </li>

--- a/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS_RU.liquid
@@ -18,7 +18,6 @@
         <ul>
           <li><b title="Например, <em>&quot;api-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">api</b></li>
           <li><b title="Например, <em>&quot;argocd-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">argocd</b></li>
-          <li><b title="Например, <em>&quot;cdi-uploadproxy-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">cdi-uploadproxy</b></li>
           <li><b title="Например,  <em>&quot;dashboard-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">dashboard</b></li>
           <li><b title="Например, <em>&quot;documentation-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">documentation</b></li>
           <li><b title="Например,  <em>&quot;dex-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">dex</b></li>
@@ -68,7 +67,7 @@ BALANCER_IP='<BALANCER_IP>'
 <li><p>{% if page.platform_code != 'existing' %}<b>[Выполните на ПК]</b> {% endif %}Добавьте записи в файл <code>/etc/hosts</code>:</p>
 {% snippetcut %}
 ```shell
-for i in api argocd cdi-uploadproxy dashboard documentation dex grafana hubble istio istio-api-proxy kubeconfig openvpn-admin prometheus status upmeter; do echo "${BALANCER_IP}  ${DOMAIN_TEMPLATE} "| sed "s/%s/$i/"; done  | sudo bash -c "cat >>/etc/hosts"
+for i in api argocd dashboard documentation dex grafana hubble istio istio-api-proxy kubeconfig openvpn-admin prometheus status upmeter; do echo "${BALANCER_IP}  ${DOMAIN_TEMPLATE} "| sed "s/%s/$i/"; done  | sudo bash -c "cat >>/etc/hosts"
 ```
 {% endsnippetcut %}
 </li>


### PR DESCRIPTION
## Description

An unused domain `cdi-uploadproxy` has been removed from Getting Started.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## What is the expected result?

Getting Started will become more correct.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: |
  An unused domain `cdi-uploadproxy` has been removed from Getting Started.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
