### PR TITLE
[deckhouse] Various KIND fixes

### DIFF
--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
@@ -32,7 +32,7 @@ bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/t
 - Or run the following command for installing Deckhouse **Enterprise Edition** by providing a license key:
   {% snippetcut selector="kind-install" %}
 ```shell
-echo <LICENSE_KEY> | docker login -u license-token --password-stdin registry.deckhouse.io
+ echo <LICENSE_KEY> | docker login -u license-token --password-stdin registry.deckhouse.io
 bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/tools/kind-d8.sh)" -- --key <LICENSE_KEY>
 ```
   {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
@@ -32,6 +32,7 @@ bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/t
 - Or run the following command for installing Deckhouse **Enterprise Edition** by providing a license key:
   {% snippetcut selector="kind-install" %}
 ```shell
+echo <LICENSE_KEY> | docker login -u license-token --password-stdin registry.deckhouse.io
 bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/tools/kind-d8.sh)" -- --key <LICENSE_KEY>
 ```
   {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
@@ -32,7 +32,7 @@ bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/t
 - Либо выполните следующую команду для установки Deckhouse **Enterprise Edition**, указав лицензионный ключ:
   {% snippetcut selector="kind-install" %}
 ```shell
-echo <LICENSE_KEY> | docker login -u license-token --password-stdin registry.deckhouse.io
+ echo <LICENSE_KEY> | docker login -u license-token --password-stdin registry.deckhouse.io
 bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/tools/kind-d8.sh)" -- --key <LICENSE_KEY>
 ```
   {% endsnippetcut %}

--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
@@ -32,6 +32,7 @@ bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/t
 - Либо выполните следующую команду для установки Deckhouse **Enterprise Edition**, указав лицензионный ключ:
   {% snippetcut selector="kind-install" %}
 ```shell
+echo <LICENSE_KEY> | docker login -u license-token --password-stdin registry.deckhouse.io
 bash -c "$(curl -Ls https://raw.githubusercontent.com/deckhouse/deckhouse/main/tools/kind-d8.sh)" -- --key <LICENSE_KEY>
 ```
   {% endsnippetcut %}

--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -364,6 +364,10 @@ configs_create() {
   cat <<EOF >${CONFIG_DIR}/kind.cfg
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+featureGates:
+  "ValidatingAdmissionPolicy": true
+runtimeConfig:
+  "admissionregistration.k8s.io/v1alpha1": true
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -466,6 +470,10 @@ EOF
   if [[ -n "$D8_LICENSE_KEY" ]]; then
     generate_ee_access_string "$D8_LICENSE_KEY"
     cat <<EOF >>${CONFIG_DIR}/config.yml
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
   imagesRepo: $D8_REGISTRY_PATH
   registryDockerCfg: $D8_EE_ACCESS_STRING
 EOF


### PR DESCRIPTION
## Description
Upon testing KIND installs from Getting Started, various issues came up

1. `ValidatingAdmissionPolicy` resource is missing and is required by multitenancy-manager on setup (both EE and CE)
2. Instructions for EE install are not valid

Fixes:

1. Added featureGate in Kind config to enable `ValidatingAdmissionPolicy` https://github.com/kubernetes-sigs/kind/issues/3029 (I have tested `kindest/node:v1.30.3`, it's not enabled by default here either, that's why I didn't upgrade the image)
2. Fixed `InitConfiguration` rendering for EE installs
4. Added `docker login` to EE step, because `install` image is pulled from the host

## Why do we need it, and what problem does it solve?

We want our Getting Started experience to be smooth

## Why do we need it in the patch release (if we do)?

If we want to fix Getting Started for 1.62

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Fixed Kind flow in Getting Started.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
