### PR TITLE
[dhctl] Count logical CPU cores instead of physical in system requirements preflight check

### DIFF
--- a/dhctl/pkg/preflight/specs_static.go
+++ b/dhctl/pkg/preflight/specs_static.go
@@ -39,17 +39,17 @@ func (pc *Checker) CheckStaticNodeSystemRequirements() error {
 	}
 
 	buf.Reset()
-	physicalCoresCount, err := extractCPULogicalCoresCountFromNode(pc.sshClient, buf)
+	coresCount, err := extractCPULogicalCoresCountFromNode(pc.sshClient, buf)
 	if err != nil {
 		return err
 	}
 
 	failures := make([]string, 0)
-	if physicalCoresCount < minimumRequiredCPUCores {
+	if coresCount < minimumRequiredCPUCores {
 		failures = append(failures, fmt.Sprintf(
 			" - System requirements mandate at least %d CPU(s) on the node, but it has %d",
 			minimumRequiredCPUCores,
-			physicalCoresCount,
+			coresCount,
 		))
 	}
 

--- a/dhctl/pkg/preflight/specs_static_test.go
+++ b/dhctl/pkg/preflight/specs_static_test.go
@@ -36,13 +36,13 @@ func TestCPUCoresCountDetection(t *testing.T) {
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "1 socket, 6 cores",
+			name:    "1 socket, 6 cores, 2 threads each",
 			cpuinfo: bytes.NewBuffer(cpuinfo6cores1socket),
-			want:    6,
+			want:    12,
 			wantErr: assert.NoError,
 		},
 		{
-			name:    "4 sockets, 1 core",
+			name:    "4 sockets, 1 core, 1 thread each",
 			cpuinfo: bytes.NewBuffer(cpuinfo1core4sockets),
 			want:    4,
 			wantErr: assert.NoError,
@@ -50,7 +50,7 @@ func TestCPUCoresCountDetection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := physicalCoresCountFromCPUInfo(tt.cpuinfo)
+			got, err := logicalCoresCountFromCPUInfo(tt.cpuinfo)
 			if !tt.wantErr(t, err) {
 				return
 			}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changed `/proc/cpuinfo` parsing to count logical CPUs instead of physical ones.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It seems we are ok with dual-core dual-thread CPUs on master nodes

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Count logical CPU cores instead of physical in system requirements preflight check.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
