### PR TITLE
[docs] Refactor resource block styles in the documentation

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -462,7 +462,7 @@ module Jekyll
                 parameterTextContent = sprintf(%q(<div id="%s" data-anchor-id="%s" class="resources__prop_name anchored">
                     <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
                     <span  class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-                    <span class="ancestors">%s</span><span>%s</span></div>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
+                    <div><span class="ancestors">%s</span><span>%s</span></div></div>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
             end
 
             if attributesType != ''

--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -458,7 +458,10 @@ module Jekyll
             if ( get_hash_value(attributes, 'x-doc-deprecated') or get_hash_value(attributes, 'deprecated') )
                 parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_title anchored"><span class="ancestors">%s</span><span>%s</span><span data-tippy-content="%s" class="resources__prop_is_deprecated">%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle,get_i18n_term('deprecated_parameter_hint'), get_i18n_term('deprecated_parameter') )
             else
-                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_name anchored"><span class="ancestors">%s</span><span>%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
+                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_name anchored">
+                    <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+                    <span  class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+                    <span class="ancestors">%s</span><span>%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
             end
 
             if attributesType != ''

--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -446,6 +446,7 @@ module Jekyll
         if parameterTitle != ''
             parameterTextContent = ''
             result.push('<li>')
+            result.push('<div class="resources__prop_wrap">')
             attributesType = ''
             if attributes.is_a?(Hash)
               if attributes.has_key?('type')
@@ -484,6 +485,7 @@ module Jekyll
           end
         end
 
+        result.push('</div>')
 
         if attributes.is_a?(Hash) and attributes.has_key?("properties")
             result.push('<ul>')

--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -458,10 +458,10 @@ module Jekyll
             if ( get_hash_value(attributes, 'x-doc-deprecated') or get_hash_value(attributes, 'deprecated') )
                 parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_title anchored"><span class="ancestors">%s</span><span>%s</span><span data-tippy-content="%s" class="resources__prop_is_deprecated">%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle,get_i18n_term('deprecated_parameter_hint'), get_i18n_term('deprecated_parameter') )
             else
-                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_name anchored">
+                parameterTextContent = sprintf(%q(<div id="%s" data-anchor-id="%s" class="resources__prop_name anchored">
                     <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
                     <span  class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-                    <span class="ancestors">%s</span><span>%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
+                    <span class="ancestors">%s</span><span>%s</span></div>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
             end
 
             if attributesType != ''

--- a/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
+++ b/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
@@ -48,7 +48,7 @@ markup:
     lineNoStart: 1
     lineNos: false
     lineNumbersInTable: true
-    noClasses: true
+    noClasses: false
     noHl: false
     style: native
     tabWidth: 4

--- a/docs/site/backends/docs-builder-template/layouts/_default/modules.html
+++ b/docs/site/backends/docs-builder-template/layouts/_default/modules.html
@@ -33,7 +33,7 @@
 {{ $sidebarRootMenu = sort $sidebarRootMenu "title" "asc" }}
 
 
-<div class="docs docs--modules">
+<div class="docs docs-modules">
     <div class="docs__wrap-title">
         <h1 class="docs__title">{{ .Title }}</h1>
     </div>

--- a/docs/site/backends/docs-builder-template/layouts/_default/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/_default/single.html
@@ -15,7 +15,7 @@
   {{- end}}
 {{- end}}
 
-<div class="docs docs--modules">
+<div class="docs docs-modules">
     <div class="docs__wrap-title">
         <h1 class="docs__title">{{ .Title }}</h1>
     </div>

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
@@ -126,26 +126,38 @@
   {{- if and $isArray }}<br>
     {{- range $example }}
       {{- if reflect.IsMap . }}
-         {{- transform.Highlight ( transform.Remarshal "yaml" ( . | jsonify ) ) "yaml" $hl_opts }}
+        <div class="language-yaml highlighter-rouge">
+          {{- transform.Highlight ( transform.Remarshal "yaml" ( . | jsonify ) ) "yaml" $hl_opts }}
+        </div>
       {{- else if reflect.IsSlice . }}
-         {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}
+        <div class="language-yaml highlighter-rouge">
+          {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}
+        </div>
       {{- else }}
          {{- if hasPrefix . "```" }}
            {{- . | markdownify }}
          {{- else }}
-           {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}
+           <div class="language-yaml highlighter-rouge">
+             {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}
+           </div>
          {{- end }}
       {{- end }}
     {{- end }}
   {{- else if reflect.IsMap $example }}
-     {{- transform.Highlight ( transform.Remarshal "yaml" ( $example | jsonify ) ) "yaml" $hl_opts }}
+    <div class="language-yaml highlighter-rouge">
+      {{- transform.Highlight ( transform.Remarshal "yaml" ( $example | jsonify ) ) "yaml" $hl_opts }}
+    </div>
   {{- else if reflect.IsSlice $example }}
-     {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $example ) ) "yaml" $hl_opts }}
+    <div class="language-yaml highlighter-rouge">
+      {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $example ) ) "yaml" $hl_opts }}
+    </div>
   {{- else }}
