### PR TITLE
[runtime-audit-engine] allow falco to match multiple rules on same event

### DIFF
--- a/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
@@ -399,5 +399,24 @@ data:
       chunk_wait_us: 1000
       # @ Watch frequency (in seconds) when fetching metadata from Kubernetes.
       watch_freq_sec: 1
-
-{{ (.Files.Glob "rules/*" ).AsConfig | indent 2 }}
+    # [Experimental] `rule_matching`
+    #
+    # The `rule_matching` configuration key's values are:
+    #  - `first`: Falco stops checking conditions of rules against upcoming event
+    #    at the first matching rule
+    #  - `all`: Falco will continue checking conditions of rules even if a matching
+    #    one was already found
+    #
+    # Rules conditions are evaluated in the order they are defined in the rules files.
+    # For this reason, when using `first` as value, only the first defined rule will
+    # trigger, possibly shadowing other rules.
+    # In case `all` is used as value, rules still trigger in the order they were
+    # defined.
+    #
+    # Effectively, with this setting, it is now possible to apply multiple rules that match
+    # the same event type. This eliminates concerns about rule prioritization based on the
+    # "first match wins" principle. However, enabling the `all` matching option may result in
+    # a performance penalty. We recommend carefully testing this alternative setting before
+    # deploying it in production.
+    rule_matching: all
+  {{ (.Files.Glob "rules/*" ).AsConfig | indent 2 }}

--- a/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
@@ -419,4 +419,4 @@ data:
     # a performance penalty. We recommend carefully testing this alternative setting before
     # deploying it in production.
     rule_matching: all
-  {{ (.Files.Glob "rules/*" ).AsConfig | indent 2 }}
+{{ (.Files.Glob "rules/*" ).AsConfig | indent 2 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Allow falco to match multiple rules on same event.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Be default, if rule matches event, than event stopped to match against rules.
This leads to the fact that user-defined rules cannot fired if event is matched against build-in deckhouse rules.
https://github.com/falcosecurity/falco/pull/2705.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: chore
summary: Allow falco to match multiple rules on same event.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
