### PR TITLE
[deckhouse] Added a VAP that prohibits specifying multiple default storage classes

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -123,7 +123,7 @@ spec:
         operations: ["CREATE", "UPDATE"]
         resources: ["storageclasses"]
   validations:
-    - expression: "object.metadata.annotations['is_default'] != 'true' || (list('storage.k8s.io/v1', 'StorageClass').items.filter(`metadata.annotations['is_default'] == 'true' && metadata.name != object.metadata.name`).isEmpty())"
+    - expression: "object.metadata.annotations['is_default'] != 'true' || (list('storage.k8s.io/v1', 'StorageClass').items.filter(metadata.annotations['is_default'] == 'true' && metadata.name != object.metadata.name).isEmpty())"
       reason: Forbidden
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
       messageExpression: '''Multiple default StorageClass if forbidden'''

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -1,4 +1,3 @@
-{{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
 {{- $policyName := "system-ns.deckhouse.io" }}
 ---
 {{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
@@ -28,7 +27,9 @@ spec:
       messageExpression: '''Creation of system namespaces is forbidden'''
 {{- end }}
 ---
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1alpha1
@@ -81,7 +82,9 @@ spec:
       reason: Forbidden
 {{- end }}
 ---
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1alpha1
@@ -99,4 +102,29 @@ spec:
     objectSelector:
       matchLabels:
         heritage: deckhouse
+---
+{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1alpha1
+{{- end }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "multiple-default-sc-deny.deckhouse.io"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["storageclasses"]
+  validations:
+    - expression: "object.metadata.annotations['is_default'] != 'true' || (list('storage.k8s.io/v1', 'StorageClass').items.filter(`metadata.annotations['is_default'] == 'true' && metadata.name != object.metadata.name`).isEmpty())"
+      reason: Forbidden
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+      messageExpression: '''Multiple default StorageClass if forbidden'''
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a VAP that prohibits specifying multiple default storage classes

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Default k8s behavior allows to specify multiple default StorageClass, this PR fixes it

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Only one default StorageClass in k8s clusters

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Added a VAP that prohibits specifying multiple default storage classes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
