### PR TITLE
[ci] Add OCI labels

### DIFF
--- a/werf.yaml
+++ b/werf.yaml
@@ -678,6 +678,14 @@ import:
 docker:
   ENV:
     EDITOR: vim
+  LABEL:
+    org.opencontainers.image.documentation: 'https://deckhouse.io/products/kubernetes-platform/documentation/'
+    org.opencontainers.image.created: {{ dateInZone "2006-01-02T15:04:05Z" (now) "UTC" | squote }}
+    org.opencontainers.image.source: 'https://github.com/deckhouse/deckhouse'
+    org.opencontainers.image.title: 'Deckhouse'
+    org.opencontainers.image.vendor: 'Flant\ JSC'
+    org.opencontainers.image.version: {{ env "CI_COMMIT_TAG" | default "dev" | nospace | squote }}
+    org.opencontainers.image.url: 'https://deckhouse.io'
 shell:
   setup:
   - |
@@ -782,6 +790,15 @@ import:
     add: /dhctl-{{- env "CI_COMMIT_TAG" | default "dev" }}.x86_64.tar.gz
     to: /
     before: setup
+docker:
+  LABEL:
+    org.opencontainers.image.documentation: 'https://deckhouse.io/products/kubernetes-platform/documentation/'
+    org.opencontainers.image.created: {{ dateInZone "2006-01-02T15:04:05Z" (now) "UTC" | squote }}
+    org.opencontainers.image.source: 'https://github.com/deckhouse/deckhouse'
+    org.opencontainers.image.title: 'Deckhouse'
+    org.opencontainers.image.vendor: 'Flant\ JSC'
+    org.opencontainers.image.version: {{ env "CI_COMMIT_TAG" | default "dev" | nospace | squote }}
+    org.opencontainers.image.url: 'https://deckhouse.io'
 
 ---
 image: release-channel-version-prebuild
@@ -1023,6 +1040,15 @@ import:
   add: /images_digests.json
   to: /deckhouse/modules/040-node-manager/images_digests.json
   after: setup
+docker:
+  LABEL:
+    org.opencontainers.image.documentation: 'https://deckhouse.io/products/kubernetes-platform/documentation/'
+    org.opencontainers.image.created: {{ dateInZone "2006-01-02T15:04:05Z" (now) "UTC" | squote }}
+    org.opencontainers.image.source: 'https://github.com/deckhouse/deckhouse'
+    org.opencontainers.image.title: 'Deckhouse'
+    org.opencontainers.image.vendor: 'Flant\ JSC'
+    org.opencontainers.image.version: {{ env "CI_COMMIT_TAG" | default "dev" | nospace | squote }}
+    org.opencontainers.image.url: 'https://deckhouse.io'
 ---
 image: tests
 fromImage: tests-prebuild


### PR DESCRIPTION
## Description
Added OCI labels to dev, dev/install, dev/install-standalone images.

Example of labels:
```
"Labels": {
    "org.opencontainers.image.created": "2024-09-02T01:57:03Z",
    "org.opencontainers.image.documentation": "https://deckhouse.io/products/kubernetes-platform/documentation/",
    "org.opencontainers.image.source": "https://github.com/deckhouse/deckhouse",
    "org.opencontainers.image.title": "Deckhouse",
    "org.opencontainers.image.url": "https://deckhouse.io",
    "org.opencontainers.image.vendor": "Flant JSC",
    "org.opencontainers.image.version": "dev"
}
```

## Why do we need it, and what problem does it solve?
OCI image-spec contains number of recommended annotation labels with miscellaneous information that might be useful.

## What is the expected result?
Labels added.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Added OCI labels to dev, dev/install, dev/install-standalone images
impact_level: low
```
