### PR TITLE
[node-manager] fix panic in mcm

### DIFF
--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -20,7 +20,8 @@ shell:
   - apk add git
   setup:
   - mkdir /src && cd /src
-  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
+#  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
+  - git clone --depth 1 --branch fix-panic-in-get-secret https://github.com/deckhouse/mcm.git .
   - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o machine-controller-manager cmd/machine-controller-manager/controller_manager.go
   - chown 64535:64535 machine-controller-manager
   - chmod 0700 machine-controller-manager

--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -20,9 +20,7 @@ shell:
   - apk add git
   setup:
   - mkdir /src && cd /src
-#  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
-#  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
-  - git clone --depth 1 --branch fix-panic-in-get-secret https://github.com/deckhouse/mcm.git .
+  - git clone --depth 1 --branch v0.36.0-flant.17 {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
   - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o machine-controller-manager cmd/machine-controller-manager/controller_manager.go
   - chown 64535:64535 machine-controller-manager
   - chmod 0700 machine-controller-manager

--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -20,7 +20,7 @@ shell:
   - apk add git
   setup:
   - mkdir /src && cd /src
-  - git clone --depth 1 --branch v0.36.0-flant.16 {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
+  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
   - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o machine-controller-manager cmd/machine-controller-manager/controller_manager.go
   - chown 64535:64535 machine-controller-manager
   - chmod 0700 machine-controller-manager

--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -21,6 +21,7 @@ shell:
   setup:
   - mkdir /src && cd /src
 #  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
+#  - git clone --depth 1 --branch fix-panic-in-get-secret {{ $.SOURCE_REPO }}/deckhouse/mcm.git .
   - git clone --depth 1 --branch fix-panic-in-get-secret https://github.com/deckhouse/mcm.git .
   - GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o machine-controller-manager cmd/machine-controller-manager/controller_manager.go
   - chown 64535:64535 machine-controller-manager


### PR DESCRIPTION
## Description
This PR fixes situation when deleting several NodeGroups mcm crashes with the error "panic: runtime error: invalid memory address or nil pointer dereference"
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
#8240
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
machine-controller-manager pod works as usual.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix panic in mcm when deleting several NodeGroups
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
