### PR TITLE
[secret-copier] Keep annotations on copied secrets

### DIFF
--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -81,9 +81,6 @@ func ApplyCopierSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 		delete(s.Annotations, "secret-copier.deckhouse.io/updated-at")
 	}
 
-	// Secrets with that annotation are always the main secret, delete to prevent loop.
-	delete(s.Annotations, "secret-copier.deckhouse.io/target-namespace-selector")
-
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
 	delete(s.Labels, "certmanager.k8s.io/certificate-name")
 

--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -79,8 +79,10 @@ func ApplyCopierSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 		// desired secret (target secret in a namespace) must not have secret-copier annotations to satisfy DeepEqual function
 		delete(s.Annotations, "secret-copier.deckhouse.io/created-at")
 		delete(s.Annotations, "secret-copier.deckhouse.io/updated-at")
-		delete(s.Annotations, "secret-copier.deckhouse.io/target-namespace-selector")
 	}
+
+	// Secrets with that annotation are always the main secret, delete to prevent loop.
+	delete(s.Annotations, "secret-copier.deckhouse.io/target-namespace-selector")
 
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
 	delete(s.Labels, "certmanager.k8s.io/certificate-name")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Keep annotations from the main secret on copied secrets.

## Why do we need it, and what problem does it solve?
In some cases, we need to keep annotations.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
After secret-copier copy the main secret, we can see on copied secrets all annotations from the main secret.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: secret-copier
type: feature
summary: Added the ability to keep annotations in copied secrets
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
