### PR TITLE
[log-shipper] Make extraLabels and CEF encoding work for Socket dest

### DIFF
--- a/modules/460-log-shipper/hooks/generate_config_test.go
+++ b/modules/460-log-shipper/hooks/generate_config_test.go
@@ -139,6 +139,7 @@ spec:
 		Entry("File to Kafka with client certificate authentication", "file-to-kafka-tls"),
 		Entry("File to Loki", "file-to-loki"),
 		Entry("File to Socket", "file-to-socket"),
+		Entry("File to Socket", "file-to-socket-cef"),
 		Entry("File to Splunk", "file-to-splunk"),
 		Entry("Two sources to single destination", "many-to-one"),
 		Entry("Throttle Transform with filter", "throttle-with-filter"),

--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -30,11 +30,13 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 	case v1alpha1.DestElasticsearch, v1alpha1.DestLogstash:
 		transforms = append(transforms, DeDotTransform())
 		fallthrough
-	case v1alpha1.DestVector, v1alpha1.DestKafka:
+	case v1alpha1.DestSocket, v1alpha1.DestVector, v1alpha1.DestKafka:
 		if len(dest.Spec.ExtraLabels) > 0 {
 			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))
 		}
-		if dest.Spec.Kafka.Encoding.Codec == v1alpha1.EncodingCodecCEF {
+
+		switch v1alpha1.EncodingCodecCEF {
+		case dest.Spec.Kafka.Encoding.Codec, dest.Spec.Socket.Encoding.Codec:
 			transforms = append(transforms, CEFNameAndSeverity())
 		}
 	}

--- a/modules/460-log-shipper/hooks/testdata/file-to-socket-cef/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-socket-cef/manifests.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-source
+spec:
+  type: File
+  file:
+    include:
+      - /var/log/kube-audit/audit.log
+  destinationRefs:
+    - test-socket1-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-socket1-dest
+spec:
+  type: Socket
+  socket:
+    address: 192.168.1.1:9200
+    mode: TCP
+    encoding:
+      codec: CEF
+    tcp:
+      tls:
+        verifyCertificate: true
+        verifyHostname: false
+  extraLabels:
+    cef.severity: '1'

--- a/modules/460-log-shipper/hooks/testdata/file-to-socket-cef/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-socket-cef/result.json
@@ -1,0 +1,86 @@
+{
+  "sources": {
+    "cluster_logging_config/test-source": {
+      "type": "file",
+      "include": [
+        "/var/log/kube-audit/audit.log"
+      ]
+    }
+  },
+  "transforms": {
+    "transform/destination/test-socket1-dest/00_extra_fields": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_local_timezone"
+      ],
+      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}\n\n.cef.severity=\"1\"",
+      "type": "remap"
+    },
+    "transform/destination/test-socket1-dest/01_cef_values": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-socket1-dest/00_extra_fields"
+      ],
+      "source": "if !exists(.cef) {\n  .cef = {};\n};\n\nif !exists(.cef.name) {\n  .cef.name = \"Deckhouse Event\";\n};\n\nif !exists(.cef.severity) {\n  .cef.severity = \"5\";\n} else if is_string(.cef.severity) {\n  if .cef.severity == \"Debug\" {\n    .cef.severity = \"0\";\n  };\n  if .cef.severity == \"Informational\" {\n    .cef.severity = \"3\";\n  };\n  if .cef.severity == \"Notice\" {\n    .cef.severity = \"4\";\n  };\n  if .cef.severity == \"Warning\" {\n    .cef.severity = \"6\";\n  };\n  if .cef.severity == \"Error\" {\n    .cef.severity = \"7\";\n  };\n  if .cef.severity == \"Critical\" {\n    .cef.severity = \"8\";\n  };\n  if .cef.severity == \"Emergency\" {\n    .cef.severity = \"10\";\n  };\n};",
+      "type": "remap"
+    },
+    "transform/source/test-source/00_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "cluster_logging_config/test-source"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
+    },
+    "transform/source/test-source/01_local_timezone": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/00_clean_up"
+      ],
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "type": "remap"
+    }
+  },
+  "sinks": {
+    "destination/cluster/test-socket1-dest": {
+      "type": "socket",
+      "inputs": [
+        "transform/destination/test-socket1-dest/01_cef_values"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "encoding": {
+        "codec": "cef",
+        "timestamp_format": "rfc3339",
+        "cef": {
+          "device_vendor": "Deckhouse",
+          "device_product": "log-shipper-agent",
+          "device_version": "1",
+          "device_event_class_id": "Log event",
+          "name": "cef.name",
+          "severity": "cef.severity",
+          "version": "V1",
+          "extensions": {
+            "container": "container",
+            "host": "host",
+            "image": "image",
+            "message": "message",
+            "namespace": "namespace",
+            "node": "node",
+            "pod": "pod",
+            "podip": "pod_ip",
+            "podowner": "pod_owner",
+            "timestamp": "timestamp"
+          }
+        }
+      },
+      "mode": "tcp",
+      "address": "192.168.1.1:9200",
+      "tls": {
+        "verify_hostname": false,
+        "verify_certificate": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
 The extraLabels option is in the spec but does not work for the `Socket` dst. Also, without extraLabels, it is impossible to configure CEF encoding fields, and defaults for CEF encoding also do not work properly.

## Why do we need it, and what problem does it solve?
This PR changes the logic of the way both CEF and extra labels work correctly. The error was in the destination transformation clauses.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  log.shipper
type: fix
summary: Make extraLabels and CEF encoding work for Socket destination.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
