### PR TITLE
[deckhouse-controller] Deckhouse release controller metrics

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -178,7 +178,7 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 		return nil, err
 	}
 
-	err = deckhouse_release.NewDeckhouseReleaseController(ctx, mgr, dc, mm, dsContainer)
+	err = deckhouse_release.NewDeckhouseReleaseController(ctx, mgr, dc, mm, dsContainer, metricStorage)
 	if err != nil {
 		return nil, fmt.Errorf("new Deckhouse release controller: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
@@ -18,6 +18,7 @@ package deckhouse_release
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/flant/shell-operator/pkg/metric_storage"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/releaseutil"
@@ -86,6 +88,7 @@ func setupControllerSettings(
 		logger:         log.New(),
 		moduleManager:  stubModulesManager{},
 		updateSettings: helpers.NewDeckhouseSettingsContainer(ds),
+		metricStorage:  metric_storage.NewMetricStorage(context.Background(), "", true),
 	}
 
 	return rec, cl

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -25,9 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/shell-operator/pkg/metric_storage"
-
 	"github.com/flant/addon-operator/pkg/utils/logger"
+	"github.com/flant/shell-operator/pkg/metric_storage"
 	"github.com/gofrs/uuid/v5"
 	gcr "github.com/google/go-containerregistry/pkg/name"
 	log "github.com/sirupsen/logrus"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flant/shell-operator/pkg/metric_storage"
+
 	"github.com/flant/addon-operator/pkg/utils/logger"
 	"github.com/gofrs/uuid/v5"
 	gcr "github.com/google/go-containerregistry/pkg/name"
@@ -61,11 +63,13 @@ type deckhouseReleaseReconciler struct {
 	moduleManager moduleManager
 
 	updateSettings          *helpers.DeckhouseSettingsContainer
+	metricStorage           *metric_storage.MetricStorage
 	clusterUUID             string
 	releaseVersionImageHash string
 }
 
-func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc dependency.Container, moduleManager moduleManager, updateSettings *helpers.DeckhouseSettingsContainer) error {
+func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc dependency.Container,
+	moduleManager moduleManager, updateSettings *helpers.DeckhouseSettingsContainer, metricStorage *metric_storage.MetricStorage) error {
 	lg := log.WithField("component", "DeckhouseRelease")
 
 	r := &deckhouseReleaseReconciler{
@@ -74,6 +78,7 @@ func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc 
 		logger:         lg,
 		moduleManager:  moduleManager,
 		updateSettings: updateSettings,
+		metricStorage:  metricStorage,
 	}
 
 	// wait for cache sync

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -483,7 +483,7 @@ func (r *deckhouseReleaseReconciler) tagUpdate(ctx context.Context, pods []corev
 		return fmt.Errorf("registry (%s) get digest failed: %s", repo, err)
 	}
 
-	r.metricStorage.GaugeSet("deckhouse_kube_image_digest_check_success", 1.0, map[string]string{})
+	r.metricStorage.CounterAdd("deckhouse_kube_image_digest_check_success", 1.0, map[string]string{})
 
 	if strings.TrimSpace(repoDigest) == strings.TrimSpace(imageHash) {
 		return nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/updater/metrics.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/updater/metrics.go
@@ -18,20 +18,22 @@ package d8updater
 
 import "github.com/flant/shell-operator/pkg/metric_storage"
 
-func newMetricsUpdater(metricStorage *metric_storage.MetricStorage) *metricsUpdater {
-	return &metricsUpdater{
+const metricReleasesGroup = "d8_releases"
+
+func newMetricUpdater(metricStorage *metric_storage.MetricStorage) *metricUpdater {
+	return &metricUpdater{
 		metricStorage: metricStorage,
 	}
 }
 
-type metricsUpdater struct {
+type metricUpdater struct {
 	metricStorage *metric_storage.MetricStorage
 }
 
-func (mu *metricsUpdater) WaitingManual(_ string, _ float64) {
-	mu.metricStorage.
+func (mu metricUpdater) WaitingManual(name string, totalPendingManualReleases float64) {
+	mu.metricStorage.GroupedVault.GaugeSet(metricReleasesGroup, "d8_release_waiting_manual", totalPendingManualReleases, map[string]string{"name": name})
 }
 
-func (mu *metricsUpdater) ReleaseBlocked(_, _ string) {
-	mu.metricStorage.
+func (mu metricUpdater) ReleaseBlocked(name, reason string) {
+	mu.metricStorage.GroupedVault.GaugeSet(metricReleasesGroup, "d8_release_blocked", 1, map[string]string{"name": name, "reason": reason})
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/updater/metrics.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/updater/metrics.go
@@ -16,12 +16,22 @@ limitations under the License.
 
 package d8updater
 
-func newMetricsUpdater() *metricsUpdater {
-	return &metricsUpdater{}
+import "github.com/flant/shell-operator/pkg/metric_storage"
+
+func newMetricsUpdater(metricStorage *metric_storage.MetricStorage) *metricsUpdater {
+	return &metricsUpdater{
+		metricStorage: metricStorage,
+	}
 }
 
-type metricsUpdater struct{}
+type metricsUpdater struct {
+	metricStorage *metric_storage.MetricStorage
+}
 
-func (mu *metricsUpdater) WaitingManual(_ string, _ float64) {}
+func (mu *metricsUpdater) WaitingManual(_ string, _ float64) {
+	mu.metricStorage.
+}
 
-func (mu *metricsUpdater) ReleaseBlocked(_, _ string) {}
+func (mu *metricsUpdater) ReleaseBlocked(_, _ string) {
+	mu.metricStorage.
+}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/updater/updater.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/updater/updater.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/flant/addon-operator/pkg/utils/logger"
+	"github.com/flant/shell-operator/pkg/metric_storage"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,11 +38,11 @@ import (
 )
 
 func NewDeckhouseUpdater(logger logger.Logger, client client.Client, dc dependency.Container,
-	updateSettings *updater.DeckhouseUpdateSettings, releaseData updater.DeckhouseReleaseData,
+	updateSettings *updater.DeckhouseUpdateSettings, releaseData updater.DeckhouseReleaseData, metricStorage *metric_storage.MetricStorage,
 	podIsReady, clusterBootstrapping bool, imagesRegistry string, enabledModules []string) (*updater.Updater[*v1alpha1.DeckhouseRelease], error) {
 	return updater.NewUpdater[*v1alpha1.DeckhouseRelease](logger, updateSettings.NotificationConfig, updateSettings.Mode, releaseData,
 		podIsReady, clusterBootstrapping, newKubeAPI(client, dc, imagesRegistry),
-		newMetricsUpdater(), newValueSettings(updateSettings.DisruptionApprovalMode), newWebhookDataGetter(), enabledModules), nil
+		newMetricUpdater(metricStorage), newValueSettings(updateSettings.DisruptionApprovalMode), newWebhookDataGetter(), enabledModules), nil
 }
 
 func newWebhookDataGetter() *webhookDataGetter {

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2288,19 +2288,6 @@ alerts:
         APF flow schema d8-serviceaccounts has rejected API requests.
       severity: "9"
       markupFormat: markdown
-    - name: KubernetesAPFRejectRequests
-      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/flow-schema.yaml
-      moduleUrl: 340-monitoring-deckhouse
-      module: monitoring-deckhouse
-      edition: ce
-      description: |
-        To show APF schema queue requests, use the expr `apiserver_flowcontrol_current_inqueue_requests{flow_schema="d8-serviceaccounts"}`.
-
-        Attention: This is an experimental alert!
-      summary: |
-        APF flow schema d8-serviceaccounts has rejected API requests.
-      severity: "9"
-      markupFormat: markdown
     - name: KubernetesVersionEndOfLife
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
       moduleUrl: 040-control-plane-manager


### PR DESCRIPTION
## Description
Deckhouse update metrics restored
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Deckhouse update metrics restored.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
