### PR TITLE
[candi](yandex)  Fix externalIP detaching before deleting 

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -35,23 +35,23 @@ locals {
 }
 
 data "yandex_vpc_subnet" "existing" {
-  for_each = local.mapping
+  for_each  = local.mapping
   subnet_id = each.value
 }
 
 data "yandex_vpc_subnet" "kube_a" {
   count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-a"
+  name  = "${local.prefix}-a"
 }
 
 data "yandex_vpc_subnet" "kube_b" {
   count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-b"
+  name  = "${local.prefix}-b"
 }
 
 data "yandex_vpc_subnet" "kube_d" {
   count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-d"
+  name  = "${local.prefix}-d"
 }
 
 resource "yandex_vpc_address" "addr" {
@@ -60,6 +60,10 @@ resource "yandex_vpc_address" "addr" {
 
   external_ipv4_address {
     zone_id = local.internal_subnet.zone
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## Description

When a situation arises when the `externalIP` of the master node is switched from `Auto` to a static one created outside of terraform, then terraform first tries to delete the `externalIP` object before it is disconnected from the VM and got error.
Adding the `lifecycle` resource to the `externalIP` object fixes the problem.

The solution was taken from [similar issue](https://github.com/hashicorp/terraform-provider-google/issues/12748#issuecomment-1273958412) in terraform-provider-google

**The error may be relevant for other cloud providers.**

## Why do we need it, and what problem does it solve?

The modification helps to replace `externalIP` in master nodes correctly

## What is the expected result?
Replacing `externalIP` for master nodes without errors

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually (tested by replacing the code inside the install container (`registry.deckhouse.ru/deckhouse/ce/install`) and running the converge command).

## Changelog entries
```changes
section: candi
type: fix
summary:  Fix externalIP detaching before deleting for master node in Yandex cloud.
impact_level: default
```
