### PR TITLE
[user-authn] Fix translate to russian for option addKubeconfigGeneratorEntry

### DIFF
--- a/modules/150-user-authn/openapi/config-values.yaml
+++ b/modules/150-user-authn/openapi/config-values.yaml
@@ -57,7 +57,7 @@ properties:
       addKubeconfigGeneratorEntry:
         type: boolean
         default: true
-        description: 'Setting it to `false` will remove an entry in kubeconfig-generator'
+        description: 'Setting it to `false` will remove an entry in kubeconfig-generator.'
   kubeconfigGenerator:
     type: array
     description: |

--- a/modules/150-user-authn/openapi/doc-ru-config-values.yaml
+++ b/modules/150-user-authn/openapi/doc-ru-config-values.yaml
@@ -31,8 +31,8 @@ properties:
                   Если вы используете в кластере сертификаты, выдаваемые c помощью модуля `cert-manager` и Let's Encrypt, следует в качестве значения установить пустую строку `""`.
 
                   В качестве CA допускается указать непосредственно сертификат внешнего балансировщика. В таком случае нужно помнить, что обновление сертификата на балансировщике повредит ранее сгенерированные kubectl-конфиги.
-        addKubeconfigGeneratorEntry:
-          description: 'Если указать `false` будет удалена запись в kubeconfig-generator'
+      addKubeconfigGeneratorEntry:
+        description: 'Если указать `false` будет удалена запись в kubeconfig-generator'
   kubeconfigGenerator:
     description: |
       Массив, в котором указываются дополнительные способы доступа к API-серверу.

--- a/modules/150-user-authn/openapi/doc-ru-config-values.yaml
+++ b/modules/150-user-authn/openapi/doc-ru-config-values.yaml
@@ -32,7 +32,7 @@ properties:
 
                   В качестве CA допускается указать непосредственно сертификат внешнего балансировщика. В таком случае нужно помнить, что обновление сертификата на балансировщике повредит ранее сгенерированные kubectl-конфиги.
       addKubeconfigGeneratorEntry:
-        description: 'Если указать `false` будет удалена запись в kubeconfig-generator'
+        description: 'Если указать `false`, будет удалена запись в kubeconfig-generator.'
   kubeconfigGenerator:
     description: |
       Массив, в котором указываются дополнительные способы доступа к API-серверу.


### PR DESCRIPTION
## Description
Fix translation for `addKubeconfigGeneratorEntry` parameter.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: chore
summary: |
  Fix translation for `addKubeconfigGeneratorEntry` parameter.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
