### PR TITLE
[dhctl] Fix bashible bundles step did not break when retry attempts was exited

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -116,6 +116,11 @@ func ExecuteBashibleBundle(sshClient *ssh.Client, tmpDir string) error {
 		if errors.As(err, &ee) {
 			return fmt.Errorf("bundle '%s' error: %v\nstderr: %s", bundleDir, err, string(ee.Stderr))
 		}
+
+		if errors.Is(err, frontend.ErrBashibleTimeout) {
+			return frontend.ErrBashibleTimeout
+		}
+
 		return fmt.Errorf("bundle '%s' error: %v", bundleDir, err)
 	}
 	return nil
@@ -330,19 +335,19 @@ func StartRegistryPackagesProxy(config config.RegistryData, clusterDomain string
 type registryPackagesProxyLogger struct{}
 
 func (r registryPackagesProxyLogger) Errorf(format string, args ...interface{}) {
-	log.ErrorF(format, args...)
+	log.ErrorF(format+"\n", args...)
 }
 
 func (r registryPackagesProxyLogger) Infof(format string, args ...interface{}) {
-	log.InfoF(format, args...)
+	log.InfoF(format+"\n", args...)
 }
 
 func (r registryPackagesProxyLogger) Warnf(format string, args ...interface{}) {
-	log.WarnF(format, args...)
+	log.WarnF(format+"\n", args...)
 }
 
 func (r registryPackagesProxyLogger) Debugf(format string, args ...interface{}) {
-	log.DebugF(format, args...)
+	log.DebugF(format+"\n", args...)
 }
 
 func (r registryPackagesProxyLogger) Error(args ...interface{}) {

--- a/dhctl/pkg/system/ssh/frontend/reverse-tunnel.go
+++ b/dhctl/pkg/system/ssh/frontend/reverse-tunnel.go
@@ -175,7 +175,7 @@ func (t *ReverseTunnel) StartHealthMonitor(checker ReverseTunnelChecker, killer 
 
 			select {
 			case <-t.stopCh:
-				log.InfoLn("Stop health monitor")
+				log.DebugLn("Stop health monitor")
 				return
 			case oldId := <-restartCh:
 				restartsCount++


### PR DESCRIPTION
## Description
Fix bashible bundles step did not break when retry attempts was exited
Add new line for registry packages proxy logger
Change reverse tunnel health monitor log from info to debug

## Why do we need it, and what problem does it solve?
Dhctl should break retries bashible step if bashible step retry loop receive exited attempts error.
Logs changes will improve UX

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/user-attachments/assets/de37811a-9220-4d0f-9105-c31b28760194)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix bashible bundles step did not break when retry attempts was exited
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
