### PR TITLE
[candi] fix install empty ca module source

### DIFF
--- a/candi/bashible/common-steps/node-group/002_install_ms_ca_certificates.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_install_ms_ca_certificates.sh.tpl
@@ -16,11 +16,12 @@ mkdir -p /usr/local/share/d8-ca-certificates/
 
 {{- if eq .runType "Normal" }}
 	{{- range $registryAddr,$ca := .normal.moduleSourcesCA }}
+		{{- if $ca }}
 
 bb-log-info "Sync moduleSource CA for {{ $registryAddr }}"
 bb-sync-file /usr/local/share/d8-ca-certificates/{{ $registryAddr | lower }}-ca.crt - << "EOF"
 {{ $ca }}
 EOF
-
+		{{- end }}
 	{{- end }}
 {{- end }}

--- a/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl
@@ -151,8 +151,10 @@ oom_score = 0
   {{- end }}
   {{- if eq .runType "Normal" }}
     {{- range $registryAddr,$ca := .normal.moduleSourcesCA }}
+			{{- if $ca }}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $registryAddr | lower }}".tls]
           ca_file = "/usr/local/share/d8-ca-certificates/{{ $registryAddr | lower }}-ca.crt"
+			{{- end }}
     {{- end }}
   {{- end }}
     [plugins."io.containerd.grpc.v1.cri".image_decryption]


### PR DESCRIPTION
## Description

Don't create an empty ca cert-file if ModuleSource does not contain a custom ca.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Now bashible step create empty `"/usr/local/share/d8-ca-certificates/***registry-host***-ca.crt"` for  modulseSource without custom ca.

## Why do we need it in the patch release (if we do)?

For order. It's not necessary, but will be good.

## What is the expected result?

Create ModuleSource with empty (or without) `.spec.registry.ca`:

```bash
[root@dev-master-0 ~]# kubectl apply -f - <<EOF
apiVersion: deckhouse.io/v1alpha1
kind: ModuleSource
metadata:
  name: mysource
spec:
  registry:
    ca: ""
    dockerCfg: $DOCKERCFG
    repo: 192.168.199.92:5000/deckhouse-modules
    scheme: HTTPS
  releaseChannel: ""
EOF
modulesource.deckhouse.io/mysource created
[root@dev-master-0 ~]#
```

Behaviour before:

```bash
[root@dev-master-0 ~]# kubectl -n d8-cloud-instance-manager get nodegroupbundle common.master  -o json | jq -r '.data."002_install_ms_ca_certificates.sh"'
# Copyright 2024 Flant JSC
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

mkdir -p /usr/local/share/d8-ca-certificates/

bb-log-info "Sync moduleSource CA for 192.168.199.92:5000"
bb-sync-file /usr/local/share/d8-ca-certificates/192.168.199.92:5000-ca.crt - << "EOF"

EOF
```

Behaviour after:

```bash
[root@dev-master-0 ~]# kubectl -n d8-cloud-instance-manager get nodegroupbundle common.worker  -o json | jq -r '.data."002_install_ms_ca_certificates.sh"'
# Copyright 2024 Flant JSC
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

mkdir -p /usr/local/share/d8-ca-certificates/

```


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Don't create an empty ca cert-file if ModuleSource does not contain a custom ca.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
