### PR TITLE
[cilium-hubble] Add name to VM pod and change its icon

### DIFF
--- a/modules/500-cilium-hubble/images/ui-frontend/patches/001-hubble-ui-vm-name-icon.patch
+++ b/modules/500-cilium-hubble/images/ui-frontend/patches/001-hubble-ui-vm-name-icon.patch
@@ -1,0 +1,104 @@
+diff --git a/src/components/EndpointCardHeader/helpers.ts b/src/components/EndpointCardHeader/helpers.ts
+index 79f2ac2..829b3b0 100644
+--- a/src/components/EndpointCardHeader/helpers.ts
++++ b/src/components/EndpointCardHeader/helpers.ts
+@@ -46,6 +46,13 @@ export const extractLogo = (ep: ServiceCard): Logo => {
+     };
+   }
+ 
++  if (ep.isD8VirtualMachine) {
++    return {
++      id: 'virtualmachine',
++      type: LogoType.PROTOCOL,
++    };
++  }
++
+   const appProto = ep.appProtocol || 'kubernetes';
+   return {
+     id: appProto,
+diff --git a/src/components/EndpointCardHeader/logos.ts b/src/components/EndpointCardHeader/logos.ts
+index 2b87f16..820f41f 100644
+--- a/src/components/EndpointCardHeader/logos.ts
++++ b/src/components/EndpointCardHeader/logos.ts
+@@ -1,6 +1,7 @@
+ export const kubernetes = 'icons/logos/kubernetes-logo.svg';
+ export const world = 'icons/logos/world-logo.svg';
+ export const host = world;
++export const virtualmachine = 'icons/logos/virtualmachine-logo.svg';
+ export const mongodb = 'icons/logos/mongodb-logo.svg';
+ export const redis = 'icons/logos/redis-logo.svg';
+ export const rabbitmq = 'icons/logos/rabbitmq-logo.svg';
+diff --git a/src/domain/labels.ts b/src/domain/labels.ts
+index 72e5201..01b1c66 100644
+--- a/src/domain/labels.ts
++++ b/src/domain/labels.ts
+@@ -9,6 +9,7 @@ export interface LabelsProps {
+   isInit: boolean;
+   isHealth: boolean;
+   isPrometheusApp: boolean;
++  isD8VirtualMachine: boolean;
+   isKubeApiServer: boolean;
+   appName?: string;
+   clusterName?: string;
+@@ -28,6 +29,7 @@ export enum ReservedLabel {
+ export enum SpecialLabel {
+   KubeDNS = 'k8s:k8s-app=kube-dns',
+   PrometheusApp = 'k8s:app=prometheus',
++  D8VirtualMachine = 'k8s:kubevirt.internal.virtualization.deckhouse.io=virt-launcher',
+ }
+ 
+ export class Labels {
+@@ -89,6 +91,7 @@ export class Labels {
+         'name',
+         'functionname',
+         'k8s-app',
++        'vm.kubevirt.internal.virtualization.deckhouse.io/name',
+       ])
+     );
+   }
+@@ -172,6 +175,7 @@ export class Labels {
+       isKubeDNS: false,
+       isHealth: false,
+       isPrometheusApp: false,
++      isD8VirtualMachine: false,
+       isKubeApiServer: false,
+       appName: undefined,
+       clusterName: undefined,
+@@ -190,6 +194,8 @@ export class Labels {
+         !!props.isRemoteNode || nkey === ReservedLabel.RemoteNode;
+       props.isPrometheusApp =
+         !!props.isPrometheusApp || nkey === SpecialLabel.PrometheusApp;
++      props.isD8VirtualMachine =
++        !!props.isD8VirtualMachine || `${kv.key}=${kv.value}` === SpecialLabel.D8VirtualMachine;
+       props.isKubeApiServer =
+         !!props.isKubeApiServer || nkey === ReservedLabel.KubeApiServer;
+     });
+diff --git a/src/domain/service-map/card.ts b/src/domain/service-map/card.ts
+index 7618fd4..46538f4 100644
+--- a/src/domain/service-map/card.ts
++++ b/src/domain/service-map/card.ts
+@@ -204,6 +204,10 @@ export class ServiceCard extends AbstractCard {
+     return this.labelsProps.isPrometheusApp;
+   }
+ 
++  public get isD8VirtualMachine(): boolean {
++    return this.labelsProps.isD8VirtualMachine;
++  }
++
+   public get isKubeApiServer(): boolean {
+     return this.labelsProps.isKubeApiServer;
+   }
+diff --git a/server/public/icons/logos/virtualmachine-logo.svg b/server/public/icons/logos/virtualmachine-logo.svg
+new file mode 100644
+index 0000000..dbcc7d4
+--- /dev/null
++++ b/server/public/icons/logos/virtualmachine-logo.svg
+@@ -0,0 +1,8 @@
++<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
++<rect width="40" height="40" rx="5.1282" fill="#0064FF"/>
++<rect x="8.20533" y="10.2564" width="23.5897" height="15.3846" rx="2.05128" stroke="white" stroke-width="2.05128"/>
++<path d="M19.7334 24.6154V30.7692" stroke="white" stroke-width="2.05128"/>
++<path d="M13.3335 30.7692H26.6668" stroke="white" stroke-width="2.05128" stroke-linecap="round"/>
++<path d="M22.4285 20.9877L20.7043 15.987H20.6674C20.6756 16.099 20.6852 16.2519 20.6961 16.4457C20.707 16.6396 20.7166 16.8471 20.7248 17.0683C20.733 17.2894 20.7371 17.501 20.7371 17.7031V20.9877H19.8442V15H21.2244L22.8831 19.7795H22.9077L24.6238 15H25.9999V20.9877H25.062V17.6539C25.062 17.471 25.0647 17.273 25.0702 17.0601C25.0784 16.8471 25.0866 16.6451 25.0947 16.4539C25.1057 16.2628 25.1139 16.1099 25.1193 15.9952H25.0866L23.2968 20.9877H22.4285Z" fill="white"/>
++<path d="M19.2259 15L17.1331 20.9877H16.0928L14 15H15.0075L16.2689 18.7515C16.3072 18.8608 16.3481 18.9932 16.3918 19.1488C16.4382 19.3044 16.4805 19.4614 16.5188 19.6198C16.5597 19.7782 16.5911 19.9188 16.613 20.0416C16.6348 19.9188 16.6648 19.7782 16.7031 19.6198C16.744 19.4614 16.7863 19.3044 16.83 19.1488C16.8737 18.9932 16.9147 18.8594 16.9529 18.7474L18.2184 15H19.2259Z" fill="white"/>
++</svg>

--- a/modules/500-cilium-hubble/images/ui-frontend/patches/001-hubble-ui-vm-name-icon.patch
+++ b/modules/500-cilium-hubble/images/ui-frontend/patches/001-hubble-ui-vm-name-icon.patch
@@ -90,15 +90,77 @@ index 7618fd4..46538f4 100644
    }
 diff --git a/server/public/icons/logos/virtualmachine-logo.svg b/server/public/icons/logos/virtualmachine-logo.svg
 new file mode 100644
