### PR TITLE
[user-authn] fix: update client-groups.patch for dex

### DIFF
--- a/modules/150-user-authn/images/dex/patches/client-groups.patch
+++ b/modules/150-user-authn/images/dex/patches/client-groups.patch
@@ -1,6 +1,6 @@
 diff --git a/storage/kubernetes/types.go b/storage/kubernetes/types.go
---- a/storage/kubernetes/types.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/storage/kubernetes/types.go	(date 1718352821998)
+--- a/storage/kubernetes/types.go	(revision 43956db7fd75c488a82c70cf231f44287300a75d)
++++ b/storage/kubernetes/types.go	(date 1724337051437)
 @@ -251,6 +251,8 @@
 
  	Name    string `json:"name,omitempty"`
@@ -52,43 +52,9 @@ diff --git a/storage/kubernetes/types.go b/storage/kubernetes/types.go
  	}
  }
 
-diff --git a/server/handlers.go b/server/handlers.go
---- a/server/handlers.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/server/handlers.go	(date 1718355021185)
-@@ -22,6 +22,7 @@
- 	"github.com/gorilla/mux"
-
- 	"github.com/dexidp/dex/connector"
-+	"github.com/dexidp/dex/pkg/groups"
- 	"github.com/dexidp/dex/server/internal"
- 	"github.com/dexidp/dex/storage"
- )
-@@ -629,6 +630,22 @@
- 		s.renderError(r, w, http.StatusUnauthorized, "Unauthorized request")
- 		return
- 	}
-+
-+	client, err := s.storage.GetClient(authReq.ClientID)
-+	if err != nil {
-+		s.logger.Error("Failed to get client", "client_id", authReq.ClientID, "err", err)
-+		s.renderError(r, w, http.StatusInternalServerError, "Failed to retrieve client.")
-+		return
-+	}
-+
-+	if len(client.AllowedGroups) > 0 {
-+		authReq.Claims.Groups = groups.Filter(authReq.Claims.Groups, client.AllowedGroups)
-+		if len(authReq.Claims.Groups) == 0 {
-+			s.logger.Error(fmt.Sprintf("user not in allowed groups: %v", client.AllowedGroups))
-+			s.renderError(r, w, http.StatusInternalServerError, "User not in allowed groups.")
-+			return
-+		}
-+	}
-
- 	switch r.Method {
- 	case http.MethodGet:
 diff --git a/storage/storage.go b/storage/storage.go
---- a/storage/storage.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/storage/storage.go	(date 1718352822001)
+--- a/storage/storage.go	(revision 43956db7fd75c488a82c70cf231f44287300a75d)
++++ b/storage/storage.go	(date 1724337051440)
 @@ -171,6 +171,8 @@
  	// Name and LogoURL used when displaying this client to the end user.
  	Name    string `json:"name" yaml:"name"`
@@ -98,3 +64,77 @@ diff --git a/storage/storage.go b/storage/storage.go
  }
 
  // Claims represents the ID Token claims supported by the server.
+diff --git a/server/handlers.go b/server/handlers.go
+--- a/server/handlers.go	(revision 43956db7fd75c488a82c70cf231f44287300a75d)
++++ b/server/handlers.go	(date 1724396069272)
+@@ -18,6 +18,7 @@
+ 	"time"
+
+ 	"github.com/coreos/go-oidc/v3/oidc"
++	"github.com/dexidp/dex/pkg/groups"
+ 	"github.com/go-jose/go-jose/v4"
+ 	"github.com/gorilla/mux"
+
+@@ -380,7 +381,7 @@
+ 		redirectURL, canSkipApproval, err := s.finalizeLogin(r.Context(), identity, authReq, conn.Connector)
+ 		if err != nil {
+ 			s.logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
+-			s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++			s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Failed to authenticate: %v", err))
+ 			return
+ 		}
+
+@@ -388,7 +389,7 @@
+ 			authReq, err = s.storage.GetAuthRequest(authReq.ID)
+ 			if err != nil {
+ 				s.logger.ErrorContext(r.Context(), "failed to get finalized auth request", "err", err)
+-				s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++				s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Failed to authenticate: %v", err))
+ 				return
+ 			}
+ 			s.sendCodeResponse(w, r, authReq)
+@@ -473,14 +474,14 @@
+
+ 	if err != nil {
+ 		s.logger.ErrorContext(r.Context(), "failed to authenticate", "err", err)
+-		s.renderError(r, w, http.StatusInternalServerError, fmt.Sprintf("Failed to authenticate: %v", err))
++		s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Failed to authenticate: %v", err))
+ 		return
+ 	}
+
+ 	redirectURL, canSkipApproval, err := s.finalizeLogin(ctx, identity, authReq, conn.Connector)
+ 	if err != nil {
+ 		s.logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
+-		s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++		s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Failed to authenticate: %v", err))
+ 		return
+ 	}
+
+@@ -488,7 +489,7 @@
+ 		authReq, err = s.storage.GetAuthRequest(authReq.ID)
+ 		if err != nil {
+ 			s.logger.ErrorContext(r.Context(), "failed to get finalized auth request", "err", err)
+-			s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++			s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Failed to authenticate: %v", err))
+ 			return
+ 		}
+ 		s.sendCodeResponse(w, r, authReq)
+@@ -525,6 +526,18 @@
+ 		email += " (unverified)"
+ 	}
+
++	client, err := s.storage.GetClient(authReq.ClientID)
++	if err != nil {
++		return "", false, fmt.Errorf("failed to retrieve client")
++	}
++
++	if len(client.AllowedGroups) > 0 {
++		authReq.Claims.Groups = groups.Filter(authReq.Claims.Groups, client.AllowedGroups)
++		if len(authReq.Claims.Groups) == 0 {
++			return "", false, fmt.Errorf("user not in allowed groups")
++		}
++	}
++
+ 	s.logger.InfoContext(ctx, "login successful",
+ 		"connector_id", authReq.ConnectorID, "username", claims.Username,
+ 		"preferred_username", claims.PreferredUsername, "email", email, "groups", claims.Groups)


### PR DESCRIPTION
## Description

Our patch for checking user groups in dex stopped working due to disabled transition to approve page

## Why do we need it, and what problem does it solve?

Checking for user groups in dex should be done before checking for the need to use the approve page.

## What is the expected result?

Checking for user groups in dex works again.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Update `client-groups.patch` for dex.
impact_level: default
```