### PR TITLE
[cloud-providers][openstack] Fix network configuration in OpenStack when using DirectRoutingWithPortSecurityEnabled.

### DIFF
--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -37,7 +37,14 @@ resource "openstack_networking_port_v2" "port" {
   network_id         = data.openstack_networking_network_v2.network[count.index].id
   admin_state_up     = "true"
   security_group_ids = try(index(local.networks_with_security_disabled, data.openstack_networking_network_v2.network[count.index].name), -1) == -1 ? module.security_groups.security_group_ids : []
-  allowed_address_pairs = local.internal_network_security_enabled ? [{ip_address = local.pod_subnet_cidr}] : []
+
+  dynamic "allowed_address_pairs" {
+    for_each = local.internal_network_security_enabled ? list(local.pod_subnet_cidr) : []
+
+    content {
+      ip_address = allowed_address_pairs.value
+    }
+  }
 }
 
 resource "openstack_blockstorage_volume_v3" "volume" {

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -37,14 +37,7 @@ resource "openstack_networking_port_v2" "port" {
   network_id         = data.openstack_networking_network_v2.network[count.index].id
   admin_state_up     = "true"
   security_group_ids = try(index(local.networks_with_security_disabled, data.openstack_networking_network_v2.network[count.index].name), -1) == -1 ? module.security_groups.security_group_ids : []
-
-  dynamic "allowed_address_pairs" {
-    for_each = local.internal_network_security_enabled && local.networks[count.index] == local.prefix ? list(local.pod_subnet_cidr) : []
-
-    content {
-      ip_address = allowed_address_pairs.value
-    }
-  }
+  allowed_address_pairs = local.internal_network_security_enabled ? [{ip_address = local.pod_subnet_cidr}] : []
 }
 
 resource "openstack_blockstorage_volume_v3" "volume" {


### PR DESCRIPTION
## Description

This fix corrects configuration of [Allowed Address Pairs](https://docs.openstack.org/developer/dragonflow/specs/allowed_address_pairs.html) for static nodes created using Terraform. When using `podNetworkMode: DirectRoutingWithPortSecurityEnabled`, we add `allowed_address_pairs = ip_address='POD_NETWORK_CIDR'` to the ports of all servers.

## Why do we need it, and what problem does it solve?

This fix addresses an issue with the configuration of Allowed Address Pairs for static nodes, ensuring proper network functionality when using Direct Routing with Port Security enabled.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

After applying these changes, the ports of all servers will correctly have `allowed_address_pairs = ip_address='POD_NETWORK_CIDR'` when `podNetworkMode: DirectRoutingWithPortSecurityEnabled` is used, ensuring correct network configuration and functionality.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix 
summary:  Fix network configuration in OpenStack when using DirectRoutingWithPortSecurityEnabled.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
