### PR TITLE
[dhctl] Wait for resources required by manifest being created

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -137,7 +137,7 @@ func (c *Creator) ensureRequiredNamespacesExist() error {
 
 	for _, res := range c.resources {
 		nsName := res.Object.GetNamespace()
-		if _, nsWasSeenBefore := knownNamespaces[nsName]; nsWasSeenBefore || nsName == "" {
+		if _, nsWasSeenBefore := knownNamespaces[nsName]; nsName == "" || nsWasSeenBefore {
 			continue // If this resource is not namespaces, or we saw this namespace already, there is no need to check
 		}
 

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -105,6 +105,10 @@ func (c *Creator) createAll() error {
 		c.resources = remainResources
 	}()
 
+	if err := c.ensureRequiredNamespacesExist(); err != nil {
+		return err
+	}
+
 	for indx, resource := range c.resources {
 		resourcesList, err := apiResourceGetter.Get(&resource.GVK)
 		if err != nil {
@@ -125,6 +129,37 @@ func (c *Creator) createAll() error {
 		}
 	}
 
+	return nil
+}
+
+func (c *Creator) ensureRequiredNamespacesExist() error {
+	knownNamespaces := make(map[string]struct{})
+
+	for _, res := range c.resources {
+		nsName := res.Object.GetNamespace()
+		if _, nsWasSeenBefore := knownNamespaces[nsName]; nsWasSeenBefore || nsName == "" {
+			continue // If this resource is not namespaces, or we saw this namespace already, there is no need to check
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if _, err := c.kubeCl.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{}); err != nil {
+			cancel()
+
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("can't get namespace %q: %w", nsName, err)
+			}
+
+			return fmt.Errorf(
+				"%w: waiting for namespace %q is to create %q (%s)",
+				ErrNotAllResourcesCreated,
+				nsName,
+				res.Object.GetName(),
+				res.GVK.String(),
+			)
+		}
+		cancel()
+		knownNamespaces[nsName] = struct{}{}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a retry for resource creation for cases where resources required for manifest creation is not there yet

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We hit that case where a resource specified in `config.yml` during bootstrap was meant to be created in a module namespace. As modules are initialized only after bootstrap process is complete, it deadlocked the installer. This allows the installer to wait for such missing resources.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Wait for resources required by manifest being created.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
