### PR TITLE
[node-manager] Fix cluster-autoscaler alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -212,7 +212,7 @@ alerts:
 
         Excessive cluster-autoscaler restarts indicate that something is wrong. Normally, it should be up and running all the time.
 
-        Please, refer to the corresponding logs: `kubectl -n d8-cloud-instance-manager logs -f -l app=cluster-autoscaler -c controller`.
+        Please, refer to the corresponding logs: `kubectl -n d8-cloud-instance-manager logs -f -l app=cluster-autoscaler -c cluster-autoscaler`.
       summary: |
         Too many cluster-autoscaler restarts have been detected.
       severity: "9"

--- a/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
@@ -99,7 +99,7 @@
 
         Excessive cluster-autoscaler restarts indicate that something is wrong. Normally, it should be up and running all the time.
 
-        Please, refer to the corresponding logs: `kubectl -n d8-cloud-instance-manager logs -f -l app=cluster-autoscaler -c controller`.
+        Please, refer to the corresponding logs: `kubectl -n d8-cloud-instance-manager logs -f -l app=cluster-autoscaler -c cluster-autoscaler`.
 
   - alert: D8ClusterAutoscalerTooManyErrors
     expr: sum by(instance) (increase(cluster_autoscaler_errors_total[20m]) > 5)


### PR DESCRIPTION
## Description
Fix container name in alert.

## Why do we need it, and what problem does it solve?
Correct command in alert to get logs.
Now we have not working command:
```
~ $ kubectl -n d8-cloud-instance-manager logs -f -l app=cluster-autoscaler -c controller
error: container controller is not valid for pod cluster-autoscaler-7cff9f865b-gjhwt
```
We need to use `cluster-autoscaler` container in pod
```
~ $ kubectl -n d8-cloud-instance-manager logs -f -l app=cluster-autoscaler -c cluster-autoscaler
I0813 22:48:09.545414       1 pre_filtering_processor.go:67] Skipping vk-dh-system-f2800271-5585f-npr7q - node group min size reached (current: 2, min: 2)
I0813 22:48:09.545420       1 pre_filtering_processor.go:67] Skipping vk-dh-worker-f2800271-68c7c-b7lfp - node group min size reached (current: 1, min: 1)
I0813 22:48:09.545449       1 static_autoscaler.go:626] Scale down status: lastScaleUpTime=2024-08-13 21:35:59.007191456 +0000 UTC m=-3599.795141597 lastScaleDownDeleteTime=2024-08-13 21:35:59.007191456 +0000 UTC m=-3599.795141597 lastScaleDownFailTime=2024-08-13 21:35:59.007191456 +0000 UTC m=-3599.795141597 scaleDownForbidden=false scaleDownInCooldown=false
I0813 22:48:09.545707       1 legacy.go:296] No candidates for scale down
I0813 22:48:19.548732       1 static_autoscaler.go:554] No unschedulable pods
```
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Not necessarily
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Fix cluster-autoscaler alert
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
