### PR TITLE
[deckhouse] add skipped status

### DIFF
--- a/deckhouse-controller/crds/module-release.yaml
+++ b/deckhouse-controller/crds/module-release.yaml
@@ -68,6 +68,7 @@ spec:
                     - Deployed
                     - Superseded
                     - Suspended
+                    - Skipped
                   description: Current status of the release.
                 message:
                   type: string

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -441,17 +441,6 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 			modulesChangedReason = "one of modules is not enabled"
 		}
 
-		for _, index := range releaseUpdater.GetSkippedPatchesIndexes() {
-			release := otherReleases.Items[index]
-
-			release.Status.Phase = v1alpha1.PhaseSuperseded
-			release.Status.Message = ""
-			release.Status.TransitionTime = metav1.NewTime(c.dc.GetClock().Now().UTC())
-			if e := c.client.Status().Update(ctx, &release); e != nil {
-				return ctrl.Result{Requeue: true}, e
-			}
-		}
-
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
## Description
It provides missed skipped status for module release crd.

## Why do we need it, and what problem does it solve?
The module release controller can try to set status to Skipped, and it causes an error.

## Why do we need it in the patch release (if we do)?
The module release controller can try to set status to Skipped, and it causes a error.

## What is the expected result?
The Skipped status can be set.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
summary: Add skipped status.
```

