### PR TITLE
[testing] disabling the istio module from EKS e2e layout

### DIFF
--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -98,12 +98,3 @@ metadata:
   name: vertical-pod-autoscaler
 spec:
   enabled: true
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: istio
-spec:
-  version: 2
-  enabled: true
-  settings:


### PR DESCRIPTION
## Description
Disabling the istio module from EKS e2e layout.

## Why do we need it, and what problem does it solve?
Istio module has a hook `discovery_preflight_check.go`, which checks the cluster's k8s version. But in EKS we don't control the control-plane and don't know the k8s version. So we decided not to test the module in this layout. Will handle it later.

## What is the expected result?
EKS e2e layout is succeeding.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: The istio module is disabled EKS e2e layout.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
