### PR TITLE
[docs] Fix spec.version in mc for documentation module

### DIFF
--- a/modules/810-documentation/docs/EXAMPLES.md
+++ b/modules/810-documentation/docs/EXAMPLES.md
@@ -12,7 +12,7 @@ kind: ModuleConfig
 metadata:
   name: documentation
 spec:
-  version: 2
+  version: 1
   enabled: true
   settings:
     nodeSelector:

--- a/modules/810-documentation/docs/EXAMPLES_RU.md
+++ b/modules/810-documentation/docs/EXAMPLES_RU.md
@@ -12,7 +12,7 @@ kind: ModuleConfig
 metadata:
   name: documentation
 spec:
-  version: 2
+  version: 1
   enabled: true
   settings:
     nodeSelector:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
spec.version: 2 in module config has error
`documentation               true      2         2m33s   Error: invalid spec.version, use version 1`
We need change default to 1

```changes
section: docs
type: Fix spec.version in the example in the documentation module.
impact_level: low
```
