### PR TITLE
[dhctl] Sudo become password from non-interactive stdin

### DIFF
--- a/dhctl/pkg/terminal/ask-password.go
+++ b/dhctl/pkg/terminal/ask-password.go
@@ -16,6 +16,7 @@ package terminal
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	terminal "golang.org/x/term"
@@ -32,13 +33,14 @@ func AskBecomePassword() (err error) {
 	fd := int(os.Stdin.Fd())
 
 	var data []byte
+
 	if !terminal.IsTerminal(fd) {
-		return fmt.Errorf("stdin is not a terminal, error reading password")
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		log.InfoF("[sudo] Password: ")
+		data, err = terminal.ReadPassword(fd)
 	}
 
-	log.InfoF("[sudo] Password: ")
-
-	data, err = terminal.ReadPassword(fd)
 	log.InfoLn()
 
 	if err != nil {


### PR DESCRIPTION
## Description
Use sudo become password from non-interactive stdin with flag --ask-become-sudo. ex.:
`echo "PASSWORD" | dhctl bootstrap`
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

this allow to use become sudo password for non-interactive usage, if need for example ansible automation

## What is the expected result?
sudo become password get from non-interactive stdin
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Sudo become password from non-interactive stdin. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
