### PR TITLE
[testing] Disabling the istio module and the istio availability test from EKS e2e layout.

### DIFF
--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -98,12 +98,3 @@ metadata:
   name: vertical-pod-autoscaler
 spec:
   enabled: true
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: istio
-spec:
-  version: 2
-  enabled: true
-  settings:

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
@@ -150,7 +150,7 @@ EOF
   fi
 
   bundle=$(kubectl get mc deckhouse -o jsonpath='{.spec.settings.bundle}')
-  if [ "$bundle" == "Minimal" ] || kubectl -n d8-istio get po | grep istiod | wc -l; then
+  if [ "$bundle" == "Minimal" ] || kubectl -n d8-istio get po | grep istiod | grep -q Running; then
     istio="ok"
   else
     istio=""

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
@@ -156,7 +156,7 @@ EOF
     istio=""
   fi
 
-    cat <<EOF
+  cat <<EOF
 Istio operator check: $([ "$istio" == "ok" ] && echo "success" || echo "failed")
 EOF
 

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
@@ -149,15 +149,11 @@ Ingress $ingress_inlet check: $([ "$ingress" == "ok" ] && echo "success" || echo
 EOF
   fi
 
-  if [ "$(kubectl -n d8-istio get po | grep istiod | wc -l)" -gt 0 ]; then
+  bundle=$(kubectl get mc deckhouse -o jsonpath='{.spec.settings.bundle}')
+  if [ "$bundle" == "Minimal" ] || kubectl -n d8-istio get po | grep istiod | wc -l; then
     istio="ok"
   else
     istio=""
-  fi
-
-  bundle=$(kubectl get mc deckhouse -o jsonpath='{.spec.settings.bundle}')
-  if [ "$bundle" == "Minimal" ]; then
-    istio="ok"
   fi
 
     cat <<EOF

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -915,7 +915,7 @@ function wait_cluster_ready() {
 
   testScript=$(cat "$(pwd)/deckhouse/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh")
 
-  testRunAttempts=15
+  testRunAttempts=5
   for ((i=1; i<=$testRunAttempts; i++)); do
     if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testScript}"; then
       test_failed=""

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -915,7 +915,7 @@ function wait_cluster_ready() {
 
   testScript=$(cat "$(pwd)/deckhouse/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh")
 
-  testRunAttempts=5
+  testRunAttempts=15
   for ((i=1; i<=$testRunAttempts; i++)); do
     if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testScript}"; then
       test_failed=""


### PR DESCRIPTION
## Description
Disabling the istio module and the istio availability test from EKS e2e layout.

## Why do we need it, and what problem does it solve?
The Istio module has a hook discovery_preflight_check.go, which checks the cluster's k8s version. But in EKS we don't control the control-plane and don't know the k8s version. So we decided not to test the module in this layout. Will handle it later.

## Why do we need it in the patch release (if we do)?
Need to fix e2e tests as soon as possible.

## What is the expected result?
EKS e2e layout is succeeding.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: The istio module and istio availability test are disabled EKS e2e layout.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
