### PR TITLE
[cni-cilium] Fixing masquerading between DVP virtual machines.

### DIFF
--- a/modules/021-cni-cilium/hooks/set_vm_cidrs.go
+++ b/modules/021-cni-cilium/hooks/set_vm_cidrs.go
@@ -50,7 +50,7 @@ func applyVMCIDRsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert virtualization moduleconfig: %v", err)
 	}
-	return mc.Spec.Settings["vmCIDRs"], nil
+	return mc.Spec.Settings["virtualMachineCIDRs"], nil
 }
 
 func applyVMCIDRs(input *go_hook.HookInput) error {

--- a/modules/021-cni-cilium/hooks/set_vm_cidrs_test.go
+++ b/modules/021-cni-cilium/hooks/set_vm_cidrs_test.go
@@ -72,7 +72,7 @@ metadata:
 spec:
   enabled: true
   settings:
-    vmCIDRs:
+    virtualMachineCIDRs:
     - 10.10.10.0/24
     - 10.9.8.0/24
   version: 1


### PR DESCRIPTION
## Description

In one of the updates in mc `virtualization`, the parameter was renamed from `vmCIDRs` to `virtualMachineCIDRs`. 
Because of this, the mechanism responsible for setting up masquerading has stopped adding exceptions for DVP virtual machines.

## Why do we need it, and what problem does it solve?

Traffic between virtual machines is masqueraded, although this should not be the case.

## Why do we need it in the patch release (if we do)?

This affects some applications

## What is the expected result?

Traffic between virtual machines is not masqueraded.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixing masquerading between DVP virtual machines.
impact: This fix disables masquerading between virtual machines.
impact_level: default
```
