### PR TITLE
[migration] Fix multiport Services broken by Helm

### DIFF
--- a/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports.go
+++ b/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports.go
@@ -1,17 +1,6 @@
 /*
 Copyright 2024 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports.go
+++ b/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+type serviceInfo struct {
+	name      string
+	namespace string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "service_helm_fix",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyServiceFilterHelmFix,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"argocd-repo-server", "argocd-server"},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+	},
+}, patchServiceWithManyPorts)
+
+func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	service := &v1.Service{}
+	err := sdk.FromUnstructured(obj, service)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := service.Labels["service-helm-fix"]; !ok {
+		return serviceInfo{
+			name:      service.Name,
+			namespace: service.Namespace,
+		}, nil
+	}
+
+	return "", fmt.Errorf("no desired label found")
+}
+
+func patchServiceWithManyPorts(input *go_hook.HookInput) error {
+	serviceSnapshots := input.Snapshots["service_helm_fix"]
+	for _, serviceSnapshot := range serviceSnapshots {
+		serviceInfoObj := serviceSnapshot.(serviceInfo)
+		input.PatchCollector.Delete(
+			"v1",
+			"Service",
+			serviceInfoObj.name,
+			serviceInfoObj.namespace,
+			object_patch.InForeground(),
+		)
+	}
+	return nil
+}

--- a/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports.go
+++ b/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports.go
@@ -17,8 +17,8 @@ import (
 )
 
 type serviceInfo struct {
-	name      string
-	namespace string
+	Name      string
+	Namespace string
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -48,8 +48,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	return serviceInfo{
-		name:      obj.GetName(),
-		namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}, nil
 }
 
@@ -60,8 +60,8 @@ func patchServiceWithManyPorts(input *go_hook.HookInput) error {
 		input.PatchCollector.Delete(
 			"v1",
 			"Service",
-			serviceInfoObj.name,
-			serviceInfoObj.namespace,
+			serviceInfoObj.Name,
+			serviceInfoObj.Namespace,
 			object_patch.InForeground(),
 		)
 	}

--- a/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports_test.go
+++ b/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports_test.go
@@ -1,17 +1,6 @@
 /*
 Copyright 2024 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports_test.go
+++ b/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports_test.go
@@ -21,7 +21,7 @@ metadata:
   name: argocd-repo-server
   namespace: d8-delivery
   labels:
-    service-helm-fix: true
+    migration.deckhouse.io/fix-services-broken-by-helm: done
 spec:
   ports:
     - name: server

--- a/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports_test.go
+++ b/ee/se/modules/502-delivery/hooks/migration_service_with_many_ports_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceYAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-repo-server
+  namespace: d8-delivery
+  labels:
+    service-helm-fix: true
+spec:
+  ports:
+    - name: server
+      port: 8081
+      protocol: TCP
+      targetPort: server
+    - name: metrics
+      port: 8084
+      protocol: TCP
+      targetPort: metrics`
+
+	service2YAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server
+  namespace: d8-delivery
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: server
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: server
+      targetPort: dns-tcp`
+)
+
+var _ = Describe("ArgoCD hooks :: migration_service_with_many_ports", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There is a broken service", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML + service2YAML))
+			f.RunHook()
+		})
+		It("Service have been deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("Service", "argocd-server").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "repo-server" "app.kubernetes.io/name" "argocd-repo-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-repo-server" "service-helm-fix" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "repo-server" "app.kubernetes.io/name" "argocd-repo-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-repo-server" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
   name: argocd-repo-server
   namespace: d8-{{ .Chart.Name }}
 spec:

--- a/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "repo-server" "app.kubernetes.io/name" "argocd-repo-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-repo-server")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "repo-server" "app.kubernetes.io/name" "argocd-repo-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-repo-server" "service-helm-fix" "true")) | nindent 2 }}
   name: argocd-repo-server
   namespace: d8-{{ .Chart.Name }}
 spec:

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "server" "app.kubernetes.io/name" "argocd-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-server")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "server" "app.kubernetes.io/name" "argocd-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-server" "service-helm-fix" "true")) | nindent 2 }}
   name: argocd-server
   namespace: d8-{{ .Chart.Name }}
 spec:

--- a/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
+++ b/ee/se/modules/502-delivery/templates/argocd/server/argocd-server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "server" "app.kubernetes.io/name" "argocd-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-server" "service-helm-fix" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app.kubernetes.io/component" "server" "app.kubernetes.io/name" "argocd-server" "app.kubernetes.io/part-of" "argocd" "app" "argocd-server" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
   name: argocd-server
   namespace: d8-{{ .Chart.Name }}
 spec:

--- a/modules/002-deckhouse/hooks/migration_service_with_many_ports.go
+++ b/modules/002-deckhouse/hooks/migration_service_with_many_ports.go
@@ -28,8 +28,8 @@ import (
 )
 
 type serviceInfo struct {
-	name      string
-	namespace string
+	Name      string
+	Namespace string
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -59,8 +59,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	return serviceInfo{
-		name:      obj.GetName(),
-		namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}, nil
 }
 
@@ -71,8 +71,8 @@ func patchServiceWithManyPorts(input *go_hook.HookInput) error {
 		input.PatchCollector.Delete(
 			"v1",
 			"Service",
-			serviceInfoObj.name,
-			serviceInfoObj.namespace,
+			serviceInfoObj.Name,
+			serviceInfoObj.Namespace,
 			object_patch.InForeground(),
 		)
 	}

--- a/modules/002-deckhouse/hooks/migration_service_with_many_ports.go
+++ b/modules/002-deckhouse/hooks/migration_service_with_many_ports.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+type serviceInfo struct {
+	name      string
+	namespace string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "service_helm_fix",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyServiceFilterHelmFix,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"deckhouse-leader", "deckhouse"},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+	},
+}, patchServiceWithManyPorts)
+
+func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	service := &v1.Service{}
+	err := sdk.FromUnstructured(obj, service)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := service.Labels["service-helm-fix"]; !ok {
+		return serviceInfo{
+			name:      service.Name,
+			namespace: service.Namespace,
+		}, nil
+	}
+
+	return "", fmt.Errorf("no desired label found")
+}
+
+func patchServiceWithManyPorts(input *go_hook.HookInput) error {
+	serviceSnapshots := input.Snapshots["service_helm_fix"]
+	for _, serviceSnapshot := range serviceSnapshots {
+		serviceInfoObj := serviceSnapshot.(serviceInfo)
+		input.PatchCollector.Delete(
+			"v1",
+			"Service",
+			serviceInfoObj.name,
+			serviceInfoObj.namespace,
+			object_patch.InForeground(),
+		)
+	}
+	return nil
+}

--- a/modules/002-deckhouse/hooks/migration_service_with_many_ports.go
+++ b/modules/002-deckhouse/hooks/migration_service_with_many_ports.go
@@ -17,13 +17,11 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
@@ -45,26 +43,25 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"deckhouse-leader", "deckhouse"},
 			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "migration.deckhouse.io/fix-services-broken-by-helm",
+						Operator: v1.LabelSelectorOpNotIn,
+						Values:   []string{"done"},
+					},
+				},
+			},
 			NamespaceSelector: lib.NsSelector(),
 		},
 	},
 }, patchServiceWithManyPorts)
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	service := &v1.Service{}
-	err := sdk.FromUnstructured(obj, service)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, ok := service.Labels["service-helm-fix"]; !ok {
-		return serviceInfo{
-			name:      service.Name,
-			namespace: service.Namespace,
-		}, nil
-	}
-
-	return "", fmt.Errorf("no desired label found")
+	return serviceInfo{
+		name:      obj.GetName(),
+		namespace: obj.GetNamespace(),
+	}, nil
 }
 
 func patchServiceWithManyPorts(input *go_hook.HookInput) error {

--- a/modules/002-deckhouse/hooks/migration_service_with_many_ports_test.go
+++ b/modules/002-deckhouse/hooks/migration_service_with_many_ports_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceYAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: deckhouse
+  namespace: d8-system
+  labels:
+    service-helm-fix: true
+spec:
+  ports:
+    - name: self
+      port: 8080
+      targetPort: self
+      protocol: TCP
+    - name: webhook
+      port: 4223
+      targetPort: webhook
+      protocol: TCP`
+
+	service2YAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: deckhouse-leader
+  namespace: d8-system
+spec:
+  ports:
+    - name: self
+      port: 8080
+      targetPort: self
+      protocol: TCP
+    - name: webhook
+      port: 4223
+      targetPort: webhook
+      protocol: TCP`
+)
+
+var _ = Describe("Deckhouse hooks :: migration_service_with_many_ports", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There is a broken service", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML + service2YAML))
+			f.RunHook()
+		})
+		It("Service have been deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("Service", "deckhouse-leader").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/002-deckhouse/hooks/migration_service_with_many_ports_test.go
+++ b/modules/002-deckhouse/hooks/migration_service_with_many_ports_test.go
@@ -32,7 +32,7 @@ metadata:
   name: deckhouse
   namespace: d8-system
   labels:
-    service-helm-fix: true
+    migration.deckhouse.io/fix-services-broken-by-helm: done
 spec:
   ports:
     - name: self

--- a/modules/002-deckhouse/templates/deckhouse-leader-service.yaml
+++ b/modules/002-deckhouse/templates/deckhouse-leader-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: deckhouse-leader
   namespace: d8-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "service-helm-fix" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
 spec:
   publishNotReadyAddresses: true
   selector:

--- a/modules/002-deckhouse/templates/deckhouse-leader-service.yaml
+++ b/modules/002-deckhouse/templates/deckhouse-leader-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: deckhouse-leader
   namespace: d8-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "service-helm-fix" "true")) | nindent 2 }}
 spec:
   publishNotReadyAddresses: true
   selector:

--- a/modules/002-deckhouse/templates/service.yaml
+++ b/modules/002-deckhouse/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: deckhouse
   namespace: d8-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "service-helm-fix" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
 spec:
   ports:
     - name: self

--- a/modules/002-deckhouse/templates/service.yaml
+++ b/modules/002-deckhouse/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: deckhouse
   namespace: d8-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "service-helm-fix" "true")) | nindent 2 }}
 spec:
   ports:
     - name: self

--- a/modules/042-kube-dns/hooks/migration_service_with_many_ports.go
+++ b/modules/042-kube-dns/hooks/migration_service_with_many_ports.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+)
+
+type patchServiceStruct struct {
+	module    string
+	namespace string
+	name      string
+	patch     map[string]interface{}
+}
+
+var patchServiceData = []patchServiceStruct{
+	{
+		module:    "kube-dns",
+		namespace: "kube-system",
+		name:      "d8-kube-dns",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "dns",
+						"port":       53,
+						"targetPort": "dns",
+						"protocol":   "UDP",
+					},
+					map[string]interface{}{
+						"name":       "dns-tcp",
+						"port":       53,
+						"targetPort": "dns-tcp",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+	{
+		module:    "kube-dns",
+		namespace: "kube-system",
+		name:      "d8-kube-dns-redirect",
+		patch: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"name":       "dns",
+						"port":       53,
+						"targetPort": "dns",
+						"protocol":   "UDP",
+					},
+					map[string]interface{}{
+						"name":       "dns-tcp",
+						"port":       53,
+						"targetPort": "dns-tcp",
+						"protocol":   "TCP",
+					},
+				},
+			},
+		},
+	},
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 1},
+}, patchServiceWithManyPorts)
+
+func patchServiceWithManyPorts(input *go_hook.HookInput) error {
+	for _, service := range patchServiceData {
+		input.PatchCollector.MergePatch(
+			service.patch,
+			"v1",
+			"Service",
+			service.namespace,
+			service.name,
+		)
+	}
+	return nil
+}

--- a/modules/042-kube-dns/hooks/migration_service_with_many_ports_test.go
+++ b/modules/042-kube-dns/hooks/migration_service_with_many_ports_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceYAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: d8-kube-dns
+  namespace: kube-system
+spec:
+  clusterIP: 10.222.0.10
+  clusterIPs:
+  - 10.222.0.10
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: dns
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 5353
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: ClusterIP`
+
+	service2YAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: d8-kube-dns-redirect
+  namespace: kube-system
+spec:
+  clusterIP: 10.222.142.22
+  clusterIPs:
+  - 10.222.142.22
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: dns
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: dns-tcp
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: ClusterIP`
+
+	serviceRightPorts = `
+- name: dns
+  port: 53
+  protocol: UDP
+  targetPort: dns
+- name: dns-tcp
+  port: 53
+  protocol: TCP
+  targetPort: dns-tcp`
+)
+
+var _ = Describe("KubeDns hooks :: migration_service_with_many_ports", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There are broken service", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML + service2YAML))
+			f.RunHook()
+		})
+		It("Service have been fixed", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			dnsService := f.KubernetesResource("Service", "kube-system", "d8-kube-dns")
+
+			Expect(dnsService.Field("spec.ports").String()).To(MatchYAML(serviceRightPorts))
+		})
+	})
+})

--- a/modules/110-istio/hooks/migration_service_with_many_ports.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports.go
@@ -28,8 +28,8 @@ import (
 )
 
 type serviceInfo struct {
-	name      string
-	namespace string
+	Name      string
+	Namespace string
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -59,8 +59,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	return serviceInfo{
-		name:      obj.GetName(),
-		namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}, nil
 }
 
@@ -71,8 +71,8 @@ func patchServiceWithManyPorts(input *go_hook.HookInput) error {
 		input.PatchCollector.Delete(
 			"v1",
 			"Service",
-			serviceInfoObj.name,
-			serviceInfoObj.namespace,
+			serviceInfoObj.Name,
+			serviceInfoObj.Namespace,
 			object_patch.InForeground(),
 		)
 	}

--- a/modules/110-istio/hooks/migration_service_with_many_ports.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports.go
@@ -17,13 +17,11 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
@@ -42,17 +40,17 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion: "v1",
 			Kind:       "Service",
 			FilterFunc: applyServiceFilterHelmFix,
-                         LabelSelector: &v1.LabelSelector{
-                                MatchExpressions: []v1.LabelSelectorRequirement{
-                                        {
-                                                Key:      "migration.deckhouse.io/fix-services-broken-by-helm",
-                                                Operator: v1.LabelSelectorOpNotIn,
-                                                Values:   []string{"done"},
-                                        },
-                                },
-                        },
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"kiali"},
+			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "migration.deckhouse.io/fix-services-broken-by-helm",
+						Operator: v1.LabelSelectorOpNotIn,
+						Values:   []string{"done"},
+					},
+				},
 			},
 			NamespaceSelector: lib.NsSelector(),
 		},
@@ -60,20 +58,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, patchServiceWithManyPorts)
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	service := &v1.Service{}
-	err := sdk.FromUnstructured(obj, service)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, ok := service.Labels["service-helm-fix"]; !ok {
-		return serviceInfo{
-			name:      service.Name,
-			namespace: service.Namespace,
-		}, nil
-	}
-
-	return "", fmt.Errorf("no desired label found")
+	return serviceInfo{
+		name:      obj.GetName(),
+		namespace: obj.GetNamespace(),
+	}, nil
 }
 
 func patchServiceWithManyPorts(input *go_hook.HookInput) error {

--- a/modules/110-istio/hooks/migration_service_with_many_ports.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports.go
@@ -42,6 +42,15 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion: "v1",
 			Kind:       "Service",
 			FilterFunc: applyServiceFilterHelmFix,
+                         LabelSelector: &v1.LabelSelector{
+                                MatchExpressions: []v1.LabelSelectorRequirement{
+                                        {
+                                                Key:      "migration.deckhouse.io/fix-services-broken-by-helm",
+                                                Operator: v1.LabelSelectorOpNotIn,
+                                                Values:   []string{"done"},
+                                        },
+                                },
+                        },
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"kiali"},
 			},

--- a/modules/110-istio/hooks/migration_service_with_many_ports.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+type serviceInfo struct {
+	name      string
+	namespace string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "service_helm_fix",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyServiceFilterHelmFix,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"kiali"},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+	},
+}, patchServiceWithManyPorts)
+
+func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	service := &v1.Service{}
+	err := sdk.FromUnstructured(obj, service)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := service.Labels["service-helm-fix"]; !ok {
+		return serviceInfo{
+			name:      service.Name,
+			namespace: service.Namespace,
+		}, nil
+	}
+
+	return "", fmt.Errorf("no desired label found")
+}
+
+func patchServiceWithManyPorts(input *go_hook.HookInput) error {
+	serviceSnapshots := input.Snapshots["service_helm_fix"]
+	for _, serviceSnapshot := range serviceSnapshots {
+		serviceInfoObj := serviceSnapshot.(serviceInfo)
+		input.PatchCollector.Delete(
+			"v1",
+			"Service",
+			serviceInfoObj.name,
+			serviceInfoObj.namespace,
+			object_patch.InForeground(),
+		)
+	}
+	return nil
+}

--- a/modules/110-istio/hooks/migration_service_with_many_ports_test.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceYAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali
+  namespace: d8-istio
+spec:
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: https
+    - name: http-metrics
+      protocol: TCP
+      port: 9090
+      targetPort: http-metrics`
+)
+
+var _ = Describe("Kiali hooks :: migration_service_with_many_ports", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There is a broken service", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML))
+			f.RunHook()
+		})
+		It("Service have been deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("Service", "kiali").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/110-istio/templates/kiali/service.yaml
+++ b/modules/110-istio/templates/kiali/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: kiali
   namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali" "service-helm-fix" "true")) | nindent 2 }}
 spec:
   ports:
   - name: https

--- a/modules/110-istio/templates/kiali/service.yaml
+++ b/modules/110-istio/templates/kiali/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: kiali
   namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali" "service-helm-fix" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
 spec:
   ports:
   - name: https

--- a/modules/300-prometheus/hooks/migration_service_with_many_ports.go
+++ b/modules/300-prometheus/hooks/migration_service_with_many_ports.go
@@ -28,8 +28,8 @@ import (
 )
 
 type serviceInfo struct {
-	name      string
-	namespace string
+	Name      string
+	Namespace string
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -59,8 +59,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	return serviceInfo{
-		name:      obj.GetName(),
-		namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}, nil
 }
 
@@ -71,8 +71,8 @@ func patchServiceWithManyPorts(input *go_hook.HookInput) error {
 		input.PatchCollector.Delete(
 			"v1",
 			"Service",
-			serviceInfoObj.name,
-			serviceInfoObj.namespace,
+			serviceInfoObj.Name,
+			serviceInfoObj.Namespace,
 			object_patch.InForeground(),
 		)
 	}

--- a/modules/300-prometheus/hooks/migration_service_with_many_ports.go
+++ b/modules/300-prometheus/hooks/migration_service_with_many_ports.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+type serviceInfo struct {
+	name      string
+	namespace string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "service_helm_fix",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyServiceFilterHelmFix,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"memcached"},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+	},
+}, patchServiceWithManyPorts)
+
+func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	service := &v1.Service{}
+	err := sdk.FromUnstructured(obj, service)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := service.Labels["service-helm-fix"]; !ok {
+		return serviceInfo{
+			name:      service.Name,
+			namespace: service.Namespace,
+		}, nil
+	}
+
+	return "", fmt.Errorf("no desired label found")
+}
+
+func patchServiceWithManyPorts(input *go_hook.HookInput) error {
+	serviceSnapshots := input.Snapshots["service_helm_fix"]
+	for _, serviceSnapshot := range serviceSnapshots {
+		serviceInfoObj := serviceSnapshot.(serviceInfo)
+		input.PatchCollector.Delete(
+			"v1",
+			"Service",
+			serviceInfoObj.name,
+			serviceInfoObj.namespace,
+			object_patch.InForeground(),
+		)
+	}
+	return nil
+}

--- a/modules/300-prometheus/hooks/migration_service_with_many_ports.go
+++ b/modules/300-prometheus/hooks/migration_service_with_many_ports.go
@@ -17,13 +17,11 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
@@ -45,26 +43,25 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"memcached"},
 			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "migration.deckhouse.io/fix-services-broken-by-helm",
+						Operator: v1.LabelSelectorOpNotIn,
+						Values:   []string{"done"},
+					},
+				},
+			},
 			NamespaceSelector: lib.NsSelector(),
 		},
 	},
 }, patchServiceWithManyPorts)
 
 func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	service := &v1.Service{}
-	err := sdk.FromUnstructured(obj, service)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, ok := service.Labels["service-helm-fix"]; !ok {
-		return serviceInfo{
-			name:      service.Name,
-			namespace: service.Namespace,
-		}, nil
-	}
-
-	return "", fmt.Errorf("no desired label found")
+	return serviceInfo{
+		name:      obj.GetName(),
+		namespace: obj.GetNamespace(),
+	}, nil
 }
 
 func patchServiceWithManyPorts(input *go_hook.HookInput) error {

--- a/modules/300-prometheus/hooks/migration_service_with_many_ports_test.go
+++ b/modules/300-prometheus/hooks/migration_service_with_many_ports_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceYAML = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached
+  namespace: d8-monitoring
+spec:
+  ports:
+    - name: memcached
+      port: 11211
+      targetPort: memcached
+    - name: http-metrics
+      port: 9150
+      targetPort: http-metrics`
+)
+
+var _ = Describe("Prometheus hooks :: migration_service_with_many_ports", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There is a broken service", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(serviceYAML))
+			f.RunHook()
+		})
+		It("Service have been deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("Service", "memcached").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/300-prometheus/templates/memcached/service.yaml
+++ b/modules/300-prometheus/templates/memcached/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: memcached
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "memcached")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "memcached" "service-helm-fix" "true")) | nindent 2 }}
 spec:
   clusterIP: None
   ports:

--- a/modules/300-prometheus/templates/memcached/service.yaml
+++ b/modules/300-prometheus/templates/memcached/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: memcached
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "memcached" "service-helm-fix" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "memcached" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
## Description
Fixing the broken Services with multiple ports. Helm didn't handle Service resource modification well while deploying https://github.com/deckhouse/deckhouse/pull/8955.

## Why do we need it, and what problem does it solve?
In some clusters, Services became broken. In some clusters it was kube-dns.

## What is the expected result?
All Services are corresponded to their templates.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
---
section: kube-dns
type: fix
summary: Fixed the d8-kube-dns and d8-kube-dns-redirect Services with multiple ports broken by Helm (pr #8955).
---
section: delivery
type: fix
summary: Fixed the argocd-repo-server and argocd-server Services with multiple ports broken by Helm (pr #8955).
---
section: deckhouse
type: fix
summary: Fixed the deckhouse-leader and deckhouse Services with multiple ports broken by Helm (pr #8955).
---
section: istio
type: fix
summary: Fixed the kiali Service with multiple ports broken by Helm (pr #8955).
---
section: prometheus
type: fix
summary: Fixed the memcached Service with multiple ports broken by Helm (pr #8955).
```