### PR TITLE
[common] update common/shell-operator images

### DIFF
--- a/ee/be/modules/600-flant-integration/images/flant-pricing/werf.inc.yaml
+++ b/ee/be/modules/600-flant-integration/images/flant-pricing/werf.inc.yaml
@@ -1,5 +1,5 @@
 ---
-image: {{ .ModuleName }}/flant-pricing
+image: {{ .ModuleName }}/{{ $.ImageName }}
 fromImage: common/shell-operator
 git:
 - add: /{{ $.ModulePath }}/modules/600-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -19,7 +19,8 @@ shell:
     - apt-get update
     - apt-get install -y python3 python3-module-pip curl
     - apt-get clean
+    - find /var/lib/apt/lists/ /var/cache/apt/ -type f -delete
   install:
     - python3 -m pip install -r /src/requirements.txt
 docker:
-  ENTRYPOINT: ["/shell-operator"]
+  ENTRYPOINT: ["tini", "--", "/shell-operator"]

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $jqVersion := "b6be13d5"}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}
-from: {{ $.Images.BASE_ALT }}
+from: {{ $.Images.BASE_ALT_P11 }}
 import:
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /shell-operator/shell-operator
@@ -26,8 +26,12 @@ import:
   add: /src/_output/bin/kubectl
   to: /usr/local/bin/kubectl
   before: setup
+- artifact: tini-artifact
+  add: /tini/tini-static
+  to: /sbin/tini
+  before: setup
 docker:
-  ENTRYPOINT: ["/shell-operator"]
+  ENTRYPOINT: ["tini", "--", "/shell-operator"]
 ---
 artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -14,20 +14,13 @@ import:
     add: /bin/promtool
     to: /usr/local/bin/promtool
     before: setup
-  - image: common/shell-operator
-    add: /shell-operator
-    to: /shell-operator
-    before: setup
-  - artifact: tini-artifact
-    add: /tini/tini-static
-    to: /sbin/tini
-    before: setup
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /relocate
-    to: /
+    add: /usr/bin
+    to: /usr/bin
     before: setup
     includePaths:
-      - '**/*'
+    - python3
+    - python3.12
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib/python3
     to: /usr/lib/python3
@@ -37,8 +30,8 @@ import:
     to: /usr/lib64/python3
     before: setup
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /usr/lib64/python3.9
-    to: /usr/lib64/python3.9
+    add: /usr/lib64/python3.12
+    to: /usr/lib64/python3.12
     before: setup
 git:
 - add: /{{ .ModulePath }}
@@ -59,9 +52,9 @@ docker:
   ENTRYPOINT: ["/entrypoint.sh"]
 
 ---
-{{- $pythonBinaries := "/usr/bin/python3" }}
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-from: {{ $.Images.BASE_ALT_DEV }}
+from: {{ $.Images.BASE_ALT_P11 }}
 shell:
-  setup:
-    - /binary_replace.sh -i "{{ $pythonBinaries }}" -o /relocate
+  beforeInstall:
+    - apt-get update
+    - apt-get install -y python3

--- a/modules/110-istio/images/metadata-discovery/werf.inc.yaml
+++ b/modules/110-istio/images/metadata-discovery/werf.inc.yaml
@@ -1,11 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/shell-operator
-import:
-- artifact: tini-artifact
-  add: /tini/tini-static
-  to: /sbin/tini
-  before: install
 git:
 - add: /{{ $.ModulePath }}modules/110-{{ $.ModuleName }}/images/{{ $.ImageName }}/hooks
   to: /hooks

--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
@@ -1,28 +1,25 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/shell-operator
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /relocate
-  to: /
-  before: setup
-  includePaths:
-    - '**/*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /usr/lib/python3
-  to: /usr/lib/python3
-  before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /usr/lib64/python3
-  to: /usr/lib64/python3
-  before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /usr/lib64/python3.9
-  to: /usr/lib64/python3.9
-  before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /usr/local/lib/python3
-  to: /usr/local/lib/python3
-  before: setup
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/bin
+    to: /usr/bin
+    before: setup
+    includePaths:
+    - python3
+    - python3.12
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib/python3
+    to: /usr/lib/python3
+    before: setup
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3
+    to: /usr/lib64/python3
+    before: setup
+  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3.12
+    to: /usr/lib64/python3.12
+    before: setup
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/hooks
   to: /hooks
@@ -31,9 +28,8 @@ git:
     - '**/*'
 
 ---
-{{- $pythonBinaries := "/usr/bin/python3" }}
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_ALT_DEV }}
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+from: {{ $.Images.BASE_ALT_P11 }}
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/requirements.txt
   to: /requirements.txt
@@ -41,8 +37,8 @@ git:
     install:
     - '**/*'
 shell:
+  beforeInstall:
+    - apt-get update
+    - apt-get install -y python3 python3-module-pip-run
   install:
-    - export SOURCE_REPO={{ .SOURCE_REPO }}
-    - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
-    - pip3 install -f file:///wheels --no-index -r /requirements.txt
-    - /binary_replace.sh -i "{{ $pythonBinaries }}" -o /relocate
+    - pip3 install -r /requirements.txt


### PR DESCRIPTION
## Description
The base image and Python version in dependent images have been updated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
---
section: common
type: chore
summary: Update base images in `common/shell-operator`.
impact_level: default
---
section: flant-integration
type: chore
summary: Update Python in images `flant-pricing`.
impact_level: default
---
section: deckhouse
type: chore
summary: Update Python in images `webhook-handler`.
impact_level: default
---
section: prometheus
type: chore
summary: Update Python in images `grafana-dashboard-provisioner`.
impact_level: default
```