-     {{- if hasPrefix $example "```" }}
-       {{- $example | markdownify }}
-     {{- else }}
-       {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $example ) ) "yaml" $hl_opts }}
+    {{- if hasPrefix $example "```" }}
+      {{- $example | markdownify }}
+    {{- else }}
+      <div class="language-yaml highlighter-rouge">
+        {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $example ) ) "yaml" $hl_opts }}
+      </div>
      {{- end }}
   {{- end }}
 {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
@@ -122,43 +122,34 @@
   {{- end }}
 
 <p class="resources__attrs"><span class="resources__attrs_name">{{ $title }}:</span>
+  <div class="language-yaml highlighter-rouge">
 
   {{- if and $isArray }}<br>
     {{- range $example }}
       {{- if reflect.IsMap . }}
-        <div class="language-yaml highlighter-rouge">
           {{- transform.Highlight ( transform.Remarshal "yaml" ( . | jsonify ) ) "yaml" $hl_opts }}
-        </div>
       {{- else if reflect.IsSlice . }}
-        <div class="language-yaml highlighter-rouge">
           {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}
-        </div>
       {{- else }}
          {{- if hasPrefix . "```" }}
            {{- . | markdownify }}
          {{- else }}
-           <div class="language-yaml highlighter-rouge">
              {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}
-           </div>
          {{- end }}
       {{- end }}
     {{- end }}
   {{- else if reflect.IsMap $example }}
-    <div class="language-yaml highlighter-rouge">
       {{- transform.Highlight ( transform.Remarshal "yaml" ( $example | jsonify ) ) "yaml" $hl_opts }}
-    </div>
   {{- else if reflect.IsSlice $example }}
-    <div class="language-yaml highlighter-rouge">
       {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $example ) ) "yaml" $hl_opts }}
-    </div>
   {{- else }}
     {{- if hasPrefix $example "```" }}
       {{- $example | markdownify }}
     {{- else }}
-      <div class="language-yaml highlighter-rouge">
         {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $example ) ) "yaml" $hl_opts }}
-      </div>
      {{- end }}
   {{- end }}
+  </div>
+
 {{- end }}
 

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
@@ -46,11 +46,14 @@
 
 {{- if gt ($parameterTitle | len ) 0 }}
   <li>
-
+    <div class="resources__prop_wrap">
   {{- if and (reflect.IsMap $data) (or (index $data "x-doc-deprecated") (index $data "deprecated")) }}
   <span id="{{ $linkAnchor }}" data-anchor-id="{{ $linkAnchor }}" class="resources__prop_title anchored"><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span><span data-tippy-content="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span></span>
   {{- else }}
-  <span id="{{ $linkAnchor }}" data-anchor-id="{{ $linkAnchor }}" class="resources__prop_name anchored"><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></span>
+  <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
+  <span class="plus-icon"><svg fill="none" height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></svg></span>
+                    <span  class="minus-icon"><svg fill="none" height="8" viewBox="0 0 10 8" width="10" xmlns="http://www.w3.org/2000/svg"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></svg></span>
+  <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div></div>
   {{- end }}
 
   {{ if reflect.IsMap $data }}
@@ -68,6 +71,8 @@
 {{- if reflect.IsMap $data }}
   {{- partial "openapi/format-attributes" ( dict "name" $name "attributes" $data "parent" $parent "langData" $langData "linkAnchor" $linkAnchor) }}
 {{- end }}
