### PR TITLE
[testing] feat: add probes linter

### DIFF
--- a/testing/matrix/linter/storage/storage.go
+++ b/testing/matrix/linter/storage/storage.go
@@ -179,6 +179,14 @@ func (s *StoreObject) GetContainers() ([]v1.Container, error) {
 		}
 
 		containers = cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers
+	case "ReplicaSet":
+		replicaSet := new(appsv1.ReplicaSet)
+		err := converter.FromUnstructured(s.Unstructured.UnstructuredContent(), replicaSet)
+		if err != nil {
+			return []v1.Container{}, fmt.Errorf("convert Unstructured to ReplicaSet failed: %v", err)
+		}
+
+		containers = replicaSet.Spec.Template.Spec.Containers
 	}
 	return containers, nil
 }


### PR DESCRIPTION
## Description

Check that a controller manifest (CronJob, DaemonSet, Deployment, Job, ReplicaSet, StatefulSet) has defined liveness and readiness probes.

## Why do we need it, and what problem does it solve?

Fixed: #4594

## What is the expected result?

Controller manifest has defined liveness and readiness probes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: feature
summary: add probes linter
impact_level: low
```
