### PR TITLE
[multitenancy-manager] add virtual projects and used namespaces to status

### DIFF
--- a/ee/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
@@ -21,20 +21,8 @@ spec:
             status:
               description: ""
               properties:
-                conditions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      status:
-                        type: string
-                      message:
-                        type: string
+                message:
+                  description: Сообщение, указывающее на причину появления текущего статуса.
                 state:
                   description: Короткое описание состояния проекта, например, Ready, Error, Pending, и т.д.
                 sync:
@@ -57,8 +45,27 @@ spec:
 
                     Перед созданием, значения согласовываются со [схемой](cr.html#projecttemplate-v1alpha1-spec-parametersschema-openapiv3schema) входных параметров шаблона ресурсов.
             status:
+              description: ""
               properties:
-                message:
-                  description: Сообщение, указывающее на причину появления текущего статуса.
+                namespaces:
+                  description: Используемые пространства имен.
+                observedGeneration:
+                  description: Последний generation проекта.
+                templateGeneration:
+                  description: Последний generation шаблона.
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      status:
+                        type: string
+                      message:
+                        type: string
                 state:
-                  description: Короткое описание состояния проекта, например, Ready, Error, Pending, и т.д.
+                  description: Короткое описание состояния проекта, например, Error, Deploying, Deployed, и т.д.

--- a/ee/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/projects.yaml
@@ -108,9 +108,16 @@ spec:
             status:
               type: object
               properties:
+                namespaces:
+                  description: Used namespaces.
+                  type: array
+                  items:
+                    type: string
                 observedGeneration:
+                  description: The last observed project`s generation
                   type: integer
                 templateGeneration:
+                  description: The last observed template`s generation
                   type: integer
                 conditions:
                   type: array

--- a/ee/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/projects.yaml
@@ -121,7 +121,6 @@ spec:
                   type: integer
                 conditions:
                   type: array
-                  x-kubernetes-patch-strategy: "retainKeys"
                   items:
                     type: object
                     properties:

--- a/ee/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/projects.yaml
@@ -16,7 +16,7 @@ spec:
   scope: Cluster
   versions:
     - name: v1alpha1
-      served: true
+      served: false
       storage: false
       deprecated: true
       subresources:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
 	"time"
 
 	"controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -132,11 +131,11 @@ func setupRuntimeManager(log logr.Logger) (ctrl.Manager, error) {
 	}
 	if err = runtimeManager.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		log.Error(err, "unable to set up health check")
-		os.Exit(1)
+		return nil, err
 	}
 	if err = runtimeManager.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		log.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		return nil, err
 	}
 	return runtimeManager, nil
 }

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/apis/deckhouse.io/v1alpha2/project.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/apis/deckhouse.io/v1alpha2/project.go
@@ -122,6 +122,9 @@ func (p *ProjectSpec) DeepCopyInto(newObj *ProjectSpec) {
 }
 
 type ProjectStatus struct {
+	// Used namespaces
+	Namespaces []string `json:"namespaces,omitempty"`
+
 	// Observed generation
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
@@ -151,6 +154,11 @@ func (p *ProjectStatus) DeepCopyInto(newObj *ProjectStatus) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if p.Namespaces != nil {
+		in, out := &p.Namespaces, &newObj.Namespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	newObj.ObservedGeneration = p.ObservedGeneration
 	newObj.TemplateGeneration = p.TemplateGeneration

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/consts/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/consts/main.go
@@ -27,7 +27,7 @@ const ReleaseHashLabel = "hashsum"
 
 const (
 	DeckhouseProjectName = "deckhouse"
-	OthersProjectName    = "others"
+	DefaultProjectName   = "default"
 
 	VirtualTemplate = "virtual"
 )

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/consts/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/consts/main.go
@@ -5,15 +5,14 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 
 package consts
 
-const (
-	ProjectRequireSyncAnnotation = "projects.deckhouse.io/require-sync"
-	ProjectRequireSyncKeyTrue    = "true"
-	ProjectRequireSyncKeyFalse   = "false"
-)
+const ProjectRequireSyncAnnotation = "projects.deckhouse.io/require-sync"
+
+const ProjectFinalizer = "projects.deckhouse.io/project-exists"
 
 const (
 	ProjectLabel         = "projects.deckhouse.io/project"
 	ProjectTemplateLabel = "projects.deckhouse.io/project-template"
+	ProjectVirtualLabel  = "projects.deckhouse.io/virtual-project"
 )
 
 const (
@@ -22,8 +21,17 @@ const (
 	DeckhouseHeritage    = "deckhouse"
 )
 
-const ProjectFinalizer = "projects.deckhouse.io/project-exists"
-
 const HelmDriver = "secret"
 
 const ReleaseHashLabel = "hashsum"
+
+const (
+	DeckhouseProjectName = "deckhouse"
+	OthersProjectName    = "others"
+
+	VirtualTemplate = "virtual"
+)
+const (
+	DeckhouseNamespacePrefix  = "d8-"
+	KubernetesNamespacePrefix = "kube-"
+)

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/controller/project/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/controller/project/main.go
@@ -65,7 +65,7 @@ func Register(runtimeManager manager.Manager, helmClient *helm.Client, log logr.
 			predicate.AnnotationChangedPredicate{},
 			predicate.GenerationChangedPredicate{},
 			customPredicate[client.Object]{log: log})).
-		WatchesMetadata(&v1.Namespace{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+		Watches(&v1.Namespace{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			if _, ok := object.GetLabels()[consts.ProjectTemplateLabel]; ok {
 				return nil
 			}

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/controller/project/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/controller/project/main.go
@@ -72,7 +72,7 @@ func Register(runtimeManager manager.Manager, helmClient *helm.Client, log logr.
 			if strings.HasPrefix(object.GetName(), consts.KubernetesNamespacePrefix) || strings.HasPrefix(object.GetName(), consts.DeckhouseNamespacePrefix) {
 				return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: consts.DeckhouseProjectName}}}
 			}
-			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: consts.OthersProjectName}}}
+			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: consts.DefaultProjectName}}}
 		})).
 		Complete(projectController)
 }
