### PR TITLE
[CI] Add check cooldown for release

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -152,8 +152,22 @@ Jobs for visual control allowed editions when approving deploy to environments.
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check cooldown for release
+        if: ${{ github.event.inputs.cooldown }}
+        env:
+          COOLDOWN: ${{ github.event.inputs.cooldown }}
+        run: |
+          CURRENT_TIMESTAMP=$(date +%s)
+          COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
+            echo "The cooldown has expired"
+            exit 1
+          fi
+
       {!{ range $werfEnv := slice "CE" "EE" "FE" "BE" "SE" }!}
       - name: Set cooldown for release ({!{ $werfEnv }!})
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -166,8 +166,6 @@ Jobs for visual control allowed editions when approving deploy to environments.
 
       {!{ range $werfEnv := slice "CE" "EE" "FE" "BE" "SE" }!}
       - name: Set cooldown for release ({!{ $werfEnv }!})
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -159,6 +159,17 @@ Jobs for visual control allowed editions when approving deploy to environments.
         run: |
           CURRENT_TIMESTAMP=$(date +%s)
           COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          # Check datetime format
+          if ! [[ "$COOLDOWN" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+            echo "Invalid datetime format."
+            exit 1
+          fi
+          # Check datetime is valid
+          if ! date -d "$COOLDOWN" >/dev/null 2>&1; then
+            echo "Invalid datetime."
+            exit 1
+          fi
+          # Check datetime is expired
           if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
             echo "The cooldown has expired"
             exit 1

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -348,8 +348,6 @@ jobs:
 
 
       - name: Set cooldown for release (CE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -371,8 +369,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -394,8 +390,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -417,8 +411,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -440,8 +432,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -341,6 +341,17 @@ jobs:
         run: |
           CURRENT_TIMESTAMP=$(date +%s)
           COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          # Check datetime format
+          if ! [[ "$COOLDOWN" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+            echo "Invalid datetime format."
+            exit 1
+          fi
+          # Check datetime is valid
+          if ! date -d "$COOLDOWN" >/dev/null 2>&1; then
+            echo "Invalid datetime."
+            exit 1
+          fi
+          # Check datetime is expired
           if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
             echo "The cooldown has expired"
             exit 1

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -334,8 +334,22 @@ jobs:
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check cooldown for release
+        if: ${{ github.event.inputs.cooldown }}
+        env:
+          COOLDOWN: ${{ github.event.inputs.cooldown }}
+        run: |
+          CURRENT_TIMESTAMP=$(date +%s)
+          COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
+            echo "The cooldown has expired"
+            exit 1
+          fi
+
 
       - name: Set cooldown for release (CE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -357,6 +371,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -378,6 +394,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -399,6 +417,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -420,6 +440,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -348,8 +348,6 @@ jobs:
 
 
       - name: Set cooldown for release (CE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -371,8 +369,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -394,8 +390,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -417,8 +411,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -440,8 +432,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -341,6 +341,17 @@ jobs:
         run: |
           CURRENT_TIMESTAMP=$(date +%s)
           COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          # Check datetime format
+          if ! [[ "$COOLDOWN" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+            echo "Invalid datetime format."
+            exit 1
+          fi
+          # Check datetime is valid
+          if ! date -d "$COOLDOWN" >/dev/null 2>&1; then
+            echo "Invalid datetime."
+            exit 1
+          fi
+          # Check datetime is expired
           if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
             echo "The cooldown has expired"
             exit 1

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -334,8 +334,22 @@ jobs:
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check cooldown for release
+        if: ${{ github.event.inputs.cooldown }}
+        env:
+          COOLDOWN: ${{ github.event.inputs.cooldown }}
+        run: |
+          CURRENT_TIMESTAMP=$(date +%s)
+          COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
+            echo "The cooldown has expired"
+            exit 1
+          fi
+
 
       - name: Set cooldown for release (CE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -357,6 +371,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -378,6 +394,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -399,6 +417,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -420,6 +440,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -348,8 +348,6 @@ jobs:
 
 
       - name: Set cooldown for release (CE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -371,8 +369,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -394,8 +390,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -417,8 +411,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -440,8 +432,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -341,6 +341,17 @@ jobs:
         run: |
           CURRENT_TIMESTAMP=$(date +%s)
           COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          # Check datetime format
+          if ! [[ "$COOLDOWN" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+            echo "Invalid datetime format."
+            exit 1
+          fi
+          # Check datetime is valid
+          if ! date -d "$COOLDOWN" >/dev/null 2>&1; then
+            echo "Invalid datetime."
+            exit 1
+          fi
+          # Check datetime is expired
           if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
             echo "The cooldown has expired"
             exit 1

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -334,8 +334,22 @@ jobs:
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check cooldown for release
+        if: ${{ github.event.inputs.cooldown }}
+        env:
+          COOLDOWN: ${{ github.event.inputs.cooldown }}
+        run: |
+          CURRENT_TIMESTAMP=$(date +%s)
+          COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
+            echo "The cooldown has expired"
+            exit 1
+          fi
+
 
       - name: Set cooldown for release (CE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -357,6 +371,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -378,6 +394,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -399,6 +417,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -420,6 +440,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -348,8 +348,6 @@ jobs:
 
 
       - name: Set cooldown for release (CE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -371,8 +369,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -394,8 +390,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -417,8 +411,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -440,8 +432,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -341,6 +341,17 @@ jobs:
         run: |
           CURRENT_TIMESTAMP=$(date +%s)
           COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          # Check datetime format
+          if ! [[ "$COOLDOWN" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+            echo "Invalid datetime format."
+            exit 1
+          fi
+          # Check datetime is valid
+          if ! date -d "$COOLDOWN" >/dev/null 2>&1; then
+            echo "Invalid datetime."
+            exit 1
+          fi
+          # Check datetime is expired
           if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
             echo "The cooldown has expired"
             exit 1

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -334,8 +334,22 @@ jobs:
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check cooldown for release
+        if: ${{ github.event.inputs.cooldown }}
+        env:
+          COOLDOWN: ${{ github.event.inputs.cooldown }}
+        run: |
+          CURRENT_TIMESTAMP=$(date +%s)
+          COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
+            echo "The cooldown has expired"
+            exit 1
+          fi
+
 
       - name: Set cooldown for release (CE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -357,6 +371,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -378,6 +394,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -399,6 +417,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -420,6 +440,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -348,8 +348,6 @@ jobs:
 
 
       - name: Set cooldown for release (CE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -371,8 +369,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -394,8 +390,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -417,8 +411,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -440,8 +432,6 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
-        needs:
-          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -341,6 +341,17 @@ jobs:
         run: |
           CURRENT_TIMESTAMP=$(date +%s)
           COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          # Check datetime format
+          if ! [[ "$COOLDOWN" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+            echo "Invalid datetime format."
+            exit 1
+          fi
+          # Check datetime is valid
+          if ! date -d "$COOLDOWN" >/dev/null 2>&1; then
+            echo "Invalid datetime."
+            exit 1
+          fi
+          # Check datetime is expired
           if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
             echo "The cooldown has expired"
             exit 1

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -334,8 +334,22 @@ jobs:
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check cooldown for release
+        if: ${{ github.event.inputs.cooldown }}
+        env:
+          COOLDOWN: ${{ github.event.inputs.cooldown }}
+        run: |
+          CURRENT_TIMESTAMP=$(date +%s)
+          COOLDOWN_TIMESTAMP=$(date -u +%s -d "${COOLDOWN}")
+          if [ "$CURRENT_TIMESTAMP" -gt "$COOLDOWN_TIMESTAMP" ]; then
+            echo "The cooldown has expired"
+            exit 1
+          fi
+
 
       - name: Set cooldown for release (CE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -357,6 +371,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (EE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -378,6 +394,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (FE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -399,6 +417,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (BE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
@@ -420,6 +440,8 @@ jobs:
           echo "⚓️ 📤 [$(date -u)] Push '${SOURCE_RELEASE_VERSION_IMAGE}' image with cooldown."
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       - name: Set cooldown for release (SE)
+        needs:
+          - Check cooldown for release
         if: ${{ github.event.inputs.cooldown }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}


### PR DESCRIPTION
## Description
Add check cooldown for release action

## Why do we need it, and what problem does it solve?
Closes #5306 

## Changelog entries

```changes
section: ci
type: fix
summary: Add check cooldown for release.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
