### PR TITLE
[dhctl] test coverage of secretedit function

### DIFF
--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -15,24 +15,15 @@
 package commands
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
-
-const allowUnsafeAnnotation = "deckhouse.io/allow-unsafe"
 
 func connectionFlags(parent *kingpin.CmdClause) {
 	app.DefineKubeFlags(parent)
@@ -56,70 +47,10 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			return err
 		}
 
-		config, err := kubeCl.CoreV1().Secrets("kube-system").Get(context.TODO(), secret, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		configData := config.Data[dataKey]
-
-		var modifiedData []byte
-		tomb.WithoutInterruptions(func() { modifiedData, err = operations.Edit(configData) })
-		if err != nil {
-			return err
-		}
-
-		// This flag is validating by webhooks to allow editing unsafe resource's fields.
-		if app.SanityCheck {
-			addUnsafeAnnotation(config)
-		}
-
-		return log.Process(
-			"common",
-			fmt.Sprintf("Save %s back to the Kubernetes cluster", name), func() error {
-				if string(configData) == string(modifiedData) {
-					log.InfoLn("Configurations are equal. Nothing to update.")
-					return nil
-				}
-
-				config.Data[dataKey] = modifiedData
-
-				return retry.
-					NewLoop(fmt.Sprintf("Update %s secret", name), 5, 5*time.Second).
-					Run(func() error {
-						_, err = kubeCl.CoreV1().
-							Secrets("kube-system").
-							Update(context.TODO(), config, metav1.UpdateOptions{})
-						if err != nil {
-							return err
-						}
-
-						if app.SanityCheck {
-							log.InfoLn("Remove allow-unsafe annotation")
-							removeUnsafeAnnotation(config)
-
-							_, err = kubeCl.CoreV1().
-								Secrets("kube-system").
-								Update(context.TODO(), config, metav1.UpdateOptions{})
-						}
-
-						return err
-					})
-			})
+		return operations.SecretEdit(kubeCl, name, "kube-system", secret, dataKey)
 	})
 
 	return cmd
-}
-
-func addUnsafeAnnotation(doc *v1.Secret) {
-	if doc.Annotations == nil {
-		doc.Annotations = make(map[string]string)
-	}
-	doc.Annotations[allowUnsafeAnnotation] = "true"
-}
-
-func removeUnsafeAnnotation(doc *v1.Secret) {
-	delete(doc.Annotations, allowUnsafeAnnotation)
 }
 
 func DefineEditCommands(parent *kingpin.CmdClause, wConnFlags bool) {

--- a/dhctl/pkg/operations/secretedit.go
+++ b/dhctl/pkg/operations/secretedit.go
@@ -1,0 +1,97 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
+)
+
+const allowUnsafeAnnotation = "deckhouse.io/allow-unsafe"
+
+func SecretEdit(kubeCl *client.KubernetesClient, name string, NameSpase string, secret string, dataKey string) error {
+	config, err := kubeCl.CoreV1().Secrets("kube-system").Get(context.TODO(), secret, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	configData := config.Data[dataKey]
+
+	var modifiedData []byte
+	tomb.WithoutInterruptions(func() { modifiedData, err = Edit(configData) })
+	if err != nil {
+		return err
+	}
+
+	// This flag is validating by webhooks to allow editing unsafe resource's fields.
+	if app.SanityCheck {
+		addUnsafeAnnotation(config)
+	}
+
+	return log.Process(
+		"common",
+		fmt.Sprintf("Save %s back to the Kubernetes cluster", name), func() error {
+			if string(configData) == string(modifiedData) {
+				log.InfoLn("Configurations are equal. Nothing to update.")
+				return nil
+			}
+
+			config.Data[dataKey] = modifiedData
+
+			return retry.
+				NewLoop(fmt.Sprintf("Update %s secret", name), 5, 5*time.Second).
+				Run(func() error {
+					_, err = kubeCl.CoreV1().
+						Secrets("kube-system").
+						Update(context.TODO(), config, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+
+					if app.SanityCheck {
+						log.InfoLn("Remove allow-unsafe annotation")
+						removeUnsafeAnnotation(config)
+
+						_, err = kubeCl.CoreV1().
+							Secrets("kube-system").
+							Update(context.TODO(), config, metav1.UpdateOptions{})
+					}
+
+					return err
+				})
+		})
+
+}
+
+func addUnsafeAnnotation(doc *v1.Secret) {
+	if doc.Annotations == nil {
+		doc.Annotations = make(map[string]string)
+	}
+	doc.Annotations[allowUnsafeAnnotation] = "true"
+}
+
+func removeUnsafeAnnotation(doc *v1.Secret) {
+	delete(doc.Annotations, allowUnsafeAnnotation)
+}


### PR DESCRIPTION
## Description
Adding tests for the secrets editor in dhctl.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
test coverage of code from change https://github.com/deckhouse/deckhouse/pull/6486
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Adding tests for the secrets editor in dhctl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
