### PR TITLE
[e2e] vcd e2e workflow renaming

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -11,7 +11,7 @@
 {!{- if eq $ctx.provider "vsphere"  -}!}
 {!{-   $layout = "Standard" -}!}
 {!{- end -}!}
-{!{- if eq $ctx.provider "vclouddirector"  -}!}
+{!{- if eq $ctx.provider "vcd"  -}!}
 {!{-   $layout = "Standard" -}!}
 {!{- end -}!}
 {!{- if eq $ctx.provider "static"  -}!}
@@ -86,7 +86,7 @@
 {!{- else if eq $provider "vsphere" }!}
   LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
   LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
-{!{- else if eq $provider "vclouddirector" }!}
+{!{- else if eq $provider "vcd" }!}
   LAYOUT_VCD_PASSWORD: ${{ secrets.LAYOUT_VCD_PASSWORD }}
   LAYOUT_VCD_USERNAME: ${{ secrets.LAYOUT_VCD_USERNAME }}
   LAYOUT_STATIC_BASTION_IP: 80.249.129.56
@@ -136,7 +136,7 @@ run: |
   bastion_ip_file=""
   if [[ "${PROVIDER}" == "Static" ]] ; then
     bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-  elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+  elif [[ "${PROVIDER}" == "VCD" ]] ; then
     bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
   fi
 
@@ -244,7 +244,7 @@ run: |
 {!{- else if eq $provider "vsphere" }!}
     -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
     -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
-{!{- else if eq $provider "vclouddirector" }!}
+{!{- else if eq $provider "vcd" }!}
     -e LAYOUT_VCD_PASSWORD=${LAYOUT_VCD_PASSWORD:-not_provided} \
     -e LAYOUT_VCD_USERNAME=${LAYOUT_VCD_USERNAME:-not_provided} \
     -e LAYOUT_VCD_SERVER=${LAYOUT_VCD_SERVER:-not_provided} \

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -34,7 +34,7 @@ const labels = {
   'e2e/run/gcp': { type: 'e2e-run', provider: 'gcp' },
   'e2e/run/openstack': { type: 'e2e-run', provider: 'openstack' },
   'e2e/run/vsphere': { type: 'e2e-run', provider: 'vsphere' },
-  'e2e/run/vcd': { type: 'e2e-run', provider: 'vclouddirector' },
+  'e2e/run/vcd': { type: 'e2e-run', provider: 'vcd' },
   'e2e/run/yandex-cloud': { type: 'e2e-run', provider: 'yandex-cloud' },
   'e2e/run/static': { type: 'e2e-run', provider: 'static' },
 

--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -49,7 +49,7 @@ jobs:
 {!{/* Jobs for each CRI and Kubernetes version */}!}
 {!{- $criName := "Containerd" -}!}
 {!{- $kubernetesVersion := "1.27" -}!}
-{!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "vCloudDirector" "Static" -}!}
+{!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "VCD" "Static" -}!}
 {!{- if $enableWorkflowOnTestRepos -}!}
 {!{-   $providerNames = slice "AWS" "OpenStack" "Azure" -}!}
 {!{- end -}!}

--- a/.github/workflow_templates/e2e.abort.multi.yml
+++ b/.github/workflow_templates/e2e.abort.multi.yml
@@ -32,7 +32,7 @@ $CI_COMMIT_REF_SLUG is a tag of published deckhouse images. It has a form
 
 */}!}
 
-{!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "vCloudDirector" "Static" "EKS" -}!}
+{!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "VCD" "Static" "EKS" -}!}
 {!{- $criNames := slice "Containerd" -}!}
 {!{- $kubernetesVersions := slice "1.26" "1.27" "1.28" "1.29" "1.30" "Automatic" -}!}
 

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -32,7 +32,7 @@ $CI_COMMIT_REF_SLUG is a tag of published deckhouse images. It has a form
 
 */}!}
 
-{!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "vCloudDirector" "Static" "EKS" -}!}
+{!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "VCD" "Static" "EKS" -}!}
 {!{- $criNames := slice "Containerd" -}!}
 {!{- $kubernetesVersions := slice "1.26" "1.27" "1.28" "1.29" "1.30" "Automatic" -}!}
 

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -3,7 +3,7 @@
 #
 
 # <template: e2e_workflow_template>