-index 0000000..dbcc7d4
+index 0000000..e4a253a
 --- /dev/null
 +++ b/server/public/icons/logos/virtualmachine-logo.svg
-@@ -0,0 +1,8 @@
-+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-+<rect width="40" height="40" rx="5.1282" fill="#0064FF"/>
-+<rect x="8.20533" y="10.2564" width="23.5897" height="15.3846" rx="2.05128" stroke="white" stroke-width="2.05128"/>
-+<path d="M19.7334 24.6154V30.7692" stroke="white" stroke-width="2.05128"/>
-+<path d="M13.3335 30.7692H26.6668" stroke="white" stroke-width="2.05128" stroke-linecap="round"/>
-+<path d="M22.4285 20.9877L20.7043 15.987H20.6674C20.6756 16.099 20.6852 16.2519 20.6961 16.4457C20.707 16.6396 20.7166 16.8471 20.7248 17.0683C20.733 17.2894 20.7371 17.501 20.7371 17.7031V20.9877H19.8442V15H21.2244L22.8831 19.7795H22.9077L24.6238 15H25.9999V20.9877H25.062V17.6539C25.062 17.471 25.0647 17.273 25.0702 17.0601C25.0784 16.8471 25.0866 16.6451 25.0947 16.4539C25.1057 16.2628 25.1139 16.1099 25.1193 15.9952H25.0866L23.2968 20.9877H22.4285Z" fill="white"/>
-+<path d="M19.2259 15L17.1331 20.9877H16.0928L14 15H15.0075L16.2689 18.7515C16.3072 18.8608 16.3481 18.9932 16.3918 19.1488C16.4382 19.3044 16.4805 19.4614 16.5188 19.6198C16.5597 19.7782 16.5911 19.9188 16.613 20.0416C16.6348 19.9188 16.6648 19.7782 16.7031 19.6198C16.744 19.4614 16.7863 19.3044 16.83 19.1488C16.8737 18.9932 16.9147 18.8594 16.9529 18.7474L18.2184 15H19.2259Z" fill="white"/>
+@@ -0,0 +1,70 @@
++<?xml version="1.0" encoding="UTF-8" standalone="no"?>
++<svg
++   width="40"
++   height="40"
++   viewBox="0 0 40 40"
++   fill="none"
++   version="1.1"
++   id="svg14"
++   sodipodi:docname="vm.svg"
++   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
++   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
++   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
++   xmlns="http://www.w3.org/2000/svg"
++   xmlns:svg="http://www.w3.org/2000/svg">
++  <defs
++     id="defs18" />
++  <sodipodi:namedview
++     id="namedview16"
++     pagecolor="#ffffff"
++     bordercolor="#666666"
++     borderopacity="1.0"
++     inkscape:pageshadow="2"
++     inkscape:pageopacity="0.0"
++     inkscape:pagecheckerboard="0"
++     showgrid="false"
++     inkscape:zoom="1.5207603"
++     inkscape:cx="54.24918"
++     inkscape:cy="88.442602"
++     inkscape:window-width="1117"
++     inkscape:window-height="1371"
++     inkscape:window-x="25"
++     inkscape:window-y="35"
++     inkscape:window-maximized="1"
++     inkscape:current-layer="svg14" />
++  <rect
++     width="40"
++     height="40"
++     rx="5.1282"
++     fill="#0064FF"
++     id="rect2"
++     style="fill:#326de6;fill-opacity:1" />
++  <rect
++     x="8.20533"
++     y="10.2564"
++     width="23.5897"
++     height="15.3846"
++     rx="2.05128"
++     stroke="white"
++     stroke-width="2.05128"
++     id="rect4" />
++  <path
++     d="M19.7334 24.6154V30.7692"
++     stroke="white"
++     stroke-width="2.05128"
++     id="path6" />
++  <path
++     d="M13.3335 30.7692H26.6668"
++     stroke="white"
++     stroke-width="2.05128"
++     stroke-linecap="round"
++     id="path8" />
++  <path
++     d="M22.4285 20.9877L20.7043 15.987H20.6674C20.6756 16.099 20.6852 16.2519 20.6961 16.4457C20.707 16.6396 20.7166 16.8471 20.7248 17.0683C20.733 17.2894 20.7371 17.501 20.7371 17.7031V20.9877H19.8442V15H21.2244L22.8831 19.7795H22.9077L24.6238 15H25.9999V20.9877H25.062V17.6539C25.062 17.471 25.0647 17.273 25.0702 17.0601C25.0784 16.8471 25.0866 16.6451 25.0947 16.4539C25.1057 16.2628 25.1139 16.1099 25.1193 15.9952H25.0866L23.2968 20.9877H22.4285Z"
++     fill="white"
++     id="path10" />
++  <path
++     d="M19.2259 15L17.1331 20.9877H16.0928L14 15H15.0075L16.2689 18.7515C16.3072 18.8608 16.3481 18.9932 16.3918 19.1488C16.4382 19.3044 16.4805 19.4614 16.5188 19.6198C16.5597 19.7782 16.5911 19.9188 16.613 20.0416C16.6348 19.9188 16.6648 19.7782 16.7031 19.6198C16.744 19.4614 16.7863 19.3044 16.83 19.1488C16.8737 18.9932 16.9147 18.8594 16.9529 18.7474L18.2184 15H19.2259Z"
++     fill="white"
++     id="path12" />
 +</svg>

