### PR TITLE
[cilium][monitoring] Modify the CiliumAgentUnreachableHealthEndpoints alarm expression

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -1,7 +1,7 @@
 - name: cni-cilium
   rules:
   - alert: CiliumAgentUnreachableHealthEndpoints
-    # Show all current `cilium_unreachable_health_endpoints` if the condition is met:
+    # Select all current `cilium_unreachable_health_endpoints` if the condition is met:
     # no changes in pod states for the last N minutes (number of pods including changes - number of pods N minutes ago)
     expr: |
       max by (namespace, pod) (cilium_unreachable_health_endpoints) > 0

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -1,7 +1,17 @@
 - name: cni-cilium
   rules:
   - alert: CiliumAgentUnreachableHealthEndpoints
-    expr: max by (namespace, pod) (cilium_unreachable_health_endpoints) > 0
+    # Show all current `cilium_unreachable_health_endpoints` if the condition is met:
+    # no changes in pod states for the last N minutes (number of pods including changes - number of pods N minutes ago)
+    expr: |
+      max by (namespace, pod) (cilium_unreachable_health_endpoints) > 0
+      and on()
+      (
+        (
+          count(changes(kube_pod_info{created_by_name="agent",namespace="d8-cni-cilium"}[2m])) -
+          count(kube_pod_info{created_by_name="agent",namespace="d8-cni-cilium"} offset 2m)
+        ) == 0
+      )
     for: 5m
     labels:
       d8_module: cni-cilium


### PR DESCRIPTION
## Description
When pods start or restart in a cluster, cilium agents lose communication with each other and export the metric `cilium_unreachable_health_endpoints` to Prometheus. There are no settings in cilium to change this behavior (probe delay for just started agents, for example), and it is not possible to develop them due to internal API limitations.

## Why do we need it, and what problem does it solve?
It is necessary to change the conditions in the expression to avoid receiving false positive alarms from the monitoring system.

## What is the expected result?
When pods are started or rebooted, the monitoring system will not register an alarm for 7 minutes after the changes. If there are no changes in the pod states, but the cilium agents have lost communication with each other, an alarm is sent through Prometheus Alarm Manager.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-cilium
type: fix 
summary: Improved the CiliumAgentUnreachableHealthEndpoints metric expression to avoid false positives.
```