### PR TITLE
[dhctl] Fix static installation consume 100% of cpu

### DIFF
--- a/dhctl/pkg/system/process/executor.go
+++ b/dhctl/pkg/system/process/executor.go
@@ -110,7 +110,10 @@ type Executor struct {
 	StdoutBuffer   *bytes.Buffer
 	StdoutSplitter bufio.SplitFunc
 	StdoutHandler  func(l string)
-	stdoutReadPipe *os.File
+
+	pipesMutex     sync.Mutex
+	stdoutPipeFile *os.File
+	stderrPipeFile *os.File
 
 	StderrBuffer   *bytes.Buffer
 	StderrSplitter bufio.SplitFunc
@@ -247,8 +250,12 @@ func (e *Executor) SetupStreamHandlers() (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to create os pipe for stdout: %s", err)
 		}
-		e.stdoutReadPipe = stdoutReadPipe
+
 		e.cmd.Stdout = stdoutWritePipe
+
+		e.pipesMutex.Lock()
+		e.stdoutPipeFile = stdoutWritePipe
+		e.pipesMutex.Unlock()
 
 		// create pipe for StdoutHandler
 		if e.StdoutHandler != nil {
@@ -270,6 +277,10 @@ func (e *Executor) SetupStreamHandlers() (err error) {
 			return fmt.Errorf("unable to create os pipe for stderr: %s", err)
 		}
 		e.cmd.Stderr = stderrWritePipe
+
+		e.pipesMutex.Lock()
+		e.stderrPipeFile = stderrWritePipe
+		e.pipesMutex.Unlock()
 
 		// create pipe for StderrHandler
 		if e.StderrHandler != nil {
@@ -313,6 +324,9 @@ func (e *Executor) SetupStreamHandlers() (err error) {
 			return
 		}
 
+		log.DebugLn("Start reading from stderr pipe")
+		defer log.DebugLn("Stop reading from stderr pipe")
+
 		buf := make([]byte, 16)
 		for {
 			n, err := stderrReadPipe.Read(buf)
@@ -346,17 +360,31 @@ func (e *Executor) SetupStreamHandlers() (err error) {
 }
 
 func (e *Executor) readFromStreams(stdoutReadPipe io.Reader, stdoutHandlerWritePipe io.Writer) {
+	defer log.DebugLn("stop readFromStreams")
+
 	if stdoutReadPipe == nil || reflect.ValueOf(stdoutReadPipe).IsNil() {
 		return
 	}
+
 	log.DebugLn("Start read from streams for command: ", e.cmd.String())
+
 	buf := make([]byte, 16)
 	matchersDone := false
 	if len(e.Matchers) == 0 {
 		matchersDone = true
 	}
+
+	errorsCount := 0
 	for {
 		n, err := stdoutReadPipe.Read(buf)
+		if err != nil && err != io.EOF {
+			log.DebugF("Error reading from stdout: %s\n", err)
+			errorsCount++
+			if errorsCount > 1000 {
+				panic(fmt.Errorf("readFromStreams: too many errors, last error %v", err))
+			}
+			continue
+		}
 
 		m := 0
 		if !matchersDone {
@@ -501,6 +529,30 @@ func (e *Executor) ProcessWait() {
 	}()
 }
 
+func (e *Executor) closePipes() {
+	log.DebugLn("Starting close piped")
+	defer log.DebugLn("Stop close piped")
+
+	e.pipesMutex.Lock()
+	defer e.pipesMutex.Unlock()
+
+	if e.stdoutPipeFile != nil {
+		err := e.stdoutPipeFile.Close()
+		if err != nil {
+			log.DebugF("Cannot close stdout pipe: %v\n", err)
+		}
+		e.stdoutPipeFile = nil
+	}
+
+	if e.stderrPipeFile != nil {
+		err := e.stderrPipeFile.Close()
+		if err != nil {
+			log.DebugF("Cannot close stderr pipe: %v\n", err)
+		}
+		e.stderrPipeFile = nil
+	}
+}
+
 func (e *Executor) Stop() {
 	if e.stop {
 		log.DebugF("Stop '%s': already stopped\n", e.cmd.String())
@@ -521,8 +573,8 @@ func (e *Executor) Stop() {
 		close(e.stopCh)
 	}
 	<-e.waitCh
-
 	log.DebugF("Stopped '%s': %d\n", e.cmd.String(), e.cmd.ProcessState.ExitCode())
+	e.closePipes()
 }
 
 // Run executes a command and blocks until it is finished or stopped.
@@ -535,6 +587,9 @@ func (e *Executor) Run() error {
 	}
 
 	<-e.waitCh
+
+	e.closePipes()
+
 	return e.WaitError()
 }
 

--- a/dhctl/pkg/system/ssh/frontend/upload-script.go
+++ b/dhctl/pkg/system/ssh/frontend/upload-script.go
@@ -118,7 +118,7 @@ func (u *UploadScript) Execute() (stdout []byte, err error) {
 
 	if u.cleanupAfterExec {
 		defer func() {
-			err := NewCommand(u.Session, "rm", "-f", scriptFullPath).Start()
+			err := NewCommand(u.Session, "rm", "-f", scriptFullPath).Run()
 			if err != nil {
 				log.DebugF("Failed to delete uploaded script %s: %v", scriptFullPath, err)
 			}


### PR DESCRIPTION
## Description
Add cpu profiling while DHCTL_TRACE=yes env provided.

While bootstrap static cluster dhctl start consume all cpu cores.
This will begin to appear after adding additional prefly checks https://github.com/deckhouse/deckhouse/pull/8867/files.
It happens  because reader in executor returns error which not handled.
Error raised because we was check interfaced variable on nil itself only, but should check on interfaced typed value.
Also we had leaking goroutines because we did not close pipes.

## Why do we need it, and what problem does it solve?
DHCTL should not consume a lot of cpu during work.

## Why do we need it in the patch release (if we do)?
DHCTL should not consume a lot of cpu during work.
Affecter >= 1.62 DKP version

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix static installation consume 100% of cpu
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
