### PR TITLE
[cloud-provider-*] Update VolumeSnapshotClass apiVersion

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/csi/volume-snapshot-class.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/csi/volume-snapshot-class.yaml
@@ -1,7 +1,7 @@
 # Source https://github.com/openshift/openstack-cinder-csi-driver-operator/blob/master/assets/volumesnapshotclass.yaml
 {{- if (.Values.global.enabledModules | has "snapshot-controller") }}
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "cinder-csi-driver")) | nindent 2 }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/volume-snapshot-class.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/volume-snapshot-class.yaml
@@ -1,7 +1,7 @@
 # Source https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-E0B41C69-7EEB-450F-A73D-5FD2FF39E891.html
 {{- if (.Values.global.enabledModules | has "snapshot-controller") }}
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}

--- a/modules/030-cloud-provider-aws/templates/csi/volume-snapshot-class.yaml
+++ b/modules/030-cloud-provider-aws/templates/csi/volume-snapshot-class.yaml
@@ -1,7 +1,7 @@
 # Source https://aws.amazon.com/ru/blogs/containers/using-ebs-snapshots-for-persistent-storage-with-your-eks-cluster/
 {{- if (.Values.global.enabledModules | has "snapshot-controller") }}
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "ebs-csi-driver")) | nindent 2 }}

--- a/modules/030-cloud-provider-azure/templates/csi/volume-snapshot-class.yaml
+++ b/modules/030-cloud-provider-azure/templates/csi/volume-snapshot-class.yaml
@@ -1,7 +1,7 @@
 # Source https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/deploy/example/snapshot/storageclass-azuredisk-snapshot.yaml
 {{- if (.Values.global.enabledModules | has "snapshot-controller") }}
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "csi-driver")) | nindent 2 }}

--- a/modules/030-cloud-provider-gcp/templates/csi/volume-snapshot-class.yaml
+++ b/modules/030-cloud-provider-gcp/templates/csi/volume-snapshot-class.yaml
@@ -1,7 +1,7 @@
 # Source https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/volume-snapshots#create-snapshotclass
 {{- if (.Values.global.enabledModules | has "snapshot-controller") }}
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "cinder-csi-driver")) | nindent 2 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Update `VolumeSnapshotClass.apiVersion` from v1beta1 to v1.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`VolumeSnapshotClass.apiVersion` v1beta1 is deprecated.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Update `VolumeSnapshotClass.apiVersion` from v1beta1 to v1.
impact_level: default

section: cloud-provider-aws
type: fix
summary: Update `VolumeSnapshotClass.apiVersion` from v1beta1 to v1.
impact_level: default

section: cloud-provider-azure
type: fix
summary: Update `VolumeSnapshotClass.apiVersion` from v1beta1 to v1.
impact_level: default

section: cloud-provider-gcp
type: fix
summary: Update `VolumeSnapshotClass.apiVersion` from v1beta1 to v1.
impact_level: default

section: cloud-provider-vsphere
type: fix
summary: Update `VolumeSnapshotClass.apiVersion` from v1beta1 to v1.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
