### PR TITLE
[multitenancy-manager] fix templates

### DIFF
--- a/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/default-project-template.yaml
@@ -188,16 +188,16 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-monitoring"
-                podSelector:
-                  matchLabels:
-                    app: prometheus
+              podSelector:
+                matchLabels:
+                  app: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-ingress-nginx"
-                podSelector:
-                  matchLabels:
-                    app: controller
+              podSelector:
+                matchLabels:
+                  app: controller
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-project-template.yaml
@@ -225,16 +225,16 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-monitoring"
-                podSelector:
-                  matchLabels:
-                    app: prometheus
+              podSelector:
+                matchLabels:
+                  app: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-ingress-nginx"
-                podSelector:
-                  matchLabels:
-                    app: controller
+              podSelector:
+                 matchLabels:
+                  app: controller
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/user-resources/secure-with-dedicated-nodes-project-template.yaml
@@ -272,16 +272,16 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-monitoring"
-                podSelector:
-                  matchLabels:
-                    app: prometheus
+              podSelector:
+                matchLabels:
+                  app: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-ingress-nginx"
-                podSelector:
-                  matchLabels:
-                    app: controller
+              podSelector:
+                matchLabels:
+                  app: controller
       egress:
         # Traffic within the project is allowed.
         - to:


### PR DESCRIPTION
## Description
It provides fix for templates.

## Why do we need it, and what problem does it solve?
The PodSelector field is not in the right place.

## Why do we need it in the patch release (if we do)?
This field may be ignored by helm.

## What is the expected result?
The PodSelector field is in the right place.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Fix templates.
```

