### PR TITLE
[admission-policy-engine] Added new checks for OperationPolicy 

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/ingress-class.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/ingress-class.yaml
@@ -1,0 +1,39 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: d8ingressclass
+  labels:
+    heritage: deckhouse
+    module: admission-policy-engine
+    security.deckhouse.io: operation-policy
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Ingress Class"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: "Required Ingress Class"
+spec:
+  crd:
+    spec:
+      names:
+        kind: D8IngressClass
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            ingressClassNames:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package d8.operation_policies
+
+        violation[{"msg": msg}] {
+          ingressClass := input.review.object.spec.ingressClassName
+          not contains(input.parameters.ingressClassNames, ingressClass)
+          msg := sprintf("Ingress <%v> has invalid ingress class: %v, allowed: %v", [input.review.object.metadata.name, ingressClass, input.parameters.ingressClassNames])
+        }
+
+        contains(list, elem) {
+          list[_] = elem
+        }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/storage-class.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/operation/storage-class.yaml
@@ -1,0 +1,39 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: d8storageclass
+  labels:
+    heritage: deckhouse
+    module: admission-policy-engine
+    security.deckhouse.io: operation-policy
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Storage Class"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: "Required Storage Class"
+spec:
+  crd:
+    spec:
+      names:
+        kind: D8StorageClass
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            storageClassNames:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package d8.operation_policies
+
+        violation[{"msg": msg}] {
+          storageClass := input.review.object.spec.storageClassName
+          not contains(input.parameters.storageClassNames, storageClass)
+          msg := sprintf("PersistentVolumeClaim <%v> has invalid storage class: %v, allowed: %v", [input.review.object.metadata.name, storageClass, input.parameters.storageClassNames])
+        }
+
+        contains(list, elem) {
+          list[_] = elem
+        }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/allowed.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/allowed.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: allowed
+  namespace: default
+spec:
+  ingressClassName: "foo"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/constraint.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8IngressClass
+metadata:
+  name: test
+spec:
+  enforcementAction: "deny"
+  match:
+    kinds:
+      - apiGroups: ["", "networking", "networking.k8s.io"]
+        kinds: ["Ingress"]
+  parameters:
+    ingressClassNames:
+      - "foo"
+      - "baz"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/constraint.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/constraint.yaml
@@ -6,7 +6,7 @@ spec:
   enforcementAction: "deny"
   match:
     kinds:
-      - apiGroups: ["", "networking", "networking.k8s.io"]
+      - apiGroups: ["networking.k8s.io"]
         kinds: ["Ingress"]
   parameters:
     ingressClassNames:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/disallowed.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/disallowed.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: disallowed
+  namespace: default
+spec:
+  ingressClassName: "bar"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/suite.yaml
@@ -1,0 +1,19 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: d8ingressclass
+tests:
+  - name: d8ingressclass
+    template: ../../templates/operation/ingress-class.yaml
+    constraint: constraint.yaml
+    cases:
+      - name: example-allowed
+        object: allowed.yaml
+        assertions:
+          - violations: no
+      - name: example-disallowed
+        object: disallowed.yaml
+        assertions:
+          - violations: yes
+            message: >-
+              Ingress <disallowed> has invalid ingress class: bar

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/allowed.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/allowed.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: allowed
+  namespace: default
+spec:
+  storageClassName: "foo"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/constraint.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8StorageClass
+metadata:
+  name: test
+spec:
+  enforcementAction: "deny"
+  match:
+    kinds:
+      - apiGroups: ["", "storage", "storage.k8s.io"]
+        kinds: ["PersistentVolumeClaim"]
+  parameters:
+    storageClassNames:
+      - "foo"
+      - "baz"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/constraint.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/constraint.yaml
@@ -6,7 +6,7 @@ spec:
   enforcementAction: "deny"
   match:
     kinds:
-      - apiGroups: ["", "storage", "storage.k8s.io"]
+      - apiGroups: [""]
         kinds: ["PersistentVolumeClaim"]
   parameters:
     storageClassNames:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/disallowed.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/disallowed.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: disallowed
+  namespace: default
+spec:
+  storageClassName: "bar"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/suite.yaml
@@ -1,0 +1,19 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: d8storageclass
+tests:
+  - name: d8storageclass
+    template: ../../templates/operation/storage-class.yaml
+    constraint: constraint.yaml
+    cases:
+      - name: example-allowed
+        object: allowed.yaml
+        assertions:
+          - violations: no
+      - name: example-disallowed
+        object: disallowed.yaml
+        assertions:
+          - violations: yes
+            message: >-
+              PersistentVolumeClaim <disallowed> has invalid storage class: bar

--- a/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
@@ -67,8 +67,12 @@ spec:
                       description: "Список проб, которые необходимы (например, `readinessProbe`)."
                     maxRevisionHistoryLimit:
                       description: "Максимальное значение для истории ревизий."
-                    priorityClassName:
+                    priorityClassNames:
                       description: "Список возможных классов приоритета."
+                    ingressClassNames:
+                      description: "Список возможных классов ингресса."
+                    storageClassNames:
+                      description: "Список возможных классов хранилища."
                     imagePullPolicy:
                       description: "Требуемая политика скачивания образов для контейнеров."
                     checkHostNetworkDNSPolicy:

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -159,6 +159,16 @@ spec:
                       description: "List of allowed priority class names."
                       items:
                         type: string
+                    ingressClassNames:
+                      type: array
+                      description: "List of allowed ingress class names."
+                      items:
+                        type: string
+                    storageClassNames:
+                      type: array
+                      description: "List of allowed storage class names."
+                      items:
+                        type: string
                     imagePullPolicy:
                       type: string
                       description: "Required image pull policy for containers."

--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package hooks
 
 import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
