### PR TITLE
[ci] Add CLOUD_PROVIDERS_SOURCE_REPO env for build protected cloud providers

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -12,8 +12,10 @@ GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
 
 {!{ define "git_source_envs" }!}
 # <template: git_source_envs>
-# source repo contains should creds for repo for ex https://user:password@my-repo.com/group
+# source repo should contain creds for repo for ex https://user:password@my-repo.com/group
 SOURCE_REPO: "${{secrets.SOURCE_REPO}}"
+# cloud providers source repo should contain creds for repo for ex https://user:password@my-repo.com/group
+CLOUD_PROVIDERS_SOURCE_REPO: "${{secrets.CLOUD_PROVIDERS_SOURCE_REPO}}"
 GOPROXY: "${{secrets.GOPROXY}}"
 # </template: git_source_envs>
 {!{- end -}!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -35,8 +35,10 @@ env:
   # </template: werf_envs>
 
   # <template: git_source_envs>
-  # source repo contains should creds for repo for ex https://user:password@my-repo.com/group
+  # source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   SOURCE_REPO: "${{secrets.SOURCE_REPO}}"
+  # cloud providers source repo should contain creds for repo for ex https://user:password@my-repo.com/group
+  CLOUD_PROVIDERS_SOURCE_REPO: "${{secrets.CLOUD_PROVIDERS_SOURCE_REPO}}"
   GOPROXY: "${{secrets.GOPROXY}}"
   # </template: git_source_envs>
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -37,8 +37,10 @@ env:
   # </template: werf_envs>
 
   # <template: git_source_envs>
-  # source repo contains should creds for repo for ex https://user:password@my-repo.com/group
+  # source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   SOURCE_REPO: "${{secrets.SOURCE_REPO}}"
+  # cloud providers source repo should contain creds for repo for ex https://user:password@my-repo.com/group
+  CLOUD_PROVIDERS_SOURCE_REPO: "${{secrets.CLOUD_PROVIDERS_SOURCE_REPO}}"
   GOPROXY: "${{secrets.GOPROXY}}"
   # </template: git_source_envs>
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -46,8 +46,10 @@ env:
   # </template: werf_envs>
 
   # <template: git_source_envs>
-  # source repo contains should creds for repo for ex https://user:password@my-repo.com/group
+  # source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   SOURCE_REPO: "${{secrets.SOURCE_REPO}}"
+  # cloud providers source repo should contain creds for repo for ex https://user:password@my-repo.com/group
+  CLOUD_PROVIDERS_SOURCE_REPO: "${{secrets.CLOUD_PROVIDERS_SOURCE_REPO}}"
   GOPROXY: "${{secrets.GOPROXY}}"
   # </template: git_source_envs>
 

--- a/tools/images_tags/main.go
+++ b/tools/images_tags/main.go
@@ -75,7 +75,7 @@ func main() {
 	// Run werf config render to get config file from which  we calculate images names
 	cmd := exec.Command("werf", "config", "render", "--dev", "--log-quiet")
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "CI_COMMIT_REF_NAME=", "CI_COMMIT_TAG=", "WERF_ENV=FE", "SOURCE_REPO=", "GOPROXY=")
+	cmd.Env = append(cmd.Env, "CI_COMMIT_REF_NAME=", "CI_COMMIT_TAG=", "WERF_ENV=FE", "SOURCE_REPO=", "GOPROXY=", "CLOUD_PROVIDERS_SOURCE_REPO=")
 	cmd.Dir = path.Join("..")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -1,7 +1,7 @@
 giterminismConfigVersion: 1
 config:
   goTemplateRendering:	# The rules for the Go-template functions
-    allowEnvVariables: [ /CI_.+/, /REPO_MCM_.+/, SOURCE_REPO, GOPROXY, WERF_DISABLE_META_TAGS ]
+    allowEnvVariables: [ /CI_.+/, /REPO_MCM_.+/, SOURCE_REPO, GOPROXY, WERF_DISABLE_META_TAGS, CLOUD_PROVIDERS_SOURCE_REPO ]
     allowUncommittedFiles: [ "tools/build_includes/*" ]
   stapel:
     mount:

--- a/werf.yaml
+++ b/werf.yaml
@@ -56,6 +56,10 @@ cleanup:
 # Source repo  settings
 {{- $_ := set . "SOURCE_REPO" (env "SOURCE_REPO" | default "https://github.com") }}
 
+# source repo with protected cloud providers
+# use example.com as default because we can fail build without env
+{{- $_ := set . "CLOUD_PROVIDERS_SOURCE_REPO" (env "CLOUD_PROVIDERS_SOURCE_REPO" | default "https://example.com") }}
+
 # goproxy  settings
 {{- $_ := set . "GOPROXY" (env "GOPROXY") }}
 
@@ -880,6 +884,7 @@ args:
   BASE_JEKYLL: {{ .Images.BASE_JEKYLL }}
   BASE_SCRATCH: {{ .Images.BASE_SCRATCH }}
   SOURCE_REPO: {{ .SOURCE_REPO }}
+  CLOUD_PROVIDERS_SOURCE_REPO: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
   # proxies for various packages
   GOPROXY: {{ .GOPROXY }}
   {{- if not (has (list .ModuleName .ImageName | join "/") (list "common/distroless")) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add CLOUD_PROVIDERS_SOURCE_REPO env

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Need to build protected cloud providers.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add CLOUD_PROVIDERS_SOURCE_REPO env for build protected cloud providers
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
