### PR TITLE
[docs] Remove deprecated parameters from examples in the InitConfiguration

### DIFF
--- a/candi/openapi/doc-ru-init_configuration.yaml
+++ b/candi/openapi/doc-ru-init_configuration.yaml
@@ -55,14 +55,4 @@ apiVersions:
 
               Структура, указанная в параметре, будет использована для создания [глобальной конфигурации Deckhouse](../deckhouse-configure-global.html) (moduleConfig `global`) и [настроек модулей](../#настройка-модуля) (moduleConfig `<module-name>`).
 
-              Формат структуры:
-              ```yaml
-              configOverrides:
-                global:
-                  ... секция глобальных параметров
-                <moduleName>Enabled: true|false
-                <moduleName>:
-                  ... секция параметров модуля
-              ```
-
               **Внимание!** В `configOverrides` для включения/отключения модуля и указания его настроек используется название модуля в **camelCase** (например, `userAuthn`). После установки Deckhouse для управления модулем используется ресурс moduleConfig с названием модуля в **snake-case** (например, `user-authn`).

--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -11,7 +11,6 @@ apiVersions:
     - apiVersion: deckhouse.io/v1
       kind: InitConfiguration
       deckhouse:
-        releaseChannel: Stable
         imagesRepo: nexus.company.my/deckhouse/ee
         registryDockerCfg: eyJhdXRocyI6IHsgIm5leHVzLmNvbXBhbnkubXkiOiB7InVzZXJuYW1lIjoibmV4dXMtdXNlciIsInBhc3N3b3JkIjoibmV4dXMtcEBzc3cwcmQiLCJhdXRoIjoiYm1WNGRYTXRkWE5sY2pwdVpYaDFjeTF3UUhOemR6QnlaQW89In19fQo=
         registryScheme: HTTPS
@@ -19,13 +18,6 @@ apiVersions:
           -----BEGIN CERTIFICATE-----
           ...
           -----END CERTIFICATE-----
-        configOverrides:
-          global:
-            modules:
-              publicDomainTemplate: "%s.kube.company.my"
-          cniFlannelEnabled: true
-          cniFlannel:
-            podNetworkMode: VXLAN
     properties:
       apiVersion:
         type: string
@@ -109,31 +101,4 @@ apiVersions:
 
               The structure specified in the parameter will be used to create a [global Deckhouse configuration](../deckhouse-configure-global.html) (moduleConfig `global`) and [module settings](../#configuring-the-module) (moduleConfig `<module-name>`).
 
-              Structure format
-              ```yaml
-              configOverrides:
-                global:
-                  ... global parameters section
-                <moduleName>Enabled: true|false
-                <moduleName>:
-                  ... the module parameters section
-              ```
-
               **Caution!** The module name in **camelCase** is used to enable/disable the module and specify its settings (for example, `userAuthn`) in the `configOverrides` structure. After installing Deckhouse, the moduleConfig resource is used to manage the module with the module name in **snake-case** (for example, `user-authn`).
-            x-doc-example: |
-              ```yaml
-              configOverrides:
-                global:
-                  modules:
-                    publicDomainTemplate: "%s.k8s.company.my"
-                monitoringPingEnabled: false
-                userAuthn:
-                  publishAPI:
-                    enable: true
-                    https:
-                      mode: Global
-                prometheus:
-                  longtermRetentionDays: 5
-              ```
-
-


### PR DESCRIPTION
## Description
Remove deprecated parameters from examples in the InitConfiguration.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Remove deprecated parameters from examples in the InitConfiguration
impact_level: low
```
