### PR TITLE
[dhctl] Fix wrong skip flag for CheckLocalhostDomain preflight check

### DIFF
--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -205,7 +205,13 @@ func (pc *Checker) do(title string, checks []checkStep) error {
 			return nil
 		}
 
+		knownSkipFlags := make(map[string]struct{})
 		for _, check := range checks {
+			if _, skipFlagDuplicated := knownSkipFlags[check.skipFlag]; skipFlagDuplicated {
+				panic("duplicated skip flag " + check.skipFlag)
+			}
+			knownSkipFlags[check.skipFlag] = struct{}{}
+
 			loop := retry.NewLoop(
 				fmt.Sprintf("Checking %s", check.successMessage),
 				1,

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -120,7 +120,7 @@ func (pc *Checker) Static() error {
 		{
 			fun:            pc.CheckLocalhostDomain,
 			successMessage: "resolve the localhost domain",
-			skipFlag:       app.RegistryCredentialsCheckArgName,
+			skipFlag:       app.ResolvingLocalhostArgName,
 		},
 		{
 			fun:            pc.CheckSudoIsAllowedForUser,


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed wrong skip flag in preflight check and added logic to detect such duplicates in the future

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This improves bad user experience

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix wrong skip flag for CheckLocalhostDomain preflight check
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
