### PR TITLE
feat: add DELETE verbs for restrict operations on deckhouse heritage

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -60,7 +60,7 @@ spec:
     resourceRules:
       - apiGroups:   ["*"]
         apiVersions: ["*"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["*"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
@@ -71,7 +71,7 @@ spec:
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
-      messageExpression: '''Creating an object with the `heritage: deckhouse` label is forbidden'''
+      messageExpression: '''Creating, updating and deleting an objects with the `heritage: deckhouse` label is forbidden'''
   auditAnnotations:
     - key: 'source-user'
       valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with the heritage label'"


### PR DESCRIPTION
## Description

Previously, rules were added to check whether changes can be made to objects with the `heritage=deckhouse` label.

It is necessary to additionally prohibit deletion of such objects for users who are not administrators or system users.

Fixed: #9108

## Why do we need it, and what problem does it solve?

An additional layer of system security needs to be provided to prevent users from deleting objects that have the `heritage=deckhouse` label.

## What is the expected result?

Users who are not system or administrators cannot create, update, or delete objects that have the `heritage=deckhouse` label.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: add DELETE verbs for restrict operations on deckhouse heritage
impact_level: default
```