@@ -88,14 +88,14 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// wait for init
 	r.init.Wait()
 
-	r.log.Info("reconciling project", "project", req.Name)
+	r.log.Info("reconciling the project", "project", req.Name)
 	project := &v1alpha2.Project{}
 	if err := r.client.Get(ctx, req.NamespacedName, project); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.log.Info("project not found", "project", req.Name)
+			r.log.Info("the project not found", "project", req.Name)
 			return reconcile.Result{}, nil
 		}
-		r.log.Error(err, "error getting project", "project", req.Name)
+		r.log.Error(err, "error getting the project", "project", req.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/controller/template/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/controller/template/main.go
@@ -83,7 +83,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return reconcile.Result{}, nil
 	}
 
-	// handle deletion
+	// handle the project template deletion
 	if !template.DeletionTimestamp.IsZero() {
 		r.log.Info("template was deleted", "template", template.Name)
 		return reconcile.Result{}, nil

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/main.go
@@ -187,7 +187,7 @@ func (m *Manager) HandleVirtual(ctx context.Context, project *v1alpha2.Project) 
 		if project.Name == consts.DeckhouseProjectName && isDeckhouseNamespace {
 			involvedNamespaces = append(involvedNamespaces, namespace.Name)
 		}
-		if project.Name == consts.OthersProjectName && !isDeckhouseNamespace {
+		if project.Name == consts.DefaultProjectName && !isDeckhouseNamespace {
 			involvedNamespaces = append(involvedNamespaces, namespace.Name)
 		}
 	}

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/main.go
@@ -143,7 +143,7 @@ func (m *Manager) Handle(ctx context.Context, project *v1alpha2.Project) (ctrl.R
 			m.log.Error(statusErr, "failed to set the project status", "project", project.Name, "projectTemplate", projectTemplate.Name)
 			return ctrl.Result{Requeue: true}, nil
 		}
-		// TODO: come with a better solution handling helm errors
+		// TODO: come up with a better solution to handle helm errors
 		// requeue to avoid helm fluky errors
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
@@ -7,6 +7,7 @@ package project
 
 import (
 	"context"
+	"slices"
 
 	"controller/pkg/apis/deckhouse.io/v1alpha1"
 	"controller/pkg/apis/deckhouse.io/v1alpha2"
@@ -19,6 +20,82 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+func (m *Manager) ensureVirtualProjects(ctx context.Context) error {
+	deckhouseProject := &v1alpha2.Project{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			Kind:       v1alpha2.ProjectKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: consts.DeckhouseProjectName,
+			Labels: map[string]string{
+				consts.HeritageLabel:       consts.MultitenancyHeritage,
+				consts.ProjectVirtualLabel: "true",
+			},
+		},
+		Spec: v1alpha2.ProjectSpec{
+			ProjectTemplateName: consts.VirtualTemplate,
+		},
+	}
+	if err := m.ensureProject(ctx, deckhouseProject); err != nil {
+		return err
+	}
+	othersProject := &v1alpha2.Project{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			Kind:       v1alpha2.ProjectKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: consts.OthersProjectName,
+			Labels: map[string]string{
+				consts.HeritageLabel:       consts.MultitenancyHeritage,
+				consts.ProjectVirtualLabel: "true",
+			},
+		},
+		Spec: v1alpha2.ProjectSpec{
+			ProjectTemplateName: consts.VirtualTemplate,
+		},
+	}
+	if err := m.ensureProject(ctx, othersProject); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) ensureProject(ctx context.Context, project *v1alpha2.Project) error {
+	m.log.Info("ensuring project", "project", project.Name)
+	if err := m.client.Create(ctx, project); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				existingProject := new(v1alpha2.Project)
+				if err = m.client.Get(ctx, types.NamespacedName{Name: project.Name}, existingProject); err != nil {
+					m.log.Error(err, "failed to fetch project")
+					return err
+				}
+
+				existingProject.Spec = project.Spec
+				existingProject.Labels = project.Labels
+				existingProject.Annotations = project.Annotations
+
+				m.log.Info("project already exists, try to update it")
+				if err = m.client.Update(ctx, existingProject); err != nil {
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				m.log.Error(err, "failed to update project")
+				return err
+			}
+		} else {
+			m.log.Error(err, "failed to create project", "project", project.Name)
+			return err
+		}
+	}
+	m.log.Info("successfully ensured project", "project", project.Name)
+	return nil
+}
 
 func (m *Manager) projectTemplateByName(ctx context.Context, name string) (*v1alpha1.ProjectTemplate, error) {
 	template := new(v1alpha1.ProjectTemplate)
@@ -43,6 +120,14 @@ func (m *Manager) updateProjectStatus(ctx context.Context, project *v1alpha2.Pro
 				// clear conditions before reconcile
 				project.Status.Conditions = []v1alpha2.Condition{}
 			}
+		}
+
+		if project.Status.Namespaces == nil {
+			project.Status.Namespaces = []string{}
+		}
+
+		if !slices.Contains(project.Status.Namespaces, project.Name) {
+			project.Status.Namespaces = append(project.Status.Namespaces, project.Name)
 		}
 
 		if project.Status.ObservedGeneration != project.Generation {

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
@@ -36,6 +36,7 @@ func (m *Manager) ensureVirtualProjects(ctx context.Context) error {
 		},
 		Spec: v1alpha2.ProjectSpec{
 			ProjectTemplateName: consts.VirtualTemplate,
+			Description:         "This is a virtual project",
 		},
 	}
 	if err := m.ensureProject(ctx, deckhouseProject); err != nil {
@@ -55,6 +56,7 @@ func (m *Manager) ensureVirtualProjects(ctx context.Context) error {
 		},
 		Spec: v1alpha2.ProjectSpec{
 			ProjectTemplateName: consts.VirtualTemplate,
+			Description:         "This is a virtual project",
 		},
 	}
 	if err := m.ensureProject(ctx, othersProject); err != nil {

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
@@ -44,7 +44,7 @@ func (m *Manager) ensureVirtualProjects(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: consts.DeckhouseProjectName,
 			Labels: map[string]string{
-				consts.HeritageLabel:       consts.MultitenancyHeritage,
+				consts.HeritageLabel:       consts.DeckhouseHeritage,
 				consts.ProjectVirtualLabel: "true",
 			},
 		},
@@ -56,15 +56,15 @@ func (m *Manager) ensureVirtualProjects(ctx context.Context) error {
 	if err := m.ensureProject(ctx, deckhouseProject); err != nil {
 		return err
 	}
-	othersProject := &v1alpha2.Project{
+	defaultProject := &v1alpha2.Project{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha2.SchemeGroupVersion.String(),
 			Kind:       v1alpha2.ProjectKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: consts.OthersProjectName,
+			Name: consts.DefaultProjectName,
 			Labels: map[string]string{
-				consts.HeritageLabel:       consts.MultitenancyHeritage,
+				consts.HeritageLabel:       consts.DeckhouseHeritage,
 				consts.ProjectVirtualLabel: "true",
 			},
 		},
@@ -73,20 +73,20 @@ func (m *Manager) ensureVirtualProjects(ctx context.Context) error {
 			Description:         "This is a virtual project",
 		},
 	}
-	if err := m.ensureProject(ctx, othersProject); err != nil {
+	if err := m.ensureProject(ctx, defaultProject); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (m *Manager) ensureProject(ctx context.Context, project *v1alpha2.Project) error {
-	m.log.Info("ensuring project", "project", project.Name)
+	m.log.Info("ensuring the project", "project", project.Name)
 	if err := m.client.Create(ctx, project); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				existingProject := new(v1alpha2.Project)
 				if err = m.client.Get(ctx, types.NamespacedName{Name: project.Name}, existingProject); err != nil {
-					m.log.Error(err, "failed to fetch project")
+					m.log.Error(err, "failed to fetch the project")
 					return err
 				}
 
@@ -94,22 +94,22 @@ func (m *Manager) ensureProject(ctx context.Context, project *v1alpha2.Project) 
 				existingProject.Labels = project.Labels
 				existingProject.Annotations = project.Annotations
 
-				m.log.Info("project already exists, try to update it")
+				m.log.Info("the project already exists, try to update it")
 				if err = m.client.Update(ctx, existingProject); err != nil {
 					return err
 				}
 				return nil
 			})
 			if err != nil {
-				m.log.Error(err, "failed to update project")
+				m.log.Error(err, "failed to update the project")
 				return err
 			}
 		} else {
-			m.log.Error(err, "failed to create project", "project", project.Name)
+			m.log.Error(err, "failed to create the project", "project", project.Name)
 			return err
 		}
 	}
