### PR TITLE
[ingress-nginx] Adding an example with L2LoadBalancer

### DIFF
--- a/modules/402-ingress-nginx/docs/EXAMPLES.md
+++ b/modules/402-ingress-nginx/docs/EXAMPLES.md
@@ -39,7 +39,13 @@ spec:
   inlet: "LoadBalancer"
 ```
 
-> **Caution!** In **GCP**, nodes must have an annotation enabling them to accept connections to external addresses for the NodePort type services.
+{% endraw %}
+
+{% alert level="warning" %}
+In **GCP**, nodes must have an annotation enabling them to accept connections to external addresses for the NodePort type services.
+{% endalert %}
+
+{% raw %}
 
 ## An example for OpenStack
 
@@ -91,9 +97,11 @@ spec:
     behindL7Proxy: true
 ```
 
+{% endraw %}
+
 ## An example for Bare metal (MetalLB Load Balancer)
 
-The `metallb` module is currently available only in the Enterprise Edition version.
+{% alert level="warning" %}This feature is available in Enterprise Edition only.{% endalert %}
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -130,58 +138,56 @@ metallb:
 
 ## An example for Bare metal (with L2LoadBalancer)
 
-{% alert level="warning" %} This feature is available in Enterprise Edition only. {% endalert %}
+{% alert level="warning" %}This feature is available in Enterprise Edition only.{% endalert %}
 
-Enable the `l2-load-balancer` module:
+1. Enable the `l2-load-balancer` module:
 
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: l2-load-balancer
-spec:
-  enabled: true
-  version: 1
-```
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: l2-load-balancer
+   spec:
+     enabled: true
+     version: 1
+   ```
 
-Deploy the _L2LoadBalancer_ resource:
+1. Deploy the _L2LoadBalancer_ resource:
 
-```yaml
-apiVersion: network.deckhouse.io/v1alpha1
-kind: L2LoadBalancer
-metadata:
-  name: ingress
-spec:
-  addressPool:
-  - 192.168.2.100-192.168.2.150
-  nodeSelector:
-    node-role.kubernetes.io/loadbalancer: ""
-```
+   ```yaml
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: L2LoadBalancer
+   metadata:
+     name: ingress
+   spec:
+     addressPool:
+     - 192.168.2.100-192.168.2.150
+     nodeSelector:
+       node-role.kubernetes.io/loadbalancer: ""
+   ```
 
-Deploy the _IngressNginxController_ resource:
-* The **network.deckhouse.io/l2-load-balancer-name** annotation specifies the name of _L2LoadBalancer_ resource.
-* The **network.deckhouse.io/l2-load-balancer-external-ips-count** annotation specifies how many addresses will be allocated from the pool described in _L2LoadBalancer_.
+1. Deploy the _IngressNginxController_ resource:
 
-```yaml
-apiVersion: deckhouse.io/v1
-kind: IngressNginxController
-metadata:
- name: main
-spec:
-  ingressClass: nginx
-  inlet: LoadBalancer
-  loadBalancer:
-    annotations:
-      network.deckhouse.io/l2-load-balancer-name: ingress
-      network.deckhouse.io/l2-load-balancer-external-ips-count: "3"
-```
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: IngressNginxController
+   metadata:
+    name: main
+   spec:
+     ingressClass: nginx
+     inlet: LoadBalancer
+     loadBalancer:
+       annotations:
+         # The name of _L2LoadBalancer_ resource.
+         network.deckhouse.io/l2-load-balancer-name: ingress
+         # The number of addresses that will be allocated from the pool described in _L2LoadBalancer_.
+         network.deckhouse.io/l2-load-balancer-external-ips-count: "3"
+   ```
 
-The platform created Service with the type `LoadBalancer`. It will be assigned the specified number of addresses:
+1. The platform will create a service with the type `LoadBalancer`, to which a specified number of addresses will be assigned:
 
-```shell
-$ kubectl -n d8-ingress-nginx get svc
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                 PORT(S)                      AGE
-main-load-balancer     LoadBalancer   10.222.130.11   192.168.2.100,192.168.2.101,192.168.2.102   80:30689/TCP,443:30668/TCP   11s
-```
-
-{% endraw %}
+   ```shell
+   $ kubectl -n d8-ingress-nginx get svc
+   NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                 PORT(S)                      AGE
+   main-load-balancer     LoadBalancer   10.222.130.11   192.168.2.100,192.168.2.101,192.168.2.102   80:30689/TCP,443:30668/TCP   11s
+   ```

--- a/modules/402-ingress-nginx/docs/EXAMPLES_RU.md
+++ b/modules/402-ingress-nginx/docs/EXAMPLES_RU.md
@@ -39,7 +39,13 @@ spec:
   inlet: LoadBalancer
 ```
 
