### PR TITLE
[cloud-providers][aws] available_except_local_zone for aws standart layout

### DIFF
--- a/candi/cloud-providers/aws/layouts/standard/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/base-infrastructure/main.tf
@@ -31,6 +31,13 @@ module "security-groups" {
 
 data "aws_availability_zones" "available" {}
 
+data "aws_availability_zones" "available_except_local_zone" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 locals {
   az_count    = length(data.aws_availability_zones.available.names)
   subnet_cidr = lookup(var.providerClusterConfiguration, "nodeNetworkCIDR", module.vpc.cidr_block)


### PR DESCRIPTION
## Description

small fix for this [pr](https://github.com/deckhouse/deckhouse/pull/9063) 
Added forgotten “available_except_local_zone” block to layout standard for AWS Cloud Provider

## Why do we need it, and what problem does it solve?

Fix for bootstrap or upgrade an existing cluster  installed in AWS using the "Standard" layout 

## Why do we need it in the patch release (if we do)?

Without this fix, bootstrap problems happen

## What is the expected result?

Bootstrap or upgrade an existing cluster in AWS using the “Standard” layout runs successfully

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix for bootstrap or upgrade an existing cluster  installed in AWS using the "Standard" layout 
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
