### PR TITLE
[deckhouse] fix: allow admins to change objects with kind=StorageClass

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -68,6 +68,8 @@ spec:
       expression: '!(["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-users'
       expression: '!(["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)))'
+    - name: 'exclude-kinds'
+      expression: '!(["StorageClass"].exists(e, (e == object.kind)))'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
@@ -77,7 +79,7 @@ spec:
       valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with the heritage label'"
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups))'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || ["StorageClass"].exists(e, (e == object.kind))'
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -69,7 +69,7 @@ spec:
     - name: 'exclude-users'
       expression: '!(["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)))'
     - name: 'exclude-kinds'
-      expression: '!(["StorageClass"].exists(e, (e == object.kind)))'
+      expression: '!(has(object.kind) && ["StorageClass"].exists(e, (e == object.kind)))'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden
@@ -79,7 +79,7 @@ spec:
       valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with the heritage label'"
 {{- else }}
   validations:
-    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || ["StorageClass"].exists(e, (e == object.kind))'
+    - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-") || ["kubernetes-admin", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler"].exists(e, (e == request.userInfo.username)) || ["system:nodes", "system:masters", "system:serviceaccounts:kube-system"].exists(e, (e in request.userInfo.groups)) || (has(object.kind) && ["StorageClass"].exists(e, (e == object.kind)))'
       reason: Forbidden
 {{- end }}
 ---


### PR DESCRIPTION
## Description

After introducing restrictions on changing objects with heritage-deckhouse labels, administrators lost the ability to change objects with kind StorageClass

This situation needs to be corrected.

## Why do we need it, and what problem does it solve?

Administrators should be able to modify system objects that have kind StorageClass.

## What is the expected result?

Administrators are given the ability to modify system kind StorageClass objects.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: allow admins to change objects with kind=StorageClass
impact_level: default
```