+
+</div>
 
 {{ if and (reflect.IsMap $data) $data.properties }}
   {{- $requiredParameters := $data.required }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
@@ -51,9 +51,10 @@
   <span id="{{ $linkAnchor }}" data-anchor-id="{{ $linkAnchor }}" class="resources__prop_title anchored"><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span><span data-tippy-content="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span></span>
   {{- else }}
   <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
-  <span class="plus-icon"><svg fill="none" height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></svg></span>
-                    <span  class="minus-icon"><svg fill="none" height="8" viewBox="0 0 10 8" width="10" xmlns="http://www.w3.org/2000/svg"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></svg></span>
-  <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div></div>
+    <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+    <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+    <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
+  </div>
   {{- end }}
 
   {{ if reflect.IsMap $data }}

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -28,7 +28,8 @@
     }
 
     &_name {
-      display: block;
+      display: flex;
+      gap: 11px;
       color: $color-main;
       font-weight: $font-weight-bold;
       font-family: monospace, 'Source Code Pro';
@@ -37,8 +38,8 @@
       cursor: pointer;
     }
 
-    &_name > .ancestors,
-    &_title > .ancestors {
+    &_name .ancestors,
+    &_title .ancestors {
       opacity: 55%;
       word-break: break-all;
     }
@@ -50,11 +51,6 @@
       text-transform: uppercase;
       line-height: 22px;
       margin-left: 20px;
-
-      //&:has(+ .resources__prop_description),
-      //&:has(+ .resources__attrs) {
-      //  padding-bottom: $text-spacing-s;
-      //}
 
       & + p.resources__attrs.required {
         display: inline-flex;

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -51,9 +51,10 @@
       line-height: 22px;
       margin-left: 20px;
 
-      &:has(+ .resources__prop_description) {
-        padding-bottom: $text-spacing-s;
-      }
+      //&:has(+ .resources__prop_description),
+      //&:has(+ .resources__attrs) {
+      //  padding-bottom: $text-spacing-s;
+      //}
 
       & + p.resources__attrs.required {
         display: inline-flex;
@@ -65,6 +66,7 @@
 
     &_description {
       margin-left: 20px;
+      padding-top: 12px;
 
       & ul {
         padding: rem(5px);

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -22,8 +22,9 @@
       width: calc(100% + 16px);
 
       &:hover {
-        background: linear-gradient(180deg, #EFF3F9 0%, #FFF 100%);
+        background: linear-gradient(180deg, #EFF3F9 0%, #FFF 100%) no-repeat;
         border-radius: 4px;
+        background-size: auto 80px;
       }
     }
 

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -20,20 +20,23 @@
       display: block;
       color: $color-main;
       //width: fit-content;
-      width: 100%;
+      //width: 100%;
+      width: calc(100% + 16px);
       font-weight: $font-weight-bold;
       font-family: monospace, 'Source Code Pro';
       //padding: 0;
       line-height: 22px;
-      margin-bottom: $text-spacing-s;
+      margin-bottom: 6px;
       cursor: pointer;
       margin-left: -24px;
-      padding: 8px 8px 10px;
+      padding: 8px 8px 0;
 
       &:hover {
         //background: $background-blue;
-        background-color: rgba(239, 243, 249, .5);
+        //background-color: rgba(239, 243, 249, .5);
+        background: linear-gradient(180deg, #EFF3F9 0%, #FFF 100%);
         border-radius: 4px;
+        //opacity: 0.5;
       }
     }
 

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -1,17 +1,17 @@
 @import "components/common/_variables.scss";
 
 .resources {
-  ul li {
-    margin: rem(14px) 0;
-    position: relative;
-  }
-
   ul, ol, li {
     & p:not(.resources__attrs) {
-        font-size: 14px;
-        margin: 0;
-        line-height: rem(20px);
-        padding-top: 0;
+      font-size: 14px;
+      margin: 0;
+      line-height: rem(20px);
+      padding-top: 0;
+      padding-bottom: $text-spacing-m;
+
+      &:last-child {
+        padding-bottom: 0;
+      }
     }
   }
 
@@ -19,10 +19,22 @@
     &_name {
       display: block;
       color: $color-main;
-      width: fit-content;
+      //width: fit-content;
+      width: 100%;
       font-weight: $font-weight-bold;
       font-family: monospace, 'Source Code Pro';
-      padding: 0;
+      //padding: 0;
+      line-height: 22px;
+      margin-bottom: $text-spacing-s;
+      cursor: pointer;
+      margin-left: -24px;
+      padding: 8px 8px 10px;
+
+      &:hover {
+        //background: $background-blue;
+        background-color: rgba(239, 243, 249, .5);
+        border-radius: 4px;
+      }
     }
 
     &_name > .ancestors,
@@ -32,10 +44,16 @@
     }
 
     &_type {
+      display: inline-block;
       color: $color-muted;
       font-style: normal;
       text-transform: uppercase;
-      font-size: rem(11px);
+      //font-size: rem(11px);
+      line-height: 22px;
+
+      &:has(+ .resources__prop_description) {
+        padding-bottom: $text-spacing-s;
+      }
 
       & + p.resources__attrs.required {
         display: inline-flex;
@@ -46,7 +64,8 @@
     }
 
     &_description {
-      margin-top: rem(7px);
+      //margin-top: rem(7px);
+      //padding-bottom: $text-spacing-l;
 
       & ul {
         padding: rem(5px);
@@ -59,7 +78,7 @@
   }
 
   &__attrs {
-    margin-top: rem(7px);
+    margin-top: 1rem;
     margin-bottom: 0;
     display: flex;
     gap: 7px;

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -16,28 +16,25 @@
   }
 
   &__prop {
+    &_wrap {
+      padding: 8px 8px 0;
+      margin-left: -24px;
+      width: calc(100% + 16px);
+
+      &:hover {
+        background: linear-gradient(180deg, #EFF3F9 0%, #FFF 100%);
+        border-radius: 4px;
+      }
+    }
+
     &_name {
       display: block;
       color: $color-main;
-      //width: fit-content;
-      //width: 100%;
-      width: calc(100% + 16px);
       font-weight: $font-weight-bold;
       font-family: monospace, 'Source Code Pro';
-      //padding: 0;
       line-height: 22px;
       margin-bottom: 6px;
       cursor: pointer;
-      margin-left: -24px;
-      padding: 8px 8px 0;
-
-      &:hover {
-        //background: $background-blue;
-        //background-color: rgba(239, 243, 249, .5);
-        background: linear-gradient(180deg, #EFF3F9 0%, #FFF 100%);
-        border-radius: 4px;
-        //opacity: 0.5;
-      }
     }
 
     &_name > .ancestors,
@@ -51,8 +48,8 @@
       color: $color-muted;
       font-style: normal;
       text-transform: uppercase;
-      //font-size: rem(11px);
       line-height: 22px;
+      margin-left: 20px;
 
       &:has(+ .resources__prop_description) {
         padding-bottom: $text-spacing-s;
@@ -67,8 +64,7 @@
     }
 
     &_description {
-      //margin-top: rem(7px);
-      //padding-bottom: $text-spacing-l;
+      margin-left: 20px;
 
       & ul {
         padding: rem(5px);
@@ -91,6 +87,7 @@
       font-weight: $font-weight-regular;
       font-style: italic;
       color: $color-muted;
+
       &.required {
         font-style: normal;
         color: #ff7a7a;

--- a/docs/site/css/components/common/_variables.scss
+++ b/docs/site/css/components/common/_variables.scss
@@ -21,6 +21,8 @@ $color-danger: #ff4141;
 $color-inverse: #FFFFFF;
 $color-smooth: #F3F3F3;
 $color-muted: #939fb1;
+$color-text-secondary: #5E6697;
+$background-blue: #EFF3F9;
 
 // Colors from theme.json
 $white: #fff;
@@ -65,3 +67,6 @@ $font-weight-light: 300;
 $spacing-s: 10px;
 $spacing-m: 20px;
 $spacing-l: 30px;
+$text-spacing-s: 12px;
+$text-spacing-m: 16px;
+$text-spacing-l: 24px;

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -806,6 +806,16 @@ a.comparison-table__module-proprietaryOkmeter::after {
     padding-bottom: 0;
 }
 
+.docs .resources ul li .resources__prop_description + p,
+.docs .resources ul li .resources__attrs + p {
+    margin-left: 20px;
+    padding-top: 12px;
+}
+
+.docs .resources__prop_description ul {
+  padding-bottom: 16px;
+}
+
 .docs .resources__prop_description > ul > li {
     padding-left: 32px;
 }

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -726,9 +726,32 @@ a.comparison-table__module-proprietaryOkmeter::after {
     position: relative;
 }
 
+.docs ul > li::before {
+  content: '';
+  display: block;
+  background: #0066FF;
+  width: 6px;
+  height: 6px;
+  border-radius: 6px;
+  position: absolute;
+  left: -15px;
+  top: 7px;
+}
+
 .docs ul.resources li {
     padding-left: 0;
     margin-left: 0;
+}
+
+.docs ul.resources li::before {
+  position: absolute;
+  top: 52px;
+  left: 4px;
+  content: '';
+  display: block;
+  width: 1px;
+  height: calc(100% - 52px);
+  background: #ccc;
 }
 
 .docs ul.resources > li {
@@ -778,17 +801,6 @@ a.comparison-table__module-proprietaryOkmeter::after {
 
 .docs ul li:last-child, .docs ol li:last-child {
     padding-bottom: 0;
-}
-
-.docs ul > li::before {
-    position: absolute;
-    top: 52px;
-    left: 4px;
-    content: '';
-    display: block;
-    width: 1px;
-    height: calc(100% - 52px);
-    background: #ccc;
 }
 
 .docs .resources__prop_description > ul > li {

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -743,6 +743,11 @@ a.comparison-table__module-proprietaryOkmeter::after {
     margin-left: 0;
 }
 
+// For anchorjs-link offset
+.docs :target {
+  scroll-margin-top: 20px;
+}
+
 .docs ul.resources li::before {
   position: absolute;
   top: 52px;

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -5,7 +5,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    margin: 25px 0 10px;
+    margin: 25px 0 40px;
 }
 
 .breadcrumbs__left {
@@ -677,7 +677,8 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs {
-    margin-bottom: 50px;
+    //margin-bottom: 50px;
+    margin-bottom: 112px;
 }
 
 .docs .hidden {
@@ -737,6 +738,7 @@ a.comparison-table__module-proprietaryOkmeter::after {
 
     & > .resources__prop_name {
         margin-left: -8px;
+        width: 100%;
     }
 
     & > .resources__prop_name > .plus-icon,
@@ -809,14 +811,19 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs ul > li.closed > ul,
-.docs ul > li.closed > div,
-.docs ul > li.closed > span:not(.resources__prop_name),
-.docs ul > li.closed > p {
+.docs ul > li.closed > div:not(.resources__prop_name),
+.docs ul > li.closed > span,
+.docs ul > li.closed > p,
+.docs ul > li.closed > p.resources__attrs {
     display: none;
     //max-height: 0;
     //overflow: hidden;
     //padding: 0;
     //margin: 0;
+}
+
+.docs .resources pre.highlight {
+  padding-left: 16px;
 }
 
 .docs ol {
@@ -855,7 +862,7 @@ a.comparison-table__module-proprietaryOkmeter::after {
 .docs:not(.docs--modules) h4,
 .docs:not(.docs--modules) h5,
 .docs:not(.docs--modules) h6 {
-    margin-bottom: 40px;
+    margin-bottom: 30px;
     margin-top: 30px;
 }
 

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -774,7 +774,10 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs ul.resources > li > .resources__prop_wrap {
-    & > .resources__prop_type {
+    & > .resources__prop_type,
+    & > .resources__prop_description,
+    & > p.resources__attrs:not(.required),
+    & > .language-yaml.highlighter-rouge {
         margin-left: 0;
     }
 
@@ -837,6 +840,11 @@ a.comparison-table__module-proprietaryOkmeter::after {
     }
 }
 
+.docs ul > li.closed > .resources__prop_wrap:hover {
+    background: linear-gradient(180deg, #EFF3F9 0%, #FFF 100%);
+    border-radius: 4px;
+}
+
 .docs ul > li.closed > .resources__prop_wrap > span.resources__prop_name {
     margin-bottom: 0;
 }
@@ -873,7 +881,7 @@ a.comparison-table__module-proprietaryOkmeter::after {
     margin-bottom: 0;
 }
 
-.docs .language-yaml.highlighter-rouge {
+.docs .resources div:not(.resources__prop_description) > .language-yaml.highlighter-rouge {
     margin: 5px 0 10px 24px;
 }
 

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -9,11 +9,14 @@
 }
 
 .breadcrumbs__left {
-  width: 300px;
+    //width: 300px;
+    width: 297px;
+    margin-right: 64px;
 }
 
 .breadcrumbs__right {
   flex: 1;
+  margin-right: 64px;
 }
 
 .breadcrumbs {
@@ -225,7 +228,8 @@
 .search {
     display: inline-block;
     margin-left: 5px;
-    width: 250px;
+    //width: 250px;
+    width: 297px;
 }
 
 .search__results.active {
@@ -317,20 +321,17 @@
 
 .layout-sidebar {
   display: flex;
-  gap: 40px;
+  gap: 64px;
 }
 
 .layout-sidebar__wrap {
   margin-top: 25px;
 }
 
-.layout-sidebar__sidebar {
-  width: 330px;
-}
-
 .layout-sidebar__sidebar,
 .layout-sidebar__sidebar_right {
   position: relative;
+  width: 297px;
 }
 
 .layout-sidebar__sidebar_right {
@@ -691,9 +692,8 @@ a.comparison-table__module-proprietaryOkmeter::after {
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
-    /* opacity: 0.7;
-    color: #00122c; */
-    color: #00122c;
+    //color: #00122c;
+    color: $color-text-secondary;
 }
 
 .docs p {
@@ -707,19 +707,51 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs ul, .docs ol {
-    font-size: 14px;
+    font-size: 15px;
     line-height: 1.5;
     letter-spacing: -0.3px;
-    /* margin: 0; */
     padding: 0;
     list-style-type: none;
-    /* color: #00122c; */
+}
+
+.docs p font {
+    font-style: italic;
+    margin-bottom: 40px;
 }
 
 .docs ul li {
     padding-bottom: 10px;
-    margin-left: 30px;
+    //margin-left: $text-spacing-m;
+    padding-left: 32px;
+    margin-left: -16px;
     position: relative;
+}
+
+.docs ul.resources > li {
+    margin-left: 0;
+    padding-left: 0;
+
+    &::before {
+        display: none;
+    }
+
+    & > .resources__prop_name {
+        margin-left: -8px;
+    }
+
+    & > .resources__prop_name > .plus-icon,
+    & > .resources__prop_name > .minus-icon {
+        display: none;
+    }
+}
+
+.docs ul.resources ul > li:not(.resources__prop_description li) {
+    padding-top: $text-spacing-l;
+    padding-bottom: 16px;
+
+    &.closed {
+        padding-bottom: 0;
+    }
 }
 
 .docs ol li {
@@ -731,48 +763,64 @@ a.comparison-table__module-proprietaryOkmeter::after {
     padding-bottom: 0px;
 }
 
-.docs ul ol, .docs ol ul, .docs ul ul, .docs ol ol {
-    padding-top: 10px;
-}
-
 .docs ul > li::before {
+    position: absolute;
+    top: 52px;
+    left: 20px;
     content: '';
     display: block;
-    background: #0066FF;
-    width: 6px;
-    height: 6px;
-    border-radius: 6px;
+    width: 1px;
+    height: calc(100% - 52px);
+    background: #ccc;
+}
+
+.docs .resources__prop_description > ul > li::before {
     position: absolute;
-    left: -15px;
-    top: 7px;
+    content: '';
+    left: 16px;
+    top: 8px;
+    display: block;
+    background: #0066FF;
+    width: 8px;
+    height: 8px;
+    border-radius: 6px;
+}
+
+.docs ul > li .plus-icon {
+    display: none;
+}
+
+.docs ul > li.closed {
+    &::before {
+        display: none;
+    }
+
+    & .minus-icon {
+        display: none;
+    }
+
+    & .plus-icon {
+        display: inline-block;
+    }
+}
+
+.docs ul > li.closed > span.resources__prop_name {
+    margin-bottom: 0;
+}
+
+.docs ul > li.closed > ul,
+.docs ul > li.closed > div,
+.docs ul > li.closed > span:not(.resources__prop_name),
+.docs ul > li.closed > p {
+    display: none;
+    //max-height: 0;
+    //overflow: hidden;
+    //padding: 0;
+    //margin: 0;
 }
 
 .docs ol {
     list-style-type: decimal;
-}
-
-.docs ul ul > li::before {
-    content: '';
-    display: block;
-    border: 1px solid #0066FF;
-    background: transparent;
-    width: 5px;
-    height: 5px;
-    border-radius: 6px;
-    position: absolute;
-    left: -15px;
-    top: 6px;
-}
-
-.docs ul ul ul li::before {
-    content: '';
-    display: block;
-    background: #0066FF;
-    width: 4px;
-    height: 4px;
-    position: absolute;
-    left: -15px;
-    top: 8px;
 }
 
 .docs ul li > p:first-child, .docs ol li > p:first-child {
@@ -784,7 +832,21 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs ul li pre, .docs ol li pre {
-    margin: 5px 0 10px 0px;
+    margin-bottom: 0;
+}
+
+.docs .language-yaml.highlighter-rouge {
+    margin: 5px 0 10px 0;
+}
+
+.docs li > .language-yaml.highlighter-rouge:last-child {
+    margin-bottom: 0;
+}
+
+.docs .resources__prop_description code,
+.docs code.resources__attrs_content {
+    background: transparent;
+    color: #00122C;
 }
 
 .docs:not(.docs--modules) h1,
@@ -793,7 +855,7 @@ a.comparison-table__module-proprietaryOkmeter::after {
 .docs:not(.docs--modules) h4,
 .docs:not(.docs--modules) h5,
 .docs:not(.docs--modules) h6 {
-    margin-bottom: 15px;
+    margin-bottom: 40px;
     margin-top: 30px;
 }
 
@@ -811,17 +873,10 @@ a.comparison-table__module-proprietaryOkmeter::after {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 20px;
+    margin-bottom: 40px;
 }
 
 .docs h1.docs__title {
-    /* font-size: 72px;
-    font-weight: 600;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: 1.11;
-    letter-spacing: normal;
-    color: #00122c; */
     margin-top: 0;
     margin-bottom: 0;
 }

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -722,23 +722,37 @@ a.comparison-table__module-proprietaryOkmeter::after {
 
 .docs ul li {
     padding-bottom: 10px;
-    //margin-left: $text-spacing-m;
-    padding-left: 32px;
-    margin-left: -16px;
+    margin-left: 30px;
     position: relative;
 }
 
-.docs ul.resources > li {
-    margin-left: 0;
+.docs ul.resources li {
     padding-left: 0;
+    margin-left: 0;
+}
 
+.docs ul.resources > li {
     &::before {
         display: none;
     }
 
-    & > .resources__prop_name {
+    & > .resources__prop_wrap {
         margin-left: -8px;
         width: 100%;
+
+        > .resources__prop_name {
+            cursor: auto;
+        }
+
+        &:hover {
+            background: transparent;
+        }
+    }
+}
+
+.docs ul.resources > li > .resources__prop_wrap {
+    & > .resources__prop_type {
+        margin-left: 0;
     }
 
     & > .resources__prop_name > .plus-icon,
@@ -750,6 +764,7 @@ a.comparison-table__module-proprietaryOkmeter::after {
 .docs ul.resources ul > li:not(.resources__prop_description li) {
     padding-top: $text-spacing-l;
     padding-bottom: 16px;
+    padding-left: 16px;
 
     &.closed {
         padding-bottom: 0;
@@ -762,18 +777,22 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs ul li:last-child, .docs ol li:last-child {
-    padding-bottom: 0px;
+    padding-bottom: 0;
 }
 
 .docs ul > li::before {
     position: absolute;
     top: 52px;
-    left: 20px;
+    left: 4px;
     content: '';
     display: block;
     width: 1px;
     height: calc(100% - 52px);
     background: #ccc;
+}
+
+.docs .resources__prop_description > ul > li {
+    padding-left: 32px;
 }
 
 .docs .resources__prop_description > ul > li::before {
@@ -806,20 +825,20 @@ a.comparison-table__module-proprietaryOkmeter::after {
     }
 }
 
-.docs ul > li.closed > span.resources__prop_name {
+.docs ul > li.closed > .resources__prop_wrap > span.resources__prop_name {
     margin-bottom: 0;
 }
 
 .docs ul > li.closed > ul,
-.docs ul > li.closed > div:not(.resources__prop_name),
-.docs ul > li.closed > span,
-.docs ul > li.closed > p,
-.docs ul > li.closed > p.resources__attrs {
+.docs ul > li.closed > .resources__prop_wrap > div:not(.resources__prop_name),
+.docs ul > li.closed > .resources__prop_wrap > span,
+.docs ul > li.closed > .resources__prop_wrap > p,
+.docs ul > li.closed > .resources__prop_wrap > p.resources__attrs {
     display: none;
-    //max-height: 0;
-    //overflow: hidden;
-    //padding: 0;
-    //margin: 0;
+}
+
+.docs ul > li > .resources__prop_wrap > p.resources__attrs:not(.required) {
+    margin-left: 24px;
 }
 
 .docs .resources pre.highlight {
@@ -843,7 +862,7 @@ a.comparison-table__module-proprietaryOkmeter::after {
 }
 
 .docs .language-yaml.highlighter-rouge {
-    margin: 5px 0 10px 0;
+    margin: 5px 0 10px 24px;
 }
 
 .docs li > .language-yaml.highlighter-rouge:last-child {

--- a/docs/site/css/syntax.css
+++ b/docs/site/css/syntax.css
@@ -35,7 +35,7 @@
 
 .highlight .p,
 .highlight .pi {
-  color: #f8f8f2;
+  color: #c6c6c6
 }
 
 .highlight .gi {

--- a/docs/site/css/syntax.css
+++ b/docs/site/css/syntax.css
@@ -35,7 +35,7 @@
 
 .highlight .p,
 .highlight .pi {
-  color: #c6c6c6
+  color: #525252
 }
 
 .highlight .gi {

--- a/docs/site/css/syntax.css
+++ b/docs/site/css/syntax.css
@@ -1,7 +1,10 @@
 .highlight,
 .highlight .w {
-  color: #f8f8f2;
-  background-color: #272822;
+  /*color: #f8f8f2;*/
+  /*background-color: #272822;*/
+  color: #00122C;
+  border-radius: 4px;
+  background: #F1F2F4;
 }
 
 .highlight .err {
@@ -77,7 +80,8 @@
 .highlight .sh,
 .highlight .sx,
 .highlight .s1 {
-  color: #a6e22e;
+  /*color: #a6e22e;*/
+  color: #2ABB5B;
 }
 
 .highlight .sr {
@@ -105,7 +109,8 @@
 }
 
 .highlight .na {
-  color: #66d9ef;
+  /*color: #66d9ef;*/
+  color: #00122C;
 }
 
 .highlight .m,
@@ -116,7 +121,8 @@
 .highlight .mo,
 .highlight .mb,
 .highlight .mx {
-  color: #a6e22e;
+  /*color: #a6e22e;*/
+  color: #2ABB5B;
 }
 
 .highlight .ss {

--- a/docs/site/js/customscripts.js
+++ b/docs/site/js/customscripts.js
@@ -178,11 +178,11 @@ $(document).ready(function(){
 
   titles.each((i, title) => {
     $(title).click(() => {
-      const firstList = $(title).parent('li').parent('ul');
+      const firstList = $(title).parent('.resources__prop_wrap').parent('li').parent('ul');
 
       if (firstList.hasClass('resources')) return;
 
-      const parentElem = $(title).parent('li');
+      const parentElem = $(title).parent('.resources__prop_wrap').parent('li');
 
       parentElem.toggleClass('closed');
     })

--- a/docs/site/js/customscripts.js
+++ b/docs/site/js/customscripts.js
@@ -175,6 +175,13 @@ $(document).ready(function(){
 
 $(document).ready(function(){
   const titles = $('.resources__prop_name');
+  const links = $('.resources__prop_wrap .anchorjs-link');
+
+  links.each((i, link) => {
+    $(link).click((e) => {
+      e.stopPropagation();
+    })
+  })
 
   titles.each((i, title) => {
     $(title).click(() => {

--- a/docs/site/js/customscripts.js
+++ b/docs/site/js/customscripts.js
@@ -173,6 +173,22 @@ $(document).ready(function(){
   })
 });
 
+$(document).ready(function(){
+  const titles = $('.resources__prop_name');
+
+  titles.each((i, title) => {
+    $(title).click(() => {
+      const firstList = $(title).parent('li').parent('ul');
+
+      if (firstList.hasClass('resources')) return;
+
+      const parentElem = $(title).parent('li');
+
+      parentElem.toggleClass('closed');
+    })
+  })
+});
+
 const openDiagram = function () {
   const button = $('[data-open-scheme]');
   const wrap = $('.functionality-block__diagram-wrap')


### PR DESCRIPTION
## Description
Refactor resource block styles in the documentation.
- Change styles of Open API specifications and code blocks.
- Add the ability to collapse a section of parameters in an Open API specification.

## What is the expected result?

![Screenshot from 2024-08-16 16-28-26](https://github.com/user-attachments/assets/ed79c93a-ec9c-477f-a36b-6cf1bbf4fee1)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Refactor resource block styles in the documentation.
impact_level: low
```
