### PR TITLE
[monitoring] Fix cni cilium dashboard

### DIFF
--- a/ee/modules/021-cni-cilium/templates/monitoring.yaml
+++ b/ee/modules/021-cni-cilium/templates/monitoring.yaml
@@ -1,1 +1,2 @@
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
 {{- include "helm_lib_prometheus_rules" (list . "d8-cni-cilium") }}

--- a/ee/modules/021-cni-cilium/templates/monitoring.yaml
+++ b/ee/modules/021-cni-cilium/templates/monitoring.yaml
@@ -1,2 +1,0 @@
-{{- include "helm_lib_grafana_dashboard_definitions" . }}
-{{- include "helm_lib_prometheus_rules" (list . "d8-cni-cilium") }}

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-agent.json
@@ -8519,6 +8519,25 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "ds_prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": true,

--- a/tools/build_includes/modules-EE.yaml
+++ b/tools/build_includes/modules-EE.yaml
@@ -99,11 +99,6 @@
   stageDependencies:
     setup:
         - '**/*.go'
-- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
-  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
-  stageDependencies:
-    setup:
-        - '**/*.go'
 - add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
   stageDependencies:

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -99,11 +99,6 @@
   stageDependencies:
     setup:
         - '**/*.go'
-- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
-  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
-  stageDependencies:
-    setup:
-        - '**/*.go'
 - add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-EE.yaml
+++ b/tools/build_includes/modules-with-dependencies-EE.yaml
@@ -459,29 +459,6 @@
   stageDependencies:
     setup:
         - '**/*.go'
-- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
-  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
-  excludePaths:
-    - images
-    - templates
-    - charts
-    - crds
-    - docs
-    - monitoring
-    - openapi
-    - oss.yaml
-    - cloud-instance-manager
-    - values_matrix_test.yaml
-    - values.yaml
-    - .helmignore
-    - candi
-    - Chart.yaml
-    - .namespace
-    - '**/*_test.go'
-    - '**/*.sh'
-  stageDependencies:
-    setup:
-        - '**/*.go'
 - add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -459,29 +459,6 @@
   stageDependencies:
     setup:
         - '**/*.go'
-- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
-  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
-  excludePaths:
-    - images
-    - templates
-    - charts
-    - crds
-    - docs
-    - monitoring
-    - openapi
-    - oss.yaml
-    - cloud-instance-manager
-    - values_matrix_test.yaml
-    - values.yaml
-    - .helmignore
-    - candi
-    - Chart.yaml
-    - .namespace
-    - '**/*_test.go'
-    - '**/*.sh'
-  stageDependencies:
-    setup:
-        - '**/*.go'
 - add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -246,19 +246,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
-- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
-  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
 - add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -246,19 +246,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
-- add: /ee/modules/021-cni-cilium/templates/monitoring.yaml
-  to: /deckhouse/modules/021-cni-cilium/templates/monitoring.yaml
-  excludePaths:
-    - docs
-    - README.md
-    - images
-    - hooks/**/*.go
-    - hooks/*.go
-    - hack
-    - template_tests
-    - .namespace
-    - values_matrix_test.yaml
-    - .build.yaml
 - add: /ee/modules/021-cni-cilium/monitoring/prometheus-rules
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules
   excludePaths:


### PR DESCRIPTION
## Description
This PR addresses two main issues:
1. It adds a missing variable to define the datasource in the Grafana dashboard. This variable was lost in a previous PR.
2. It fixes the `cni-cilium` module by deleting the `monitoring.yaml` template for EE version, which was added by mistake. This issue was specific to the EE version, and this template was preventing the `cni-cilium` dashboard from appearing in the EE version entirely.

## Why do we need it, and what problem does it solve?

This PR is essential for ensuring that the Grafana dashboard functions correctly by defining the datasource. Moreover, it resolves the issue with the `cni-cilium` module in the EE version, ensuring that the dashboard is rendered correctly. This fix is critical as it reinstates the visibility of the `cni-cilium` dashboard in the EE version, which was completely missing due to the previous error.

## Why do we need it in the patch release (if we do)?
Given that these issues directly impact the functionality and visibility of critical monitoring dashboards, it is important to include these fixes in the upcoming patch release. This will ensure that users have a fully operational environment and can continue to monitor `cni-cilium` metrics effectively without disruptions.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixed missing datasource variable and dashboard rendering in the cni-cilium module for the EE version.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
