### PR TITLE
[deckhouse-controller] set default release channel for embedded deckhouse policy

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -100,8 +100,13 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	}
 
 	dc := dependency.NewDependencyContainer()
-	// create a policy with empty spec, it'll be filled in with relevant settings from the deckhouse moduleConfig, see runDeckhouseConfigObserver method
-	embeddedDeckhousePolicy := v1alpha1.NewModuleUpdatePolicySpecContainer(&v1alpha1.ModuleUpdatePolicySpec{})
+	// create a default policy, it'll be filled in with relevant settings from the deckhouse moduleConfig, see runDeckhouseConfigObserver method
+	embeddedDeckhousePolicy := v1alpha1.NewModuleUpdatePolicySpecContainer(&v1alpha1.ModuleUpdatePolicySpec{
+		Update: v1alpha1.ModuleUpdatePolicySpecUpdate{
+			Mode: "Auto",
+		},
+		ReleaseChannel: "Stable",
+	})
 	ds := &helpers.DeckhouseSettings{ReleaseChannel: ""}
 	ds.Update.DisruptionApprovalMode = "Auto"
 	ds.Update.Mode = "Auto"
@@ -310,6 +315,7 @@ func (dml *DeckhouseController) runDeckhouseConfigObserver(deckhouseConfigC <-ch
 		}
 		dml.deckhouseSettings.Set(settings)
 
+		// if deckhouse moduleConfig has releaseChannel unset, apply default releaseChannel Stable to the embedded Deckhouse policy
 		if len(settings.ReleaseChannel) == 0 {
 			settings.ReleaseChannel = "Stable"
 			log.Debugf("Embedded deckhouse policy release channel set to %s", settings.ReleaseChannel)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/utils/logger"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,10 +49,6 @@ import (
 const (
 	defaultScanInterval        = 3 * time.Minute
 	registryChecksumAnnotation = "modules.deckhouse.io/registry-spec-checksum"
-)
-
-var (
-	ErrNoPolicyFound = errors.New("no matching update policy found")
 )
 
 type moduleSourceReconciler struct {
@@ -272,14 +267,9 @@ func (c *moduleSourceReconciler) processSourceModule(ctx context.Context, md *do
 		av.Overridden = true
 		return "", av, nil
 	}
-	// check if we have an update policy for the moduleName
+	// get an update policy for the moduleName or, if there is no matching policy, use the embedded on
 	policy, err := c.getReleasePolicy(ms.Name, moduleName, policies)
 	if err != nil {
-		// if policy not found - drop all previous module's errors
-		if errors.Is(err, ErrNoPolicyFound) {
-			return "", av, nil
-			// if another error - update module's error status field
-		}
 		return "", av, err
 	}
 	av.Policy = policy.Name
@@ -368,6 +358,7 @@ func (c *moduleSourceReconciler) createModuleRelease(ctx context.Context, ms *v1
 
 // getReleasePolicy checks if any update policy matches the module release and if it's so - returns the policy and its release channel.
 // if several policies match the module release labels, conflict=true is returned
+// if no policy matches the module release, deckhouseEmbeddedPolicy is returned
 func (c *moduleSourceReconciler) getReleasePolicy(sourceName, moduleName string, policies []v1alpha1.ModuleUpdatePolicy) (*v1alpha1.ModuleUpdatePolicy, error) {
 	var releaseLabelsSet labels.Set = map[string]string{"module": moduleName, "source": sourceName}
 	var matchedPolicy *v1alpha1.ModuleUpdatePolicy


### PR DESCRIPTION
## Description
Adds default releaseChannel value "Stable" for embedded deckhouse policy if releaseChannel isn't specified in the `deckhouse` module config.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
In some clusters `deckhouse` may be running without .releaseChannel attribute set, yet its value is used for getting available module releases. Having an empty value when checking available module releases doesn't make sense, so a default value of "Stable" is applied.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

## What is the expected result?
If deckhouse isn't subscribed to any release channel, module sources are still able to fetch available module releases from the "Stable" channel.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Set default releaseChannel for ebedded deckhouse policy.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
