### PR TITLE
removing ValidatingAdmissionPolicy/machines.deckhouse.io

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -101,12 +101,4 @@ spec:
     objectSelector:
       matchLabels:
         heritage: deckhouse
----
-{{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}
-apiVersion: admissionregistration.k8s.io/v1
-{{- else if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1alpha1
 {{- end }}
-

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -109,36 +109,4 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1alpha1
 {{- end }}
-{{- $policyName := "machines.deckhouse.io" }}
-kind: ValidatingAdmissionPolicy
-metadata:
-  name: {{ $policyName }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
-spec:
-  failurePolicy: Fail
-  matchConstraints:
-    resourceRules:
-      - apiGroups: ["machine.sapcloud.io", "cluster.x-k8s.io"]
-        apiVersions: ["*"]
-        operations: ["DELETE"]
-        resources: ["*"]
-  validations:
-    - expression: '(request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username == "kubernetes-admin")'
-      reason: Forbidden
-      messageExpression: '''Operation on machine object is forbidden for this user by ValidatingAdmissionPolicy {{ $policyName }}'''
----
-{{- if semverCompare ">= 1.28" .Values.global.discovery.kubernetesVersion }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1alpha1
-{{- end }}
-kind: ValidatingAdmissionPolicyBinding
-metadata:
-  name: {{ $policyName }}-binding
-  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
-spec:
-  policyName: {{ $policyName }}
-{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
-  validationActions: [Deny]
-{{- end }}
-{{- end }}
+


### PR DESCRIPTION
## Description

`ValidatingAdmissionPolicy/heritage-label-objects.deckhouse.io`  is a more general solution to the problem of removing a machine resource. Also `machines.deckhouse.io` denied the `generic-garbage-collector` user from deleting resources resulting in `machines.cluster.x-k8s.io` not being deleted after deleting `MachineDeployments`

## Why do we need it in the patch release (if we do)?


## What is the expected result?

MachineDeployments are deleted after MachineDeployments is deleted. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Remove unnecessary `ValidatingAdmissionPolicy`, fix cluster destroying when using cluster api
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
