### PR TITLE
[global-hooks][migration] Fix multiport Services broken by Helm

### DIFF
--- a/global-hooks/migration_service_with_many_ports.go
+++ b/global-hooks/migration_service_with_many_ports.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+)
+
+type patchServiceStruct struct {
+	module    string
+	namespace string
+	name      string
+	patch     map[string]interface{}
+}
+
+var patchServiceData = []patchServiceStruct{
+	{
+		module:    "kube-dns",
+		namespace: "kube-system",
+		name:      "d8-kube-dns",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "dns",
+						"port":       53,
+						"targetPort": "dns",
+						"protocol":   "UDP",
+					},
+					map[string]interface{}{
+						"name":       "dns-tcp",
+						"port":       53,
+						"targetPort": "dns-tcp",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "kube-dns",
+		namespace: "kube-system",
+		name:      "d8-kube-dns-redirect",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "dns",
+						"port":       53,
+						"targetPort": "dns",
+						"protocol":   "UDP",
+					},
+					map[string]interface{}{
+						"name":       "dns-tcp",
+						"port":       53,
+						"targetPort": "dns-tcp",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "delivery",
+		namespace: "d8-delivery",
+		name:      "argocd-repo-server",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "server",
+						"port":       8081,
+						"targetPort": "server",
+						"protocol":   "TCP",
+					},
+					map[string]interface{}{
+						"name":       "metrics",
+						"port":       8084,
+						"targetPort": "metrics",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "delivery",
+		namespace: "d8-delivery",
+		name:      "argocd-server",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "http",
+						"port":       80,
+						"targetPort": "server",
+						"protocol":   "TCP",
+					},
+					map[string]interface{}{
+						"name":       "https",
+						"port":       443,
+						"targetPort": "server",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "deckhouse",
+		namespace: "d8-system",
+		name:      "deckhouse-leader",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "self",
+						"port":       8080,
+						"targetPort": "self",
+						"protocol":   "TCP",
+					},
+					map[string]interface{}{
+						"name":       "webhook",
+						"port":       4223,
+						"targetPort": "webhook",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "deckhouse",
+		namespace: "d8-system",
+		name:      "deckhouse",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "self",
+						"port":       8080,
+						"targetPort": "self",
+						"protocol":   "TCP",
+					},
+					map[string]interface{}{
+						"name":       "webhook",
+						"port":       4223,
+						"targetPort": "webhook",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "istio",
+		namespace: "d8-istio",
+		name:      "kiali",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "http",
+						"port":       20001,
+						"targetPort": "api",
+						"protocol":   "TCP",
+					},
+					map[string]interface{}{
+						"name":       "http-metrics",
+						"port":       9090,
+						"targetPort": "http-metrics",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "prometheus",
+		namespace: "d8-monitoring",
+		name:      "memcached",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "memcached",
+						"port":       11211,
+						"targetPort": "memcached",
+						"protocol":   "TCP",
+					},
+					map[string]interface{}{
+						"name":       "http-metrics",
+						"port":       9150,
+						"targetPort": "http-metrics",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterAll: &go_hook.OrderedConfig{Order: 20},
+}, patchServiceWithManyPorts)
+
+func patchServiceWithManyPorts(input *go_hook.HookInput) error {
+	for _, service := range patchServiceData {
+		enabledModules := set.NewFromValues(input.Values, "global.enabledModules")
+		if !enabledModules.Has(service.module) {
+			continue
+		}
+
+		input.PatchCollector.MergePatch(
+			service.patch,
+			"v1",
+			"Service",
+			service.namespace,
+			service.name,
+		)
+	}
+	return nil
+}

--- a/global-hooks/migration_service_with_many_ports_test.go
+++ b/global-hooks/migration_service_with_many_ports_test.go
@@ -103,7 +103,7 @@ spec:
   targetPort: 5353`
 )
 
-var _ = FDescribe("Global hooks :: migration_service_with_many_ports", func() {
+var _ = Describe("Global hooks :: migration_service_with_many_ports", func() {
 	f := HookExecutionConfigInit("{}", "{}")
 
 	Context("There are broken services and enabled modules", func() {

--- a/global-hooks/migration_service_with_many_ports_test.go
+++ b/global-hooks/migration_service_with_many_ports_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceYAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: d8-kube-dns
+  namespace: kube-system
+spec:
+  clusterIP: 10.222.0.10
+  clusterIPs:
+  - 10.222.0.10
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: dns
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 5353
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: ClusterIP`
+
+	service2YAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: d8-kube-dns-redirect
+  namespace: kube-system
+spec:
+  clusterIP: 10.222.142.22
+  clusterIPs:
+  - 10.222.142.22
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: dns
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: dns-tcp
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: ClusterIP`
+
+	serviceRightPorts = `
+- name: dns
+  port: 53
+  protocol: UDP
+  targetPort: dns
+- name: dns-tcp
+  port: 53
+  protocol: TCP
+  targetPort: dns-tcp`
+
+	serviceBrokenPorts = `
+- name: dns
+  port: 53
+  protocol: UDP
+  targetPort: dns
+- name: dns-tcp
+  port: 53
+  protocol: TCP
+  targetPort: 5353`
+)
+
+var _ = FDescribe("Global hooks :: migration_service_with_many_ports", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There are broken services and enabled modules", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["kube-dns"]`))
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML + service2YAML))
+			f.RunHook()
+		})
+		It("Service have been fixed", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dnsService := f.KubernetesResource("Service", "kube-system", "d8-kube-dns")
+
+			Expect(dnsService.Field("spec.ports").String()).To(MatchYAML(serviceRightPorts))
+		})
+	})
+
+	Context("There are broken services and disabled module", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[]`))
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML + service2YAML))
+			f.RunHook()
+		})
+		It("Service have not been fixed", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dnsService := f.KubernetesResource("Service", "kube-system", "d8-kube-dns")
+
+			Expect(dnsService.Field("spec.ports").String()).To(MatchYAML(serviceBrokenPorts))
+		})
+	})
+})


### PR DESCRIPTION
## Description
Fixing the broken Services with multiple ports. Helm didn't handle Service resource modification well while deploying https://github.com/deckhouse/deckhouse/pull/8955.

## Why do we need it, and what problem does it solve?
In some clusters Services became broken. In some clusters it was kube-dns.

## Why do we need it in the patch release (if we do)?
The release 1.63 is blocked.

## What is the expected result?
All Services are correspond to their templates.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix
summary: Fixed the Services with multiple ports broken by Helm.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
