### PR TITLE
[go_lib] Skipping migration `diskSizeGB` for dev build

### DIFF
--- a/go_lib/hooks/migrate_root_disk_size/hook.go
+++ b/go_lib/hooks/migrate_root_disk_size/hook.go
@@ -263,10 +263,9 @@ func needMigrateForDeckhouseInstallVersion(snaps go_hook.Snapshots) (bool, error
 	}
 
 	versionStr := is[0].(string)
-	// for dev build migrate always
+	// do not migrate for dev build
 	if versionStr == "dev" {
-		// for dev branches always run migration for testing purposes
-		return true, nil
+		return false, nil
 	}
 
 	version, err := semver.NewVersion(versionStr)

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default.go
@@ -252,10 +252,9 @@ func needMigrateForDeckhouseInstallVersion(snaps go_hook.Snapshots) (bool, error
 	}
 
 	versionStr := is[0].(string)
-	// for dev build migrate always
+	// do not migrate for dev build
 	if versionStr == "dev" {
-		// for dev branches always run migration for testing purposes
-		return true, nil
+		return false, nil
 	}
 
 	version, err := semver.NewVersion(versionStr)

--- a/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/migrate_disk_gb_size_before_changing_default_test.go
@@ -285,8 +285,8 @@ sshPublicKey: ssh-rsa AAAAAbbbb
 			})
 
 			It("Hook should set diskSizeGB for old default 20", func() {
-				assertSetOldDiskSizeForMasterNG(f)
-				assertSaveBackupBeforeMigrate(f, pccs)
+				assertNoChangeSecret(f, pccs)
+				assertSaveBackupBeforeMigrate(f, "")
 			})
 		})
 	})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Skipping migration `diskSizeGB` for dev build.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

After bootstrapping, `dhctl converge` attempts to resize the master boot disk from 50gb to 20gb. 
 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: go_lib
type: fix
summary: Skipping migration `diskSizeGB` for dev branch.
impact_level: default

section: cloud-provider-yandex
type: fix
summary: Skipping migration `diskSizeGB` for dev branch.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
