### PR TITLE
[docs][getting started] Fix comment about noProxy parameter in GS

### DIFF
--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -15,8 +15,8 @@ kubernetesVersion: "Automatic"
 # [<en>] Cluster domain (used for local routing).
 # [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
-# [<en>] Proxy server settings. In the exception list (noProxy parameter), also specify the subnet of the cluster nodes.
-# [<ru>] Настройки proxy-сервера. В списке исключений (параметр noProxy) также укажите подсеть узлов кластера.
+# [<en>] Proxy server settings. In the exception list (noProxy parameter), also specify the сomma-separated IP addresses of cluster nodes, container registry, or proxy server.
+# [<ru>] Настройки proxy-сервера. В списке исключений (параметр noProxy) также укажите IP-адреса узлов кластера, container registry или прокси-сервера, разделённые запятой.
 proxy:
   httpProxy: <HTTP_PROXY_ADDRESS>
   httpsProxy: <HTTPS_PROXY_ADDRESS>

--- a/docs/site/js/getting-started-private.js
+++ b/docs/site/js/getting-started-private.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
     if (noProxyAddressList && noProxyAddressList.length > 0) {
       noProxyAddressList = ('["' + noProxyAddressList.split(',').join('", "') + '"]').replaceAll('""', '"')
     } else {
-      noProxyAddressList = '<NO_PROXY_LIST_WITH_INTERNAL_NETWORK_CIDRS>';
+      noProxyAddressList = '<NO_PROXY_LIST>';
       }
     update_parameter(noProxyAddressList, 'noProxy', '<NO_PROXY_LIST>', null, '[config-yml]');
 


### PR DESCRIPTION
## Description

Replaced the description of the `noProxy` parameter in `config.yml` in GS.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## What is the expected result?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Replaced the description of the `noProxy` parameter in `config.yml` in GS.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
