### PR TITLE
[docs] Clarifying network security infrastracture requirements

### DIFF
--- a/docs/documentation/pages/NETWORK_SECURITY_SETUP.md
+++ b/docs/documentation/pages/NETWORK_SECURITY_SETUP.md
@@ -4,7 +4,7 @@ permalink: en/network_security_setup.html
 lang: en
 ---
 
-If the infrastructure where Deckhouse Kubernetes Platform is running has requirements to limit network communication, the following conditions must be met:
+If the infrastructure where Deckhouse Kubernetes Platform is running has requirements to limit host-to-host network communications, the following conditions must be met:
 
 * Tunneling mode for traffic between pods is enabled ([configuration](modules/021-cni-cilium/configuration.html#parameters-tunnelmode) for CNI Cilium, [configuration](modules/035-cni-flannel/configuration.html#parameters-podnetworkmode) for CNI Flannel).
 * If there is integration with external systems (e.g. LDAP, SMTP or other external APIs), it is required to allow network communication with them.

--- a/docs/documentation/pages/NETWORK_SECURITY_SETUP_RU.md
+++ b/docs/documentation/pages/NETWORK_SECURITY_SETUP_RU.md
@@ -4,7 +4,7 @@ permalink: ru/network_security_setup.html
 lang: ru
 ---
 
-Если в инфраструктуре, где работает Deckhouse Kubernetes Platform, есть требования для ограничения сетевого взаимодействия, то необходимо соблюсти следующие условия:
+Если на площадке, где работает Deckhouse Kubernetes Platform, есть требования для ограничения сетевого взаимодействия между серверами на уровне инфраструктуры, то необходимо соблюсти следующие условия:
 
 * Включен режим туннелирования трафика между подами ([настройки](modules/021-cni-cilium/configuration.html#parameters-tunnelmode) для CNI Cilium, [настройки](modules/035-cni-flannel/configuration.html#parameters-podnetworkmode) для CNI Flannel).
 * В случае необходимости интеграции с внешними системами (например, LDAP, SMTP или прочие внешние API), с ними разрешено сетевое взаимодействие.


### PR DESCRIPTION
## Description
Clarifying network security infrastracture requirements in "Network security settings" section.

## Why do we need it, and what problem does it solve?
Some customers thaught that they have to turn VXLAN on to use NetworoPolicies.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Clarified network security infrastracture requirements in "Network security settings" section.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
