### PR TITLE
helper change-registry bearer or basic auth support

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -72,7 +72,7 @@ func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTa
 
 	caTransport := cr.GetHTTPTransport(caContent)
 
-	if err := checkBearerSupport(ctx, newRepo.Registry, caTransport); err != nil {
+	if err := checkAuthSupport(ctx, newRepo.Registry, caTransport); err != nil {
 		return err
 	}
 
@@ -337,7 +337,7 @@ func checkImageExists(imageRef name.Reference, opts []remote.Option) error {
 // checkBearerSupport func checks that registry accepts bearer token authentification.
 // This is modified "ping" func from
 // https://github.com/google/go-containerregistry/blob/v0.5.1/pkg/v1/remote/transport/ping.go
-func checkBearerSupport(ctx context.Context, reg name.Registry, roundTripper http.RoundTripper) error {
+func checkAuthSupport(ctx context.Context, reg name.Registry, roundTripper http.RoundTripper) error {
 	client := &http.Client{Transport: roundTripper}
 
 	// This first attempts to use "https" for every request, falling back to http
@@ -356,12 +356,12 @@ func checkBearerSupport(ctx context.Context, reg name.Registry, roundTripper htt
 			continue
 		}
 
-		err = checkResponseForBearerSupport(resp, reg.Name())
+		err = checkResponseForAuthSupport(resp, reg.Name())
 		if err == nil {
 			return nil
 		}
 
-		errs = multierror.Append(errs, fmt.Errorf("check bearer support with %q scheme failed: %w", scheme, err))
+		errs = multierror.Append(errs, fmt.Errorf("check auth support with %q scheme failed: %w", scheme, err))
 	}
 
 	return errs.ErrorOrNil()
@@ -387,31 +387,34 @@ func makeRequestWithScheme(ctx context.Context, client *http.Client, scheme, reg
 	return resp, resp.Body.Close()
 }
 
-func checkResponseForBearerSupport(resp *http.Response, registryHost string) error {
+func checkResponseForAuthSupport(resp *http.Response, registryHost string) error {
 	if resp.StatusCode != http.StatusUnauthorized {
 		return transport.CheckError(resp, http.StatusUnauthorized)
 	}
 
-	if authHeaderWithBearer(resp.Header) {
+	if authHeader(resp.Header) {
 		return nil
 	}
 
-	return fmt.Errorf("can't use bearer token auth with registry %s", registryHost)
+	return fmt.Errorf("can't use bearer or basic auth with registry %s", registryHost)
 }
 
-func authHeaderWithBearer(header http.Header) bool {
-	const (
-		wwwAuthHeader = "WWW-Authenticate"
-		bearer        = "bearer"
-	)
+func authHeader(headers http.Header) bool {
+	authSchemes := []string{"bearer", "basic"}
+	authHeader := headers.Get("WWW-Authenticate")
+	if authHeader == "" {
+		log.Info("Empty WWW-Authenticate header")
+		return false
+	}
 
-	for _, h := range header[http.CanonicalHeaderKey(wwwAuthHeader)] {
-		if strings.HasPrefix(strings.ToLower(h), bearer) {
+	lowerHeader := strings.ToLower(authHeader)
+	for _, scheme := range authSchemes {
+		if strings.HasPrefix(lowerHeader, scheme) {
 			return true
 		}
 	}
-
-	return strings.ToLower(header.Get(wwwAuthHeader)) == bearer
+	log.Infof("WWW-Authenticate header has an incorrect value: %s", authHeader)
+	return false
 }
 
 type dockerCfgAuthEntry struct {

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry_test.go
@@ -247,7 +247,7 @@ func TestCheckResponseForBearerSupport(t *testing.T) {
 			resp.Header.Add("WWW-Authenticate", tt.headerValue)
 			resp.Request.URL = u
 
-			if err := checkResponseForBearerSupport(resp, tt.host); (err != nil) != tt.wantErr {
+			if err := checkResponseForAuthSupport(resp, tt.host); (err != nil) != tt.wantErr {
 				t.Errorf("checkResponseForBearerSupport() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -279,8 +279,40 @@ func TestAuthHeaderWithBearer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			header := http.Header{}
 			header.Set("WWW-Authenticate", tt.headerValue)
-			if !authHeaderWithBearer(header) && !tt.wantFalse {
+			if !authHeader(header) && !tt.wantFalse {
 				t.Error("Unexpected scheme in auth header: must be 'bearer'")
+			}
+		})
+	}
+}
+
+func TestAuthHeaderWithBasic(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerValue string
+		wantFalse   bool
+	}{
+		{
+			name:        "full header",
+			headerValue: `BASIC realm="Sonatype Nexus Repository Manager"`,
+		},
+		{
+			name:        "short header",
+			headerValue: "BASIC;",
+		},
+		{
+			name:        "no auth",
+			headerValue: "anonymous;",
+			wantFalse:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			header.Set("WWW-Authenticate", tt.headerValue)
+			if !authHeader(header) && !tt.wantFalse {
+				t.Error("Unexpected scheme in auth header: must be 'basic'")
 			}
 		})
 	}
@@ -344,7 +376,7 @@ func Test_checkBearerSupport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := checkBearerSupport(tt.args.ctx, reg, http.DefaultTransport); (err != nil) != tt.wantErr {
+			if err := checkAuthSupport(tt.args.ctx, reg, http.DefaultTransport); (err != nil) != tt.wantErr {
 				t.Errorf("checkBearerSupport() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Description

Update validation of the response header from registry for change-registry helper. Previously there was strict validation for bearer token support now basic auth is allowed. 

## Why do we need it, and what problem does it solve?

Some legacy container registries only support basic auth.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

change-registry helper runs successfully for repository with basic-auth

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Adding basic-auth support for change-registry helper 
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
