### PR TITLE
[dhctl] Skip preflight checks after restarting bootstrap if checks were finished successfully 

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -259,12 +259,12 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	deckhouseInstallConfig.KubeadmBootstrap = true
 	deckhouseInstallConfig.MasterNodeSelector = true
 
-	preflightChecker := preflight.NewChecker(b.NodeInterface, deckhouseInstallConfig, metaConfig)
+	bootstrapState := NewBootstrapState(stateCache)
+
+	preflightChecker := preflight.NewChecker(b.NodeInterface, deckhouseInstallConfig, metaConfig, bootstrapState)
 	if err := preflightChecker.Global(); err != nil {
 		return err
 	}
-
-	bootstrapState := NewBootstrapState(stateCache)
 
 	if shouldStop, err := b.PhasedExecutionContext.StartPhase(phases.BaseInfraPhase, true, stateCache); err != nil {
 		return err

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -21,8 +21,9 @@ import (
 )
 
 const PostBootstrapResultCacheKey = "post-bootstrap-result"
-
-const PreflightBootstrapResultCacheKey = "preflight-bootstrap-result"
+const PreflightBootstrapCloudResultCacheKey = "preflight-bootstrap-cloud-result"
+const PreflightBootstrapGlobalResultCacheKey = "preflight-bootstrap-global-result"
+const PreflightBootstrapStaticResultCacheKey = "preflight-bootstrap-static-result"
 
 type State struct {
 	cache state.Cache
@@ -43,29 +44,29 @@ func (s *State) PostBootstrapScriptResult() ([]byte, error) {
 }
 
 func (s *State) SetGlobalPreflightchecksWasRan() error {
-	return s.cache.Save(PreflightBootstrapResultCacheKey, []byte("yes"))
+	return s.cache.Save(PreflightBootstrapGlobalResultCacheKey, []byte("yes"))
 }
 
 func (s *State) GlobalPreflightchecksWasRan() (bool, error) {
-	preflightcachefile, err := s.cache.InCache(PreflightBootstrapResultCacheKey)
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapGlobalResultCacheKey)
 	return preflightcachefile, err
 }
 
 func (s *State) SetCloudPreflightchecksWasRan() error {
-	return s.cache.Save(PreflightBootstrapResultCacheKey, []byte("yes"))
+	return s.cache.Save(PreflightBootstrapCloudResultCacheKey, []byte("yes"))
 }
 
 func (s *State) CloudPreflightchecksWasRan() (bool, error) {
-	preflightcachefile, err := s.cache.InCache(PreflightBootstrapResultCacheKey)
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapCloudResultCacheKey)
 	return preflightcachefile, err
 }
 
 func (s *State) SetStaticPreflightchecksWasRan() error {
-	return s.cache.Save(PreflightBootstrapResultCacheKey, []byte("yes"))
+	return s.cache.Save(PreflightBootstrapStaticResultCacheKey, []byte("yes"))
 }
 
 func (s *State) StaticPreflightchecksWasRan() (bool, error) {
-	preflightcachefile, err := s.cache.InCache(PreflightBootstrapResultCacheKey)
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapStaticResultCacheKey)
 	return preflightcachefile, err
 }
 

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -16,9 +16,13 @@
 
 package bootstrap
 
-import "github.com/deckhouse/deckhouse/dhctl/pkg/state"
+import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+)
 
 const PostBootstrapResultCacheKey = "post-bootstrap-result"
