### PR TITLE
[monitoring][chrony] Reduce memory requests in ds

### DIFF
--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -1,6 +1,6 @@
 {{- define "monitoring_ping_resources" }}
 cpu: 25m
-memory: 50Mi
+memory: 25Mi
 {{- end }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
@@ -25,7 +25,7 @@ spec:
         {{- include "monitoring_ping_resources" . | nindent 8 }}
       maxAllowed:
         cpu: 50m
-        memory: 50Mi
+        memory: 25Mi
 {{- end }}
 ---
 apiVersion: apps/v1

--- a/modules/460-log-shipper/template_tests/module_test.go
+++ b/modules/460-log-shipper/template_tests/module_test.go
@@ -121,10 +121,10 @@ memory: 64Mi
 - containerName: vector-reloader
   maxAllowed:
     cpu: 20m
-    memory: 25Mi
+    memory: 15Mi
   minAllowed:
     cpu: 10m
-    memory: 25Mi
+    memory: 15Mi
 - containerName: kube-rbac-proxy
   maxAllowed:
     cpu: 20m

--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "vector_reloader_resources" . | nindent 8 }}
       maxAllowed:
         cpu: 20m
-        memory: 25Mi
+        memory: 15Mi
       {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- define "vector_reloader_resources" }}
 cpu: 10m
-memory: 25Mi
+memory: 15Mi
 {{- end }}
 
 {{- if .Values.logShipper.internal.activated }}

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- define "chrony_resources" }}
 cpu: 10m
-memory: 25Mi
+memory: 10Mi
 {{- end }}
 
 {{ $ntpServers := list }}
@@ -34,7 +34,7 @@ spec:
         {{- include "chrony_resources" . | nindent 8 }}
       maxAllowed:
         cpu: 25m
-        memory: 50Mi
+        memory: 20Mi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Reduce the memory request for daemonsets
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In most clusters, we get a large over requests for some ds on each nodes. Unused memory can be used for client workload
Monitoring-ping:
![image](https://github.com/user-attachments/assets/bc714077-7b74-4223-bf63-873905e163ce)
![image](https://github.com/user-attachments/assets/869dd661-41a2-4ffd-b805-d35a187d16ca)
Vector-reloader:
![image](https://github.com/user-attachments/assets/19e5b15e-ab9f-4b57-92bb-6d5635fbe06a)
Chrony:
![image](https://github.com/user-attachments/assets/1a5454f9-6a51-466f-be96-b55390143042)
![image](https://github.com/user-attachments/assets/c29e08b5-3aac-4500-867c-4cc424df466e)
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Over-requests reduce in large clusters without performance losses
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony
type: fix
summary: Reduce over-requested memory.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
