### PR TITLE
[dhctl] Add cleanup resources confirmation on destroy

### DIFF
--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -53,6 +53,9 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		if !app.SanityCheck {
 			log.WarnLn(destroyApprovalsMessage)
+			if !input.NewConfirmation().WithYesByDefault().WithMessage("Do you really want to cleanup cluster resources?").Ask() {
+				return fmt.Errorf("Cleanup cluster resources disallow")
+			}
 		}
 
 		sshClient, err := ssh.NewClientFromFlags().Start()
@@ -65,10 +68,6 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 
 		if err = cache.Init(sshClient.Check().String()); err != nil {
 			return fmt.Errorf(destroyCacheErrorMessage, err)
-		}
-
-		if !input.NewConfirmation().WithMessage("Do you really want to cleanup cluster resources?").Ask() {
-			return fmt.Errorf("Cleanup cluster resources disallow")
 		}
 
 		destroyer, err := destroy.NewClusterDestroyer(&destroy.Params{

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
 
 const (
@@ -64,6 +65,10 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 
 		if err = cache.Init(sshClient.Check().String()); err != nil {
 			return fmt.Errorf(destroyCacheErrorMessage, err)
+		}
+
+		if !input.NewConfirmation().WithMessage("Do you really want to cleanup cluster resources?").Ask() {
+			return fmt.Errorf("Cleanup cluster resources disallow")
 		}
 
 		destroyer, err := destroy.NewClusterDestroyer(&destroy.Params{

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -53,7 +53,7 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		if !app.SanityCheck {
 			log.WarnLn(destroyApprovalsMessage)
-			if !input.NewConfirmation().WithYesByDefault().WithMessage("Do you really want to cleanup cluster resources?").Ask() {
+			if !input.NewConfirmation().WithYesByDefault().WithMessage("Do you really want to DELETE all cluster resources?").Ask() {
 				return fmt.Errorf("Cleanup cluster resources disallow")
 			}
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
If key `--yes-i-am-sane-and-i-understand-what-i-am-doing` not used, all resources was deleted from cluster without confirmation, closed [issue](https://github.com/deckhouse/deckhouse/issues/8375)

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add cleanup resources confirmation on destroy 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
