### PR TITLE
[docs] Remove outdated warnings about proxy settings in Deckhouse v1.42

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -8,9 +8,6 @@
 {% alert level="warning" %}
 Доступно только в Enterprise Edition.
 {% endalert %}
-{% alert level="warning" %}
-В версии Deckhouse 1.42 изменились [параметры](../../products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-proxy) настройки работы через proxy-сервер ([подробнее](https://github.com/deckhouse/deckhouse/pull/3185)). Текущее руководство рассчитано на версию Deckhouse 1.42+.
-{% endalert %}
 {%- endif %}
 {%- else %}
 {%- if page.platform_code == "azure" %}
@@ -21,9 +18,6 @@ Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-regi
 {%- if page.platform_code == 'bm-private' %}
 {% alert level="warning" %}
 This feature is available in Enterprise Edition only.
-{% endalert %}
-{% alert level="warning" %}
-The [settings for working through a proxy server](../../products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-proxy) have changed in Deckhouse 1.42 ([issue](https://github.com/deckhouse/deckhouse/pull/3185)). The guide is for Deckhouse 1.42+.
 {% endalert %}
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
## Description
Remove outdated warnings about proxy settings in Deckhouse v1.42.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove outdated warnings about proxy settings in Deckhouse v1.42.
impact_level: low
```
