### PR TITLE
[istio] Forcing istiod to restart when mTLS ca configuration changes

### DIFF
--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -78,6 +78,8 @@ spec:
 
     pilot:
       enabled: true
+      podAnnotations:
+        istio-mtls-ca-bundle-hashsum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
       k8s:
         env:
         - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
@@ -97,9 +99,6 @@ spec:
     egressGateways:
     - name: istio-egressgateway
       enabled: false
-
-    podAnnotations:
-      istio-mtls-ca-bundle-hashsum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
 
     # We're deploying the istio-cni DS with module templates.
     cni:

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -99,7 +99,7 @@ spec:
       enabled: false
 
     podAnnotations:
-      istio-mtls-ca-bundle-hashsum: {{ md5sum (.Values.istio.internal.ca | toYaml) }}
+      istio-mtls-ca-bundle-hashsum: {{ .Values.istio.internal.ca | toYaml | sha256sum }}
 
     # We're deploying the istio-cni DS with module templates.
     cni:

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -99,7 +99,7 @@ spec:
       enabled: false
 
     podAnnotations:
-      istio-mtls-ca-bundle-hashsum: {{ .Values.istio.internal.ca | toYaml | sha256sum }}
+      istio-mtls-ca-bundle-hashsum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
 
     # We're deploying the istio-cni DS with module templates.
     cni:

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -78,8 +78,6 @@ spec:
 
     pilot:
       enabled: true
-      podAnnotations:
-        istio-mtls-ca-bundle-hashsum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
       k8s:
         env:
         - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
@@ -218,6 +216,8 @@ spec:
 
     pilot:
       autoscaleEnabled: false
+      podAnnotations:
+        istio-mtls-ca-bundle-hashsum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
   {{- if eq $.Values.istio.controlPlane.replicasManagement.mode "Standard" }}
       replicaCount: {{ include "helm_lib_is_ha_to_value" (list $ 2 1) }}
   {{- else if eq $.Values.istio.controlPlane.replicasManagement.mode "Static" }}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -98,6 +98,9 @@ spec:
     - name: istio-egressgateway
       enabled: false
 
+    podAnnotations:
+      istio-mtls-ca-bundle-hashsum: {{ md5sum (.Values.istio.internal.ca | toYaml) }}
+
     # We're deploying the istio-cni DS with module templates.
     cni:
       enabled: false

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -217,7 +217,7 @@ spec:
     pilot:
       autoscaleEnabled: false
       podAnnotations:
-        istio-mtls-ca-bundle-hashsum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
+        istio-mtls-ca-bundle-checksum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
   {{- if eq $.Values.istio.controlPlane.replicasManagement.mode "Standard" }}
       replicaCount: {{ include "helm_lib_is_ha_to_value" (list $ 2 1) }}
   {{- else if eq $.Values.istio.controlPlane.replicasManagement.mode "Static" }}


### PR DESCRIPTION
## Description
Add an annotation `istio-mtls-ca-bundle-checksum: <sha256sum>` to the `istiod` pods to force restarting when ca changes.

## Why do we need it, and what problem does it solve?
When configuring custom CA and intermediate certificates for mTLS issuing, you must reload `istiod` pod for the settings to take effect.

## What is the expected result?
After changing the `spec.settings.ca` settings of the **istio** module, an annotation is added and **helm** generates a new manifest for `istiod`. All newly created pods with **istio** side-cars will use custom certificates for mTLS operation.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed an issue with automatically applying new custom certificates for mTLS issuing.
impact_level: default
```