### PR TITLE
[user-authn] feat: refresh groups on updating tokens

### DIFF
--- a/modules/150-user-authn/images/dex/patches/static-user-groups.patch
+++ b/modules/150-user-authn/images/dex/patches/static-user-groups.patch
@@ -1,112 +1,8 @@
-diff --git a/storage/kubernetes/types.go b/storage/kubernetes/types.go
---- a/storage/kubernetes/types.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/storage/kubernetes/types.go	(date 1718355089197)
-@@ -431,9 +431,10 @@
- 	// This field is IMMUTABLE. Do not change.
- 	Email string `json:"email,omitempty"`
-
--	Hash     []byte `json:"hash,omitempty"`
--	Username string `json:"username,omitempty"`
--	UserID   string `json:"userID,omitempty"`
-+	Hash     []byte   `json:"hash,omitempty"`
-+	Username string   `json:"username,omitempty"`
-+	UserID   string   `json:"userID,omitempty"`
-+	Groups   []string `json:"groups,omitempty"`
- }
-
- // PasswordList is a list of Passwords.
-@@ -458,6 +459,7 @@
- 		Hash:     p.Hash,
- 		Username: p.Username,
- 		UserID:   p.UserID,
-+		Groups:   p.Groups,
- 	}
- }
-
-@@ -467,6 +469,7 @@
- 		Hash:     p.Hash,
- 		Username: p.Username,
- 		UserID:   p.UserID,
-+		Groups:   p.Groups,
- 	}
- }
-
-diff --git a/server/server.go b/server/server.go
---- a/server/server.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/server/server.go	(date 1718355089194)
-@@ -484,6 +484,7 @@
- 		Username:      p.Username,
- 		Email:         p.Email,
- 		EmailVerified: true,
-+		Groups:        p.Groups,
- 	}, true, nil
- }
-
-diff --git a/storage/sql/crud.go b/storage/sql/crud.go
---- a/storage/sql/crud.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/storage/sql/crud.go	(date 1718355089201)
-@@ -598,13 +598,13 @@
- 	p.Email = strings.ToLower(p.Email)
- 	_, err := c.Exec(`
- 		insert into password (
--			email, hash, username, user_id
-+			email, hash, username, user_id, groups
- 		)
- 		values (
--			$1, $2, $3, $4
-+			$1, $2, $3, $4, $5
- 		);
- 	`,
--		p.Email, p.Hash, p.Username, p.UserID,
-+		p.Email, p.Hash, p.Username, p.UserID, encoder(p.Groups),
- 	)
- 	if err != nil {
- 		if c.alreadyExistsCheck(err) {
-@@ -629,10 +629,10 @@
- 		_, err = tx.Exec(`
- 			update password
- 			set
--				hash = $1, username = $2, user_id = $3
--			where email = $4;
-+				hash = $1, username = $2, user_id = $3, groups = $4
-+			where email = $5;
- 		`,
--			np.Hash, np.Username, np.UserID, p.Email,
-+			np.Hash, np.Username, np.UserID, encoder(p.Groups), p.Email,
- 		)
- 		if err != nil {
- 			return fmt.Errorf("update password: %v", err)
-@@ -648,7 +648,7 @@
- func getPassword(q querier, email string) (p storage.Password, err error) {
- 	return scanPassword(q.QueryRow(`
- 		select
--			email, hash, username, user_id
-+			email, hash, username, user_id, groups
- 		from password where email = $1;
- 	`, strings.ToLower(email)))
- }
-@@ -656,7 +656,7 @@
- func (c *conn) ListPasswords() ([]storage.Password, error) {
- 	rows, err := c.Query(`
- 		select
--			email, hash, username, user_id
-+			email, hash, username, user_id, groups
- 		from password;
- 	`)
- 	if err != nil {
-@@ -680,7 +680,7 @@
-
- func scanPassword(s scanner) (p storage.Password, err error) {
- 	err = s.Scan(
--		&p.Email, &p.Hash, &p.Username, &p.UserID,
-+		&p.Email, &p.Hash, &p.Username, &p.UserID, decoder(&p.Groups),
- 	)
- 	if err != nil {
- 		if err == sql.ErrNoRows {
-diff --git a/cmd/dex/config.go b/cmd/dex/config.go
---- a/cmd/dex/config.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/cmd/dex/config.go	(date 1718355089189)
-@@ -94,11 +94,12 @@
+diff --git i/cmd/dex/config.go w/cmd/dex/config.go
+index dd6d2e2a..7880252c 100644
+--- i/cmd/dex/config.go
++++ w/cmd/dex/config.go
+@@ -95,11 +95,12 @@ type password storage.Password
 
  func (p *password) UnmarshalJSON(b []byte) error {
  	var data struct {
@@ -124,7 +20,7 @@ diff --git a/cmd/dex/config.go b/cmd/dex/config.go
  	}
  	if err := json.Unmarshal(b, &data); err != nil {
  		return err
-@@ -107,6 +108,7 @@
+@@ -108,6 +109,7 @@ func (p *password) UnmarshalJSON(b []byte) error {
  		Email:    data.Email,
  		Username: data.Username,
  		UserID:   data.UserID,
@@ -132,10 +28,127 @@ diff --git a/cmd/dex/config.go b/cmd/dex/config.go
  	})
  	if len(data.Hash) == 0 && len(data.HashFromEnv) > 0 {
  		data.Hash = os.Getenv(data.HashFromEnv)
-diff --git a/storage/storage.go b/storage/storage.go
---- a/storage/storage.go	(revision 23efe9200ccd9e0a69242bf61cd221462370d1f4)
-+++ b/storage/storage.go	(date 1718355089203)
-@@ -354,6 +354,9 @@
+diff --git i/server/server.go w/server/server.go
+index 1cf71c50..dad96051 100644
+--- i/server/server.go
++++ w/server/server.go
+@@ -532,6 +532,7 @@ func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, passw
+ 		Username:      p.Username,
+ 		Email:         p.Email,
+ 		EmailVerified: true,
++		Groups:        p.Groups,
+ 	}, true, nil
+ }
+
+@@ -556,6 +557,7 @@ func (db passwordDB) Refresh(ctx context.Context, s connector.Scopes, identity c
+ 	// No other fields are expected to be refreshable as email is effectively used
+ 	// as an ID and this implementation doesn't deal with groups.
+ 	identity.Username = p.Username
++	identity.Groups = p.Groups
+
+ 	return identity, nil
+ }
+diff --git i/storage/kubernetes/types.go w/storage/kubernetes/types.go
+index c126ddc0..38c910b5 100644
+--- i/storage/kubernetes/types.go
++++ w/storage/kubernetes/types.go
+@@ -431,9 +431,10 @@ type Password struct {
+ 	// This field is IMMUTABLE. Do not change.
+ 	Email string `json:"email,omitempty"`
+
+-	Hash     []byte `json:"hash,omitempty"`
+-	Username string `json:"username,omitempty"`
+-	UserID   string `json:"userID,omitempty"`
++	Hash     []byte   `json:"hash,omitempty"`
++	Username string   `json:"username,omitempty"`
++	UserID   string   `json:"userID,omitempty"`
++	Groups   []string `json:"groups,omitempty"`
+ }
+
+ // PasswordList is a list of Passwords.
+@@ -458,6 +459,7 @@ func (cli *client) fromStoragePassword(p storage.Password) Password {
+ 		Hash:     p.Hash,
+ 		Username: p.Username,
+ 		UserID:   p.UserID,
++		Groups:   p.Groups,
+ 	}
+ }
+
+@@ -467,6 +469,7 @@ func toStoragePassword(p Password) storage.Password {
+ 		Hash:     p.Hash,
+ 		Username: p.Username,
+ 		UserID:   p.UserID,
++		Groups:   p.Groups,
+ 	}
+ }
+
+diff --git i/storage/sql/crud.go w/storage/sql/crud.go
+index 1249243c..0126aa3f 100644
+--- i/storage/sql/crud.go
++++ w/storage/sql/crud.go
+@@ -598,13 +598,13 @@ func (c *conn) CreatePassword(ctx context.Context, p storage.Password) error {
+ 	p.Email = strings.ToLower(p.Email)
+ 	_, err := c.Exec(`
+ 		insert into password (
+-			email, hash, username, user_id
++			email, hash, username, user_id, groups
+ 		)
+ 		values (
+-			$1, $2, $3, $4
++			$1, $2, $3, $4, $5
+ 		);
+ 	`,
+-		p.Email, p.Hash, p.Username, p.UserID,
++		p.Email, p.Hash, p.Username, p.UserID, encoder(p.Groups),
+ 	)
+ 	if err != nil {
+ 		if c.alreadyExistsCheck(err) {
+@@ -629,10 +629,10 @@ func (c *conn) UpdatePassword(email string, updater func(p storage.Password) (st
+ 		_, err = tx.Exec(`
+ 			update password
+ 			set
+-				hash = $1, username = $2, user_id = $3
+-			where email = $4;
++				hash = $1, username = $2, user_id = $3, groups = $4
++			where email = $5;
+ 		`,
+-			np.Hash, np.Username, np.UserID, p.Email,
++			np.Hash, np.Username, np.UserID, encoder(p.Groups), p.Email,
+ 		)
+ 		if err != nil {
+ 			return fmt.Errorf("update password: %v", err)
+@@ -648,7 +648,7 @@ func (c *conn) GetPassword(email string) (storage.Password, error) {
+ func getPassword(q querier, email string) (p storage.Password, err error) {
+ 	return scanPassword(q.QueryRow(`
+ 		select
+-			email, hash, username, user_id
++			email, hash, username, user_id, groups
+ 		from password where email = $1;
+ 	`, strings.ToLower(email)))
+ }
+@@ -656,7 +656,7 @@ func getPassword(q querier, email string) (p storage.Password, err error) {
+ func (c *conn) ListPasswords() ([]storage.Password, error) {
+ 	rows, err := c.Query(`
+ 		select
+-			email, hash, username, user_id
++			email, hash, username, user_id, groups
+ 		from password;
+ 	`)
+ 	if err != nil {
+@@ -680,7 +680,7 @@ func (c *conn) ListPasswords() ([]storage.Password, error) {
+
+ func scanPassword(s scanner) (p storage.Password, err error) {
+ 	err = s.Scan(
+-		&p.Email, &p.Hash, &p.Username, &p.UserID,
++		&p.Email, &p.Hash, &p.Username, &p.UserID, decoder(&p.Groups),
+ 	)
+ 	if err != nil {
+ 		if err == sql.ErrNoRows {
+diff --git i/storage/storage.go w/storage/storage.go
+index 03883ef5..543bfa04 100644
+--- i/storage/storage.go
++++ w/storage/storage.go
+@@ -354,6 +354,9 @@ type Password struct {
 
  	// Randomly generated user ID. This is NOT the primary ID of the Password object.
  	UserID string `json:"userID"`


### PR DESCRIPTION
## Description

When we added groups to users, we did not add groups when refreshing the token. As a result, the groups were not updated if the token was refreshed.

## Why do we need it, and what problem does it solve?

Fixed: #6928

## What is the expected result?

When updating a token, the user's groups are updated

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: feature
summary: refresh groups on updating tokens
impact_level: default
```
