### PR TITLE
[node-manager] Setting nvidia-ctk log-level to error in docs

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -642,6 +642,7 @@ spec:
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
     fi
     bb-apt-install nvidia-container-toolkit nvidia-driver-535-server
+    nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu
   weight: 30
@@ -677,6 +678,7 @@ spec:
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     fi
     bb-yum-install nvidia-container-toolkit nvidia-driver
+    nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu
   weight: 30

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -642,7 +642,7 @@ spec:
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
     fi
     bb-apt-install nvidia-container-toolkit nvidia-driver-535-server
-    nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
+    nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place 
   nodeGroups:
   - gpu
   weight: 30

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -649,6 +649,7 @@ spec:
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
     fi
     bb-apt-install nvidia-container-toolkit nvidia-driver-535-server
+    nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu
   weight: 30
@@ -684,6 +685,7 @@ spec:
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     fi
     bb-yum-install nvidia-container-toolkit nvidia-driver
+    nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu
   weight: 30


### PR DESCRIPTION
## Description
Adding a config edit command to our nvidia-container-toolkit installation example in docs to lower the log level:
```
nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
```

## Why do we need it, and what problem does it solve?
Workaround for https://github.com/deckhouse/deckhouse/issues/6186
Basically, on default log-level `info` every exec into a container is logged in log.json, which leads to the log file growth when pods have exec probes. That's why we suggest to lower the log level
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Update to nvidia GPU support FAQ.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
