### PR TITLE
[multitenancy-manager] delete wrong adopted resources

### DIFF
--- a/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
+++ b/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
@@ -1,0 +1,63 @@
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+	Queue:     "/modules/multitenancy-manager/delete-adopted-roles",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "roles",
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"heritage":                "deckhouse",
+					"rbac.deckhouse.io/kind":  "manage",
+					"rbac.deckhouse.io/level": "module",
+					"module":                  "multitenancy-manager",
+				},
+			},
+			FilterFunc: filterRoles,
+		},
+	},
+}, deleteAdoptedRoles)
+
+type filteredRole struct {
+	Name string `json:"name"`
+}
+
+func filterRoles(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	role := new(rbacv1.ClusterRole)
+	if err := sdk.FromUnstructured(obj, role); err != nil {
+		return nil, err
+	}
+	if role.Annotations == nil || len(role.Annotations) == 0 {
+		return nil, nil
+	}
+	if val, ok := role.Annotations["meta.helm.sh/release-namespace"]; ok || val == "d8-multitenancy-manager" {
+		return &filteredRole{Name: role.Name}, nil
+	}
+	if val, ok := role.Annotations["meta.helm.sh/release-name"]; ok && val == "d8:manage:capability:module:multitenancy-manager:edit" {
+		return &filteredRole{Name: role.Name}, nil
+	}
+	return nil, nil
+}
+
+func deleteAdoptedRoles(input *go_hook.HookInput) error {
+	for _, snap := range input.Snapshots["roles"] {
+		if snap == nil {
+			continue
+		}
+		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "ClusterRole", "", snap.(*filteredRole).Name)
+	}
+	return nil
+}

--- a/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
+++ b/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
@@ -1,3 +1,8 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
 package hooks
 
 import (

--- a/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
+++ b/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
@@ -46,7 +46,7 @@ func filterRoles(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	if role.Annotations == nil || len(role.Annotations) == 0 {
 		return nil, nil
 	}
-	if val, ok := role.Annotations["meta.helm.sh/release-namespace"]; ok || val == "d8-multitenancy-manager" {
+	if val, ok := role.Annotations["meta.helm.sh/release-namespace"]; ok && val == "d8-multitenancy-manager" {
 		return &filteredRole{Name: role.Name}, nil
 	}
 	if val, ok := role.Annotations["meta.helm.sh/release-name"]; ok && val == "d8:manage:capability:module:multitenancy-manager:edit" {

--- a/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
+++ b/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
@@ -49,9 +49,6 @@ func filterRoles(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	if val, ok := role.Annotations["meta.helm.sh/release-namespace"]; ok && val == "d8-multitenancy-manager" {
 		return &filteredRole{Name: role.Name}, nil
 	}
-	if val, ok := role.Annotations["meta.helm.sh/release-name"]; ok && val == "d8:manage:capability:module:multitenancy-manager:edit" {
-		return &filteredRole{Name: role.Name}, nil
-	}
 	return nil, nil
 }
 

--- a/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
+++ b/ee/modules/160-multitenancy-manager/hooks/delete_adopted_roles.go
@@ -8,16 +8,14 @@ package hooks
 import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
-
 	rbacv1 "k8s.io/api/rbac/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnStartup: &go_hook.OrderedConfig{Order: 10},
-	Queue:     "/modules/multitenancy-manager/delete-adopted-roles",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/multitenancy-manager/delete-adopted-roles",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "roles",


### PR DESCRIPTION
## Description
It provides fix to avoid migration problem due to wrong adopted resources.

## Why do we need it, and what problem does it solve?
There was a [hook](https://github.com/deckhouse/deckhouse/blob/v1.63.7/ee/modules/160-multitenancy-manager/hooks/migrate_project_releases.go) that adopted projects resources from ```d8-system``` namespace to  ```d8-multitenancy-manager``` but the hook filter [passes some new resources](https://github.com/deckhouse/deckhouse/blob/5b3f8fed6c45e6315f048d5f188b4c7094b418ab/ee/modules/160-multitenancy-manager/hooks/migrate_project_releases.go#L73), and adopts them. This causes a problem, when we switch a branch to an older one and then switch back.

## What is the expected result?
No this problem during switching.

<img width="1511" alt="Screenshot 2024-09-02 at 12 49 40 PM" src="https://github.com/user-attachments/assets/8a241246-0fce-4964-9f2e-069d8ebedf03">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Delete wrong adopted resources.
```