-name: 'destroy cluster: vCloudDirector'
+name: 'destroy cluster: VCD'
 on:
   workflow_dispatch:
     inputs:
@@ -74,10 +74,10 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "destroy cluster: vCloudDirector, Containerd, Kubernetes 1.26"
+    name: "destroy cluster: VCD, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -222,7 +222,7 @@ jobs:
         if: ${{ success() }}
         id: cleanup_cluster
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.26"
@@ -337,7 +337,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.26';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -358,10 +358,10 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "destroy cluster: vCloudDirector, Containerd, Kubernetes 1.27"
+    name: "destroy cluster: VCD, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
@@ -392,7 +392,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -506,7 +506,7 @@ jobs:
         if: ${{ success() }}
         id: cleanup_cluster
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.27"
@@ -621,7 +621,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.27';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -642,10 +642,10 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "destroy cluster: vCloudDirector, Containerd, Kubernetes 1.28"
+    name: "destroy cluster: VCD, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
@@ -676,7 +676,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -790,7 +790,7 @@ jobs:
         if: ${{ success() }}
         id: cleanup_cluster
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.28"
@@ -905,7 +905,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.28';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -926,10 +926,10 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_29:
-    name: "destroy cluster: vCloudDirector, Containerd, Kubernetes 1.29"
+    name: "destroy cluster: VCD, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
@@ -960,7 +960,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.29';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.29';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1074,7 +1074,7 @@ jobs:
         if: ${{ success() }}
         id: cleanup_cluster
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.29"
@@ -1189,7 +1189,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.29';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.29';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1210,10 +1210,10 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_30:
-    name: "destroy cluster: vCloudDirector, Containerd, Kubernetes 1.30"
+    name: "destroy cluster: VCD, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
@@ -1244,7 +1244,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.30';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.30';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1358,7 +1358,7 @@ jobs:
         if: ${{ success() }}
         id: cleanup_cluster
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.30"
@@ -1473,7 +1473,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes 1.30';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes 1.30';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1494,10 +1494,10 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_automatic:
-    name: "destroy cluster: vCloudDirector, Containerd, Kubernetes Automatic"
+    name: "destroy cluster: VCD, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
@@ -1528,7 +1528,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes Automatic';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes Automatic';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1642,7 +1642,7 @@ jobs:
         if: ${{ success() }}
         id: cleanup_cluster
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "Automatic"
@@ -1757,7 +1757,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'destroy cluster: vCloudDirector, Containerd, Kubernetes Automatic';
+            const name = 'destroy cluster: VCD, Containerd, Kubernetes Automatic';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1784,7 +1784,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_26":"destroy cluster: vCloudDirector, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: vCloudDirector, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: vCloudDirector, Containerd, Kubernetes 1.28","run_containerd_1_29":"destroy cluster: vCloudDirector, Containerd, Kubernetes 1.29","run_containerd_1_30":"destroy cluster: vCloudDirector, Containerd, Kubernetes 1.30","run_containerd_automatic":"destroy cluster: vCloudDirector, Containerd, Kubernetes Automatic"}
+        {"run_containerd_1_26":"destroy cluster: VCD, Containerd, Kubernetes 1.26","run_containerd_1_27":"destroy cluster: VCD, Containerd, Kubernetes 1.27","run_containerd_1_28":"destroy cluster: VCD, Containerd, Kubernetes 1.28","run_containerd_1_29":"destroy cluster: VCD, Containerd, Kubernetes 1.29","run_containerd_1_30":"destroy cluster: VCD, Containerd, Kubernetes 1.30","run_containerd_automatic":"destroy cluster: VCD, Containerd, Kubernetes Automatic"}
     steps:
 
       # <template: checkout_step>
@@ -1806,7 +1806,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'destroy cluster: vCloudDirector';
+            const name = 'destroy cluster: VCD';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -466,7 +466,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -937,7 +937,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1408,7 +1408,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1879,7 +1879,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2350,7 +2350,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2821,7 +2821,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -468,7 +468,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -947,7 +947,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1426,7 +1426,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1905,7 +1905,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2384,7 +2384,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2863,7 +2863,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -2787,8 +2787,8 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  run_vclouddirector_containerd_1_27:
-    name: "vCloudDirector, Containerd, Kubernetes 1.27"
+  run_vcd_containerd_1_27:
+    name: "VCD, Containerd, Kubernetes 1.27"
     needs:
       - git_info
     outputs:
