### PR TITLE
[network-policy-engine][registrypackages] Downgrading iptables version to 1.8.9

### DIFF
--- a/candi/bashible/common-steps/all/003_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/003_install_mandatory_packages.sh.tpl
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bb-package-install "jq:{{ .images.registrypackages.jq16 }}" "curl:{{ .images.registrypackages.d8Curl821 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1470 }}" "netcat:{{ .images.registrypackages.netcat110481 }}" "iptables:{{ .images.registrypackages.iptables1810 }}" "growpart:{{ .images.registrypackages.growpart033 }}"
+bb-package-install "jq:{{ .images.registrypackages.jq16 }}" "curl:{{ .images.registrypackages.d8Curl821 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1470 }}" "netcat:{{ .images.registrypackages.netcat110481 }}" "iptables:{{ .images.registrypackages.iptables189 }}" "growpart:{{ .images.registrypackages.growpart033 }}"

--- a/modules/007-registrypackages/images/iptables/werf.inc.yaml
+++ b/modules/007-registrypackages/images/iptables/werf.inc.yaml
@@ -1,5 +1,5 @@
 {{/* Important! The iptables binaries from artifact are also used in kube-router image of network-policy-engine module. */}}
-{{- $version := "1.8.10" }}
+{{- $version := "1.8.9" }}
 {{- $image_version := $version | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
@@ -47,5 +47,5 @@ shell:
     - ./configure --enable-static --disable-shared --libdir=/opt/deckhouse/bin/.libs
     - make LDFLAGS='-all-static'
     - strip ./iptables/xtables-legacy-multi && strip ./iptables/xtables-nft-multi
-    - mv ./iptables/xtables-legacy-multi /xtables-legacy-multi && mv ./iptables/xtables-nft-multi /xtables-nft-multi 
+    - mv ./iptables/xtables-legacy-multi /xtables-legacy-multi && mv ./iptables/xtables-nft-multi /xtables-nft-multi
     - chmod +x /xtables-legacy-multi /xtables-nft-multi /install /uninstall

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -1,5 +1,5 @@
 {{- $binaries := "/usr/lib64/libnetfilter_conntrack.so* /sbin/ipset /sbin/ip /usr/sbin/conntrack" }}
-{{- $iptables_version := "1.8.10" }}
+{{- $iptables_version := "1.8.9" }}
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -389,7 +389,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"ecrCredentialProvider129":  "imageHash-registrypackages-ecrCredentialProvider129",
 		"ecrCredentialProvider130":  "imageHash-registrypackages-ecrCredentialProvider130",
 		"growpart033":               "imageHash-registrypackages-growpart033",
-		"iptables1810":              "imageHash-registrypackages-iptables1810",
+		"iptables189":               "imageHash-registrypackages-iptables189",
 		"jq16":                      "imageHash-registrypackages-jq16",
 		"kubeadm12615":              "imageHash-registrypackages-kubeadm12615",
 		"kubeadm12716":              "imageHash-registrypackages-kubeadm12716",


### PR DESCRIPTION
## Description
Downgrading iptables version from 1.8.10 to 1.8.9 in network-policy-engine (kube-router) and registrypackages (iptables binary on nodes).

## Why do we need it, and what problem does it solve?
With the current version of iptables there is a problem with kube-router endlessly adding a rule like 
```shell
-t filter -A KUBE-ROUTER-INPUT -p tcp -m comment --comment "allow LOCAL TCP traffic to node ports - <some-id>" -m addrtype --dst-type LOCAL -m multiport --dports 30000:32767 -j RETURN
```

It happens because kube-router perform check by executing the iptables command:
```shell 
iptables -t filter -C KUBE-ROUTER-INPUT -p tcp -m comment --comment "allow LOCAL TCP traffic to node ports - <some-id>" -m addrtype --dst-type LOCAL -m multiport --dports 30000:32767 -j RETURN
```
Which sometimes fails with EXIT_CODE 1. So, kube-router decides there isn't a rule and adds it.

Theres is similar issue in upstream - https://github.com/cloudnativelabs/kube-router/issues/1676.

You need to clear unwanted rule manually or reboot affected nodes.

## Why do we need it in the patch release (if we do)?
Duplicate rules create a load on the CPU if kube-router is used.

## What is the expected result?

There won't be duplicate rules in the KUBE-ROUTER-INPUT chain:
```shell
iptables-save | grep "allow LOCAL TCP traffic to node ports" | wc -l
1
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: network-policy-engine
type: fix
summary: Downgraded iptables version from 1.8.10 to 1.8.9 due to iptables chains overflow. You need to clear unwanted iptables rules manually or reboot the affected nodes.
impact_level: default
---
section: registrypackages
type: fix
summary: Downgraded iptables version from 1.8.10 to 1.8.9.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
