### PR TITLE
[node-local-dns] Use prefer_udp to connect with kube-dns

### DIFF
--- a/ee/be/modules/350-node-local-dns/templates/configmap.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/configmap.yaml
@@ -22,6 +22,7 @@ data:
       loop
       forward . {{ .Values.nodeLocalDns.internal.clusterDNSRedirectAddress }} {
         max_fails 0
+        prefer_udp
       }
 {{- if not (.Values.global.enabledModules | has "cni-cilium") }}
       bind {{ .Values.global.discovery.clusterDNSAddress }} 169.254.20.10


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add prefer_udp to forward in forward plugin configuration of node-local-dns container coredns.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If application uses TCP to send request to node-local-dns than TCP is used to establish connection with kube-dns.
![image](https://github.com/user-attachments/assets/ec4d0670-c67f-4c8f-91dc-7b7601a25d80)
![image](https://github.com/user-attachments/assets/7ba918fd-2d59-481f-9434-ef95fd20170e)


We previously solved the same problem for kube-dns https://github.com/deckhouse/deckhouse/pull/2413

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
TCP resolve is used quite rarely, but some clients are affected. It happened presumably because of service `d8-kube-dns-redirect` update in https://github.com/deckhouse/deckhouse/pull/8955

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: fix
summary: Use prefer_udp to connect with kube-dns
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
