### PR TITLE
[candi] kubelet files strict permissions

### DIFF
--- a/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
+++ b/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
@@ -1,0 +1,19 @@
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find /etc/kubernetes -type d -exec chmod 700 {} \;
+find /etc/kubernetes -type f -exec chmod 600 {} \;
+
+find /var/lib/kubelet -type d -exec chmod 700 {} \;
+find /var/lib/kubelet -type f -exec chmod 600 {} \;

--- a/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
+++ b/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
@@ -15,5 +15,5 @@
 find /etc/kubernetes -type d -exec chmod 700 {} \;
 find /etc/kubernetes -type f -exec chmod 600 {} \;
 
-find /var/lib/kubelet -type d -exec chmod 700 {} \;
-find /var/lib/kubelet -type f -exec chmod 600 {} \;
+find /var/lib/kubelet -type d -name pods -prune -o -type d -exec chmod 700 {} \;
+find /var/lib/kubelet -type d -name pods -prune -o -type f -exec chmod 600 {} \;

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/config.go
@@ -212,5 +212,5 @@ func (c *Config) getLastAppliedConfigurationChecksum() error {
 }
 
 func (c *Config) writeLastAppliedConfigurationChecksum() error {
-	return os.WriteFile(filepath.Join(deckhousePath, "last_applied_configuration_checksum"), []byte(c.LastAppliedConfigurationChecksum), 0644)
+	return os.WriteFile(filepath.Join(deckhousePath, "last_applied_configuration_checksum"), []byte(c.LastAppliedConfigurationChecksum), 0600)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -42,7 +42,7 @@ func installExtraFiles() error {
 		return err
 	}
 
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
+	if err := os.MkdirAll(dstDir, 0700); err != nil {
 		return err
 	}
 
@@ -59,7 +59,7 @@ func installExtraFiles() error {
 			continue
 		}
 
-		if err := installFileIfChanged(filepath.Join(configPath, entry.Name()), filepath.Join(dstDir, strings.TrimPrefix(entry.Name(), "extra-file-")), 0644); err != nil {
+		if err := installFileIfChanged(filepath.Join(configPath, entry.Name()), filepath.Join(dstDir, strings.TrimPrefix(entry.Name(), "extra-file-")), 0600); err != nil {
 			return err
 		}
 	}
@@ -227,7 +227,7 @@ metadata:
 	log.Infof("write checksum patch for component %s", componentName)
 	patchFile := filepath.Join(deckhousePath, "kubeadm", "patches", componentName+"999checksum.yaml")
 	content := fmt.Sprintf(patch, componentName, checksum)
-	return os.WriteFile(patchFile, []byte(content), 0644)
+	return os.WriteFile(patchFile, []byte(content), 0600)
 }
 
 func etcdJoinConverge() error {

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/kubeconfig.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/kubeconfig.go
@@ -205,15 +205,15 @@ func checkKubeletConfig() error {
 
 func installKubeadmConfig() error {
 	log.Info("phase: install kubeadm configuration")
-	if err := os.MkdirAll(filepath.Join(deckhousePath, "kubeadm", "patches"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(deckhousePath, "kubeadm", "patches"), 0700); err != nil {
 		return err
 	}
 
-	if err := installFileIfChanged(filepath.Join(configPath, "kubeadm-config.yaml"), filepath.Join(deckhousePath, "kubeadm", "config.yaml"), 0644); err != nil {
+	if err := installFileIfChanged(filepath.Join(configPath, "kubeadm-config.yaml"), filepath.Join(deckhousePath, "kubeadm", "config.yaml"), 0600); err != nil {
 		return err
 	}
 	for _, component := range []string{"etcd", "kube-apiserver", "kube-controller-manager", "kube-scheduler"} {
-		if err := installFileIfChanged(filepath.Join(configPath, component+".yaml.tpl"), filepath.Join(deckhousePath, "kubeadm", "patches", component+".yaml"), 0644); err != nil {
+		if err := installFileIfChanged(filepath.Join(configPath, component+".yaml.tpl"), filepath.Join(deckhousePath, "kubeadm", "patches", component+".yaml"), 0600); err != nil {
 			return err
 		}
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/pki.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/pki.go
@@ -32,17 +32,11 @@ import (
 
 func installBasePKIfiles() error {
 	log.Info("phase: install base pki files")
-	if err := os.MkdirAll(filepath.Join(kubernetesPkiPath, "etcd"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(kubernetesPkiPath, "etcd"), 0700); err != nil {
 		return err
 	}
 
 	for _, f := range []string{"ca.crt", "front-proxy-ca.crt"} {
-		if err := installFileIfChanged(filepath.Join(pkiPath, f), filepath.Join(kubernetesPkiPath, f), 0644); err != nil {
-			return err
-		}
-	}
-
-	for _, f := range []string{"ca.key", "sa.pub", "sa.key", "front-proxy-ca.key"} {
 		if err := installFileIfChanged(filepath.Join(pkiPath, f), filepath.Join(kubernetesPkiPath, f), 0600); err != nil {
 			return err
 		}
@@ -54,7 +48,13 @@ func installBasePKIfiles() error {
 		}
 	}
 
-	if err := installFileIfChanged(filepath.Join(pkiPath, "etcd-ca.crt"), filepath.Join(kubernetesPkiPath, "etcd", "ca.crt"), 0644); err != nil {
+	for _, f := range []string{"ca.key", "sa.pub", "sa.key", "front-proxy-ca.key"} {
+		if err := installFileIfChanged(filepath.Join(pkiPath, f), filepath.Join(kubernetesPkiPath, f), 0600); err != nil {
+			return err
+		}
+	}
+
+	if err := installFileIfChanged(filepath.Join(pkiPath, "etcd-ca.crt"), filepath.Join(kubernetesPkiPath, "etcd", "ca.crt"), 0600); err != nil {
 		return err
 	}
 
@@ -167,11 +167,11 @@ func fillTmpDirWithPKIData() error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(config.TmpPath, kubernetesPkiPath, "etcd"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(config.TmpPath, kubernetesPkiPath, "etcd"), 0700); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(config.TmpPath, deckhousePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(config.TmpPath, deckhousePath), 0700); err != nil {
 		return err
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/util.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/util.go
@@ -71,7 +71,7 @@ func backupFile(src string) error {
 
 	backupDir := filepath.Join(deckhousePath, "backup", fmt.Sprintf("%d-%02d-%02d_%s", nowTime.Year(), nowTime.Month(), nowTime.Day(), config.ConfigurationChecksum))
 
-	if err := os.MkdirAll(backupDir, 0755); err != nil {
+	if err := os.MkdirAll(backupDir, 0700); err != nil {
 		return err
 	}
 	return copy.Copy(src, backupDir+src)


### PR DESCRIPTION
## Description

Stricter permissions (0700 for directories, 0600 for files) to all kubelet config files and PKI files. This is done to improve security.

## Why do we need it, and what problem does it solve?

These changes are needed to make the Kubernetes cluster more secure. With these permissions, only the necessary services and the root user can access important configuration files, reducing the risk of unauthorized access.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

After these changes, the permissions on kubelet directories and files will be stricter—0700 for directories and 0600 for files. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager,candi
type: fix | feature | chore
summary: Stricter permissions (0700/0600) applied to kubelet configuration and PKI files to improve security.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
