### PR TITLE
[log-shipper] Fix json codec socket

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
@@ -101,6 +101,8 @@ func NewSocket(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Socket {
 		}
 	case v1alpha1.EncodingCodecGELF:
 		encoding.Codec = "gelf"
+	default:
+		encoding.Codec = "json"
 	}
 
 	result.Encoding = encoding

--- a/modules/460-log-shipper/hooks/testdata/file-to-socket/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-socket/manifests.yaml
@@ -11,6 +11,8 @@ spec:
   destinationRefs:
     - test-socket1-dest
     - test-socket2-dest
+    - test-socket3-dest
+    - test-socket4-dest
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
@@ -40,3 +42,30 @@ spec:
     mode: UDP
     encoding:
       codec: Syslog
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-socket3-dest
+spec:
+  extraLabels:
+    cef.name: d8
+    cef.severity: "1"
+  socket:
+    address: 0.0.0.0:7252
+    encoding:
+      codec: Text
+    mode: TCP
+  type: Socket
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-socket4-dest
+spec:
+  socket:
+    address: 0.0.0.0:7252
+    encoding:
+      codec: CEF
+    mode: UDP
+  type: Socket

--- a/modules/460-log-shipper/hooks/testdata/file-to-socket/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-socket/result.json
@@ -32,6 +32,38 @@
       "source": "if !exists(.syslog.severity) {\n  .syslog.severity = 6;\n} else if is_string(.syslog.severity) {\n  .syslog.severity = to_syslog_severity!(.syslog.severity);\n} else {\n  .syslog.severity = 6;\n};\n\npri = 1 * 8 + .syslog.severity;\n\n., err = join([\n  \"\u003c\" + to_string(pri) + \"\u003e\" + \"1\",     # \u003cpri\u003eversion\n  to_string!(.timestamp),\n  to_string!(.kubernetes.pod_name || .hostname || \"${VECTOR_SELF_NODE_NAME}\"),\n  to_string!(.app || .kubernetes.labels.app || .syslog.app || \"-\"),\n  \"-\", # procid\n  to_string!(.syslog.message_id || \"-\"), # msgid\n  \"-\", # structured-data\n  decode_base16!(\"EFBBBF\") + to_string!(.message || encode_json(.)) # msg\n], separator: \" \")\n\nif err != null {\n  log(\"Unable to construct syslog message for event:\" + err + \". Dropping invalid event: \" + encode_json(.), level: \"error\", rate_limit_secs: 10)\n}",
       "type": "remap"
     },
+    "transform/destination/test-socket3-dest/00_extra_fields": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_local_timezone"
+      ],
+      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}\n\n.cef.name=\"d8\" \n .cef.severity=\"1\"",
+      "type": "remap"
+    },
+    "transform/destination/test-socket3-dest/01_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-socket3-dest/00_extra_fields"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    },
+    "transform/destination/test-socket4-dest/00_cef_values": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_local_timezone"
+      ],
+      "source": "if !exists(.cef) {\n  .cef = {};\n};\n\nif !exists(.cef.name) {\n  .cef.name = \"Deckhouse Event\";\n};\n\nif !exists(.cef.severity) {\n  .cef.severity = \"5\";\n} else if is_string(.cef.severity) {\n  if .cef.severity == \"Debug\" {\n    .cef.severity = \"0\";\n  };\n  if .cef.severity == \"Informational\" {\n    .cef.severity = \"3\";\n  };\n  if .cef.severity == \"Notice\" {\n    .cef.severity = \"4\";\n  };\n  if .cef.severity == \"Warning\" {\n    .cef.severity = \"6\";\n  };\n  if .cef.severity == \"Error\" {\n    .cef.severity = \"7\";\n  };\n  if .cef.severity == \"Critical\" {\n    .cef.severity = \"8\";\n  };\n  if .cef.severity == \"Emergency\" {\n    .cef.severity = \"10\";\n  };\n};",
+      "type": "remap"
+    },
+    "transform/destination/test-socket4-dest/01_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-socket4-dest/00_cef_values"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    },
     "transform/source/test-source/00_clean_up": {
       "drop_on_abort": false,
       "inputs": [
@@ -59,6 +91,7 @@
         "enabled": false
       },
       "encoding": {
+        "codec": "json",
         "timestamp_format": "rfc3339"
       },
       "mode": "tcp",
@@ -82,6 +115,61 @@
       },
       "mode": "udp",
       "address": "192.168.1.1:3000"
+    },
+    "destination/cluster/test-socket3-dest": {
+      "type": "socket",
+      "inputs": [
+        "transform/destination/test-socket3-dest/01_del_parsed_data"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "encoding": {
+        "codec": "text",
+        "timestamp_format": "rfc3339"
+      },
+      "mode": "tcp",
+      "address": "0.0.0.0:7252",
+      "tls": {
+        "verify_hostname": true,
+        "verify_certificate": true
+      }
+    },
+    "destination/cluster/test-socket4-dest": {
+      "type": "socket",
+      "inputs": [
+        "transform/destination/test-socket4-dest/01_del_parsed_data"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "encoding": {
+        "codec": "cef",
+        "timestamp_format": "rfc3339",
+        "cef": {
+          "device_vendor": "Deckhouse",
+          "device_product": "log-shipper-agent",
+          "device_version": "1",
+          "device_event_class_id": "Log event",
+          "name": "cef.name",
+          "severity": "cef.severity",
+          "version": "V1",
+          "extensions": {
+            "container": "container",
+            "host": "host",
+            "image": "image",
+            "message": "message",
+            "namespace": "namespace",
+            "node": "node",
+            "pod": "pod",
+            "podip": "pod_ip",
+            "podowner": "pod_owner",
+            "timestamp": "timestamp"
+          }
+        }
+      },
+      "mode": "udp",
+      "address": "0.0.0.0:7252"
     }
   }
 }


### PR DESCRIPTION
## Description
- Set codec field to JSON by default
- Add tests

## Why do we need it, and what problem does it solve?
JSON codec for Socket doesn't work (and this codec is the default one)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary:  Fix json codec for socket destination
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