@@ -2797,12 +2797,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;1.27"
+      ran_for: "vcd;Standard;containerd;1.27"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
@@ -2990,11 +2990,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/1.27"
+      - name: "Run e2e test: VCD/Containerd/1.27"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.27"
@@ -3069,7 +3069,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.27"
@@ -3143,7 +3143,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_1_27
+          name: failed_cluster_state_vcd_containerd_1_27
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -3153,7 +3153,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_1_27
+          name: test_output_vcd_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -3206,7 +3206,7 @@ jobs:
               "cri": "Containerd",
               "kube_version": "1.27",
               "layout": "Standard",
-              "provider": "vCloudDirector",
+              "provider": "VCD",
               "trigger": "CloudLayoutTestFailed",
 
               "severity_level": 7
@@ -3682,7 +3682,7 @@ jobs:
   send_alert_about_workflow_problem:
     name: Send alert about workflow problem
     runs-on: ubuntu-latest
-    needs: ["skip_tests_repos","git_info","run_aws_containerd_1_27","run_azure_containerd_1_27","run_gcp_containerd_1_27","run_yandex_cloud_containerd_1_27","run_openstack_containerd_1_27","run_vsphere_containerd_1_27","run_vclouddirector_containerd_1_27","run_static_containerd_1_27"]
+    needs: ["skip_tests_repos","git_info","run_aws_containerd_1_27","run_azure_containerd_1_27","run_gcp_containerd_1_27","run_yandex_cloud_containerd_1_27","run_openstack_containerd_1_27","run_vsphere_containerd_1_27","run_vcd_containerd_1_27","run_static_containerd_1_27"]
     if: ${{ failure() }}
     steps:
 

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -474,7 +474,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -988,7 +988,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1502,7 +1502,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2016,7 +2016,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2530,7 +2530,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -3044,7 +3044,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -465,7 +465,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -932,7 +932,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1399,7 +1399,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1866,7 +1866,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2333,7 +2333,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2800,7 +2800,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -465,7 +465,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -932,7 +932,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1399,7 +1399,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1866,7 +1866,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2333,7 +2333,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2800,7 +2800,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -465,7 +465,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -932,7 +932,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1399,7 +1399,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1866,7 +1866,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2333,7 +2333,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2800,7 +2800,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 # <template: e2e_workflow_template>
-name: 'e2e: vCloudDirector'
+name: 'e2e: VCD'
 on:
   workflow_dispatch:
     inputs:
@@ -185,7 +185,7 @@ jobs:
         uses: actions/github-script@v6.4.1
         with:
           script: |
-            const provider = 'vclouddirector';
+            const provider = 'vcd';
             const kubernetesDefaultVersion = '1.27';
 
             const ci = require('./.github/scripts/js/ci');
@@ -195,7 +195,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_26:
-    name: "e2e: vCloudDirector, Containerd, Kubernetes 1.26"
+    name: "e2e: VCD, Containerd, Kubernetes 1.26"
     needs:
       - check_e2e_labels
       - git_info
@@ -206,12 +206,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;1.26"
+      ran_for: "vcd;Standard;containerd;1.26"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
@@ -242,7 +242,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.26';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.26';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -413,11 +413,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/1.26"
+      - name: "Run e2e test: VCD/Containerd/1.26"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.26"
@@ -469,7 +469,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -530,7 +530,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.26"
@@ -604,7 +604,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_1_26
+          name: failed_cluster_state_vcd_containerd_1_26
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -614,7 +614,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_1_26
+          name: test_output_vcd_containerd_1_26
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -657,7 +657,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.26';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.26';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -678,7 +678,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_27:
-    name: "e2e: vCloudDirector, Containerd, Kubernetes 1.27"
+    name: "e2e: VCD, Containerd, Kubernetes 1.27"
     needs:
       - check_e2e_labels
       - git_info