-> **Внимание!** В GCP на узлах должна присутствовать аннотация, разрешающая принимать подключения на внешние адреса для сервисов с типом NodePort.
+{% endraw %}
+
+{% alert level="warning" %}
+В GCP на узлах должна присутствовать аннотация, разрешающая принимать подключения на внешние адреса для сервисов с типом NodePort.
+{% endalert %}
+
+{% raw %}
 
 ## Пример для OpenStack
 
@@ -91,9 +97,11 @@ spec:
     behindL7Proxy: true
 ```
 
+{% endraw %}
+
 ## Пример для bare metal (балансировщик MetalLB в режиме BGP)
 
-Модуль `metallb` на текущий момент доступен только в редакции Enterprise Edition Deckhouse.
+{% alert level="warning" %}Доступно только в Enterprise Edition.{% endalert %}
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -130,58 +138,56 @@ metallb:
 
 ## Пример для bare metal (балансировщик L2LoadBalancer)
 
-{% alert level="warning" %} Доступно только в Enterprise Edition. {% endalert %}
+{% alert level="warning" %}Доступно только в Enterprise Edition.{% endalert %}
 
-Включите модуль `l2-load-balancer`:
+1. Включите модуль `l2-load-balancer`:
 
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: l2-load-balancer
-spec:
-  enabled: true
-  version: 1
-```
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: l2-load-balancer
+   spec:
+     enabled: true
+     version: 1
+   ```
 
-Создайте ресурс _L2LoadBalancer_:
+1. Создайте ресурс _L2LoadBalancer_:
 
-```yaml
-apiVersion: network.deckhouse.io/v1alpha1
-kind: L2LoadBalancer
-metadata:
-  name: ingress
-spec:
-  addressPool:
-  - 192.168.2.100-192.168.2.150
-  nodeSelector:
-    node-role.kubernetes.io/loadbalancer: "" # селектор узлов-балансировщиков
-```
+   ```yaml
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: L2LoadBalancer
+   metadata:
+     name: ingress
+   spec:
+     addressPool:
+     - 192.168.2.100-192.168.2.150
+     nodeSelector:
+       node-role.kubernetes.io/loadbalancer: "" # селектор узлов-балансировщиков
+   ```
 
-Создайте ресурс _IngressNginxController_:
-* В аннотации **network.deckhouse.io/l2-load-balancer-name** указывается имя _L2LoadBalancer_.
-* Аннотация **network.deckhouse.io/l2-load-balancer-external-ips-count** указывает сколько адресов будет выделено из пула, описанного в _L2LoadBalancer_.
+1. Создайте ресурс _IngressNginxController_:
 
-```yaml
-apiVersion: deckhouse.io/v1
-kind: IngressNginxController
-metadata:
- name: main
-spec:
-  ingressClass: nginx
-  inlet: LoadBalancer
-  loadBalancer:
-    annotations:
-      network.deckhouse.io/l2-load-balancer-name: ingress
-      network.deckhouse.io/l2-load-balancer-external-ips-count: "3"
-```
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: IngressNginxController
+   metadata:
+    name: main
+   spec:
+     ingressClass: nginx
+     inlet: LoadBalancer
+     loadBalancer:
+       annotations:
+         # Имя _L2LoadBalancer_.
+         network.deckhouse.io/l2-load-balancer-name: ingress
+         # Количество адресов, которые будут выделены из пула, описанного в _L2LoadBalancer_.
+         network.deckhouse.io/l2-load-balancer-external-ips-count: "3"
+   ```
 
-Платформа создаст сервис с типом `LoadBalancer`. Ему будут присвоены адреса в заданном количестве:
+1. Платформа создаст сервис с типом `LoadBalancer`, которому будет присвоено заданное количество адресов:
 
-```shell
-$ kubectl -n d8-ingress-nginx get svc
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                 PORT(S)                      AGE
-main-load-balancer     LoadBalancer   10.222.130.11   192.168.2.100,192.168.2.101,192.168.2.102   80:30689/TCP,443:30668/TCP   11s
-```
-
-{% endraw %}
+   ```shell
+   $ kubectl -n d8-ingress-nginx get svc
+   NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                 PORT(S)                      AGE
+   main-load-balancer     LoadBalancer   10.222.130.11   192.168.2.100,192.168.2.101,192.168.2.102   80:30689/TCP,443:30668/TCP   11s
+   ```


### PR DESCRIPTION
## Description
Adding an example of usage ingress-nginx with L2LoadBalancer.

## Why do we need it, and what problem does it solve?
Examples will help improve the customer experience with the platform.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Add an example of usage ingress-nginx with _L2LoadBalancer_ inlet.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
