### PR TITLE
[istio] Fixes graph display issue in Kiali

### DIFF
--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -159,6 +159,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - trickster
+  resources:
+  - deployments/http
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Added permissions for Kiali to get metrics from Prothemeus (trickster).

## Why do we need it, and what problem does it solve?
When trying to open the traffic graph, error 403 is generated.

<img width="923" alt="image" src="https://github.com/user-attachments/assets/c4fb1e97-86e6-432c-bc3a-ce0bec683ef5">

## What is the expected result?
The traffic graph is displayed correctly.

<img width="986" alt="image" src="https://github.com/user-attachments/assets/6c731bed-bde6-4363-95a0-796d8579216c">

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed graph display issue in Kiali.
impact_level: default
```