### PR TITLE
[kube-dns] ability to change vpa mode

### DIFF
--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -109,15 +109,6 @@ properties:
         memory:
           min: "256Mi"
           max: "2Gi"
-    - mode: VPA
-      vpa:
-        mode: Initial
-        cpu:
-          min: 1
-          max: 3000m
-        memory:
-          min: 1024
-          max: 4096
     - mode: Static
       static:
         cpu: "55m"
@@ -155,7 +146,7 @@ properties:
             description: |
               The VPA usage mode.
             enum: ["Initial", "Auto"]
-            default: "Initial"
+            default: "Auto"
           cpu:
             type: object
             description: |
@@ -169,7 +160,7 @@ properties:
                   - type: number
                 description: |
                   The maximum value that the VPA can set for the CPU requests.
-                default: "500m"
+                default: "40m"
               min:
                 oneOf:
                   - type: string
@@ -177,7 +168,7 @@ properties:
                   - type: number
                 description: |
                   The minimum value that the VPA can set for the CPU requests.
-                default: "50m"
+                default: "20m"
           memory:
             type: object
             description: |
@@ -191,7 +182,7 @@ properties:
                   - type: number
                 description: |
                   The maximum memory requests the VPA can set.
-                default: "2048Mi"
+                default: "50Mi"
               min:
                 oneOf:
                   - type: string
@@ -199,7 +190,7 @@ properties:
                   - type: number
                 description: |
                   The minimum memory requests the VPA can set.
-                default: "64Mi"
+                default: "40Mi"
       static:
         type: object
         description: |
@@ -216,7 +207,7 @@ properties:
               - type: number
             description: |
               Configuring CPU requests.
-            default: "50m"
+            default: "20m"
           memory:
             oneOf:
               - type: string
@@ -224,4 +215,4 @@ properties:
               - type: number
             description: |
               Configuring memory requests.
-            default: "64Mi"
+            default: "40Mi"

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -91,3 +91,50 @@ properties:
     items:
       type: string
       pattern: '^[0-9a-zA-Z\.-]+$'
+  resourcesRequests:
+    required: ['mode']
+    type: object
+    description: |
+      Max amounts of CPU and memory resources that the pod can request when selecting a node (if the VPA is disabled, then these values become the default ones).
+    properties:
+      vpa:
+        type: object
+        description: |
+          Parameters of the vpa mode.
+        properties:
+          mode:
+            type: string
+            description: |
+              The VPA usage mode.
+            enum: ['Initial', 'Auto']
+            default: 'Auto'
+          cpu:
+            type: object
+            description: |
+              CPU-related parameters.
+            properties:
+              max:
+                description: |
+                  Maximum allowed CPU requests.
+                default: '40m'
+                type: string
+              min:
+                description: |
+                  Minimum allowed CPU requests.
+                default: '20m'
+                type: string
+          memory:
+            type: object
+            description: |
+              The amount of memory requested.
+            properties:
+              max:
+                description: |
+                  Maximum allowed memory requests.
+                default: '50Mi'
+                type: string
+              min:
+                description: |
+                  Minimum allowed memory requests.
+                default: '40Mi'
+                type: string

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -92,49 +92,136 @@ properties:
       type: string
       pattern: '^[0-9a-zA-Z\.-]+$'
   resourcesRequests:
-    required: ['mode']
+    required: ["mode"]
     type: object
     description: |
-      Max amounts of CPU and memory resources that the pod can request when selecting a node (if the VPA is disabled, then these values become the default ones).
+      Max amounts of CPU and memory resources that the pod can request when selecting a node.
+
+      If the `vertical-pod-autoscaler` module is disabled, then these values become the default ones.
+    default: {}
+    x-examples:
+    - mode: VPA
+      vpa:
+        mode: Auto
+        cpu:
+          min: "50m"
+          max: 2
+        memory:
+          min: "256Mi"
+          max: "2Gi"
+    - mode: VPA
+      vpa:
+        mode: Initial
+        cpu:
+          min: 1
+          max: 3000m
+        memory:
+          min: 1024
+          max: 4096
+    - mode: Static
+      static:
+        cpu: "55m"
+        memory: "256Ki"
+    oneOf:
+      - properties:
+          mode:
+            enum: ["VPA"]
+          vpa: {}
+      - properties:
+          mode:
+            enum: ["Static"]
+          static: {}
     properties:
