### PR TITLE
[deckhouse-controller] Restart controller if a ModuleRelease is Deployed phase is deleted

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -189,6 +189,10 @@ func (c *moduleReleaseReconciler) deleteReconcile(ctx context.Context, mr *v1alp
 		}
 		// TODO(yalosev): we have to disable module here somehow.
 		// otherwise, hooks from file system will fail
+
+		// restart controller for completely remove module
+		// TODO: we need another solution for remove module from modulemanager
+		c.emitRestart("a module release was removed")
 	}
 
 	if !controllerutil.ContainsFinalizer(mr, fsReleaseFinalizer) {


### PR DESCRIPTION
## Description

After removing the module release, we need to restart the controller to completely remove the module from the system.

## Why do we need it, and what problem does it solve?

Fixed: #9074

## What is the expected result?

If a deployed module release gets deleted, corresponding module should also be deleted from the ModuleManager and DeckhouseController to reflect new state of the cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: Restart controller if a ModuleRelease is Deployed phase is deleted
impact_level: default
```
