### PR TITLE
[ci] Fix missing -y flag for apt

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
@@ -25,7 +25,7 @@ mount:
     to: /go/pkg
 shell:
   beforeInstall:
-    - apt update && apt install ca-certificates git
+    - apt update && apt install -y ca-certificates git
   install:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}

--- a/ee/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/werf.inc.yaml
@@ -24,7 +24,7 @@ mount:
     to: /go/pkg
 shell:
   beforeInstall:
-    - apt update && apt install ca-certificates
+    - apt update && apt install -y ca-certificates
   install:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}


### PR DESCRIPTION
## Description
Fixed missing -y flag for build in modules cloud-provider-vcd/capcd-controller-manager and cloud-provider-zvirt/cloud-controller-manager

## Why do we need it, and what problem does it solve?
Modules might not build if the flag is not present.

## What is the expected result?
Successful build of modules.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Fix missing -y flag for build in modules
impact_level: low
```
