### PR TITLE
[runtime-audin-engine] fix monitoring rbac permissions

### DIFF
--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -134,6 +134,8 @@ spec:
       - name: falcosidekick
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "falcosidekick") }}
+        command:
+        - /falcosidekick
         env:
         - name: LISTENADDRESS
           value: "127.0.0.1"

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/deployment.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/deployment.yaml
@@ -92,9 +92,6 @@ spec:
           timeoutSeconds: 5
           periodSeconds: 15
         ports:
-        - name: metrics
-          containerPort: 8080
-          protocol: "TCP"
         - name: health-probe
           containerPort: 8081
           protocol: "TCP"

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/podmonitor.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/podmonitor.yaml
@@ -17,7 +17,7 @@ spec:
   podMetricsEndpoints:
   - port: https-metrics
     scheme: https
-    path: /
+    path: /metrics
     bearerTokenSecret:
       name: "prometheus-token"
       key: "token"

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-for-us.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-for-us.yaml
@@ -42,6 +42,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-to-us.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-to-us.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: access-to-k8s-metacollector
+  name: access-to-k8s-metacollector-metrics
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 rules:
@@ -15,13 +15,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: access-to-k8s-metacollector
+  name: access-to-k8s-metacollector-metrics
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: access-to-k8s-metacollector
+  name: access-to-k8s-metacollector-metrics
 subjects:
 - kind: User
   name: d8-monitoring:scraper

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-to-us.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-to-us.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-k8s-metacollector
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments/prometheus-metrics"]
+  resourceNames: [{{ $.Chart.Name }}]
+  verbs: ["get"]
+{{- if (.Values.global.enabledModules | has "prometheus") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-k8s-metacollector
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-k8s-metacollector
+subjects:
+- kind: User
+  name: d8-monitoring:scraper
+- kind: ServiceAccount
+  name: prometheus
+  namespace: d8-monitoring
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix monitoring rbac permissions.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: fix monitoring rbac permissions
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
