### PR TITLE
[common] fixed the displayed version of shell-operator

### DIFF
--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -54,5 +54,4 @@ shell:
     - git clone --branch {{ $shellOperatorVersion }} --depth 1 {{ .SOURCE_REPO }}/flant/shell-operator.git
     - cd /shell-operator
     - go mod tidy
-    - export DOMAIN_REPO=`echo {{ .SOURCE_REPO }} | cut -d '@' -f 2`
-    - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '${DOMAIN_REPO}/flant/shell-operator/pkg/app.Version={{ $shellOperatorVersion }}'" -tags use_libjq -o shell-operator ./cmd/shell-operator
+    - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X 'github.com/flant/shell-operator/pkg/app.Version={{ $shellOperatorVersion }}'" -tags use_libjq -o shell-operator ./cmd/shell-operator

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -30,7 +30,7 @@ docker:
   ENTRYPOINT: ["/shell-operator"]
 ---
 artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
+from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
 shell:
   install:
     - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=1 GOOS=linux
@@ -53,4 +53,4 @@ shell:
     - git clone --branch {{ $shellOperatorVersion }} --depth 1 {{ .SOURCE_REPO }}/flant/shell-operator.git
     - cd /shell-operator
     - go mod tidy
-    - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '{{ .SOURCE_REPO }}/flant/shell-operator/pkg/app.Version=latest'" -tags use_libjq -o shell-operator ./cmd/shell-operator
+    - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '{{ .SOURCE_REPO }}/flant/shell-operator/pkg/app.Version={{ $shellOperatorVersion }}'" -tags use_libjq -o shell-operator ./cmd/shell-operator

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -44,6 +44,7 @@ shell:
           url = {{ .SOURCE_REPO }}/flant/oniguruma.git
       EOF
     - git submodule update --init
+    - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf autotools-dev automake
     - autoreconf -fi
     - ./configure CFLAGS=-fPIC --disable-maintainer-mode --enable-all-static --disable-shared --disable-docs --disable-tls --disable-valgrind --with-oniguruma=builtin --prefix=/libjq
     - make -j4

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -33,6 +33,7 @@ artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 shell:
   install:
+    - set -x
     - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=1 GOOS=linux
     - git clone {{ .SOURCE_REPO }}/flant/jq.git
     - cd /jq
@@ -53,4 +54,5 @@ shell:
     - git clone --branch {{ $shellOperatorVersion }} --depth 1 {{ .SOURCE_REPO }}/flant/shell-operator.git
     - cd /shell-operator
     - go mod tidy
-    - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '{{ .SOURCE_REPO }}/flant/shell-operator/pkg/app.Version={{ $shellOperatorVersion }}'" -tags use_libjq -o shell-operator ./cmd/shell-operator
+    - export DOMAIN_REPO=`echo {{ .SOURCE_REPO }} | cut -d '@' -f 2`
+    - CGO_CFLAGS="-I/libjq/include" CGO_LDFLAGS="-L/libjq/lib" go build -ldflags="-linkmode external -extldflags '-static' -s -w -X '${DOMAIN_REPO}/flant/shell-operator/pkg/app.Version={{ $shellOperatorVersion }}'" -tags use_libjq -o shell-operator ./cmd/shell-operator

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -34,6 +34,7 @@ from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
 shell:
   install:
     - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=1 GOOS=linux
+    - apk add build-essential ca-certificates autoconf autotools-dev automake
     - git clone {{ .SOURCE_REPO }}/flant/jq.git
     - cd /jq
     - git reset --hard {{ $jqVersion }}
@@ -44,7 +45,6 @@ shell:
           url = {{ .SOURCE_REPO }}/flant/oniguruma.git
       EOF
     - git submodule update --init
-    - apt update && apt install -y --no-install-recommends git build-essential ca-certificates autoconf autotools-dev automake
     - autoreconf -fi
     - ./configure CFLAGS=-fPIC --disable-maintainer-mode --enable-all-static --disable-shared --disable-docs --disable-tls --disable-valgrind --with-oniguruma=builtin --prefix=/libjq
     - make -j4

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -33,7 +33,6 @@ artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 shell:
   install:
-    - set -x
     - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=1 GOOS=linux
     - git clone {{ .SOURCE_REPO }}/flant/jq.git
     - cd /jq

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -30,7 +30,7 @@ docker:
   ENTRYPOINT: ["/shell-operator"]
 ---
 artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
+from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 shell:
   install:
     - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=1 GOOS=linux

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -30,11 +30,10 @@ docker:
   ENTRYPOINT: ["/shell-operator"]
 ---
 artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
+from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
 shell:
   install:
     - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=1 GOOS=linux
-    - apk add build-essential ca-certificates autoconf autotools-dev automake
     - git clone {{ .SOURCE_REPO }}/flant/jq.git
     - cd /jq
     - git reset --hard {{ $jqVersion }}


### PR DESCRIPTION
## Description
Configured version variable setting when building shell-operator image
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Closed https://github.com/deckhouse/deckhouse/issues/9178 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: fixed the displayed version of shell-operator
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
