### PR TITLE
[prometheus] Disable grafana-v10 unified alerting navigation

### DIFF
--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -134,6 +134,8 @@ spec:
           value: "true"
         - name: GF_UNIFIED_ALERTING_ENABLED
           value: "false"
+        - name: GF_UNIFIED_ALERTING_DISABLED_ORGS
+          value: "1"
         {{- if hasKey .Values.prometheus "grafana" }}
           {{- if hasKey .Values.prometheus.grafana "customPlugins" }}
         - name: GF_INSTALL_PLUGINS


### PR DESCRIPTION
## Description
Disable grafana-v10 unified alerting navigation

## Why do we need it, and what problem does it solve?
In last minor versions of Grafana v10 by default, home page navigation contains 2 links:  

- `Alerting (legacy)`
-  `Alerting` (even if `GF_UNIFIED_ALERTING_ENABLED` is set to false)

It is required to explicitly specify org id in `GF_UNIFIED_ALERTING_DISABLED_ORGS` to disable unified alerting navigation

Closes #9151 

## What is the expected result?
Home page navigation contains only `Alerting (legacy)` link
 
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: chore
summary: Disable grafana-v10 unified alerting navigation
impact_level: default
```