### PR TITLE
[docs] Refactoring sections in the documentation of cloud providers

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION.md
@@ -15,8 +15,6 @@ If you need to configure a module because, say, you have a bare metal cluster an
 > **Note!** If the parameters provided below are changed, the **existing `Machines` are NOT redeployed** (new `Machines` will be created with the updated parameters). Redeployment is only performed when `NodeGroup` and `OpenStackInstanceClass` parameters are changed. You can learn more in the [node-manager](../../modules/040-node-manager/faq.html#how-do-i-redeploy-ephemeral-machines-in-the-cloud-with-a-new-configuration) module's documentation.
 > To authenticate using the `user-authn` module, you need to create a new `Generic` application in the project's Crowd.
 
-{% include module-settings.liquid %}
-
 ## List of required OpenStack services
 
 A list of OpenStack services required for Deckhouse Kubernetes Platform to work in OpenStack:
@@ -30,3 +28,5 @@ A list of OpenStack services required for Deckhouse Kubernetes Platform to work 
 | Load Balancing (Octavia) &#8432;  | v2          |
 
 &#8432;  If you need to order a Load Balancer.
+
+{% include module-settings.liquid %}

--- a/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION_RU.md
@@ -15,8 +15,6 @@ title: "Сloud provider — OpenStack: настройки"
 > **Внимание!** При изменении настроек модуля **пересоздания существующих объектов `Machines` в кластере НЕ происходит** (новые объекты `Machine` будут создаваться с новыми параметрами). Пересоздание происходит только при изменении параметров `NodeGroup` и `OpenStackInstanceClass`. См. подробнее [в документации модуля node-manager](../../modules/040-node-manager/faq.html#как-пересоздать-эфемерные-машины-в-облаке-с-новой-конфигурацией).
 > Для настройки аутентификации с помощью модуля `user-authn` необходимо в Crowd'е проекта создать новое `Generic` приложение.
 
-{% include module-settings.liquid %}
-
 ## Список необходимых сервисов OpenStack
 
 Список сервисов OpenStack, необходимых для работы Deckhouse Kubernetes Platform в OpenStack:
@@ -30,3 +28,5 @@ title: "Сloud provider — OpenStack: настройки"
 | Load Balancing (Octavia) &#8432; | v2         |
 
 &#8432;  Если нужно заказывать Load Balancer.
+
+{% include module-settings.liquid %}

--- a/ee/modules/030-cloud-provider-vsphere/docs/CONFIGURATION.md
+++ b/ee/modules/030-cloud-provider-vsphere/docs/CONFIGURATION.md
@@ -11,8 +11,6 @@ If the cluster control plane is hosted on a virtual machines or bare-metal serve
 
 You can configure the number and parameters of ordering machines in the cloud via the [`NodeGroup`](../../modules/040-node-manager/cr.html#nodegroup) custom resource of the `node-manager` module. Also, in this custom resource, you can specify the instance class's name for the above group of nodes (the `cloudInstances.ClassReference` parameter of NodeGroup). In the case of the vSphere cloud provider, the instance class is the [`VsphereInstanceClass`](cr.html#vsphereinstanceclass) custom resource that stores specific parameters of the machines.
 
-{% include module-settings.liquid %}
-
 ## Storage
 
 The module automatically creates a StorageClass for each Datastore and DatastoreCluster in the zone (or zones).
@@ -85,3 +83,5 @@ A detailed list of privileges required for Deckhouse Kubernetes Platform to work
     </tr>
   </tbody>
 </table>
+
+{% include module-settings.liquid %}

--- a/ee/modules/030-cloud-provider-vsphere/docs/CONFIGURATION_RU.md
+++ b/ee/modules/030-cloud-provider-vsphere/docs/CONFIGURATION_RU.md
@@ -70,7 +70,7 @@ force_searchable: true
     </tr>
     <tr>
         <td><code>Global.GlobalTag</code><br><code>Global.SystemTag</code><br><code>InventoryService.Tagging.AttachTag</code><br><code>InventoryService.Tagging.CreateCategory</code><br><code>InventoryService.Tagging.CreateTag</code><br><code>InventoryService.Tagging.DeleteCategory</code><br><code>InventoryService.Tagging.DeleteTag</code><br><code>InventoryService.Tagging.EditCategory</code><br><code>InventoryService.Tagging.EditTag</code><br><code>InventoryService.Tagging.ModifyUsedByForCategory</code><br><code>InventoryService.Tagging.ModifyUsedByForTag</code><br><code>InventoryService.Tagging.ObjectAttachable</code></td>
-        <td>Deckhouse Kubernetes Platform использует теги для определения доступных ему объектов <code>Datacenter</code>, <code>Cluster</code> и <code>Datastore</code>, а также, для определения виртуальных машин, находящихся под его управлением.</td>
+        <td>Deckhouse Kubernetes Platform использует теги для определения доступных ему объектов <code>Datacenter</code>, <code>Cluster</code> и <code>Datastore</code>, а также для определения виртуальных машин, находящихся под его управлением.</td>
     </tr>
     <tr>
         <td><code>Folder.Create</code><br><code>Folder.Delete</code><br><code>Folder.Move</code><br><code>Folder.Rename</code></td>

--- a/ee/modules/030-cloud-provider-vsphere/docs/CONFIGURATION_RU.md
+++ b/ee/modules/030-cloud-provider-vsphere/docs/CONFIGURATION_RU.md
@@ -11,8 +11,6 @@ force_searchable: true
 
 Количество и параметры процесса заказа машин в облаке настраиваются в custom resource [`NodeGroup`](../../modules/040-node-manager/cr.html#nodegroup) модуля `node-manager`, в котором также указывается название используемого для этой группы узлов инстанс-класса (параметр `cloudInstances.classReference` NodeGroup). Инстанс-класс для cloud-провайдера vSphere — это custom resource [`VsphereInstanceClass`](cr.html#vsphereinstanceclass), в котором указываются конкретные параметры самих машин.
 
-{% include module-settings.liquid %}
-
 ## Storage
 
 Модуль автоматически создает StorageClass для каждого Datastore и DatastoreCluster из зон (зоны).
@@ -84,3 +82,5 @@ force_searchable: true
     </tr>
   </tbody>
 </table>
+
+{% include module-settings.liquid %}

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -6,8 +6,6 @@ title: "Cloud provider — Yandex Cloud: configuration"
 
 {% include module-alerts.liquid %}
 
-{% include module-settings.liquid %}
-
 ## Storage
 
 The module automatically creates StorageClasses covering all available disks in Yandex:
@@ -36,3 +34,5 @@ Due to the [nature](https://github.com/kubernetes-csi/external-resizer/issues/44
 The module subscribes to Service objects of the `LoadBalancer` type and creates the corresponding `NetworkLoadBalancer` and `TargetGroup` in Yandex Cloud.
 
 For more information, see the [Kubernetes Cloud Controller Manager for Yandex Cloud documentation](https://github.com/flant/yandex-cloud-controller-manager).
+
+{% include module-settings.liquid %}

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
@@ -6,8 +6,6 @@ title: "Cloud provider — Yandex Cloud: настройки"
 
 {% include module-alerts.liquid %}
 
-{% include module-settings.liquid %}
-
 ## Storage
 
 Модуль автоматически создает StorageClass'ы, покрывающие все варианты дисков в Yandex Cloud:
@@ -36,3 +34,5 @@ title: "Cloud provider — Yandex Cloud: настройки"
 Модуль подписывается на объекты Service с типом `LoadBalancer` и создает соответствующие `NetworkLoadBalancer` и `TargetGroup` в Yandex Cloud.
 
 Больше информации [в документации Kubernetes Cloud Controller Manager for Yandex Cloud](https://github.com/flant/yandex-cloud-controller-manager).
+
+{% include module-settings.liquid %}


### PR DESCRIPTION
## Description

The parameter pages are aligned to a single element layout style.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-openstack
type: fix
summary: The layout of the elements on the page has been changed.
impact_level: low
---
section: cloud-provider-vsphere
type: fix
summary: The layout of the elements on the page has been changed.
impact_level: low
---
section: cloud-provider-yandex
type: fix
summary: The layout of the elements on the page has been changed.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
