### PR TITLE
[cloud-provider-vcd] Fix impossibility to use 0 as value of Max IOPS in storage policy

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
@@ -49,7 +49,7 @@ shell:
   - mkdir -p /src
   - git clone --depth 1 --branch ${VERSION} {{ $.SOURCE_REPO }}/vmware/cloud-director-named-disk-csi-driver.git /src
   - cd /src
-  - find /patches -name '*.patch' -exec git apply {} \;
+  - git apply /patches/*.patch --verbose
   - go mod vendor
   - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version=${VERSION}" -o bin/cloud-director-named-disk-csi-driver cmd/csi/main.go
 ---

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/patches/01-add-iops-calculation.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/patches/01-add-iops-calculation.patch
@@ -6,8 +6,8 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/pkg/vcdcsiclient/disks.go b/pkg/vcdcsiclient/disks.go
---- a/pkg/vcdcsiclient/disks.go	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
-+++ b/pkg/vcdcsiclient/disks.go	(date 1707645953306)
+--- a/pkg/vcdcsiclient/disks.go	(revision 4d45eb49052c9ff2e5a72c80a74f7fb4484e7b74)
++++ b/pkg/vcdcsiclient/disks.go	(date 1722439754789)
 @@ -9,17 +9,19 @@
  	"context"
  	"encoding/json"
@@ -20,7 +20,7 @@ diff --git a/pkg/vcdcsiclient/disks.go b/pkg/vcdcsiclient/disks.go
 +	"time"
 +
  	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
- 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_36_0"
+ 	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_37_2"
  	"github.com/vmware/go-vcloud-director/v2/govcd"
  	"github.com/vmware/go-vcloud-director/v2/types/v56"
  	"k8s.io/klog"
@@ -73,39 +73,3 @@ diff --git a/pkg/vcdcsiclient/disks.go b/pkg/vcdcsiclient/disks.go
  	}
 
  	task, err := diskManager.createDisk(diskParams)
-Index: go.sum
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/go.sum b/go.sum
---- a/go.sum	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
-+++ b/go.sum	(date 1707644360350)
-@@ -370,8 +370,8 @@
- github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
- github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230928223648-8134f65b3f61 h1:5OBXV9Q84GleGRrznPmKsEYKFtbaS8tTFL8d/hsDvy4=
- github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230928223648-8134f65b3f61/go.mod h1:LXs88jpAH7nny7nQcLaXzjyCvg4Q1JhttSoD9mI5kaQ=
--github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3 h1:VJolXzgomaRPrgzSr0EduuUtJIJEf5RdoLbktZFQqIc=
--github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
-+github.com/vmware/go-vcloud-director/v2 v2.21.0 h1:zIONrJpM+Fj+rDyXmsRfMAn1sP5WAP87USL0T9GS4DY=
-+github.com/vmware/go-vcloud-director/v2 v2.21.0/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
- github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
- github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
- github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-Index: go.mod
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/go.mod b/go.mod
---- a/go.mod	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
-+++ b/go.mod	(date 1707644360350)
-@@ -13,7 +13,7 @@
- 	github.com/stretchr/testify v1.7.0
- 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
- 	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230928223648-8134f65b3f61
--	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3
-+	github.com/vmware/go-vcloud-director/v2 v2.21.0
- 	golang.org/x/oauth2 v0.4.0 // indirect
- 	golang.org/x/sys v0.5.0
- 	google.golang.org/grpc v1.53.0

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
@@ -49,7 +49,7 @@ shell:
   - mkdir -p /src
   - git clone --depth 1 --branch ${VERSION} {{ $.SOURCE_REPO }}/vmware/cloud-director-named-disk-csi-driver.git /src
   - cd /src
-  - find /patches -name '*.patch' -exec git apply {} \;
+  - git apply /patches/*.patch --verbose;
   - go mod vendor
   - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version=${VERSION}" -o bin/cloud-director-named-disk-csi-driver cmd/csi/main.go
 ---


### PR DESCRIPTION
## Description
Fix build csi-controller. Use right command for apply patch

## Why do we need it, and what problem does it solve?
CSI controller cannot work with storage policy using 0 as Max IOPS 

## Why do we need it in the patch release (if we do)?

Affect new clients

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Fix impossibility to use 0 as value of Max IOPS in storage policy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