--- a/modules/500-cilium-hubble/images/ui-frontend/patches/README.md
+++ b/modules/500-cilium-hubble/images/ui-frontend/patches/README.md
@@ -9,4 +9,4 @@ Hubble UI:
 - Uses the label value `vm.kubevirt.internal.virtualization.deckhouse.io/name=<name>` as the name.
 - Uses the presence of the `label kubevirt.internal.virtualization.deckhouse.io=virt-launcher` to change the icon.
 
-> **NOTE:**  There is a SVG-file in patch.
+> **NOTE:**  There is a SVG-file in the patch.

--- a/modules/500-cilium-hubble/images/ui-frontend/patches/README.md
+++ b/modules/500-cilium-hubble/images/ui-frontend/patches/README.md
@@ -1,0 +1,12 @@
+# Patches
+
+## 001-hubble-ui-vm-name-icon.patch
+
+Improved VM pod appearance in hubble-ui. Now it isn't an "Unknown App", but some VM with name and proper icon.
+
+Hubble UI:
+
+- Uses the label value `vm.kubevirt.internal.virtualization.deckhouse.io/name=<name>` as the name.
+- Uses the presence of the `label kubevirt.internal.virtualization.deckhouse.io=virt-launcher` to change the icon.
+
+> **NOTE:**  There is a SVG-file in patch.

