### PR TITLE
[registry-packages] add docker-registry package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -205,15 +205,6 @@ updates:
   open-pull-requests-limit: 0
 
 - package-ecosystem: "gomod"
-  directory: "/modules/007-registrypackages/images/docker-registry/src"
-  labels:
-  - "type/dependencies"
-  - "status/ok-to-test"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 0
-
-- package-ecosystem: "gomod"
   directory: "/modules/007-registrypackages/images/toml-merge/src"
   labels:
   - "type/dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -205,6 +205,15 @@ updates:
   open-pull-requests-limit: 0
 
 - package-ecosystem: "gomod"
+  directory: "/modules/007-registrypackages/images/docker-registry/src"
+  labels:
+  - "type/dependencies"
+  - "status/ok-to-test"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 0
+
+- package-ecosystem: "gomod"
   directory: "/modules/007-registrypackages/images/toml-merge/src"
   labels:
   - "type/dependencies"

--- a/modules/007-registrypackages/images/docker-registry/scripts/install
+++ b/modules/007-registrypackages/images/docker-registry/scripts/install
@@ -15,4 +15,4 @@
 
 set -Eeo pipefail
 mkdir -p /opt/deckhouse/bin
-cp -f auth_server /opt/deckhouse/bin
+cp -f auth_server registry /opt/deckhouse/bin

--- a/modules/007-registrypackages/images/docker-registry/scripts/install
+++ b/modules/007-registrypackages/images/docker-registry/scripts/install
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+mkdir -p /opt/deckhouse/bin
+cp -f auth_server /opt/deckhouse/bin

--- a/modules/007-registrypackages/images/docker-registry/scripts/uninstall
+++ b/modules/007-registrypackages/images/docker-registry/scripts/uninstall
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 set -Eeo pipefail
-rm -f /opt/deckhouse/bin/auth_server
+rm -f /opt/deckhouse/bin/auth_server /opt/deckhouse/bin/registry

--- a/modules/007-registrypackages/images/docker-registry/scripts/uninstall
+++ b/modules/007-registrypackages/images/docker-registry/scripts/uninstall
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+rm -f /opt/deckhouse/bin/auth_server

--- a/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
+++ b/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
@@ -32,7 +32,7 @@ git:
       - '**/*'
 shell:
   setup:
-  - export GOPROXY={{ $.GOPROXY }}
+  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=auto
   - git clone --depth 1 --branch {{ $docker_auth_version }} {{ $.SOURCE_REPO }}/cesanta/docker_auth.git
   - cd /docker_auth/auth_server
   - make build

--- a/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
+++ b/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
@@ -30,11 +30,6 @@ git:
     stageDependencies:
       setup:
       - '**/*'
-  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
-    to: /src
-    stageDependencies:
-      setup:
-        - '**/*'
 shell:
   setup:
   - export GOPROXY={{ $.GOPROXY }}

--- a/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
+++ b/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
@@ -1,0 +1,50 @@
+{{- $docker_version := "2.8.3" }}
+{{- $docker_auth_version := "1.12.0" }}
+
+{{- $image_version := $docker_version | replace "." "-" }}
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+from: {{ $.Images.BASE_SCRATCH }}
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+  add: /
+  to: /
+  includePaths:
+  - registry
+  - auth_server
+  - install
+  - uninstall
+  before: setup
+docker:
+  LABEL:
+    distro: all
+    version: all
+    docker: {{ $docker_version }}
+    cesanta_auth: {{ $docker_auth_version }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
+git:
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+    to: /
+    stageDependencies:
+      setup:
+      - '**/*'
+  - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
+    to: /src
+    stageDependencies:
+      setup:
+        - '**/*'
+shell:
+  setup:
+  - export GOPROXY={{ $.GOPROXY }}
+  - git clone --depth 1 --branch {{ $docker_auth_version }} {{ $.SOURCE_REPO }}/cesanta/docker_auth.git
+  - cd /docker_auth/auth_server
+  - make build
+  - mv ./auth_server /auth_server
+  - mkdir -p /go/src/github.com/docker/distribution
+  - cd /go/src/github.com/docker/distribution
+  - git clone --depth 1 --branch v{{ $docker_version }} {{ $.SOURCE_REPO }}/distribution/distribution.git .
+  - make
+  - cp bin/registry /
+  - chmod +x /auth_server /registry /install /uninstall

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -380,6 +380,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"crictl130":                 "imageHash-registrypackages-crictl130",
 		"d8":                        "imageHash-registrypackages-d8",
 		"d8Curl821":                 "imageHash-registrypackages-d8Curl821",
+		"dockerRegistry283":         "imageHash-registrypackages-dockerRegistry283",
 		"drbd":                      "imageHash-registrypackages-drbd",
 		"e2fsprogs1470":             "imageHash-registrypackages-e2fsprogs1470",
 		"ec2DescribeTagsV001Flant2": "imageHash-registrypackages-ec2DescribeTagsV001Flant2",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add standalone docker-registry package.

How to install it ?
```
apiVersion: deckhouse.io/v1alpha1
kind: NodeGroupConfiguration
metadata:
  labels:
    heritage: deckhouse
  name: install-docker-registry.sh
spec:
  bundles:
  - '*'
  content: |
    # Copyright 2024 Flant JSC
    #
    # Licensed under the Apache License, Version 2.0 (the "License");
    # you may not use this file except in compliance with the License.
    # You may obtain a copy of the License at
    #
    #     http://www.apache.org/licenses/LICENSE-2.0
    #
    # Unless required by applicable law or agreed to in writing, software
    # distributed under the License is distributed on an "AS IS" BASIS,
    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    # See the License for the specific language governing permissions and
    # limitations under the License.

    if [[ $HOSTNAME != "master-0" ]]; then
      exit 1
    fi

    bb-package-install "docker-registry:{{- index $.images.registrypackages "dockerRegistry283" }}"
  nodeGroups:
  - 'master'
  weight: 100
```

Take note about
```
if [[ $HOSTNAME != "master-0" ]]; then
      exit 1
    fi
```
This code set up registry binary only on one master if master hosts more than one.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Sometimes we need own in-cluster registry.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry-packages
type: chore
summary: add standalone docker-registry package
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
