### PR TITLE
[node-manager] Add alert about unavailable CAPS instances

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1,4 +1,15 @@
 alerts:
+    - name: CapsInstanceUnavailable
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        In MachineDeployment `{{ $labels.machine_deployment_name }}` number of unavailable instances is **{{ $value }}**. Take a look and check at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{ $labels.machine_deployment_name }}`
+      summary: |
+        There are unavailable instances in the {{ $labels.machine_deployment_name }} MachineDeployment.
+      severity: "8"
+      markupFormat: markdown
     - name: CertmanagerCertificateExpired
       sourceFile: modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
       moduleUrl: 101-cert-manager

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2024 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
@@ -62,8 +62,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			LabelSelector: &v1.LabelSelector{
 				MatchExpressions: []v1.LabelSelectorRequirement{
 					{
-						Key:      "caps-controller",
-						Operator: v1.LabelSelectorOpExists,
+						Key:      "app",
+						Operator: v1.LabelSelectorOpIn,
+						Values: []string{
+							"caps-controller",
+						},
 					},
 				},
 			},

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	"github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/capi/v1beta1"
+)
+
+const (
+	capsMachineDeploymentMetricsGroup          = "caps_md"
+	capsMachineDeploymentMetricReplicasName    = "d8_caps_md_replicas"
+	capsMachineDeploymentMetricDesiredName     = "d8_caps_md_desired"
+	capsMachineDeploymentMetricReadyName       = "d8_caps_md_ready"
+	capsMachineDeploymentMetricUnavailableName = "d8_caps_md_unavailable"
+	capsMachineDeploymentMetricPhaseName       = "d8_caps_md_phase"
+)
+
+type machineDeploymentStatus struct {
+	Name        string
+	Replicas    float64
+	Desired     float64
+	Ready       float64
+	Unavailable float64
+	Phase       float64
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/metrics",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                   "machinedeployment_status",
+			ApiVersion:             "cluster.x-k8s.io/v1beta1",
+			Kind:                   "MachineDeployment",
+			WaitForSynchronization: pointer.Bool(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cloud-instance-manager"},
+				},
+			},
+			FilterFunc: filterMachineDeploymentStatus,
+		},
+	},
+}, handleMachineDeploymentStatus)
+
+func filterMachineDeploymentStatus(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var md v1beta1.MachineDeployment
+
+	err := sdk.FromUnstructured(obj, &md)
+	if err != nil {
+		return nil, err
+	}
+
+	var replicas int32
+	if md.Spec.Replicas != nil {
+		replicas = *md.Spec.Replicas
+	}
+
+	var Phase float64
+	switch md.Status.Phase {
+	case "Running":
+		Phase = 1
+	case "ScalingUp":
+		Phase = 2
+	case "ScalingDown":
+		Phase = 3
+	case "Failed":
+		Phase = 4
+	default:
+		Phase = 5
+	}
+
+	return machineDeploymentStatus{
+		Name:        md.Name,
+		Replicas:    float64(md.Status.Replicas),
+		Desired:     float64(replicas),
+		Ready:       float64(md.Status.ReadyReplicas),
+		Unavailable: float64(md.Status.UnavailableReplicas),
+		Phase:       Phase,
+	}, nil
+}
+
+func handleMachineDeploymentStatus(input *go_hook.HookInput) error {
+	mdStatusSnapshots := input.Snapshots["machinedeployment_status"]
+
+	input.MetricsCollector.Expire(capsMachineDeploymentMetricsGroup)
+
+	options := []metrics.Option{
+		metrics.WithGroup(capsMachineDeploymentMetricsGroup),
+	}
+
+	for _, mdStatusSnapshot := range mdStatusSnapshots {
+		mdStatus := mdStatusSnapshot.(machineDeploymentStatus)
+
+		labels := map[string]string{"machine_deployment_name": mdStatus.Name}
+
+		input.MetricsCollector.Set(capsMachineDeploymentMetricReplicasName, mdStatus.Replicas, labels, options...)
+
+		input.MetricsCollector.Set(capsMachineDeploymentMetricDesiredName, mdStatus.Desired, labels, options...)
+
+		input.MetricsCollector.Set(capsMachineDeploymentMetricReadyName, mdStatus.Ready, labels, options...)
+
+		input.MetricsCollector.Set(capsMachineDeploymentMetricUnavailableName, mdStatus.Unavailable, labels, options...)
+
+		input.MetricsCollector.Set(capsMachineDeploymentMetricPhaseName, mdStatus.Phase, labels, options...)
+	}
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
 
@@ -56,6 +57,14 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
 					MatchNames: []string{"d8-cloud-instance-manager"},
+				},
+			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "caps-controller",
+						Operator: v1.LabelSelectorOpExists,
+					},
 				},
 			},
 			FilterFunc: filterMachineDeploymentStatus,

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
@@ -72,11 +72,11 @@ metadata:
   namespace: d8-cloud-instance-manager
   labels:
     app.kubernetes.io/managed-by: Helm
+    app: caps-controller
     cluster.x-k8s.io/cluster-name: static
     heritage: deckhouse
     module: node-manager
     node-group: caps-worker
-    caps-controller: ""
 spec:
   clusterName: static
   minReadySeconds: 0

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const MachineDeploymentWith1Unavailable = `
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: caps-worker
+  namespace: d8-cloud-instance-manager
+spec:
+  clusterName: static
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: static
+      cluster.x-k8s.io/deployment-name: caps-worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+status:
+  availableReplicas: 1
+  observedGeneration: 9
+  phase: ScalingUp
+  readyReplicas: 1
+  replicas: 2
+  unavailableReplicas: 1
+  updatedReplicas: 2
+`
+
+const MachineDeploymentWith1Available = `
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: caps-worker
+  namespace: d8-cloud-instance-manager
+spec:
+  clusterName: static
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
+  replicas: 1
+status:
+  availableReplicas: 1
+  observedGeneration: 9
+  phase: Running
+  readyReplicas: 1
+  replicas: 1
+  unavailableReplicas: 0
+  updatedReplicas: 1
+`
+
+var _ = Describe("Modules :: node-manager :: hooks :: machine_deployments_caps_metrics_test ::", func() {
+	f := HookExecutionConfigInit(`{"nodeManager":{"internal":{}}}`, `{}`)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta1", "MachineDeployment", true)
+
+	assertMetric := func(f *HookExecutionConfig, name string, expected float64) {
+		metrics := f.MetricsCollector.CollectedMetrics()
+
+		ok := false
+		for _, m := range metrics {
+			if m.Name == name {
+				Expect(m.Value).To(Equal(pointer.Float64(expected)))
+				Expect(m.Labels).To(HaveKey("machine_deployment_name"))
+				Expect(m.Labels["machine_deployment_name"]).To(Equal("caps-worker"))
+
+				ok = true
+
+				break
+			}
+		}
+
+		Expect(ok).To(BeTrue())
+	}
+
+	Context("MachineDeployment with 1 unavailable instance", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(MachineDeploymentWith1Unavailable))
+
+			f.RunHook()
+		})
+
+		It("Test metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			tests := []struct {
+				name  string
+				value float64
+			}{
+				{
+					name:  capsMachineDeploymentMetricReplicasName,
+					value: 2.0,
+				},
+				{
+					name:  capsMachineDeploymentMetricDesiredName,
+					value: 2.0,
+				},
+				{
+					name:  capsMachineDeploymentMetricReadyName,
+					value: 1.0,
+				},
+				{
+					name:  capsMachineDeploymentMetricUnavailableName,
+					value: 1.0,
+				},
+				{
+					name:  capsMachineDeploymentMetricPhaseName,
+					value: 2.0,
+				},
+			}
+
+			for _, test := range tests {
+				assertMetric(f, test.name, test.value)
+			}
+		})
+	})
+})

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
@@ -33,11 +33,11 @@ metadata:
   namespace: d8-cloud-instance-manager
   labels:
     app.kubernetes.io/managed-by: Helm
+    app: caps-controller
     cluster.x-k8s.io/cluster-name: static
     heritage: deckhouse
     module: node-manager
     node-group: caps-worker
-    caps-controller: ""
 spec:
   clusterName: static
   minReadySeconds: 0

--- a/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
+++ b/modules/040-node-manager/hooks/machine_deployments_caps_metrics_test.go
@@ -31,6 +31,13 @@ kind: MachineDeployment
 metadata:
   name: caps-worker
   namespace: d8-cloud-instance-manager
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    cluster.x-k8s.io/cluster-name: static
+    heritage: deckhouse
+    module: node-manager
+    node-group: caps-worker
+    caps-controller: ""
 spec:
   clusterName: static
   minReadySeconds: 0
@@ -63,6 +70,13 @@ kind: MachineDeployment
 metadata:
   name: caps-worker
   namespace: d8-cloud-instance-manager
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    cluster.x-k8s.io/cluster-name: static
+    heritage: deckhouse
+    module: node-manager
+    node-group: caps-worker
+    caps-controller: ""
 spec:
   clusterName: static
   minReadySeconds: 0

--- a/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
@@ -1,0 +1,18 @@
+groups:
+  - name: d8.caps-node
+    rules:
+    - alert: CapsInstanceUnavailable
+      expr: max by (machine_deployment_name) (d8_caps_md_unavailable) > 0
+      for: 30m
+      labels:
+        severity_level: "8"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_labels_as_annotations: "caps_md"
+        summary: There are unavailable instances in the {{`{{ $labels.caps_md }}`}} MachineDeployment.
+        description: |
+          The number of unavailable instances is {{`{{ $value }}`}} in MachineDeployment {{`{{ $labels.caps_md }}`}}. Take a look at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.caps_md }}`}}`

--- a/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
@@ -1,18 +1,17 @@
-groups:
-  - name: d8.caps-node
-    rules:
-    - alert: CapsInstanceUnavailable
-      expr: max by (machine_deployment_name) (d8_caps_md_unavailable) > 0
-      for: 30m
-      labels:
-        severity_level: "8"
-        tier: cluster
-      annotations:
-        plk_protocol_version: "1"
-        plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_labels_as_annotations: "caps_md"
-        summary: There are unavailable instances in the {{`{{ $labels.caps_md }}`}} MachineDeployment.
-        description: |
-          The number of unavailable instances is {{`{{ $value }}`}} in MachineDeployment {{`{{ $labels.caps_md }}`}}. Take a look at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.caps_md }}`}}`
+- name: d8.caps-nodes
+  rules:
+  - alert: CapsInstanceUnavailable
+    expr: max by (machine_deployment_name) (d8_caps_md_unavailable) > 0
+    for: 30m
+    labels:
+      severity_level: "8"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_labels_as_annotations: "caps_md"
+      summary: There are unavailable instances in the {{`{{ $labels.caps_md }}`}} MachineDeployment.
+      description: |
+        The number of unavailable instances is {{`{{ $value }}`}} in MachineDeployment {{`{{ $labels.caps_md }}`}}. Take a look at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.caps_md }}`}}`

--- a/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
@@ -12,6 +12,6 @@
       plk_create_group_if_not_exists__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_labels_as_annotations: "caps_md"
-      summary: There are unavailable instances in the {{`{{ $labels.caps_md }}`}} MachineDeployment.
+      summary: There are unavailable instances in the {{`{{ $labels.machine_deployment_name }}`}} MachineDeployment.
       description: |
-        The number of unavailable instances is {{`{{ $value }}`}} in MachineDeployment {{`{{ $labels.caps_md }}`}}. Take a look at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.caps_md }}`}}`
+        The number of unavailable instances is {{`{{ $value }}`}} in MachineDeployment {{`{{ $labels.machine_deployment_name }}`}}. Take a look at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.machine_deployment_name }}`}}`

--- a/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/caps-nodes.tpl
@@ -12,6 +12,6 @@
       plk_create_group_if_not_exists__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_cluster_has_caps_machinedeployment_with_unavailable_replicas: "ClusterHasCapsMachineDeploymentWithUnavailableReplicas,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_labels_as_annotations: "caps_md"
-      summary: There are unavailable instances in the {{`{{ $labels.machine_deployment_name }}`}} MachineDeployment.
+      summary: There are unavailable instances in the `{{`{{ $labels.machine_deployment_name }}`}}` MachineDeployment.
       description: |
-        The number of unavailable instances is {{`{{ $value }}`}} in MachineDeployment {{`{{ $labels.machine_deployment_name }}`}}. Take a look at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.machine_deployment_name }}`}}`
+        In MachineDeployment `{{`{{ $labels.machine_deployment_name }}`}}` number of unavailable instances is **{{`{{ $value }}`}}**. Take a look and check at the state of the instances in the cluster: `kubectl get instance -l node.deckhouse.io/group={{`{{ $labels.machine_deployment_name }}`}}`

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -667,6 +667,7 @@ metadata:
   namespace: d8-cloud-instance-manager
   name: worker
   labels:
+    caps-controller: ""
     heritage: deckhouse
     module: node-manager
     node-group: worker

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -667,7 +667,7 @@ metadata:
   namespace: d8-cloud-instance-manager
   name: worker
   labels:
-    caps-controller: ""
+    app: caps-controller
     heritage: deckhouse
     module: node-manager
     node-group: worker

--- a/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
@@ -18,7 +18,7 @@ kind: MachineDeployment
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $machineDeploymentName | quote }}
-  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name "caps-controller" "" )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name )) | nindent 2 }}
   annotations:
     checksum/instance-class: {{ $instance_class_checksum }}
     cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: {{ $ng.cloudInstances.minPerZone | quote }}

--- a/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
@@ -18,7 +18,7 @@ kind: MachineDeployment
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $machineDeploymentName | quote }}
-  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name)) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name "caps-controller" "" )) | nindent 2 }}
   annotations:
     checksum/instance-class: {{ $instance_class_checksum }}
     cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: {{ $ng.cloudInstances.minPerZone | quote }}

--- a/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
@@ -18,7 +18,7 @@ kind: MachineDeployment
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $machineDeploymentName | quote }}
-  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name)) | nindent 2 }}
   annotations:
     checksum/instance-class: {{ $instance_class_checksum }}
     cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: {{ $ng.cloudInstances.minPerZone | quote }}

--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_machine_deployment.tpl
@@ -7,7 +7,7 @@ kind: MachineDeployment
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $ng.name }}
-  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name)) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name "caps-controller" "")) | nindent 2 }}
 spec:
   clusterName: static
   replicas: {{ $ng.staticInstances.count | default "0" }}

--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_machine_deployment.tpl
@@ -7,7 +7,7 @@ kind: MachineDeployment
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $ng.name }}
-  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name "caps-controller" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "node-group" $ng.name "app" "caps-controller")) | nindent 2 }}
 spec:
   clusterName: static
   replicas: {{ $ng.staticInstances.count | default "0" }}


### PR DESCRIPTION
## Description

Add alert about unavailable CAPS instances.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Closes #8649 .

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

1. Add new node-group for caps without  prepared StaticInstance:
```bash
[root@dev-master-0 ~]# kubectl apply -f - <<EOF
apiVersion: deckhouse.io/v1
kind: NodeGroup
metadata:
  name: caps-system
spec:
  nodeType: Static
  staticInstances:
    count: 1
    labelSelector:
      matchLabels:
        role: caps-system
EOF
nodegroup.deckhouse.io/caps-system created

[root@dev-master-0 ~]# kubectl get staticinstances.deckhouse.io  -l role=caps-system
No resources found
```
2.   Check instance in the cluster and the relevant alert about its state in prometheus:

```bash
[root@dev-master-0 ~]# kubectl get instance -l node.deckhouse.io/group=caps-system
NAME                      STATUS    AGE
caps-system-g9lc6-645tv   Pending   5m
```

<img width="2441" alt="image" src="https://github.com/user-attachments/assets/3ac40298-aa78-41f6-97bd-2efabb7390ee">


<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Add alert about unavailable CAPS instances.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
