### PR TITLE
[e2e] fix: allow kubernetes-admin to make changes

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -68,6 +68,8 @@ spec:
       expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-kube-control-plane' # Ignore kube-controller manager and kube-scheduler
       expression: '!(["system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)))'
+    - name: 'exclude-kubernetes-admin'
+      expression: '!(["kubernetes-admin"].exists(e, (e == request.userInfo.username)))'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
@@ -77,7 +79,7 @@ spec:
       valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with the heritage label'"
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups))'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || ["kubernetes-admin"].exists(e, (e == request.userInfo.username))'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -66,10 +66,8 @@ spec:
   matchConditions:
     - name: 'exclude-groups'
       expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)))'
-    - name: 'exclude-kube-control-plane' # Ignore kube-controller manager and kube-scheduler
-      expression: '!(["system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)))'
-    - name: 'exclude-kubernetes-admin'
-      expression: '!(["kubernetes-admin"].exists(e, (e == request.userInfo.username)))'
+    - name: 'exclude-users'
+      expression: '!(["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)))'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
@@ -79,7 +77,7 @@ spec:
       valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with the heritage label'"
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || ["kubernetes-admin"].exists(e, (e == request.userInfo.username))'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups))'
       reason: Forbidden
 {{- end }}
 ---


### PR DESCRIPTION
## Description

When upgrading the cluster, there was a problem where kubernetes-admin was unable to make changes to objects labeled heritage deckhouse.

You need to grant permission to modify such objects to the kubernetes-admin user

## Why do we need it, and what problem does it solve?

When conducting e2e testing, the deckhouse version is switched by directly changing the image version. In this case, kubectl can be run under a user with different groups. To solve the problem, we issue the necessary rights directly to the user.

## What is the expected result?

When running e2e testing, image switching occurs without problems.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: fix
summary: allow kubernetes-admin to make changes
impact_level: default
```
