### PR TITLE
[deckhouse-controller] Restore absent releases from a registry

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -232,9 +232,12 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		}
 	}
 
-	err = r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
-	if err != nil {
-		return fmt.Errorf("crate release %s: %w", releaseChecker.releaseMetadata.Version, err)
+	// if there are no releases in the cluster, we apply the latest release
+	if len(pointerReleases) == 0 {
+		err = r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
+		if err != nil {
+			return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
+		}
 	}
 	return nil
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -222,7 +222,7 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 
 				err = r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
 				if err != nil {
-					return fmt.Errorf("crate release %s: %w", releaseChecker.releaseMetadata.Version, err)
+					return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
 				}
 
 				if releaseChecker.releaseMetadata.Cooldown != nil {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -550,7 +550,7 @@ func (dcr *DeckhouseReleaseChecker) StepByStepUpdate(actual, target *semver.Vers
 	return nextVersion, nil
 }
 
-func (dcr *DeckhouseReleaseChecker) nextVersion(actual, target *semver.Version) (next *semver.Version, err error) {
+func (dcr *DeckhouseReleaseChecker) nextVersion(actual, target *semver.Version) (*semver.Version, error) {
 	if actual.Major() != target.Major() {
 		return nil, fmt.Errorf("major version updated") // TODO step by step update for major version
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -440,22 +440,49 @@ global:
 	})
 
 	suite.Run("Restore absent releases from a registry", func() {
-		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (i1 v1.Image, err error) {
-			if tag == "stable" {
-				tag = "v1.60.2"
-			}
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{
+					&fakeLayer{},
+					&fakeLayer{FilesContent: map[string]string{
+						"version.json": `{"version":"v1.60.2"}`,
+					}},
+				}, nil
+			},
+		}, nil)
 
-			return &fake.FakeImage{
-				LayersStub: func() ([]v1.Layer, error) {
-					return []v1.Layer{
-						&fakeLayer{},
-						&fakeLayer{FilesContent: map[string]string{
-							"version.json": fmt.Sprintf(`{"version":"%s"}`, tag),
-						}},
-					}, nil
-				},
-			}, nil
-		})
+		dependency.TestDC.CRClient.ImageMock.When("v1.58.1").Then(&fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{
+					&fakeLayer{},
+					&fakeLayer{FilesContent: map[string]string{
+						"version.json": `{"version":"v1.58.1"}`,
+					}},
+				}, nil
+			},
+		}, nil)
+
+		dependency.TestDC.CRClient.ImageMock.When("v1.59.3").Then(&fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{
+					&fakeLayer{},
+					&fakeLayer{FilesContent: map[string]string{
+						"version.json": `{"version":"v1.59.3"}`,
+					}},
+				}, nil
+			},
+		}, nil)
+
+		dependency.TestDC.CRClient.ImageMock.When("v1.60.2").Then(&fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{
+					&fakeLayer{},
+					&fakeLayer{FilesContent: map[string]string{
+						"version.json": `{"version":"v1.60.2"}`,
+					}},
+				}, nil
+			},
+		}, nil)
 
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
 			"v1.56.0",

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -428,7 +428,52 @@ global:
 			},
 		}, nil)
 
