### PR TITLE
[docs] Fixed command requesting basic-auth password for `documentation` module

### DIFF
--- a/docs/site/_includes/getting_started/existing/STEP_FINISH.md
+++ b/docs/site/_includes/getting_started/existing/STEP_FINISH.md
@@ -19,7 +19,7 @@ Access to the documentation is restricted via the basic authentication mechanism
 
     {% snippetcut %}
 ```bash
-kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.documentation.internal.auth.password'"
+kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.internal.auth.password'"
 ```
 {% endsnippetcut %}
 
@@ -33,7 +33,7 @@ kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module
 
   {% offtopic title="Sample output..." %}
 ```
-$ kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.documentation.internal.auth.password'" 
+$ kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.internal.auth.password'" 
 3aE7nY1VlfiYCH4GFIqA
 ```
   {% endofftopic %}

--- a/docs/site/_includes/getting_started/existing/STEP_FINISH_RU.md
+++ b/docs/site/_includes/getting_started/existing/STEP_FINISH_RU.md
@@ -19,7 +19,7 @@
 
     {% snippetcut %}
 ```bash
-kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.documentation.internal.auth.password'"
+kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.internal.auth.password'"
 ```
 {% endsnippetcut %}
 
@@ -33,7 +33,7 @@ kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module
 
   {% offtopic title="Пример вывода..." %}
 ```
-$ kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.documentation.internal.auth.password'" 
+$ kubectl -n d8-system exec deploy/deckhouse -- sh -c "deckhouse-controller module values documentation -o json | jq -r '.internal.auth.password'" 
 3aE7nY1VlfiYCH4GFIqA
 ```
   {% endofftopic %}

--- a/modules/810-documentation/docs/CONFIGURATION.md
+++ b/modules/810-documentation/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@ If these options are disabled, the module will use basic auth with the auto-gene
 Use kubectl to see password:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module values documentation -o json | jq '.documentation.internal.auth.password'
+kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module values documentation -o json | jq '.internal.auth.password'
 ```
 
 Delete the Secret to re-generate password:

--- a/modules/810-documentation/docs/CONFIGURATION_RU.md
+++ b/modules/810-documentation/docs/CONFIGURATION_RU.md
@@ -14,7 +14,7 @@ title: "Модуль documentation: настройки"
 Посмотреть сгенерированный пароль можно командой:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module values documentation -o json | jq '.documentation.internal.auth.password'
+kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module values documentation -o json | jq '.internal.auth.password'
 ```
 
 Чтобы сгенерировать новый пароль, нужно удалить Secret:


### PR DESCRIPTION
## Description
Fixed command asking for basic-auth password of `documentation` module. Typo found by community members

## Why do we need it, and what problem does it solve?
Improves the quality of documentation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: documentation
type: fix
summary: Fixed command for requesting basic-auth password for `documentation` module.
impact_level: low
```