### PR TITLE
[go_lib] feat: add heritage label to all crds

### DIFF
--- a/go_lib/hooks/ensure_crds/hook_test.go
+++ b/go_lib/hooks/ensure_crds/hook_test.go
@@ -40,9 +40,10 @@ func TestEnsureCRDs(t *testing.T) {
 	//
 	list, err := cluster.Client.Dynamic().Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, list.Items, 4)
+	require.Len(t, list.Items, 5)
 
 	expected := []string{
+		"deschedulers.deckhouse.io",
 		"modulereleases.deckhouse.io",
 		"modules.deckhouse.io",
 		"modulesources.deckhouse.io",
@@ -51,6 +52,7 @@ func TestEnsureCRDs(t *testing.T) {
 
 	result := make([]string, 0, len(expected))
 	for _, item := range list.Items {
+		require.Equal(t, true, item.GetLabels()["heritage"] == "deckhouse")
 		result = append(result, item.GetName())
 	}
 	sort.Strings(result)

--- a/go_lib/hooks/ensure_crds/test_data/heritage.crd
+++ b/go_lib/hooks/ensure_crds/test_data/heritage.crd
@@ -1,0 +1,13 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: deschedulers.deckhouse.io
+spec:
+  group: deckhouse.io
+  names:
+    kind: Descheduler
+    listKind: DeschedulerList
+    plural: deschedulers
+    singular: descheduler
+  scope: Cluster


### PR DESCRIPTION
## Description

Fixed: #9268

## Why do we need it, and what problem does it solve?

We have a protection to delete deckhouse installed CRDs. But some CRDs are not marked as deckhouse controlled.

## What is the expected result?

All created crd must have the deckhouse label

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: go_lib
type: feature
summary: add heritage label to all crds
impact_level: default
```
