### PR TITLE
[docs][control-plane-manager] Improve the readme page

### DIFF
--- a/modules/040-control-plane-manager/docs/README.md
+++ b/modules/040-control-plane-manager/docs/README.md
@@ -39,7 +39,7 @@ The CPM module supports `control plane` running in a *single-master* or *multi-m
 
 In the *single-master* mode:
 - `kube-apiserver` only uses the `etcd` instance that is hosted on the same node;
-- `kube-apiserver` processes localhost requests.
+- A proxy server is configured on the node that responds to localhost, `kube-apiserver` responds to the IP address of the master node.
 
 In the *multi-master* mode, `control plane` components are automatically deployed in a fault-tolerant manner:
 - `kube-apiserver`  is configured to work with all etcd instances;

--- a/modules/040-control-plane-manager/docs/README_RU.md
+++ b/modules/040-control-plane-manager/docs/README_RU.md
@@ -39,7 +39,7 @@ description: Deckhouse управляет компонентами control plane
 
 В конфигурации *single-master*:
 - `kube-apiserver` использует только тот экземпляр `etcd`, который размещен с ним на одном узле;
-- `kube-apiserver` отвечает на localhost.
+- На узле настраивается прокси-сервер, отвечающий на localhost,`kube-apiserver` отвечает на IP-адрес master-узла.
 
 В конфигурации *multi-master* компоненты `control-plane` автоматически разворачиваются в отказоустойчивом режиме:
 - `kube-apiserver` настраивается для работы со всеми экземплярами `etcd`.


### PR DESCRIPTION
## Description

Fixed the description in the scaling section.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: Fixed the description in the scaling section.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
