### PR TITLE
[dhctl] Fix panic during resources creation

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -254,7 +254,7 @@ func CreateResourcesLoop(kubeCl *client.KubernetesClient, metaConfig *config.Met
 
 	isBootstrapped := false
 
-	err = retry.NewSilentLoop("Wait for resources creation", math.MaxInt, 10*time.Second).
+	return retry.NewSilentLoop("Wait for resources creation", math.MaxInt, 10*time.Second).
 		WithContext(ctx).
 		Run(func() error {
 			err := resourceCreator.TryToCreate()
@@ -286,31 +286,33 @@ func CreateResourcesLoop(kubeCl *client.KubernetesClient, metaConfig *config.Met
 
 			return ErrNotAllResourcesCreated
 		})
-	if err != nil {
-		return err
-	}
 
-	waiter := NewWaiter(checkers)
-
-	err = retry.NewSilentLoop("Wait for resources readiness", math.MaxInt, 5*time.Second).
-		WithContext(ctx).
-		Run(func() error {
-			ready, err := waiter.ReadyAll(ctx)
-			if err != nil {
-				return err
-			}
-
-			if !ready {
-				return fmt.Errorf("not all resources are ready")
-			}
-
-			return nil
-		})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// todo (name212) need more investigation. we can lost watchers. need to simplify code
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//waiter := NewWaiter(checkers)
+	//
+	//err = retry.NewSilentLoop("Wait for resources readiness", math.MaxInt, 5*time.Second).
+	//	WithContext(ctx).
+	//	Run(func() error {
+	//		ready, err := waiter.ReadyAll(ctx)
+	//		if err != nil {
+	//			return err
+	//		}
+	//
+	//		if !ready {
+	//			return fmt.Errorf("not all resources are ready")
+	//		}
+	//
+	//		return nil
+	//	})
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//return nil
 }
 
 func getUnstructuredName(obj *unstructured.Unstructured) string {

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -275,7 +275,9 @@ func CreateResourcesLoop(kubeCl *client.KubernetesClient, metaConfig *config.Met
 				return nil
 			}
 
-			clusterIsBootstrappedChecker.outputProgressInfo()
+			if clusterIsBootstrappedChecker != nil {
+				clusterIsBootstrappedChecker.outputProgressInfo()
+			}
 
 			return ErrNotAllResourcesCreated
 		})

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -262,13 +262,18 @@ func CreateResourcesLoop(kubeCl *client.KubernetesClient, metaConfig *config.Met
 				return err
 			}
 
-			if clusterIsBootstrappedChecker != nil && !isBootstrapped {
+			if clusterIsBootstrappedChecker != nil {
 				var err error
 
-				isBootstrapped, err = clusterIsBootstrappedChecker.IsBootstrapped()
+				if !isBootstrapped {
+					isBootstrapped, err = clusterIsBootstrappedChecker.IsBootstrapped()
+				}
+
 				if err != nil {
 					return err
 				}
+			} else {
+				isBootstrapped = true
 			}
 
 			if isBootstrapped && err == nil {


### PR DESCRIPTION
## Description
Fix panic while resources creation

```
│ ┌ Create deckhouse.io/v1alpha1, Kind=ModuleSource resources
│ │ Manifest for ModuleSource deckhouse
│ │ 🎉 Succeeded!
│ └ Create deckhouse.io/v1alpha1, Kind=ModuleSource resources (0.01 seconds)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x1a7693d]

goroutine 7 [running]:
github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/resources.(*clusterIsBootstrapCheck).outputNodeGroups(0x0?)
    /dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go:174 +0x1d
github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/resources.(*clusterIsBootstrapCheck).outputProgressInfo(0x0)
    /dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go:168 +0x18
github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/resources.CreateResourcesLoop.func1()
    /dhctl/pkg/kubernetes/actions/resources/resources.go:278 +0xbe
github.com/deckhouse/deckhouse/dhctl/pkg/util/retry.(*Loop).Run.func1()
```

## Why do we need it, and what problem does it solve?

`dhctl bootstrap-phase create-resources` does not work

## Why do we need it in the patch release (if we do)?

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix 
summary: Fix panic during resources creation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
