### PR TITLE
[cilium][istio] Making hubble-ui and kiali accessible only for the to the ingress controller

### DIFF
--- a/modules/110-istio/templates/kiali/configmap.yaml
+++ b/modules/110-istio/templates/kiali/configmap.yaml
@@ -67,7 +67,7 @@ data:
       metrics_enabled: true
       metrics_port: 9090
       port: 20001
-      web_root: /kiali
+      web_root: /
     kiali_feature_flags:
       istio_annotation_action: false
       istio_injection_action: false

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       maxAllowed:
         cpu: 100m
         memory: 1000Mi
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
 ---
 apiVersion: apps/v1
@@ -64,21 +65,19 @@ spec:
         - "-config"
         - "/kiali-configuration/config.yaml"
         ports:
-        - name: api
-          containerPort: 20001
         - name: http-metrics
           containerPort: 9090
         readinessProbe:
           httpGet:
-            path: /kiali/healthz
-            port: api
+            path: /healthz
+            port: 20001
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
         livenessProbe:
           httpGet:
-            path: /kiali/healthz
-            port: api
+            path: /healthz
+            port: 20001
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
@@ -102,7 +101,53 @@ spec:
           mountPath: "/kiali-configuration"
         - name: kiali-signing-key
           mountPath: "/kiali-override-secrets/login-token-signing-key"
-
+      - name: kube-rbac-proxy
+      {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list $ "kubeRbacProxy") }}
+        args:
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8443"
+        - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+        - "--v=2"
+        - "--logtostderr=true"
+        - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            excludePaths:
+            - /api/health
+            upstreams:
+            - upstream: http://127.0.0.1:20001/
+              path: /
+              authorization:
+                resourceAttributes:
+                  namespace: d8-istio
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: deployments
+                  subresource: http
+                  name: kiali
+        ports:
+        - containerPort: 8443
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+{{- end }}
+        volumeMounts:
+          - name: kube-rbac-proxy-ca
+            mountPath: /etc/kube-rbac-proxy
       volumes:
       - name: kiali-configuration
         configMap:
@@ -114,3 +159,7 @@ spec:
           - key: key
             path: value.txt
           optional: false
+      - name: kube-rbac-proxy-ca
+        configMap:
+          defaultMode: 420
+          name: kube-rbac-proxy-ca.crt

