### PR TITLE
[dhctl] deleting storage.deckhouse.io/crs when dhctl destroy is executed

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -64,7 +64,7 @@ func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
 func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		for _, cr := range d8storageConfig.Resources {
-			resourceSchema := schema.GroupVersionResource{Group: d8storageConfig.ApiGroup, Version: d8storageConfig.ApiVersion, Resource: strings.ToLower(cr)}
+			resourceSchema := schema.GroupVersionResource{Group: d8storageConfig.ApiGroup, Version: d8storageConfig.ApiVersion, Resource: cr}
 			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -65,7 +65,8 @@ func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
-					log.DebugF("Resource %s not found, skipping...\n", cr)
+					// log.DebugF("Resource %s not found, skipping...\n", cr)
+					log.InfoF("Resource %s not found, skipping...\n", cr)
 					continue
 				}
 				return fmt.Errorf("get %s: %v", cr, err)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -75,8 +75,10 @@ func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
 func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).Run(func() error {
 		for _, cr := range d8storageConfig {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 			resourceSchema := schema.GroupVersionResource{Group: cr.Group, Version: cr.Version, Resource: cr.Resource}
-			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
 					log.InfoF("Resources kind of %s not found, skipping...\n", cr)
@@ -86,7 +88,7 @@ func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 			}
 
 			for _, obj := range storageCRs.Items {
-				err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(obj.GetNamespace()).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
+				err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(obj.GetNamespace()).Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					return fmt.Errorf("delete %s %s: %v", cr, obj.GetName(), err)
 				}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -65,8 +65,7 @@ func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
-					// log.DebugF("Resource %s not found, skipping...\n", cr)
-					log.InfoF("Resource %s not found, skipping...\n", cr)
+					log.InfoF("Resource kind of %s not found, skipping...\n", cr)
 					continue
 				}
 				return fmt.Errorf("get %s: %v", cr, err)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -77,7 +77,7 @@ func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 				if err != nil {
 					return fmt.Errorf("delete %s %s: %v", cr, obj.GetName(), err)
 				}
-				log.InfoF("%s/%s\n", obj.GetNamespace(), obj.GetName())
+				log.InfoF("%s/%s\n", obj.GetKind(), obj.GetName())
 			}
 		}
 		return nil

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -65,7 +65,7 @@ func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
-					log.InfoF("Resource kind of %s not found, skipping...\n", cr)
+					log.InfoF("Resources kind of %s not found, skipping...\n", cr)
 					continue
 				}
 				return fmt.Errorf("get %s: %v", cr, err)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -39,10 +39,10 @@ const (
 )
 
 var d8storageCRs = []string{
-	"LocalStorageClass",
-	"ReplicatedStorageClass",
-	"NFSStorageClass",
-	"CephStorageClass",
+	"localstorageclasses",
+	"replicatedstorageclasses",
+	"nfsstorageclasses",
+	"cephstorageclasses",
 }
 
 const d8storageCRsApiVersion = "v1alpha1"

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -38,16 +38,27 @@ const (
 	deckhouseDeploymentName      = "deckhouse"
 )
 
-type StorageCRsConfig struct {
-	Resources  []string
-	ApiGroup   string
-	ApiVersion string
-}
-
-var d8storageConfig = StorageCRsConfig{
-	Resources:  []string{"localstorageclasses", "replicatedstorageclasses", "nfsstorageclasses", "cephstorageclasses"},
-	ApiGroup:   "storage.deckhouse.io",
-	ApiVersion: "v1alpha1",
+var d8storageConfig = []schema.GroupVersionResource{
+	{
+		Group:    "storage.deckhouse.io",
+		Version:  "v1alpha1",
+		Resource: "localstorageclasses",
+	},
+	{
+		Group:    "storage.deckhouse.io",
+		Version:  "v1alpha1",
+		Resource: "replicatedstorageclasses",
+	},
+	{
+		Group:    "storage.deckhouse.io",
+		Version:  "v1alpha1",
+		Resource: "nfsstorageclasses",
+	},
+	{
+		Group:    "storage.deckhouse.io",
+		Version:  "v1alpha1",
+		Resource: "cephstorageclasses",
+	},
 }
 
 func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
@@ -63,8 +74,8 @@ func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
 
 func DeleteDeckhouseStorageCRs(kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).Run(func() error {
-		for _, cr := range d8storageConfig.Resources {
-			resourceSchema := schema.GroupVersionResource{Group: d8storageConfig.ApiGroup, Version: d8storageConfig.ApiVersion, Resource: cr}
+		for _, cr := range d8storageConfig {
+			resourceSchema := schema.GroupVersionResource{Group: cr.Group, Version: cr.Version, Resource: cr.Resource}
 			storageCRs, err := kubeCl.Dynamic().Resource(resourceSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -126,7 +126,7 @@ func (g *DeckhouseDestroyer) deleteEntities(kubeCl *client.KubernetesClient) err
 		return err
 	}
 
-	err = deckhouse.DeleteDeckhouseStorageCRs(kubeCl)
+	err = deckhouse.DeleteAllD8StorageResources(kubeCl)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -126,6 +126,11 @@ func (g *DeckhouseDestroyer) deleteEntities(kubeCl *client.KubernetesClient) err
 		return err
 	}
 
+	err = deckhouse.DeleteDeckhouseStorageCRs(kubeCl)
+	if err != nil {
+		return err
+	}
+
 	err = deckhouse.DeleteStorageClasses(kubeCl)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Deleting LocalStorageClass, ReplicatedStorageClass, NFSStorageClass and CephStorageClass during dhctl destroy

## Why do we need it, and what problem does it solve?

If we try to delete a storageClass that is associated with one of our storage modules we will get an error for example:
```
kubectl delete sc replicated-storage-class
Error from server: admission webhook "d8-sds-replicated-volume-sc-validation.storage.deckhouse.io" denied the request: Direct modifications to the StorageClass (other than annotations) with the provisioner linstor.csi.linbit.com are not allowed. Please use ReplicatedStorageClass for such operations.
```
So, the custom resource must be deleted first 

## Why do we need it in the patch release (if we do)?


## What is the expected result?

Successful execution of dhctl destroy for clusters where our sds modules are used for storageClass.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deleting storage.deckhouse.io/crs when dhctl destroy is executed
type: fix
summary: <ONE-LINE of what effectively changes for a user>
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
