### PR TITLE
[cloud-provider-zvirt] Fix empty private IP addresses

### DIFF
--- a/ee/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/src/pkg/cloudprovider/zvirt/instances.go
+++ b/ee/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/src/pkg/cloudprovider/zvirt/instances.go
@@ -125,7 +125,8 @@ func (zc *Cloud) extractNodeAddressesFromVM(ctx context.Context, vm ovirtclient.
 		})
 	}
 
-	if len(localIP) < 1 {
+    // If there are no local IP addresses, replace them with external ones
+	if len(localIP) == 0 {
 		localIP = externalIP
 	}
 

--- a/ee/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/src/pkg/cloudprovider/zvirt/instances.go
+++ b/ee/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/src/pkg/cloudprovider/zvirt/instances.go
@@ -125,6 +125,10 @@ func (zc *Cloud) extractNodeAddressesFromVM(ctx context.Context, vm ovirtclient.
 		})
 	}
 
+	if len(localIP) < 1 {
+		localIP = externalIP
+	}
+
 	for _, ip := range localIP {
 		nodeAddress = append(nodeAddress, v1.NodeAddress{
 			Type:    v1.NodeInternalIP,


### PR DESCRIPTION
## Description
Added a condition to use external addresses if internal ones are missing
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
So that modules such as monitoring-ping work correctly. [Monitoring-ping pods will crash if there are no targets to ping](https://github.com/deckhouse/deckhouse/blob/main/modules/340-monitoring-ping/images/monitoring-ping/monitoring-ping.py#L116)
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
zvirt nodes have internal addresses. monitoring-ping pods work as expected without crashes
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-ping
type: fix
summary: Fix monitoring-ping pods crashing
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
