### PR TITLE
[deckhouse] fix parsing kubernetes version

### DIFF
--- a/go_lib/dependency/extenders/deckhouseversion/extender.go
+++ b/go_lib/dependency/extenders/deckhouseversion/extender.go
@@ -111,11 +111,11 @@ func (e *Extender) IsTerminator() bool {
 
 // Filter implements Extender interface, it is used by scheduler in addon-operator
 func (e *Extender) Filter(name string, _ map[string]string) (*bool, error) {
-	if e.err != nil {
-		return nil, &scherror.PermanentError{Err: fmt.Errorf("parse deckhouse version failed: %s", e.err)}
-	}
 	if !e.versionMatcher.Has(name) {
 		return nil, nil
+	}
+	if e.err != nil {
+		return nil, &scherror.PermanentError{Err: fmt.Errorf("parse deckhouse version failed: %s", e.err)}
 	}
 	if err := e.versionMatcher.Validate(name); err != nil {
 		e.logger.Errorf("requirements of the '%s' module are not satisfied: current deckhouse version is not suitable: %s", name, err.Error())

--- a/go_lib/dependency/extenders/kubernetesversion/extender.go
+++ b/go_lib/dependency/extenders/kubernetesversion/extender.go
@@ -97,7 +97,7 @@ func (e *Extender) waitForFileExists(path string) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			if content == nil || len(content) == 0 {
+			if len(content) == 0 {
 				e.logger.Debugf("file %s is empty", path)
 				continue
 			}

--- a/go_lib/dependency/extenders/kubernetesversion/watcher.go
+++ b/go_lib/dependency/extenders/kubernetesversion/watcher.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/flant/addon-operator/pkg/utils/logger"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/fsnotify/fsnotify"
 )
@@ -28,6 +30,7 @@ type versionWatcher struct {
 	ch          chan<- *semver.Version
 	lastVersion *semver.Version
 	watcher     *fsnotify.Watcher
+	logger      logger.Logger
 }
 
 func (w *versionWatcher) watch(path string) (err error) {
@@ -60,8 +63,12 @@ func (w *versionWatcher) handler(path string) error {
 	if err != nil {
 		return err
 	}
+	if content == nil || len(content) == 0 {
+		return nil
+	}
 	parsed, err := semver.NewVersion(strings.TrimSpace(string(content)))
 	if err != nil {
+		w.logger.Error("failed to parse version", "path", path, "content", string(content), "err", err)
 		return err
 	}
 	if w.lastVersion == nil || !w.lastVersion.Equal(parsed) {

--- a/go_lib/dependency/extenders/kubernetesversion/watcher.go
+++ b/go_lib/dependency/extenders/kubernetesversion/watcher.go
@@ -20,9 +20,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/flant/addon-operator/pkg/utils/logger"
-
 	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/utils/logger"
 	"github.com/fsnotify/fsnotify"
 )
 

--- a/go_lib/dependency/extenders/kubernetesversion/watcher.go
+++ b/go_lib/dependency/extenders/kubernetesversion/watcher.go
@@ -63,7 +63,7 @@ func (w *versionWatcher) handler(path string) error {
 	if err != nil {
 		return err
 	}
-	if content == nil || len(content) == 0 {
+	if len(content) == 0 {
 		return nil
 	}
 	parsed, err := semver.NewVersion(strings.TrimSpace(string(content)))


### PR DESCRIPTION
## Description
It provides fix for parsing kubernetes version.

## Why do we need it, and what problem does it solve?
The file with kubernetes version might be empty.

## What is the expected result?
An empty file will be skipped.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix parsing kubernetes version.
```