+		dependency.TestDC.CRClient.ImageMock.When("v1.33.1").Then(&fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
+			},
+		}, nil)
+
 		suite.setupController("step-by-step-update-successfully.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+	})
+
+	suite.Run("Restore absent releases from a registry", func() {
+		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (i1 v1.Image, err error) {
+			if tag == "stable" {
+				tag = "v1.60.2"
+			}
+
+			return &fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{
+						&fakeLayer{},
+						&fakeLayer{FilesContent: map[string]string{
+							"version.json": fmt.Sprintf(`{"version":"%s"}`, tag),
+						}},
+					}, nil
+				},
+			}, nil
+		})
+
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.56.0",
+			"v1.57.0",
+			"v1.57.1",
+			"v1.57.2",
+			"v1.58.0",
+			"v1.58.1",
+			"v1.59.0",
+			"v1.59.1",
+			"v1.59.2",
+			"v1.59.3",
+			"v1.60.0",
+			"v1.60.1",
+			"v1.60.2",
+		}, nil)
+
+		suite.setupController("restore-absent-releases-from-registry.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
 		require.NoError(suite.T(), err)
 	})

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -99,11 +99,14 @@ type ControllerTestSuite struct {
 	ctr        *deckhouseReleaseReconciler
 
 	testDataFileName string
+	backupTZ         *time.Location
 }
 
 func (suite *ControllerTestSuite) SetupSuite() {
 	flag.Parse()
 	suite.T().Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
+	suite.backupTZ = time.Local
+	time.Local = dependency.TestTimeZone
 }
 
 func (suite *ControllerTestSuite) SetupSubTest() {
@@ -113,6 +116,10 @@ func (suite *ControllerTestSuite) SetupSubTest() {
 		Return(&http.Response{
 			StatusCode: http.StatusOK,
 		}, nil)
+}
+
+func (suite *ControllerTestSuite) TearDownSuite() {
+	time.Local = suite.backupTZ
 }
 
 func (suite *ControllerTestSuite) TearDownSubTest() {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 
@@ -50,10 +51,14 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/updater"
 )
 
-var golden bool
+var (
+	golden     bool
+	mDelimiter *regexp.Regexp
+)
 
 func init() {
 	flag.BoolVar(&golden, "golden", false, "generate golden files")
+	mDelimiter = regexp.MustCompile("(?m)^---$")
 }
 
 var embeddedMUP = &v1alpha1.ModuleUpdatePolicySpec{
@@ -112,15 +117,20 @@ func (suite *ControllerTestSuite) SetupSubTest() {
 
 func (suite *ControllerTestSuite) TearDownSubTest() {
 	goldenFile := filepath.Join("./testdata", "golden", suite.testDataFileName)
-	got := suite.fetchResults()
+	gotB := suite.fetchResults()
 
 	if golden {
-		err := os.WriteFile(goldenFile, got, 0666)
+		err := os.WriteFile(goldenFile, gotB, 0666)
 		require.NoError(suite.T(), err)
 	} else {
-		exp, err := os.ReadFile(goldenFile)
+		got := singleDocToManifests(gotB)
+		expB, err := os.ReadFile(goldenFile)
 		require.NoError(suite.T(), err)
-		assert.YAMLEq(suite.T(), string(exp), string(got))
+		exp := singleDocToManifests(expB)
+		assert.Equal(suite.T(), len(got), len(exp), "The number of `got` manifests must be equal to the number of `exp` manifests")
+		for i := range got {
+			assert.YAMLEq(suite.T(), exp[i], got[i], "Got and exp manifests must match")
+		}
 	}
 }
 func (suite *ControllerTestSuite) setupController(
@@ -662,6 +672,17 @@ func (suite *ControllerTestSuite) fetchResults() []byte {
 	}
 
 	return result.Bytes()
+}
+
+func singleDocToManifests(doc []byte) (result []string) {
+	split := mDelimiter.Split(string(doc), -1)
+
+	for i := range split {
+		if split[i] != "" {
+			result = append(result, split[i])
+		}
+	}
+	return
 }
 
 func (suite *ControllerTestSuite) getDeckhouseRelease(name string) *v1alpha1.DeckhouseRelease {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -90,7 +90,7 @@ func (suite *ReleaseTestSuite) TestCheckRelease() {
 	}
 
 	check("Patch", "1.31.0", "1.31.1", false)
-	check("Minor", "1.31.0", "1.32.0", false)
+	check("Minor", "1.31.0", "1.32.3", false)
 	check("Last Minor", "1.31.0", "1.32.3", false)
 	check("Fail Update", "1.31.0", "1.33.0", true)
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notification-basic-auth.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notification-basic-auth.yaml
@@ -29,7 +29,7 @@ spec:
   version: v1.36.0
 status:
   approved: false
-  message: 'Release is postponed until: 12 Nov 22 02:23 MSK'
+  message: 'Release is postponed until: 11 Nov 22 23:23 UTC'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notification-bearer-token-auth.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notification-bearer-token-auth.yaml
@@ -29,7 +29,7 @@ spec:
   version: v1.36.0
 status:
   approved: false
-  message: 'Release is postponed until: 12 Nov 22 02:23 MSK'
+  message: 'Release is postponed until: 11 Nov 22 23:23 UTC'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notification-release-apply-after-time-is-after-notification-period.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notification-release-apply-after-time-is-after-notification-period.yaml
@@ -29,7 +29,7 @@ spec:
   version: v1.36.0
 status:
   approved: false
-  message: 'Release is postponed until: 12 Nov 22 02:23 MSK'
+  message: 'Release is postponed until: 11 Nov 22 23:23 UTC'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/postponed-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/postponed-release.yaml
@@ -26,7 +26,7 @@ spec:
   version: v1.25.1
 status:
   approved: false
-  message: 'Release is postponed until: 12 Nov 22 02:23 MSK'
+  message: 'Release is postponed until: 11 Nov 22 23:23 UTC'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
@@ -4,10 +4,10 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
-  name: v1.31.0
+  name: v1.57.3
   resourceVersion: "999"
 spec:
-  version: v1.31.0
+  version: v1.57.3
 status:
   approved: false
   message: ""
@@ -22,11 +22,11 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.32.3
+  name: v1.58.1
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.32.3
-  version: v1.32.3
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.58.1
+  version: v1.58.1
 status:
   approved: false
   message: ""
@@ -40,11 +40,29 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.33.1
+  name: v1.59.3
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.33.1
-  version: v1.33.1
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.59.3
+  version: v1.59.3
+status:
+  approved: false
+  message: ""
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  name: v1.60.2
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.60.2
+  version: v1.60.2
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/restore-absent-releases-from-registry.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/restore-absent-releases-from-registry.yaml
@@ -1,0 +1,8 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.57.3
+spec:
+  version: "v1.57.3"
+status:
+  phase: Deployed

--- a/go_lib/dependency/dependency.go
+++ b/go_lib/dependency/dependency.go
@@ -54,8 +54,9 @@ type Container interface {
 }
 
 var (
-	defaultDC Container
-	TestDC    *mockedDependencyContainer
+	defaultDC    Container
+	TestDC       *mockedDependencyContainer
+	TestTimeZone = time.UTC
 )
 
 func init() {
@@ -346,7 +347,7 @@ func (mdc *mockedDependencyContainer) GetClock() clockwork.Clock {
 		return mdc.clock
 	}
 
-	t := time.Date(2019, time.October, 17, 15, 33, 0, 0, time.UTC)
+	t := time.Date(2019, time.October, 17, 15, 33, 0, 0, TestTimeZone)
 	cc := clockwork.NewFakeClockAt(t)
 	mdc.clock = cc
 	return cc


### PR DESCRIPTION
## Description
Restore absent releases from a registry
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/8991

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Restore absent releases from a registry
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