--- a/modules/110-istio/templates/kiali/ingress.yaml
+++ b/modules/110-istio/templates/kiali/ingress.yaml
@@ -3,50 +3,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: kiali-rewrite
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
-  annotations:
-  {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.istio.auth.externalAuthentication }}
-    nginx.ingress.kubernetes.io/auth-signin: {{ .Values.istio.auth.externalAuthentication.authSignInURL | quote }}
-    nginx.ingress.kubernetes.io/auth-url: {{ .Values.istio.auth.externalAuthentication.authURL | quote }}
-  {{- else }}
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: kiali-basic-auth
-    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite / /kiali$uri redirect;
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-  {{- end }}
-  {{- if .Values.istio.auth.satisfyAny }}
-    nginx.ingress.kubernetes.io/satisfy: "any"
-  {{- end }}
-spec:
-  ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
-  rules:
-  - host: {{ include "helm_lib_module_public_domain" (list . "istio") }}
-    http:
-      paths:
-      - backend:
-          service:
-            name: kiali
-            port:
-              name: http
-        path: /
-        pathType: ImplementationSpecific
-  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
-  tls:
-    - hosts:
-        - {{ include "helm_lib_module_public_domain" (list . "istio") }}
-      secretName: {{ include "helm_lib_module_https_secret_name" (list . "istio-ingress-tls") }}
-  {{- end }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: kiali
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
@@ -61,15 +17,16 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: kiali-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
+  {{- end }}
+  {{- if .Values.istio.auth.satisfyAny }}
+    nginx.ingress.kubernetes.io/satisfy: "any"
+  {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_ssl_certificate /etc/nginx/ssl/client.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
       proxy_ssl_protocols TLSv1.2;
       proxy_ssl_session_reuse on;
-  {{- end }}
-  {{- if .Values.istio.auth.satisfyAny }}
-    nginx.ingress.kubernetes.io/satisfy: "any"
-  {{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   rules:
@@ -80,8 +37,8 @@ spec:
           service:
             name: kiali
             port:
-              name: http
-        path: /kiali/
+              name: https
+        path: /
         pathType: ImplementationSpecific
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   tls:

--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -153,6 +153,12 @@ rules:
   - prometheuses/http
   verbs:
   - get
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/110-istio/templates/kiali/rbac-to-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-to-us.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.global.modules.publicDomainTemplate }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-kiali-http
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments/http"]
+    resourceNames: ["kiali"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-kiali-http
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-kiali-http
+subjects:
+  - kind: Group
+    name: ingress-nginx:auth
+{{- end }}

--- a/modules/110-istio/templates/kiali/service.yaml
+++ b/modules/110-istio/templates/kiali/service.yaml
@@ -7,10 +7,10 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
 spec:
   ports:
-  - name: http
+  - name: https
     protocol: TCP
-    port: 20001
-    targetPort: api
+    port: 443
+    targetPort: https
   - name: http-metrics
     protocol: TCP
     port: 9090

--- a/modules/500-cilium-hubble/templates/ui/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/ui/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       maxAllowed:
         cpu: 50m
         memory: 100Mi
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
 ---
 kind: Deployment
@@ -74,9 +75,6 @@ spec:
       - name: frontend
         {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "uiFrontend") }}
-        ports:
-        - name: http
-          containerPort: 8081
         lifecycle:
           preStop:
             exec:
@@ -128,11 +126,62 @@ spec:
         - name: hubble-ui-client-certs
           mountPath: /var/lib/hubble-ui/certs
           readOnly: true
+      - name: kube-rbac-proxy
+      {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list $ "kubeRbacProxy") }}
+        args:
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8443"
+        - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+        - "--v=2"
+        - "--logtostderr=true"
+        - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+                fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            excludePaths:
+            - /api/health
+            upstreams:
+            - upstream: http://127.0.0.1:8081/
+              path: /
+              authorization:
+                resourceAttributes:
+                  namespace: d8-cni-cilium
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: deployments
+                  subresource: http
+                  name: hubble-ui
+        ports:
+          - containerPort: 8443
+            name: https
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
+        resources:
+          requests:
+          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+          {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+{{- end }}
+        volumeMounts:
+        - name: kube-rbac-proxy-ca
+          mountPath: /etc/kube-rbac-proxy
       volumes:
       - configMap:
           defaultMode: 420
           name: hubble-ui-nginx
         name: hubble-ui-nginx-conf
+      - name: kube-rbac-proxy-ca
+        configMap:
+          defaultMode: 420
+          name: kube-rbac-proxy-ca.crt
       - emptyDir:
           medium: Memory
         name: tmp

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -18,12 +18,13 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: hubble-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
+    {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_ssl_certificate /etc/nginx/ssl/client.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
       proxy_ssl_protocols TLSv1.2;
       proxy_ssl_session_reuse on;
-    {{- end }}
     {{- if .Values.ciliumHubble.auth.whitelistSourceRanges }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ciliumHubble.auth.whitelistSourceRanges | join "," }}
     {{- end }}
@@ -37,7 +38,7 @@ spec:
               service:
                 name: hubble-ui
                 port:
-                  name: http
+                  name: https
             path: /
             pathType: ImplementationSpecific
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}

--- a/modules/500-cilium-hubble/templates/ui/rbac-for-us.yaml
+++ b/modules/500-cilium-hubble/templates/ui/rbac-for-us.yaml
@@ -81,6 +81,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/500-cilium-hubble/templates/ui/rbac-to-us.yaml
+++ b/modules/500-cilium-hubble/templates/ui/rbac-to-us.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.global.modules.publicDomainTemplate }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-ui-http
+  namespace: d8-cni-cilium
+  {{- include "helm_lib_module_labels" (list . (dict "app" "hubble-ui")) | nindent 2 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments/http"]
+    resourceNames: ["hubble-ui"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-ui-http
+  namespace: d8-cni-cilium
+  {{- include "helm_lib_module_labels" (list . (dict "app" "hubble-ui")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-ui-http
+subjects:
+  - kind: Group
+    name: ingress-nginx:auth
+{{- end }}

--- a/modules/500-cilium-hubble/templates/ui/service.yaml
+++ b/modules/500-cilium-hubble/templates/ui/service.yaml
@@ -9,6 +9,6 @@ spec:
   selector:
     app: hubble-ui
   ports:
-    - name: http
-      port: 80
-      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https


### PR DESCRIPTION
## Description
Making hubble-ui and kiali services accessible only for the ingress controller.

## Why do we need it, and what problem does it solve?
Improving security of interactions between platform components.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: Internal TLS authentication between ingress-controller and hubble-ui enabled.
---
section: istio
type: chore
summary:  Internal TLS authentication between ingress-controller and kiali enabled.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
