### PR TITLE
[registrypackages][cni-simple-bridge] adding kernel version check for installing iptables and using this iptables bins in the simple-bridge image

### DIFF
--- a/modules/007-registrypackages/images/iptables/scripts/install
+++ b/modules/007-registrypackages/images/iptables/scripts/install
@@ -22,6 +22,9 @@ if [ -f /opt/deckhouse/bin/iptables ]; then
   exit 0
 fi
 
+NFT_KERNEL_LIMIT=3.14 # nf_tables_ipv6, nf_tables_bridge, nf_tables_arp allow since Linux kernel >= 3.14.
+CURRENT_KERNEL_VERSION=$(uname -r | awk -F"-" '{print $1}') #version kernel view format: a.b.c-generic to a.b.c.
+
 function checkNFTSupportInKernelBuildConfiguration() {
   local configNFTablesRegex='CONFIG_NF_(TABLES|TABLES_IPV4)=(y|m)'
   local configFiles=(
@@ -66,6 +69,22 @@ function checkNFTSupportByAddingNFTRules() {
   return 1
 }
 
+function check_python() {
+  for pybin in python3 python2 python; do
+    if command -v "$pybin" >/dev/null 2>&1; then
+      python_binary="$pybin"
+      return 0
+    fi
+  done
+  echo "Python not found, exiting..."
+  return 1
+}
+
+function isLegacyKernel() {
+  check_python
+  $python_binary -c "exit(0) if tuple(map(int, '$CURRENT_KERNEL_VERSION'.split('.'))) < tuple(map(int, '$NFT_KERNEL_LIMIT'.split('.')))  else exit(1)"
+}
+
 function isNftSupport() {
   if checkNFTSupportInKernelBuildConfiguration; then
     return 0
@@ -79,7 +98,7 @@ function isNftSupport() {
 kubeletChainsRegex='^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)'
 IPTABLES_LEGACY_RULE=$( (/opt/deckhouse/bin/xtables-legacy-multi iptables-save || true ) 2>/dev/null | grep  -E ${kubeletChainsRegex} | wc -l )
 
-if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]]; then
+if [[ ${IPTABLES_LEGACY_RULE} -ne 0 ]] | (isLegacyKernel); then
   iptablesModeBin="xtables-legacy-multi"
 elif isNftSupport; then
   iptablesModeBin="xtables-nft-multi"

--- a/modules/007-registrypackages/images/iptables/werf.inc.yaml
+++ b/modules/007-registrypackages/images/iptables/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{/* Important! The iptables binaries from artifact are also used in kube-router image of network-policy-engine module. */}}
+{{/* Important! The iptables binaries from artifact are also used in kube-router image of network-policy-engine module and cni-simple-bridge. */}}
 {{- $version := "1.8.9" }}
 {{- $image_version := $version | replace "." "-" }}
 ---

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $iptables_version := "1.8.10" }}
+{{- $iptables_version := "1.8.9" }}
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
@@ -28,7 +28,7 @@ import:
 docker:
   ENTRYPOINT: ["/sbin/iptables-wrapper"]
 ---
-{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge "}}
+{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ .Images.BASE_ALT_DEV }}

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -1,3 +1,6 @@
+{{- $iptables_version := "1.8.10" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
@@ -5,12 +8,12 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin/
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
   before: setup
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /usr/lib64
@@ -25,7 +28,7 @@ import:
 docker:
   ENTRYPOINT: ["/sbin/iptables-wrapper"]
 ---
-{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge /usr/bin/iptables* /sbin/iptables* /sbin/ip6tables* /sbin/xtables* /sbin/arptables*" }}
+{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ .Images.BASE_ALT_DEV }}

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -28,7 +28,7 @@ import:
 docker:
   ENTRYPOINT: ["/sbin/iptables-wrapper"]
 ---
-{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge }}
+{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge "}}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ .Images.BASE_ALT_DEV }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail. 

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add kernel version check for installing iptables. According to the documentation nftables is available upstream since Linux kernel 3.13. Also cni-simple-bridge use the same iptables binaries as on the host to prevent incompatibility.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

On older kernels (e.g. centos7 with 3.10), there are problems with nftables, despite having the necessary kernel modules.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This issue may affect systems with kernel version < 3.14.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: Add kernel version check for installing iptables.
impact_level: default 
```
```changes
section: cni-simple-bridge
type: fix
summary: cni-simple-bridge use the same iptables binaries as on the host to prevent incompatibility.
impact_level: default 
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
