### PR TITLE
[e2e] fix preserve_hostname and disk.EnableUUID in vcd template debian-12

### DIFF
--- a/testing/cloud_layouts/vCloudDirector/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/configuration.tpl.yaml
@@ -54,7 +54,7 @@ nodeGroups:
     storageProfile:  Fast vHDD
     sizingPolicy: ${VCD_ORG}-MSK
     rootDiskSizeGb: 50
-    template: private-templates/debian-12-hostname
+    template: private-templates/debian-12
   name: system
   replicas: 1
   nodeTemplate:

--- a/testing/cloud_layouts/vCloudDirector/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/configuration.tpl.yaml
@@ -54,7 +54,7 @@ nodeGroups:
     storageProfile:  Fast vHDD
     sizingPolicy: ${VCD_ORG}-MSK
     rootDiskSizeGb: 50
-    template: private-templates/debian-12-template
+    template: private-templates/debian-12-hostname
   name: system
   replicas: 1
   nodeTemplate:

--- a/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
@@ -7,7 +7,7 @@ spec:
   rootDiskSizeGb: 30
   sizingPolicy: ${VCD_ORG}-MSK
   storageProfile: Fast vHDD 
-  template: private-templates/debian-12-hostname
+  template: private-templates/debian-12
 
 ---
 apiVersion: deckhouse.io/v1

--- a/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
@@ -24,6 +24,7 @@ spec:
       name: worker
   chaos:
     mode: Disabled
+
 ---
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController

--- a/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
@@ -7,7 +7,7 @@ spec:
   rootDiskSizeGb: 30
   sizingPolicy: ${VCD_ORG}-MSK
   storageProfile: Fast vHDD 
-  template: private-templates/debian-12-template
+  template: private-templates/debian-12-hostname
 
 ---
 apiVersion: deckhouse.io/v1

--- a/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
+++ b/testing/cloud_layouts/vCloudDirector/Standard/resources.tpl.yaml
@@ -24,7 +24,6 @@ spec:
       name: worker
   chaos:
     mode: Disabled
-
 ---
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController


### PR DESCRIPTION
## Description

Fix vcd template debian 12 for e2e.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

For success complete vcd e2e.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: e2e
type: fix
summary: Fix vcd template debian 12 for e2e.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
