### PR TITLE
[candi] fix exit codes in bootstrap-networks scripts

### DIFF
--- a/candi/cloud-providers/aws/bashible/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/bootstrap-networks.sh.tpl
@@ -18,6 +18,8 @@
 {{- /*
 # We need include 'bb_package_install' in this file for dhctl bootstrap render.
 */}}
+set +e
+
 {{- if $bb_package_install := .Files.Get "/deckhouse/candi/bashible/bb_package_install.sh.tpl" -}}
   {{- tpl ( $bb_package_install ) . | nindent 0 }}
 {{- end }}
@@ -49,3 +51,5 @@ if [ ! -f /var/lib/bashible/hosname-set-as-in-aws ]; then
   mkdir -p /var/lib/bashible
   touch /var/lib/bashible/hosname-set-as-in-aws
 fi
+
+set -e

--- a/candi/cloud-providers/yandex/bashible/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bootstrap-networks.sh.tpl
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+set +e
 shopt -s extglob
 
 function ip_in_subnet(){
@@ -98,5 +99,6 @@ if which netplan 2>/dev/null 1>&2; then
 fi
 
 shopt -u extglob
+set -e
 
 

--- a/ee/candi/cloud-providers/openstack/bashible/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/openstack/bashible/bootstrap-networks.sh.tpl
@@ -3,6 +3,7 @@
 # Copyright 2024 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */}}
+set +e
 shopt -s extglob
 
 function render_and_deploy_netplan_config() {
@@ -55,3 +56,4 @@ if which netplan 2>/dev/null 1>&2; then
 fi
 
 shopt -u extglob
+set -e

--- a/ee/candi/cloud-providers/vcd/bashible/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vcd/bashible/bootstrap-networks.sh.tpl
@@ -3,6 +3,7 @@
 # Copyright 2024 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */}}
+set +e
 shopt -s extglob
 
 function netplan_configure(){
@@ -48,4 +49,4 @@ if which netplan 2>/dev/null 1>&2; then
 fi
 
 shopt -u extglob
-
+set -e

--- a/ee/candi/cloud-providers/vsphere/bashible/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bootstrap-networks.sh.tpl
@@ -3,6 +3,7 @@
 # Copyright 2024 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */}}
+set +e
 shopt -s extglob
 
 function netplan_configure(){
@@ -48,3 +49,4 @@ if which netplan 2>/dev/null 1>&2; then
 fi
 
 shopt -u extglob
+set -e


### PR DESCRIPTION
## Description

Fix catch exit codes in bootstrap-network scripts.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Non-zero exit codes may be legal in bootstrap-network scripts.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Fix bootstrap new nodes in different cloud-providers.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix catch exit codes in cloud-providers bootstrap-network scripts.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