+
+const PreflightBootstrapResultCacheKey = "preflight-bootstrap-result"
 
 type State struct {
 	cache state.Cache
@@ -36,6 +40,33 @@ func (s *State) SavePostBootstrapScriptResult(result string) error {
 
 func (s *State) PostBootstrapScriptResult() ([]byte, error) {
 	return s.cache.Load(PostBootstrapResultCacheKey)
+}
+
+func (s *State) SetGlobalPreflightchecksWasRan() error {
+	return s.cache.Save(PreflightBootstrapResultCacheKey, []byte("yes"))
+}
+
+func (s *State) GlobalPreflightchecksWasRan() (bool, error) {
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapResultCacheKey)
+	return preflightcachefile, err
+}
+
+func (s *State) SetCloudPreflightchecksWasRan() error {
+	return s.cache.Save(PreflightBootstrapResultCacheKey, []byte("yes"))
+}
+
+func (s *State) CloudPreflightchecksWasRan() (bool, error) {
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapResultCacheKey)
+	return preflightcachefile, err
+}
+
+func (s *State) SetStaticPreflightchecksWasRan() error {
+	return s.cache.Save(PreflightBootstrapResultCacheKey, []byte("yes"))
+}
+
+func (s *State) StaticPreflightchecksWasRan() (bool, error) {
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapResultCacheKey)
+	return preflightcachefile, err
 }
 
 func (s *State) Clean() {

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -15,6 +15,7 @@
 package preflight
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,10 +26,20 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
+type State interface {
+	SetGlobalPreflightchecksWasRan() error
+	GlobalPreflightchecksWasRan() (bool, error)
+	SetCloudPreflightchecksWasRan() error
+	CloudPreflightchecksWasRan() (bool, error)
+	SetStaticPreflightchecksWasRan() error
+	StaticPreflightchecksWasRan() (bool, error)
+}
+
 type Checker struct {
 	nodeInterface           node.Interface
 	metaConfig              *config.MetaConfig
 	installConfig           *config.DeckhouseInstaller
+	bootstrapState          State
 	imageDescriptorProvider imageDescriptorProvider
 	buildDigestProvider     buildDigestProvider
 }
@@ -43,11 +54,13 @@ func NewChecker(
 	nodeInterface node.Interface,
 	config *config.DeckhouseInstaller,
 	metaConfig *config.MetaConfig,
+	bootstrapState State,
 ) Checker {
 	return Checker{
 		nodeInterface:           nodeInterface,
 		metaConfig:              metaConfig,
 		installConfig:           config,
+		bootstrapState:          bootstrapState,
 		imageDescriptorProvider: remoteDescriptorProvider{},
 		buildDigestProvider: &dhctlBuildDigestProvider{
 			DigestFilePath: app.DeckhouseImageDigestFile,
@@ -56,7 +69,19 @@ func NewChecker(
 }
 
 func (pc *Checker) Static() error {
-	return pc.do("Preflight checks for static-cluster", []checkStep{
+
+	ready, err := pc.bootstrapState.StaticPreflightchecksWasRan()
+
+	if err != nil {
+		msg := fmt.Sprintf("Can not get state from cache: %v", err)
+		return errors.New(msg)
+	}
+
+	if ready {
+		return nil
+	}
+
+	err = pc.do("Preflight checks for static-cluster", []checkStep{
 		{
 			fun:            pc.CheckSingleSSHHostForStatic,
 			successMessage: "only one --ssh-host parameter used",
@@ -103,20 +128,56 @@ func (pc *Checker) Static() error {
 			skipFlag:       app.SudoAllowedCheckArgName,
 		},
 	})
+
+	if err != nil {
+		return err
+	}
+
+	return pc.bootstrapState.SetStaticPreflightchecksWasRan()
 }
 
 func (pc *Checker) Cloud() error {
-	return pc.do("Cloud deployment preflight checks", []checkStep{
+
+	ready, err := pc.bootstrapState.CloudPreflightchecksWasRan()
+
+	if err != nil {
+		msg := fmt.Sprintf("Can not get state from cache: %v", err)
+		return errors.New(msg)
+	}
+
+	if ready {
+		return nil
+	}
+
+	err = pc.do("Cloud deployment preflight checks", []checkStep{
 		{
 			fun:            pc.CheckCloudMasterNodeSystemRequirements,
 			successMessage: "cloud master node system requirements are met",
 			skipFlag:       app.SystemRequirementsArgName,
 		},
 	})
+
+	if err != nil {
+		return err
+	}
+
+	return pc.bootstrapState.SetCloudPreflightchecksWasRan()
+
 }
 
 func (pc *Checker) Global() error {
-	return pc.do("Global preflight checks", []checkStep{
+	ready, err := pc.bootstrapState.GlobalPreflightchecksWasRan()
+
+	if err != nil {
+		msg := fmt.Sprintf("Can not get state from cache: %v", err)
+		return errors.New(msg)
+	}
+
+	if ready {
+		return nil
+	}
+
+	err = pc.do("Global preflight checks", []checkStep{
 		{
 			fun:            pc.CheckPublicDomainTemplate,
 			successMessage: "PublicDomainTemplate is correctly",
@@ -128,6 +189,13 @@ func (pc *Checker) Global() error {
 			skipFlag:       app.RegistryCredentialsCheckArgName,
 		},
 	})
+
+	if err != nil {
+		return err
+	}
+
+	return pc.bootstrapState.SetGlobalPreflightchecksWasRan()
+
 }
 
 func (pc *Checker) do(title string, checks []checkStep) error {

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -37,6 +37,22 @@ func (s *testState) GlobalPreflightchecksWasRan() (bool, error) {
 	return false, nil
 }
 
+func (s *testState) SetCloudPreflightchecksWasRan() error {
+	return nil
+}
+
+func (s *testState) CloudPreflightchecksWasRan() (bool, error) {
+	return false, nil
+}
+
+func (s *testState) SetStaticPreflightchecksWasRan() error {
+	return nil
+}
+
+func (s *testState) StaticPreflightchecksWasRan() (bool, error) {
+	return false, nil
+}
+
 func TestCheckRegistryAccessThroughProxy(t *testing.T) {
 	tests := map[string]func(*testing.T){
 		"getProxyFromMetaConfig_NoProxy":    getProxyFromMetaConfigSuccessNoProxy,

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -27,6 +27,16 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
+type testState struct{}
+
+func (s *testState) SetGlobalPreflightchecksWasRan() error {
+	return nil
+}
+
+func (s *testState) GlobalPreflightchecksWasRan() (bool, error) {
+	return false, nil
+}
+
 func TestCheckRegistryAccessThroughProxy(t *testing.T) {
 	tests := map[string]func(*testing.T){
 		"getProxyFromMetaConfig_NoProxy":    getProxyFromMetaConfigSuccessNoProxy,
@@ -169,7 +179,9 @@ deckhouse:
 		installer, err := config.PrepareDeckhouseInstallConfig(metaConfig)
 		s.NoError(err)
 
-		preflightChecker := NewChecker(ssh.NewNodeInterfaceWrapper(&ssh.Client{}), installer, metaConfig)
+		bootstrapState := &testState{}
+
+		preflightChecker := NewChecker(ssh.NewNodeInterfaceWrapper(&ssh.Client{}), installer, metaConfig, bootstrapState)
 
 		err = preflightChecker.CheckRegistryAccessThroughProxy()
 		if test.skipped {

--- a/dhctl/pkg/preflight/suite_test.go
+++ b/dhctl/pkg/preflight/suite_test.go
@@ -29,7 +29,7 @@ type PreflightChecksTestSuite struct {
 }
 
 func (s *PreflightChecksTestSuite) SetupSuite() {
-	s.checker = NewChecker(nil, nil, nil)
+	s.checker = NewChecker(nil, nil, nil, nil)
 }
 
 func (s *PreflightChecksTestSuite) SetupTest() {


### PR DESCRIPTION
## Description
added dhctl preflight cache files, when boostraping is interrupt it restore data preflight from cache
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this allow to not generate all bootstrap preflight checks again on bootstrap stage if bootstrap was interrupt

## What is the expected result?
preflight check status save in cache
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Skip preflight checks after restarting bootstrap if checks were finished successfully 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