--- a/modules/500-cilium-hubble/images/ui-frontend/werf.inc.yaml
+++ b/modules/500-cilium-hubble/images/ui-frontend/werf.inc.yaml
@@ -3,6 +3,12 @@
 # Based on https://github.com/cilium/hubble-ui/blob/v0.12.1/Dockerfile
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
 from: {{ $.Images.BASE_NODE_18_ALPINE_DEV }}
+git:
+  - add: /{{ $.ModulePath }}/modules/500-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+    to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
 shell:
   install:
   - export "TARGETOS=linux"
@@ -10,6 +16,7 @@ shell:
   - mkdir -p /app
   - git clone --depth 1 --branch v{{ $hubbleUIVersion }} {{ $.SOURCE_REPO }}/cilium/hubble-ui.git /app
   - cd /app
+  - find /patches -name '*.patch' -exec git apply {} \;
   - npm --target_arch=${TARGETARCH} install
   - export "NODE_ENV=production"
   - npm run build


### PR DESCRIPTION
## Description
Improved VM pod appearance in Hubble UI. Now it isn't an "Unknown App", but some VM with name and proper icon.

Hubble UI will:
- Use the label value `vm.kubevirt.internal.virtualization.deckhouse.io/name=<name>` as the name.
- Use the presence of the label `kubevirt.internal.virtualization.deckhouse.io=virt-launcher` to change the icon.

## Why do we need it, and what problem does it solve?
In the Hubble UI, the virtual machine have "Unknown App" instead of a name and have the standard Kubernetes pod icon.
![image](https://github.com/user-attachments/assets/974c1027-20e8-4398-8142-a10a769e792e)

## What is the expected result?
In the Hubble UI, the virtual machine will have the correct name and icon.
<img width="887" alt="image" src="https://github.com/user-attachments/assets/0517b696-85d1-47d7-9392-b88794c61459">


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cilium-hubble
type: chore
summary: Improved VM pod appearance in Hubble UI. Now it isn't an "Unknown App", but some VM with name and proper icon.
impact_level: default
```