-	m.log.Info("successfully ensured project", "project", project.Name)
+	m.log.Info("successfully ensured the project", "project", project.Name)
 	return nil
 }
 

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/template/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/template/main.go
@@ -56,12 +56,12 @@ func (m *Manager) Init(ctx context.Context, checker healthz.Checker, init *sync.
 		m.log.Error(err, "webhook server failed to start")
 		return fmt.Errorf("webhook server failed to start: %w", err)
 	}
-
 	// to make sure that the server is started, without working server reconcile is failed
 	if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, check); err != nil {
 		m.log.Error(err, "webhook server failed to start")
 		return fmt.Errorf("webhook server failed to start: %w", err)
 	}
+	m.log.Info("webhook server started")
 
 	m.log.Info("ensuring default project templates")
 	if err := m.ensureDefaultProjectTemplates(ctx, defaultPath); err != nil {
@@ -100,7 +100,7 @@ func (m *Manager) Handle(ctx context.Context, template *v1alpha1.ProjectTemplate
 				if project.Annotations == nil {
 					project.Annotations = map[string]string{}
 				}
-				project.Annotations[consts.ProjectRequireSyncAnnotation] = consts.ProjectRequireSyncKeyTrue
+				project.Annotations[consts.ProjectRequireSyncAnnotation] = "true"
 				return m.client.Update(ctx, project)
 			})
 			if err != nil {

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/template/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/template/main.go
@@ -51,7 +51,6 @@ func (m *Manager) Init(ctx context.Context, checker healthz.Checker, init *sync.
 		m.log.Info("webhook server started")
 		return true, nil
 	}
-
 	if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, true, check); err != nil {
 		m.log.Error(err, "webhook server failed to start")
 		return fmt.Errorf("webhook server failed to start: %w", err)

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/webhook/project/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/webhook/project/main.go
@@ -7,6 +7,7 @@ package project
 
 import (
 	"context"
+	"controller/pkg/consts"
 	"fmt"
 	"net/http"
 	"strings"
@@ -38,6 +39,11 @@ func (v *validator) Handle(_ context.Context, req admission.Request) admission.R
 	}
 	if strings.HasPrefix(project.Name, "d8-") || strings.HasPrefix(project.Name, "kube-") {
 		return admission.Denied("Projects cannot start with 'd8-' or 'kube-'")
+	}
+
+	// allow virtual projects
+	if project.Name == consts.DefaultProjectName || project.Name == consts.DeckhouseProjectName {
+		return admission.Allowed("")
 	}
 
 	namespaces := new(v1.NamespaceList)


### PR DESCRIPTION
## Description
It provides ```Deckhouse``` and ```Others``` virtual projects and the used namespaces field in a project status.

## Why do we need it, and what problem does it solve?
Fixes #9093
Fixes #9092

## What is the expected result?
All ```kube-*``` and ```d8-*``` namespaces are collected into the ```deckhouse``` virtual project (to the ```.status.namespaces``` field).
All namespaces which are not used in any projects into the ```others``` virtual project.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: multitenancy-manager
type: feature
summary: Add virtual projects and used namespaces to status.
```
