### PR TITLE
[deckhouse-controller] Trim ending slash of registry in helper change-registry command

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -65,7 +65,7 @@ func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTa
 	}
 
 	nameOpts := newNameOptions(scheme)
-	newRepo, err := name.NewRepository(newRegistry, nameOpts...)
+	newRepo, err := name.NewRepository(strings.TrimRight(newRegistry, "/"), nameOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Trim ending slash from registry.
For example, `registry.deckhouse.io/deckhouse/ee/` -> `registry.deckhouse.io/deckhouse/ee`
Like it done in dhctl https://github.com/deckhouse/deckhouse/blob/cf33d8655e04ed81d63e9725dc53f7b6c9d37239/dhctl/pkg/config/meta.go#L90
## Why do we need it, and what problem does it solve?
Users often type registry path with ending slash in command to change registry:
```
kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry  --user license-token --password PASSWORD registry.deckhouse.io/deckhouse/ee/
```

And command executes with no error:
```
~ $ kubectl exec -ti -n d8-system deploy/deckhouse -c deckhouse -- deckhouse-controller helper change-registry   --user license-token --password PASSWORD registry.deckhouse.io/deckhouse/ee/
INFO[0000] Kubernetes client is configured successfully with 'out-of-cluster' config  operator.component=KubernetesAPIClient
INFO[0000] Retrieving deckhouse deployment...            operator.component=ChangeRegistry
INFO[0000] Updating deckhouse image pull secret...       operator.component=ChangeRegistry
INFO[0000] Updating deckhouse deployment...              operator.component=ChangeRegistry
INFO[0000] Done                                          operator.component=ChangeRegistry
```

But it immediately throws problem with deckhouse deployment:

```
~ $ kubectl -n d8-system get pods -l app=deckhouse
NAME                         READY   STATUS                  RESTARTS   AGE
deckhouse-58f856ffbf-w2hbh   0/2     Init:InvalidImageName   0          46m
```

because we have image path like this:

```
image: registry.deckhouse.io/deckhouse/ee/:v1.62.6
```

To fix this situation we need manually edit deployment and remove ending slash.
After we need execute `helper change-registry` again without ending slash in registry.

## Why do we need it in the patch release (if we do)?
Not necessarily.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
`helper change-registry` change registry address to address without ending slash

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Trim ending slash of registry in helper change-registry command
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
