### PR TITLE
[CI] Delete e2e cluster after cancel e2e

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -700,7 +700,7 @@ check_e2e_labels:
         path: ${{ steps.setup.outputs.tmp-dir-path}}
 
     - name: Cleanup bootstrapped cluster
-      if: ${{ success() }}
+      if: ${{ success() || cancelled() }}
       id: cleanup_cluster
       env:
         PROVIDER: {!{ $ctx.providerName }!}

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: AWS
@@ -497,7 +497,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: AWS
@@ -775,7 +775,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: AWS
@@ -1053,7 +1053,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: AWS
@@ -1331,7 +1331,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: AWS
@@ -1609,7 +1609,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: AWS

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Azure
@@ -501,7 +501,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Azure
@@ -783,7 +783,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Azure
@@ -1065,7 +1065,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Azure
@@ -1347,7 +1347,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Azure
@@ -1629,7 +1629,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Azure

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -223,7 +223,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: EKS
@@ -504,7 +504,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: EKS
@@ -785,7 +785,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: EKS
@@ -1066,7 +1066,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: EKS
@@ -1347,7 +1347,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: EKS
@@ -1628,7 +1628,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: EKS

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: GCP
@@ -495,7 +495,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: GCP
@@ -771,7 +771,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: GCP
@@ -1047,7 +1047,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: GCP
@@ -1323,7 +1323,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: GCP
@@ -1599,7 +1599,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: GCP

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: OpenStack
@@ -495,7 +495,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: OpenStack
@@ -771,7 +771,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: OpenStack
@@ -1047,7 +1047,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: OpenStack
@@ -1323,7 +1323,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: OpenStack
@@ -1599,7 +1599,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: OpenStack

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Static
@@ -495,7 +495,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Static
@@ -771,7 +771,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Static
@@ -1047,7 +1047,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Static
@@ -1323,7 +1323,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Static
@@ -1599,7 +1599,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Static

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: VCD
@@ -503,7 +503,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: VCD
@@ -787,7 +787,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: VCD
@@ -1071,7 +1071,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: VCD
@@ -1355,7 +1355,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: VCD
@@ -1639,7 +1639,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: VCD

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: vSphere
@@ -497,7 +497,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: vSphere
@@ -775,7 +775,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: vSphere
@@ -1053,7 +1053,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: vSphere
@@ -1331,7 +1331,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: vSphere
@@ -1609,7 +1609,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: vSphere

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -219,7 +219,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Yandex.Cloud
@@ -499,7 +499,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Yandex.Cloud
@@ -779,7 +779,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Yandex.Cloud
@@ -1059,7 +1059,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Yandex.Cloud
@@ -1339,7 +1339,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Yandex.Cloud
@@ -1619,7 +1619,7 @@ jobs:
           path: ${{ steps.setup.outputs.tmp-dir-path}}
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ success() }}
+        if: ${{ success() || cancelled() }}
         id: cleanup_cluster
         env:
           PROVIDER: Yandex.Cloud


### PR DESCRIPTION
## Description
Delete e2e cluster after cancel e2e

## Changelog entries
Delete e2e cluster after cancel e2e

```changes
section: ci
type: fix
summary: Delete e2e cluster after cancel e2e.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
