### PR TITLE
[istio] Fixed operability in managed k8s setups

### DIFF
--- a/modules/110-istio/hooks/discovery_preflight_check.go
+++ b/modules/110-istio/hooks/discovery_preflight_check.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -78,9 +79,16 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 }
 
 func discoveryIsK8sVersionAutomatic(input *go_hook.HookInput) error {
+	var kubernetesVersionStr string
 	kubernetesVersion, ok := input.Snapshots["kubernetesVersion"]
 	if !ok || len(kubernetesVersion) == 0 {
-		return errors.New("cluster configuration kubernetesVersion is empty or invalid")
+		versionParts := strings.Split(input.Values.Get("global.discovery.kubernetesVersion").String(), ".")
+		if len(versionParts) < 2 {
+			return errors.New("cluster configuration kubernetesVersion is empty or invalid")
+		}
+		kubernetesVersionStr = versionParts[0] + "." + versionParts[1]
+	} else {
+		kubernetesVersionStr = kubernetesVersion[0].(string)
 	}
 
 	// Get array of compatibility k8s versions for every operator version
@@ -88,7 +96,7 @@ func discoveryIsK8sVersionAutomatic(input *go_hook.HookInput) error {
 	_ = json.Unmarshal([]byte(input.Values.Get("istio.internal.istioToK8sCompatibilityMap").String()), &k8sCompatibleVersions)
 	requirements.SaveValue(istioToK8sCompatibilityMapKey, k8sCompatibleVersions)
 
-	requirements.SaveValue(isK8sVersionAutomaticKey, kubernetesVersion[0].(string) == "Automatic")
+	requirements.SaveValue(isK8sVersionAutomaticKey, kubernetesVersionStr == "Automatic")
 
 	return nil
 }

--- a/modules/110-istio/hooks/discovery_preflight_check.go
+++ b/modules/110-istio/hooks/discovery_preflight_check.go
@@ -42,7 +42,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: lib.Queue("istio-k8s-auto-discovery"),
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:              "kubernetesVersion",
+			Name:              "cluster-configuration",
 			ApiVersion:        "v1",
 			Kind:              "Secret",
 			NamespaceSelector: &types.NamespaceSelector{NameSelector: &types.NameSelector{MatchNames: []string{"kube-system"}}},
@@ -80,7 +80,7 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 
 func discoveryIsK8sVersionAutomatic(input *go_hook.HookInput) error {
 	var kubernetesVersionStr string
-	clusterConfigurationSnapshots, ok := input.Snapshots["kubernetesVersion"]
+	clusterConfigurationSnapshots, ok := input.Snapshots["cluster-configuration"]
 	if !ok || len(clusterConfigurationSnapshots) == 0 {
 		versionParts := strings.Split(input.Values.Get("global.discovery.kubernetesVersion").String(), ".")
 		if len(versionParts) < 2 {

--- a/modules/110-istio/hooks/discovery_preflight_check.go
+++ b/modules/110-istio/hooks/discovery_preflight_check.go
@@ -80,15 +80,15 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 
 func discoveryIsK8sVersionAutomatic(input *go_hook.HookInput) error {
 	var kubernetesVersionStr string
-	kubernetesVersion, ok := input.Snapshots["kubernetesVersion"]
-	if !ok || len(kubernetesVersion) == 0 {
+	clusterConfigurationSnapshots, ok := input.Snapshots["kubernetesVersion"]
+	if !ok || len(clusterConfigurationSnapshots) == 0 {
 		versionParts := strings.Split(input.Values.Get("global.discovery.kubernetesVersion").String(), ".")
 		if len(versionParts) < 2 {
 			return errors.New("cluster configuration kubernetesVersion is empty or invalid")
 		}
 		kubernetesVersionStr = versionParts[0] + "." + versionParts[1]
 	} else {
-		kubernetesVersionStr = kubernetesVersion[0].(string)
+		kubernetesVersionStr = clusterConfigurationSnapshots[0].(string)
 	}
 
 	// Get array of compatibility k8s versions for every operator version

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -39,7 +39,7 @@ securityContext:
 
 {{ $supportedProviders := list "aws" "gcp" "azure" }}
 {{ $cloudPlatform := "none" }}
-{{ if hasKey .Values.global.clusterConfiguration "cloud" }}
+{{ if and (.Values.global.clusterConfiguration) (hasKey .Values.global.clusterConfiguration "cloud") }}
   {{ $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower }}
   {{ if has $currentProvider $supportedProviders }}
     {{ $cloudPlatform = $currentProvider }}

--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -98,3 +98,11 @@ metadata:
   name: vertical-pod-autoscaler
 spec:
   enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: istio
+spec:
+  version: 2
+  enabled: true

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script.sh
@@ -149,8 +149,7 @@ Ingress $ingress_inlet check: $([ "$ingress" == "ok" ] && echo "success" || echo
 EOF
   fi
 
-  bundle=$(kubectl get mc deckhouse -o jsonpath='{.spec.settings.bundle}')
-  if [ "$bundle" == "Minimal" ] || kubectl -n d8-istio get po | grep istiod | grep -q Running; then
+  if kubectl -n d8-istio get po | grep istiod | grep -q Running; then
     istio="ok"
   else
     istio=""

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_script_eks.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_script_eks.sh
@@ -149,7 +149,17 @@ Ingress $ingress_inlet check: $([ "$ingress" == "ok" ] && echo "success" || echo
 EOF
   fi
 
-  if [[ "$availability:$ingress" == "ok:ok" ]]; then
+  if kubectl -n d8-istio get po | grep istiod | grep -q Running; then
+    istio="ok"
+  else
+    istio=""
+  fi
+
+    cat <<EOF
+Istio operator check: $([ "$istio" == "ok" ] && echo "success" || echo "failed")
+EOF
+
+  if [[ "$availability:$ingress:$istio" == "ok:ok:ok" ]]; then
     exit 0
   fi
 done


### PR DESCRIPTION
## Description
Fixed istio module operability in managed k8s setups.

## Why do we need it, and what problem does it solve?
There is no way to run the istio module and its tests on managed clusters with minimal bundle (such EKS).

## Why do we need it in the patch release (if we do)?
There is a customer who considers using istio in EKS.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: istio
type: fix
summary: Fixed istio module operability in managed k8s setups.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
