### PR TITLE
[candi] Disable and remove unattended upgrades early for debian and ubuntu and astra

### DIFF
--- a/candi/bashible/bundles/debian/all/002_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/bundles/debian/all/002_disable_unattended_upgrades.sh.tpl
@@ -1,0 +1,1 @@
+../../ubuntu-lts/all/002_disable_unattended_upgrades.sh.tpl

--- a/candi/bashible/bundles/debian/all/010_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/bundles/debian/all/010_disable_unattended_upgrades.sh.tpl
@@ -1,1 +1,0 @@
-../../ubuntu-lts/all/010_disable_unattended_upgrades.sh.tpl

--- a/candi/bashible/bundles/ubuntu-lts/all/002_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/all/002_disable_unattended_upgrades.sh.tpl
@@ -12,4 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if systemctl is-enabled --quiet unattended-upgrades ; then
+  systemctl disable --now unattended-upgrades
+fi
+
 bb-apt-remove unattended-upgrades

--- a/ee/be/candi/bashible/bundles/astra/all/002_disable_unattended_upgrades.sh.tpl
+++ b/ee/be/candi/bashible/bundles/astra/all/002_disable_unattended_upgrades.sh.tpl
@@ -1,4 +1,8 @@
 # Copyright 2022 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 
+if systemctl is-enabled --quiet unattended-upgrades ; then
+  systemctl disable --now unattended-upgrades
+fi
+
 bb-apt-remove unattended-upgrades

--- a/testing/cloud_layouts/VCD/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/VCD/Standard/configuration.tpl.yaml
@@ -29,14 +29,6 @@ spec:
   version: 1
 
 ---
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-cilium
-spec:
-  enabled: true
-
----
 apiVersion: deckhouse.io/v1
 kind: VCDClusterConfiguration
 layout: Standard


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Disable and remove unattended upgrades early for debian and ubuntu and astra
Remove cni-cilium from cluster configuration for vcd e2e

## Why do we need it, and what problem does it solve?
In some cases unattended upgrades block apt install

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Disable and remove unattended upgrades early for debian and ubuntu and astra.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
