### PR TITLE
[dhctl] feat(dhctl-for-commander): production ready commander mode (1.62.3)

### DIFF
--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -72,6 +72,8 @@ func (d *StreamDirector) Director() proxy.StreamDirector {
 			fmt.Sprintf("--server-address=%s", address),
 		)
 
+		cmd.Env = append(cmd.Env, os.Environ()...)
+
 		// todo: handle logs from parallel server instances
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Description
This PR is not intended to merge. PR only needed to build deckhouse images into dev-registry, which is currently needed for commander and this need from commander will be removed soon.
