### PR TITLE
[deckhouse-controller] update manager's cache

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -85,14 +85,12 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator, logg
 	var identity string
 	podName := os.Getenv("DECKHOUSE_POD")
 	if len(podName) == 0 {
-		log.Info("DECKHOUSE_POD env not set or empty")
-		os.Exit(1)
+		log.Fatal("DECKHOUSE_POD env not set or empty")
 	}
 
 	podIP := os.Getenv("ADDON_OPERATOR_LISTEN_ADDRESS")
 	if len(podIP) == 0 {
-		log.Info("ADDON_OPERATOR_LISTEN_ADDRESS env not set or empty")
-		os.Exit(1)
+		log.Fatal("ADDON_OPERATOR_LISTEN_ADDRESS env not set or empty")
 	}
 
 	podNs := os.Getenv("ADDON_OPERATOR_NAMESPACE")
@@ -108,7 +106,7 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator, logg
 		identity = fmt.Sprintf("%s.%s.%s.pod.%s", podName, strings.ReplaceAll(podIP, ".", "-"), podNs, clusterDomain)
 	}
 
-	err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
+	if err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
 		// Create a leaderElectionConfig for leader election
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: v1.ObjectMeta{
@@ -134,22 +132,19 @@ func runHAMode(ctx context.Context, operator *addon_operator.AddonOperator, logg
 			OnStoppedLeading: func() {
 				operator.Logger.Info("Restarting because the leadership was handed over")
 				operator.Stop()
-				os.Exit(1)
+				os.Exit(0)
 			},
 		},
 		ReleaseOnCancel: true,
-	})
-	if err != nil {
+	}); err != nil {
 		operator.Logger.Error("run", slog.String("error", err.Error()))
 	}
 
 	go func() {
 		<-ctx.Done()
 		log.Info("Context canceled received")
-		err := syscall.Kill(1, syscall.SIGUSR2)
-		if err != nil {
-			log.Infof("Couldn't shutdown deckhouse: %s\n", err)
-			os.Exit(1)
+		if err := syscall.Kill(1, syscall.SIGUSR2); err != nil {
+			log.Fatalf("Couldn't shutdown deckhouse: %s\n", err)
 		}
 	}()
 
@@ -215,7 +210,7 @@ func run(ctx context.Context, operator *addon_operator.AddonOperator, logger *lo
 	// Block main thread by waiting signals from OS.
 	utils_signal.WaitForProcessInterruption(func() {
 		operator.Stop()
-		os.Exit(1)
+		os.Exit(0)
 	})
 
 	return nil

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -166,6 +166,15 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 						},
 					},
 				},
+				// for deckhouse.io apis
+				&v1alpha1.Module{}:              {},
+				&v1alpha1.ModuleConfig{}:        {},
+				&v1alpha1.ModuleDocumentation{}: {},
+				&v1alpha1.ModuleRelease{}:       {},
+				&v1alpha1.ModuleSource{}:        {},
+				&v1alpha1.ModuleUpdatePolicy{}:  {},
+				&v1alpha1.ModulePullOverride{}:  {},
+				&v1alpha1.DeckhouseRelease{}:    {},
 			},
 		},
 	})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bumps addon-operator to support cache for helm resources manager.
Updates the controller-runtime manager's cache options and provides some other minor improvements.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The controller's manager cache should cache deckhouse.io api's objects like modules, module releases, etc.
## Why do we need it in the patch release (if we do)?

## What is the expected result?
Helm resources manager should cease listing objects when checking helm releases.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Update manager's cache.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
