### PR TITLE
[kube-dns] rollout enhancement

### DIFF
--- a/modules/042-kube-dns/templates/configmap.yaml
+++ b/modules/042-kube-dns/templates/configmap.yaml
@@ -10,7 +10,9 @@ data:
   Corefile: |
     . {
         errors
-        health
+        health {
+          lameduck 15s
+        }
         ready
 {{- if .Values.kubeDns.hosts }}
         hosts {


### PR DESCRIPTION
## Description

Added lameduck Option to CoreDNS Health Plugin Configuration. lameduck option delays the shutdown of CoreDNS for a specified duration, allowing the `/health` endpoint to continue returning 200 OK during this period. This ensures that ongoing requests can complete before the server fully shuts down.

https://coredns.io/plugins/health/
https://github.com/coredns/coredns/blob/master/plugin/health/README.md

## Why do we need it, and what problem does it solve?

Currently, during the rollout of `d8-kube-dns` deployment, CoreDNS pod shuts down before it can process all incoming requests. The `lameduck` option ensures it remains in a terminating state for 15 seconds, allowing it to complete processing all requests and return responses before fully shutting down.

## What is the expected result?

Graceful rollout of the kube-dns deployment without disrupting connections.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: fix
summary: Graceful rollout of the `kube-dns` deployment without disrupting connections.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