@@ -689,12 +689,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;1.27"
+      ran_for: "vcd;Standard;containerd;1.27"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
@@ -725,7 +725,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.27';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.27';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -896,11 +896,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/1.27"
+      - name: "Run e2e test: VCD/Containerd/1.27"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.27"
@@ -952,7 +952,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1013,7 +1013,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.27"
@@ -1087,7 +1087,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_1_27
+          name: failed_cluster_state_vcd_containerd_1_27
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -1097,7 +1097,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_1_27
+          name: test_output_vcd_containerd_1_27
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -1140,7 +1140,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.27';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.27';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1161,7 +1161,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_28:
-    name: "e2e: vCloudDirector, Containerd, Kubernetes 1.28"
+    name: "e2e: VCD, Containerd, Kubernetes 1.28"
     needs:
       - check_e2e_labels
       - git_info
@@ -1172,12 +1172,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;1.28"
+      ran_for: "vcd;Standard;containerd;1.28"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
@@ -1208,7 +1208,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.28';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.28';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1379,11 +1379,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/1.28"
+      - name: "Run e2e test: VCD/Containerd/1.28"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.28"
@@ -1435,7 +1435,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1496,7 +1496,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.28"
@@ -1570,7 +1570,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_1_28
+          name: failed_cluster_state_vcd_containerd_1_28
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -1580,7 +1580,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_1_28
+          name: test_output_vcd_containerd_1_28
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -1623,7 +1623,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.28';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.28';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1644,7 +1644,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_29:
-    name: "e2e: vCloudDirector, Containerd, Kubernetes 1.29"
+    name: "e2e: VCD, Containerd, Kubernetes 1.29"
     needs:
       - check_e2e_labels
       - git_info
@@ -1655,12 +1655,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;1.29"
+      ran_for: "vcd;Standard;containerd;1.29"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
@@ -1691,7 +1691,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.29';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.29';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1862,11 +1862,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/1.29"
+      - name: "Run e2e test: VCD/Containerd/1.29"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.29"
@@ -1918,7 +1918,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1979,7 +1979,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.29"
@@ -2053,7 +2053,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_1_29
+          name: failed_cluster_state_vcd_containerd_1_29
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -2063,7 +2063,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_1_29
+          name: test_output_vcd_containerd_1_29
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -2106,7 +2106,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.29';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.29';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -2127,7 +2127,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_30:
-    name: "e2e: vCloudDirector, Containerd, Kubernetes 1.30"
+    name: "e2e: VCD, Containerd, Kubernetes 1.30"
     needs:
       - check_e2e_labels
       - git_info
@@ -2138,12 +2138,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;1.30"
+      ran_for: "vcd;Standard;containerd;1.30"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
@@ -2174,7 +2174,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.30';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.30';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2345,11 +2345,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/1.30"
+      - name: "Run e2e test: VCD/Containerd/1.30"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.30"
@@ -2401,7 +2401,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2462,7 +2462,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.30"
@@ -2536,7 +2536,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_1_30
+          name: failed_cluster_state_vcd_containerd_1_30
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -2546,7 +2546,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_1_30
+          name: test_output_vcd_containerd_1_30
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -2589,7 +2589,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes 1.30';
+            const name = 'e2e: VCD, Containerd, Kubernetes 1.30';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -2610,7 +2610,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_Automatic:
-    name: "e2e: vCloudDirector, Containerd, Kubernetes Automatic"
+    name: "e2e: VCD, Containerd, Kubernetes Automatic"
     needs:
       - check_e2e_labels
       - git_info
@@ -2621,12 +2621,12 @@ jobs:
       run_id: ${{ github.run_id }}
       # need for find state in artifact
       cluster_prefix: ${{ steps.setup.outputs.dhctl-prefix }}
-      ran_for: "vclouddirector;Standard;containerd;Automatic"
+      ran_for: "vcd;Standard;containerd;Automatic"
       failed_cluster_stayed: ${{ steps.check_stay_failed_cluster.outputs.failed_cluster_stayed }}
       issue_number: ${{ inputs.issue_number }}
       install_image_path: ${{ steps.setup.outputs.install-image-path }}
     env:
