### PR TITLE
[user-authn] fix: allow to create users with invalid email

### DIFF
--- a/modules/010-user-authn-crd/crds/user.yaml
+++ b/modules/010-user-authn-crd/crds/user.yaml
@@ -35,7 +35,7 @@ spec:
               properties:
                 email:
                   type: string
-                  pattern: '^[\w\-\.]+@(?:[\w-]+\.)+[\w-]{2,}$'
+                  minLength: 1
                   description: |
                     User email.
 


### PR DESCRIPTION
## Description

After adding a user check for the correctness of the email and password, we began to have problems with users who were previously created with incorrectly filled fields.

## Why do we need it, and what problem does it solve?

Since there are already created users with incorrectly filled fields, a number of operations fail. Which leads to a non-working system.

It is necessary to weaken the check to avoid these situations.

## What is the expected result?

It is possible to create a user with mandatory filled email and password. However, we do not check the correctness of the email yet.

Thus, if a new user is created with filled fields, but an invalid email, it will be allowed.

We will also not have problems with users that were created earlier.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn 
type: fix
summary: allow to create users with invalid email
impact_level: default
```
