### PR TITLE
[flannel] Removing the cilium configuration file on flannel startup

### DIFF
--- a/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
+++ b/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
@@ -77,6 +77,7 @@ func main() {
 	}
 
 	ciliumEnabledStr := os.Getenv("MODULE_CNI_CILIUM_ENABLED")
+	ciliumEnabledStr = "false"
 	fmt.Println("MODULE_CNI_CILIUM_ENABLED: ", ciliumEnabledStr) // ! DELETE
 	if ciliumEnabledStr != "true" {
 		fmt.Println("NEED remove file!") // ! DELETE

--- a/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
+++ b/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
@@ -77,7 +77,7 @@ func main() {
 	}
 
 	ciliumEnabledStr := os.Getenv("MODULE_CNI_CILIUM_ENABLED")
-	ciliumEnabledStr = "false"
+	// ciliumEnabledStr = "false"
 	fmt.Println("MODULE_CNI_CILIUM_ENABLED: ", ciliumEnabledStr) // ! DELETE
 	if ciliumEnabledStr != "true" {
 		fmt.Println("NEED remove file!") // ! DELETE

--- a/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
+++ b/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -77,10 +76,7 @@ func main() {
 	}
 
 	ciliumEnabledStr := os.Getenv("MODULE_CNI_CILIUM_ENABLED")
-	// ciliumEnabledStr = "false"
-	fmt.Println("MODULE_CNI_CILIUM_ENABLED: ", ciliumEnabledStr) // ! DELETE
 	if ciliumEnabledStr != "true" {
-		fmt.Println("NEED remove file!") // ! DELETE
 		err = os.Remove("/etc/cni/net.d/05-cilium.conflist")
 		if err != nil && !os.IsNotExist(err) {
 			log.Fatal(err)

--- a/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
+++ b/modules/035-cni-flannel/images/flanneld/entrypoint/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -73,6 +74,16 @@ func main() {
 	err = os.WriteFile("/etc/cni/net.d/10-flannel.conflist", cniConfBytes, 0666)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	ciliumEnabledStr := os.Getenv("MODULE_CNI_CILIUM_ENABLED")
+	fmt.Println("MODULE_CNI_CILIUM_ENABLED: ", ciliumEnabledStr) // ! DELETE
+	if ciliumEnabledStr != "true" {
+		fmt.Println("NEED remove file!") // ! DELETE
+		err = os.Remove("/etc/cni/net.d/05-cilium.conflist")
+		if err != nil && !os.IsNotExist(err) {
+			log.Fatal(err)
+		}
 	}
 
 	var flannelArgs []string

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -69,8 +69,8 @@ spec:
         env:
         - name: POD_NETWORK_MODE
           value: {{ .Values.cniFlannel.internal.podNetworkMode }}
-        - name: MODULE_CNI_CILIUM_ENABLED
-          value: "{{ .Values.global.enabledModules | has 'cni-cilium' | quote }}"
+        # - name: MODULE_CNI_CILIUM_ENABLED
+        #   value: "{{ .Values.global.enabledModules | has 'cni-cilium' | quote }}"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -70,7 +70,7 @@ spec:
         - name: POD_NETWORK_MODE
           value: {{ .Values.cniFlannel.internal.podNetworkMode }}
         - name: MODULE_CNI_CILIUM_ENABLED
-          value: {{ .Values.global.enabledModules | has 'cni-cilium' | quote }}
+          value: "{{ .Values.global.enabledModules | has 'cni-cilium' | quote }}"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -69,8 +69,8 @@ spec:
         env:
         - name: POD_NETWORK_MODE
           value: {{ .Values.cniFlannel.internal.podNetworkMode }}
-        # - name: MODULE_CNI_CILIUM_ENABLED
-        #   value: "{{ .Values.global.enabledModules | has 'cni-cilium' | quote }}"
+        - name: MODULE_CNI_CILIUM_ENABLED
+          value: {{ .Values.global.enabledModules | has "cni-cilium" | quote }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -69,6 +69,8 @@ spec:
         env:
         - name: POD_NETWORK_MODE
           value: {{ .Values.cniFlannel.internal.podNetworkMode }}
+        - name: MODULE_CNI_CILIUM_ENABLED
+          value: {{ .Values.global.enabledModules | has 'cni-cilium' | quote }}
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Description
When switching CNI from **cilium** to **flannel**, the **cilium** configuration file `/etc/cni/net.d/05-cilium.conflist` remains in the host file system.

## Why do we need it, and what problem does it solve?
Stale configuration file prevents CNI from working properly.

## What is the expected result?
When starting **flannel**, the **cilium** configuration file `/etc/cni/net.d/05-cilium.conflist` will be deleted.
The file will not be deleted if both CNI **cilium** and **flannel** are enabled at the same time. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: flannel
type: chore
summary: Added deletion of stale cilium cni configuration file from the host file system when starting flannel.
impact_level: default
```