### PR TITLE
[ingress-nginx] Added additional validation of inlet-related parameters for IngressNginxController

### DIFF
--- a/modules/402-ingress-nginx/templates/validation.yaml
+++ b/modules/402-ingress-nginx/templates/validation.yaml
@@ -1,0 +1,48 @@
+{{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
+---
+{{- $policyName := "ingressnginxcontroller-settings.deckhouse.io" }}
+{{- $inlets := list "LoadBalancer"  "LoadBalancerWithProxyProtocol" "HostPort" "HostPortWithProxyProtocol" "HostWithFailover"}}
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["*"]
+        operations:  ["CREATE"]
+        resources:   ["ingressnginxcontrollers"]    
+  validations:
+{{- range $inlet := $inlets }}
+{{- $spec :=  printf "%s%s" (lower $inlet | trunc 1)  (substr 1 -1 $inlet) }}
+    - expression: '!(has(object.spec.{{ $spec }} ) && object.spec.inlet != "{{ $inlet }}" )'
+      reason: Forbidden
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+      messageExpression: '''parameters "spec.{{ $spec }}" avalible only for inlet "{{ $inlet }}"'''        
+{{- end }}      
+{{- end}}  
+---
+{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  validationActions: [Deny]
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

When setting up an inlet, the user mistakenly thinks that he has access to settings and functionality related to the parameter of other inlets. This causes additional questions and wastes time on debugging.
This modification adds a check that only parameters related to the current inlet are set

## Why do we need it, and what problem does it solve?

This modification adds additional validation of user settings.
Also solves the problem described in issue #9085

## What is the expected result?
When entering settings that apply to other `inlet` an error occurs, the settings are not applied

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: feature 
summary: added additional validation of inlet-related parameters
impact_level: default 
```