### PR TITLE
[bashible] Do not use cloud metadata server for static nodegroup

### DIFF
--- a/candi/bashible/bootstrap/01-network-scripts.sh.tpl
+++ b/candi/bashible/bootstrap/01-network-scripts.sh.tpl
@@ -15,6 +15,7 @@
 # limitations under the License.
 */}}
 {{- if .provider }}
+{{- if and (ne .nodeGroup.nodeType "Static") (.provider )}}
   {{- if $bootstrap_script_network := $.Files.Get (printf "/deckhouse/candi/cloud-providers/%s/bashible/bootstrap-networks.sh.tpl" .provider) | default ($.Files.Get (printf "candi/cloud-providers/%s/bashible/bootstrap-networks.sh.tpl" .provider) ) }}
     {{- tpl ($bootstrap_script_network) $ | nindent 0 }}
   {{- end }}

--- a/candi/bashible/bootstrap/01-network-scripts.sh.tpl
+++ b/candi/bashible/bootstrap/01-network-scripts.sh.tpl
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
-{{- if .provider }}
 {{- if and (ne .nodeGroup.nodeType "Static") (.provider )}}
   {{- if $bootstrap_script_network := $.Files.Get (printf "/deckhouse/candi/cloud-providers/%s/bashible/bootstrap-networks.sh.tpl" .provider) | default ($.Files.Get (printf "candi/cloud-providers/%s/bashible/bootstrap-networks.sh.tpl" .provider) ) }}
     {{- tpl ($bootstrap_script_network) $ | nindent 0 }}


### PR DESCRIPTION
## Description

This update removes the cloud metadata request from the bootstrap script (`http://169.254.169.254/`) when adding static nodes in hybrid clusters. This change is needed to support environments where nodes are in on-premise data centers without access to cloud metadata.

## Why do we need it, and what problem does it solve?

The change fixes an issue where static nodes in hybrid clusters failed to bootstrap correctly because the script tried to use cloud metadata, which isn't available in on-prem environments.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

Static nodes in hybrid clusters should bootstrap without errors related to cloud metadata.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix bootstrap script for static nodes in hybrid clusters to avoid using cloud metadata
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