+      mode:
+        type: string
+        description: |
+          Resource request management mode:
+          - `Static` is a classic one. In it, you explicitly specify requests. The parameters of this mode are defined in the [static](#parameters-resourcesrequests-static) parameter section;
+          - `VPA` mode uses [VPA](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md). You can configure this mode by modifying parameters in the [vpa](#parameters-resourcesrequests-vpa) parameter section.
+        enum: ["VPA", "Static"]
+        default: "VPA"
       vpa:
         type: object
         description: |
-          Parameters of the vpa mode.
+          Resource request management options for the VPA mode.
+        required:
+          - mode
+          - cpu
+          - memory
+        default: {}
         properties:
           mode:
             type: string
             description: |
               The VPA usage mode.
-            enum: ['Initial', 'Auto']
-            default: 'Auto'
+            enum: ["Initial", "Auto"]
+            default: "Initial"
           cpu:
             type: object
             description: |
               CPU-related parameters.
+            default: {}
             properties:
               max:
+                oneOf:
+                  - type: string
+                    pattern: "^[0-9]+m?$"
+                  - type: number
                 description: |
-                  Maximum allowed CPU requests.
-                default: '40m'
-                type: string
+                  The maximum value that the VPA can set for the CPU requests.
+                default: "500m"
               min:
+                oneOf:
+                  - type: string
+                    pattern: "^[0-9]+m?$"
+                  - type: number
                 description: |
-                  Minimum allowed CPU requests.
-                default: '20m'
-                type: string
+                  The minimum value that the VPA can set for the CPU requests.
+                default: "50m"
           memory:
             type: object
             description: |
               The amount of memory requested.
+            default: {}
             properties:
               max:
+                oneOf:
+                  - type: string
+                    pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                  - type: number
                 description: |
-                  Maximum allowed memory requests.
-                default: '50Mi'
-                type: string
+                  The maximum memory requests the VPA can set.
+                default: "2048Mi"
               min:
+                oneOf:
+                  - type: string
+                    pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                  - type: number
                 description: |
-                  Minimum allowed memory requests.
-                default: '40Mi'
-                type: string
+                  The minimum memory requests the VPA can set.
+                default: "64Mi"
+      static:
+        type: object
+        description: |
+          Resource request management options for the `Static` mode.
+        required:
+          - cpu
+          - memory
+        default: {}
+        properties:
+          cpu:
+            oneOf:
+              - type: string
+                pattern: "^[0-9]+m?$"
+              - type: number
+            description: |
+              Configuring CPU requests.
+            default: "50m"
+          memory:
+            oneOf:
+              - type: string
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+              - type: number
+            description: |
+              Configuring memory requests.
+            default: "64Mi"

--- a/modules/042-kube-dns/openapi/doc-ru-config-values.yaml
+++ b/modules/042-kube-dns/openapi/doc-ru-config-values.yaml
@@ -41,3 +41,50 @@ properties:
       Список альтернативных доменов кластера, разрешаемых наравне с `global.discovery.clusterDomain`.
 
       **Обратите внимание:** альтернативный домен не должен совпадать с доменом, используемым в шаблоне DNS-имен в параметре [publicDomainTemplate](../../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate).
+  resourcesRequests:
+    description: |
+      Настройки максимальных значений CPU и памяти, которые может запросить под при выборе узла (CPU requests, memory requests).
+
+    properties:
+      mode:
+        description: |
+          Режим управления запросами ресурсов (requests):
+          - `Static` — классический, с помощью явного указания ограничения. Настраивается в секции параметров [static](#parameters-resourcesrequests-static);
+          - `VPA` — с помощью [VPA](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md). Настраивается в секции параметров [vpa](#parameters-resourcesrequests-vpa).
+      vpa:
+        description: |
+          Настройка управления ресурсами в режиме `VPA`.
+        properties:
+          mode:
+            description: |
+              Режим работы VPA.
+          cpu:
+            description: |
+              Настройки VPA при работе с CPU.
+            properties:
+              max:
+                description: |
+                  Максимальное значение, которое может выставить VPA для запроса CPU (CPU requests).
+              min:
+                description: |
+                  Минимальное значение, которое может выставить VPA для запроса CPU (CPU requests).
+          memory:
+            description: |
+              Настройки VPA при работе с памятью.
+            properties:
+              max:
+                description: |
+                  Максимальное значение, которое может выставить VPA для запроса к памяти (memory requests).
+              min:
+                description: |
+                  Минимальное значение, которое может выставить VPA для запроса к памяти (memory requests).
+      static:
+        description: |
+          Настройка управления ресурсами в режиме `Static`.
+        properties:
+          cpu:
+            description: |
+              Настройка запроса CPU (CPU requests).
+          memory:
+            description: |
+              Настройка запроса памяти (memory requests).

--- a/modules/042-kube-dns/openapi/openapi-case-tests.yaml
+++ b/modules/042-kube-dns/openapi/openapi-case-tests.yaml
@@ -21,6 +21,38 @@ positive:
     - clusterDomainAliases:
       - foo.bar
       - baz.qux
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: "512Mi"
+            min: "16Mi"
+          cpu:
+            max: "2000m"
+            min: "200m"
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: 512
+            min: 16
+          cpu:
+            max: 2
+            min: 0.2
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: 1.5Gi
+            min: 2.0Ki
+          cpu:
+            max: 2
+            min: 0.2
+    - resourcesRequests:
+        mode: "Static"
+        static:
+          memory: 1.5Gi
+          cpu: 0.2
   values:
     - internal:
         enablePodAntiAffinity: true
@@ -57,6 +89,25 @@ negative:
         upstreamNameservers: []
     - stubZones:
       - zone: consul.local:53
+    - somethingInConfig: yes
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: "512Hz"
+            min: "16m"
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          cpu:
+            max: "512cpu"
+            min: "16Mi"
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: "1Hi"
+            min: "1.Mi"
   values:
     - internal:
         enablePodAntiAffinity: 1

--- a/modules/042-kube-dns/openapi/values.yaml
+++ b/modules/042-kube-dns/openapi/values.yaml
@@ -29,31 +29,3 @@ properties:
             type: string
           ca:
             type: string
-      resourcesRequests:
-        type: object
-        default: {}
-        properties:
-          vpa:
-            type: object
-            default: {}
-            properties:
-              mode:
-                type: string
-              cpu:
-                type: object
-                default: {}
-                properties:
-                  max:
-                    type: string
-                    x-examples: ["200m"]
-                  min:
-                    type: string
-              memory:
-                type: object
-                default: {}
-                properties:
-                  max:
-                    type: string
-                  min:
-                    type: string
-                    x-examples: ["100Mi"]

--- a/modules/042-kube-dns/openapi/values.yaml
+++ b/modules/042-kube-dns/openapi/values.yaml
@@ -29,3 +29,31 @@ properties:
             type: string
           ca:
             type: string
+      resourcesRequests:
+        type: object
+        default: {}
+        properties:
+          vpa:
+            type: object
+            default: {}
+            properties:
+              mode:
+                type: string
+              cpu:
+                type: object
+                default: {}
+                properties:
+                  max:
+                    type: string
+                    x-examples: ["200m"]
+                  min:
+                    type: string
+              memory:
+                type: object
+                default: {}
+                properties:
+                  max:
+                    type: string
+                  min:
+                    type: string
+                    x-examples: ["100Mi"]

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -1,7 +1,9 @@
+{{- define "coredns_resources" }}
+cpu: 20m
+memory: 40Mi
+{{- end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-{{- $resourcesRequestsVPA := Values.kubeDns.resourcesRequests.vpa | default dict }}
-{{- $resourcesRequestsVPA_CPU := Values.kubeDns.resourcesRequestsVPA.cpu | default dict }}
-{{- $resourcesRequestsVPA_Memory := Values.kubeDns.resourcesRequestsVPA.memory | default dict }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -10,23 +12,10 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "d8-kube-dns" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
 spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: d8-kube-dns
-  updatePolicy:
-    updateMode: {{ $resourcesRequestsVPA.mode | default "Auto" | quote }}
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "coredns"
-      minAllowed:
-        cpu: {{ $resourcesRequestsVPA_CPU.min | default "20m" | quote }}
-        memory: {{ $resourcesRequestsVPA_Memory.min | default "40Mi" | quote }}
-      maxAllowed:
-        cpu: {{ $resourcesRequestsVPA_CPU.max | default "40m" | quote }}
-        memory: {{ $resourcesRequestsVPA_Memory.max | default "50Mi" | quote }}
-    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+  {{- include "helm_lib_resources_management_vpa_spec" (list "apps/v1" "Deployment" "d8-kube-dns" "coredns" .Values.kubeDns.resourcesRequests) | nindent 2 }}
+  {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
+
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "d8-kube-dns" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
 spec:
   {{- include "helm_lib_resources_management_vpa_spec" (list "apps/v1" "Deployment" "d8-kube-dns" "coredns" .Values.kubeDns.resourcesRequests) | nindent 2 }}
-  {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+  {{- if eq (.Values.logShipper.resourcesRequests.mode) "VPA" }}
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+  {{- end }}
 {{- end }}
 
 ---

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-{{- $resourcesRequestsVPA := $resourcesRequests.vpa | default dict }}
-{{- $resourcesRequestsVPA_CPU := $resourcesRequestsVPA.cpu | default dict }}
-{{- $resourcesRequestsVPA_Memory := $resourcesRequestsVPA.memory | default dict }}
+{{- $resourcesRequestsVPA := Values.kubeDns.resourcesRequests.vpa | default dict }}
+{{- $resourcesRequestsVPA_CPU := Values.kubeDns.resourcesRequestsVPA.cpu | default dict }}
+{{- $resourcesRequestsVPA_Memory := Values.kubeDns.resourcesRequestsVPA.memory | default dict }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -1,4 +1,7 @@
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- $resourcesRequestsVPA := $resourcesRequests.vpa | default dict }}
+{{- $resourcesRequestsVPA_CPU := $resourcesRequestsVPA.cpu | default dict }}
+{{- $resourcesRequestsVPA_Memory := $resourcesRequestsVPA.memory | default dict }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -11,10 +14,6 @@ spec:
     apiVersion: "apps/v1"
     kind: Deployment
     name: d8-kube-dns
-    {{- if eq ($resourcesRequests.mode | default "") "VPA" }}
-      {{- $resourcesRequestsVPA := $resourcesRequests.vpa | default dict }}
-      {{- $resourcesRequestsVPA_CPU := $resourcesRequestsVPA.cpu | default dict }}
-      {{- $resourcesRequestsVPA_Memory := $resourcesRequestsVPA.memory | default dict }}
   updatePolicy:
     updateMode: {{ $resourcesRequestsVPA.mode | default "Auto" | quote }}
   resourcePolicy:

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "d8-kube-dns" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
 spec:
   {{- include "helm_lib_resources_management_vpa_spec" (list "apps/v1" "Deployment" "d8-kube-dns" "coredns" .Values.kubeDns.resourcesRequests) | nindent 2 }}
-  {{- if eq (.Values.logShipper.resourcesRequests.mode) "VPA" }}
+  {{- if eq (.Values.kubeDns.resourcesRequests.mode) "VPA" }}
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -1,8 +1,3 @@
-{{- define "coredns_resources" }}
-cpu: 20m
-memory: 40Mi
-{{- end }}
-
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -16,16 +11,21 @@ spec:
     apiVersion: "apps/v1"
     kind: Deployment
     name: d8-kube-dns
+    {{- if eq ($resourcesRequests.mode | default "") "VPA" }}
+      {{- $resourcesRequestsVPA := $resourcesRequests.vpa | default dict }}
+      {{- $resourcesRequestsVPA_CPU := $resourcesRequestsVPA.cpu | default dict }}
+      {{- $resourcesRequestsVPA_Memory := $resourcesRequestsVPA.memory | default dict }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: {{ $resourcesRequestsVPA.mode | default "Auto" | quote }}
   resourcePolicy:
     containerPolicies:
     - containerName: "coredns"
       minAllowed:
-        {{- include "coredns_resources" . | nindent 8 }}
+        cpu: {{ $resourcesRequestsVPA_CPU.min | default "20m" | quote }}
+        memory: {{ $resourcesRequestsVPA_Memory.min | default "40Mi" | quote }}
       maxAllowed:
-        cpu: 40m
-        memory: 50Mi
+        cpu: {{ $resourcesRequestsVPA_CPU.max | default "40m" | quote }}
+        memory: {{ $resourcesRequestsVPA_Memory.max | default "50Mi" | quote }}
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
 ---


### PR DESCRIPTION
## Description

Added VPA configuration option for kube-dns module

## Why do we need it, and what problem does it solve?

Under high loads on kube-dns it may be necessary to fine tune VPA, added ability to configure it via ModuleConfig. Default behavior has not changed

## Why do we need it in the patch release (if we do)?


## What is the expected result?



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: fix
summary: Ability to change VPA mode via ModuleConfig.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