+	v1alpha1 "github.com/deckhouse/deckhouse/modules/015-admission-policy-engine/hooks/internal/apis"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -42,6 +48,27 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: handle operatio
 		})
 	})
 })
+
+func TestMarshalOperationPolicy(t *testing.T) {
+	var tmp map[string]any
+	err := yaml.Unmarshal([]byte(testOperationPolicy), &tmp)
+	if err != nil {
+		t.Error(err)
+	}
+
+	jsonSpec, err := json.Marshal(tmp["spec"])
+	if err != nil {
+		t.Error(err)
+	}
+
+	var spec v1alpha1.OperationPolicySpec
+	dec := json.NewDecoder(bytes.NewBuffer(jsonSpec))
+	dec.DisallowUnknownFields()
+	err = dec.Decode(&spec)
+	if err != nil {
+		t.Error(err)
+	}
+}
 
 var testOperationPolicy = `
 ---
@@ -81,6 +108,12 @@ spec:
     priorityClassNames:
       - foo
       - bar
+    ingressClassNames:
+      - ing1
+      - ing2
+    storageClassNames:
+      - st1
+      - st2
     checkHostNetworkDNSPolicy: true
     checkContainerDuplicates: true
     replicaLimits:

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -134,6 +134,8 @@ type OperationPolicySpec struct {
 		MaxRevisionHistoryLimit   *int     `json:"maxRevisionHistoryLimit,omitempty"`
 		ImagePullPolicy           string   `json:"imagePullPolicy,omitempty"`
 		PriorityClassNames        []string `json:"priorityClassNames,omitempty"`
+		IngressClassNames         []string `json:"ingressClassNames,omitempty"`
+		StorageClassNames         []string `json:"storageClassNames,omitempty"`
 		CheckHostNetworkDNSPolicy bool     `json:"checkHostNetworkDNSPolicy,omitempty"`
 		CheckContainerDuplicates  bool     `json:"checkContainerDuplicates,omitempty"`
 		ReplicaLimits             struct {

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -54,6 +54,8 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			"maxRevisionHistoryLimit":3,
 			"imagePullPolicy":"Always",
 			"priorityClassNames":["foo","bar"],
+			"ingressClassNames": ["ing1", "ing2"],
+			"storageClassNames": ["st1", "st2"],
 			"checkHostNetworkDNSPolicy":true,
 			"checkContainerDuplicates":true,
 			"replicaLimits":{
@@ -83,6 +85,8 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			Expect(f.KubernetesGlobalResource("D8RevisionHistoryLimit", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8ImagePullPolicy", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8PriorityClass", testPolicyName).Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("D8IngressClass", testPolicyName).Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("D8StorageClass", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8DNSPolicy", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8RequiredLabels", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8RequiredAnnotations", testPolicyName).Exists()).To(BeTrue())

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -268,7 +268,7 @@ spec:
   enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
   match:
     kinds:
-      - apiGroups: ["", "networking", "networking.k8s.io"]
+      - apiGroups: ["networking.k8s.io"]
         kinds: ["Ingress"]
     {{- include "constraint_selector" (list $cr) }}
   parameters:
@@ -289,7 +289,7 @@ spec:
   enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
   match:
     kinds:
-      - apiGroups: ["", "storage", "storage.k8s.io"]
+      - apiGroups: [""]
         kinds: ["PersistentVolumeClaim"]
     {{- include "constraint_selector" (list $cr) }}
   parameters:

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -30,6 +30,12 @@
   {{- if hasKey $cr.spec.policies "priorityClassNames" }}
     {{- include "priority_class_policy" (list $context $cr) }}
   {{- end }}
+  {{- if hasKey $cr.spec.policies "ingressClassNames" }}
+    {{- include "ingress_class_policy" (list $context $cr) }}
+  {{- end }}
+  {{- if hasKey $cr.spec.policies "storageClassNames" }}
+    {{- include "storage_class_policy" (list $context $cr) }}
+  {{- end }}
   {{- if hasKey $cr.spec.policies "checkHostNetworkDNSPolicy" }}
     {{- include "dns_policy" (list $context $cr) }}
   {{- end }}
@@ -249,6 +255,47 @@ spec:
       {{- $cr.spec.policies.priorityClassNames | toYaml | nindent 6 }}
 {{- end }}
 
+{{- define "ingress_class_policy" }}
+  {{- $context := index . 0 }}
+  {{- $cr := index . 1 }}
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8IngressClass
+metadata:
+  name: {{$cr.metadata.name}}
+  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
+spec:
+  enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
+  match:
+    kinds:
+      - apiGroups: ["", "networking", "networking.k8s.io"]
+        kinds: ["Ingress"]
+    {{- include "constraint_selector" (list $cr) }}
+  parameters:
+    ingressClassNames:
+      {{- $cr.spec.policies.ingressClassNames | toYaml | nindent 6 }}
+{{- end }}
+
+{{- define "storage_class_policy" }}
+  {{- $context := index . 0 }}
+  {{- $cr := index . 1 }}
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8StorageClass
+metadata:
+  name: {{$cr.metadata.name}}
+  {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
+spec:
+  enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
+  match:
+    kinds:
+      - apiGroups: ["", "storage", "storage.k8s.io"]
+        kinds: ["PersistentVolumeClaim"]
+    {{- include "constraint_selector" (list $cr) }}
+  parameters:
+    storageClassNames:
+      {{- $cr.spec.policies.storageClassNames | toYaml | nindent 6 }}
+{{- end }}
 
 {{- define "dns_policy" }}
   {{- $context := index . 0 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/9087
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: feature
summary: Added ability to limit ingressClassName for Ingress and storageClassName for PersistentVolumeClaim for project / namespace / etc
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
