### PR TITLE
[loki] add missing RBAC subject. Closes #9518

### DIFF
--- a/modules/462-loki/templates/rbac-to-us.yaml
+++ b/modules/462-loki/templates/rbac-to-us.yaml
@@ -59,6 +59,9 @@ subjects:
   - kind: ServiceAccount
     name: prometheus
     namespace: d8-monitoring
+  - kind: ServiceAccount
+    name: grafana
+    namespace: d8-monitoring
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description

This PR add missing subject. Grafana can not use loki storage for log exploration.

## Why do we need it, and what problem does it solve?

Functianality was missed.

## What is the expected result?

Work with build-in module without problems

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: modules
type: fix 
summary: Added missing RBAC rule
impact: Build-in Grafana can interact with build-in log storage
impact_level: low
```
