### PR TITLE
[upmeter] Fix public API status values

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -96,7 +96,8 @@ type ProbeAvailability struct {
 	Availability float64 `json:"availability"`
 
 	// Status is the high-level interpretation of the probe result
-	Status PublicStatus `json:"status"`
+	status PublicStatus
+	Status string `json:"status"`
 }
 
 type PublicStatusHandler struct {
@@ -218,10 +219,12 @@ func (h *PublicStatusHandler) calcStatuses(rng ranges.StepRange, lister entity.R
 			if av < 0 {
 				continue
 			}
+			status := calculateStatus(probeSummaryList)
 			probeAvails = append(probeAvails, ProbeAvailability{
 				Probe:        probeRef.Probe,
 				Availability: av,
-				Status:       calculateStatus(probeSummaryList),
+				status:       status,
+				Status:       status.String(),
 			})
 		}
 


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

There is an issue with JSON API returning integers instead of words "Operational", "Degraded", or "Outage"

## Why do we need it, and what problem does it solve?

It breaks UI's

## Why do we need it in the patch release (if we do)?

It is small fix that should be considered in a patch release


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: fix
summary: Fixed API status summary showing numbers instead of "Operational", "Degraded", or "Outage"
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