-      PROVIDER: vCloudDirector
+      PROVIDER: VCD
       CRI: Containerd
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
@@ -2657,7 +2657,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes Automatic';
+            const name = 'e2e: VCD, Containerd, Kubernetes Automatic';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2828,11 +2828,11 @@ jobs:
 
           echo '::echo::off'
 
-      - name: "Run e2e test: vCloudDirector/Containerd/Automatic"
+      - name: "Run e2e test: VCD/Containerd/Automatic"
         id: e2e_test_run
         timeout-minutes: 80
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "Automatic"
@@ -2884,7 +2884,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2945,7 +2945,7 @@ jobs:
         id: cleanup_cluster
         timeout-minutes: 60
         env:
-          PROVIDER: vCloudDirector
+          PROVIDER: VCD
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "Automatic"
@@ -3019,7 +3019,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: failed_cluster_state_vclouddirector_containerd_Automatic
+          name: failed_cluster_state_vcd_containerd_Automatic
           path: |
             ${{ steps.setup.outputs.tmp-dir-path}}/dhctl
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
@@ -3029,7 +3029,7 @@ jobs:
         if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: test_output_vclouddirector_containerd_Automatic
+          name: test_output_vcd_containerd_Automatic
           path: |
             ${{ steps.setup.outputs.dhctl-log-file}}*
             ${{ steps.setup.outputs.tmp-dir-path}}/logs
@@ -3072,7 +3072,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,separate';
-            const name = 'e2e: vCloudDirector, Containerd, Kubernetes Automatic';
+            const name = 'e2e: VCD, Containerd, Kubernetes Automatic';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -3099,7 +3099,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_26":"e2e: vCloudDirector, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e: vCloudDirector, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e: vCloudDirector, Containerd, Kubernetes 1.28","run_containerd_1_29":"e2e: vCloudDirector, Containerd, Kubernetes 1.29","run_containerd_1_30":"e2e: vCloudDirector, Containerd, Kubernetes 1.30","run_containerd_Automatic":"e2e: vCloudDirector, Containerd, Kubernetes Automatic"}
+        {"run_containerd_1_26":"e2e: VCD, Containerd, Kubernetes 1.26","run_containerd_1_27":"e2e: VCD, Containerd, Kubernetes 1.27","run_containerd_1_28":"e2e: VCD, Containerd, Kubernetes 1.28","run_containerd_1_29":"e2e: VCD, Containerd, Kubernetes 1.29","run_containerd_1_30":"e2e: VCD, Containerd, Kubernetes 1.30","run_containerd_Automatic":"e2e: VCD, Containerd, Kubernetes Automatic"}
     steps:
 
       # <template: checkout_step>
@@ -3121,7 +3121,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'workflow,final,no-skipped,restore-separate';
-            const name = 'e2e: vCloudDirector';
+            const name = 'e2e: VCD';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -466,7 +466,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -937,7 +937,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1408,7 +1408,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1879,7 +1879,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2350,7 +2350,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2821,7 +2821,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -467,7 +467,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -942,7 +942,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1417,7 +1417,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -1892,7 +1892,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2367,7 +2367,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 
@@ -2842,7 +2842,7 @@ jobs:
           bastion_ip_file=""
           if [[ "${PROVIDER}" == "Static" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-ssh-bastion-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
-          elif [[ "${PROVIDER}" == "vCloudDirector" ]] ; then
+          elif [[ "${PROVIDER}" == "VCD" ]] ; then
             bastion_ip_file="${DHCTL_LOG_FILE}-${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION}"
           fi
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -80,7 +80,7 @@ Provider specific environment variables:
 
 \$LAYOUT_VSPHERE_PASSWORD
 
-  vCloudDirector:
+  VCD:
 
 \$LAYOUT_VCLOUD_DIRECTOR_PASSWORD
 
@@ -338,7 +338,7 @@ function prepare_environment() {
     ssh_user="ubuntu"
     ;;
 
-"vCloudDirector")
+"VCD")
     # shellcheck disable=SC2016
     env VCD_PASSWORD="$(base64 -d <<<"$LAYOUT_VCD_PASSWORD")" \
         KUBERNETES_VERSION="$KUBERNETES_VERSION" \


### PR DESCRIPTION
## Description

Renaming VCD e2e tests. Fixes the issue of running tests via comments, e.g., `/e2e/run/vcd release-123`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
