### PR TITLE
[secret-copier] Delete argocd labels from copied secrets

### DIFF
--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -82,6 +82,10 @@ func ApplyCopierSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
 	delete(s.Labels, "certmanager.k8s.io/certificate-name")
 
+	// Secrets with that labels lead to ArgoCD control over them.
+	delete(s.Labels, "argocd.argoproj.io/instance")
+	delete(s.Labels, "argocd.argoproj.io/secret-type")
+
 	return s, nil
 }
 

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -144,7 +144,7 @@ metadata:
 data:
   supersecret: czVkYXRh
 `
-stateSecretOriginalYAML6 = `
+		stateSecretOriginalYAML6 = `
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -144,19 +144,6 @@ metadata:
 data:
   supersecret: czVkYXRh
 `
-		stateSecretOriginalYAML6 = `
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: s6
-  namespace: default
-  labels:
-    secret-copier.deckhouse.io/enabled: ""
-	argocd.argoproj.io/instance: "argoapp"
-data:
-  supersecret: czZkYXRhCg==
-`
 		stateSecretExtraYAML1 = `
 apiVersion: v1
 kind: Secret
@@ -218,7 +205,6 @@ data:
 		secretOriginal3 *corev1.Secret
 		secretOriginal4 *corev1.Secret
 		secretOriginal5 *corev1.Secret
-		secretOriginal6 *corev1.Secret
 		secretExtra1    *corev1.Secret
 		secretExtra2    *corev1.Secret
 		secretUpToDate  *corev1.Secret
@@ -239,7 +225,6 @@ data:
 		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML3), &secretOriginal3)
 		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML4), &secretOriginal4)
 		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML5), &secretOriginal5)
-		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML6), &secretOriginal6)
 		_ = yaml.Unmarshal([]byte(stateSecretExtraYAML1), &secretExtra1)
 		_ = yaml.Unmarshal([]byte(stateSecretExtraYAML2), &secretExtra2)
 		_ = yaml.Unmarshal([]byte(stateSecretUpToDateYAML), &secretUpToDate)
@@ -255,7 +240,6 @@ data:
 		secretOriginalYAML3, _ := yaml.Marshal(&secretOriginal3)
 		secretOriginalYAML4, _ := yaml.Marshal(&secretOriginal4)
 		secretOriginalYAML5, _ := yaml.Marshal(&secretOriginal5)
-		secretOriginalYAML6, _ := yaml.Marshal(&secretOriginal6)
 		secretNeutralYAML, _ := yaml.Marshal(&secretNeutral)
 		secretExtraYAML1, _ := yaml.Marshal(&secretExtra1)
 		secretExtraYAML2, _ := yaml.Marshal(&secretExtra2)
@@ -273,7 +257,6 @@ data:
 			string(secretOriginalYAML3),
 			string(secretOriginalYAML4),
 			string(secretOriginalYAML5),
-			string(secretOriginalYAML6),
 			string(secretNeutralYAML),
 			string(secretExtraYAML1),
 			string(secretExtraYAML2),
@@ -310,7 +293,6 @@ data:
 			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal1.Namespace).Create(context.TODO(), secretOriginal1, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal2.Namespace).Create(context.TODO(), secretOriginal2, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal3.Namespace).Create(context.TODO(), secretOriginal3, metav1.CreateOptions{})
-			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal6.Namespace).Create(context.TODO(), secretOriginal6, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretExtra1.Namespace).Create(context.TODO(), secretExtra1, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretExtra2.Namespace).Create(context.TODO(), secretExtra2, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretUpToDate.Namespace).Create(context.TODO(), secretUpToDate, metav1.CreateOptions{})
@@ -407,16 +389,6 @@ data:
 
 			_, err = f.KubeClient().CoreV1().Secrets("ns4u").Get(context.TODO(), "s5", metav1.GetOptions{})
 			Expect(err).ToNot(BeNil())
-		})
-
-		It("Custom Secret #6 must not to have a ArgoCD labels", func() {
-			Expect(f).To(ExecuteSuccessfully())
-
-			s, err := f.KubeClient().CoreV1().Secrets("ns1").Get(context.TODO(), "s6", metav1.GetOptions{})
-			Expect(err).To(BeNil())
-			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
-			_, found := s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
-			Expect(found).To(BeFalse())
 		})
 	})
 })

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -348,7 +348,7 @@ data:
 			_, found = s.ObjectMeta.Labels["certmanager.k8s.io/certificate-name"]
 			Expect(found).To(BeFalse())
 
-			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s6", metav1.GetOptions{})
+			s, err := f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s6", metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
 			_, found := s.ObjectMeta.Labels["argocd.argoproj.io/instance"]

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -144,6 +144,19 @@ metadata:
 data:
   supersecret: czVkYXRh
 `
+stateSecretOriginalYAML6 = `
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: s6
+  namespace: default
+  labels:
+    secret-copier.deckhouse.io/enabled: ""
+	argocd.argoproj.io/instance: "argoapp"
+data:
+  supersecret: czZkYXRhCg==
+`
 		stateSecretExtraYAML1 = `
 apiVersion: v1
 kind: Secret
@@ -205,6 +218,7 @@ data:
 		secretOriginal3 *corev1.Secret
 		secretOriginal4 *corev1.Secret
 		secretOriginal5 *corev1.Secret
+		secretOriginal6 *corev1.Secret
 		secretExtra1    *corev1.Secret
 		secretExtra2    *corev1.Secret
 		secretUpToDate  *corev1.Secret
@@ -225,6 +239,7 @@ data:
 		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML3), &secretOriginal3)
 		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML4), &secretOriginal4)
 		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML5), &secretOriginal5)
+		_ = yaml.Unmarshal([]byte(stateSecretOriginalYAML6), &secretOriginal6)
 		_ = yaml.Unmarshal([]byte(stateSecretExtraYAML1), &secretExtra1)
 		_ = yaml.Unmarshal([]byte(stateSecretExtraYAML2), &secretExtra2)
 		_ = yaml.Unmarshal([]byte(stateSecretUpToDateYAML), &secretUpToDate)
@@ -240,6 +255,7 @@ data:
 		secretOriginalYAML3, _ := yaml.Marshal(&secretOriginal3)
 		secretOriginalYAML4, _ := yaml.Marshal(&secretOriginal4)
 		secretOriginalYAML5, _ := yaml.Marshal(&secretOriginal5)
+		secretOriginalYAML6, _ := yaml.Marshal(&secretOriginal6)
 		secretNeutralYAML, _ := yaml.Marshal(&secretNeutral)
 		secretExtraYAML1, _ := yaml.Marshal(&secretExtra1)
 		secretExtraYAML2, _ := yaml.Marshal(&secretExtra2)
@@ -257,6 +273,7 @@ data:
 			string(secretOriginalYAML3),
 			string(secretOriginalYAML4),
 			string(secretOriginalYAML5),
+			string(secretOriginalYAML6)
 			string(secretNeutralYAML),
 			string(secretExtraYAML1),
 			string(secretExtraYAML2),
@@ -293,6 +310,7 @@ data:
 			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal1.Namespace).Create(context.TODO(), secretOriginal1, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal2.Namespace).Create(context.TODO(), secretOriginal2, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal3.Namespace).Create(context.TODO(), secretOriginal3, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Secrets(secretOriginal6.Namespace).Create(context.TODO(), secretOriginal6, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretExtra1.Namespace).Create(context.TODO(), secretExtra1, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretExtra2.Namespace).Create(context.TODO(), secretExtra2, metav1.CreateOptions{})
 			_, _ = f.KubeClient().CoreV1().Secrets(secretUpToDate.Namespace).Create(context.TODO(), secretUpToDate, metav1.CreateOptions{})
@@ -328,6 +346,12 @@ data:
 			Expect(err).To(BeNil())
 			Expect(string(s.Data["supersecret"])).To(Equal("s1data"))
 			_, found = s.ObjectMeta.Labels["certmanager.k8s.io/certificate-name"]
+			Expect(found).To(BeFalse())
+
+			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s6", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
+			_, found = s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
 			Expect(found).To(BeFalse())
 
 			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s2", metav1.GetOptions{})

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -348,12 +348,6 @@ data:
 			_, found = s.ObjectMeta.Labels["certmanager.k8s.io/certificate-name"]
 			Expect(found).To(BeFalse())
 
-			s, err = f.KubeClient().CoreV1().Secrets("ns1").Get(context.TODO(), "s6", metav1.GetOptions{})
-			Expect(err).To(BeNil())
-			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
-			_, found = s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
-			Expect(found).To(BeFalse())
-
 			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s2", metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(string(s.Data["supersecret"])).To(Equal("s2data"))
@@ -413,6 +407,16 @@ data:
 
 			_, err = f.KubeClient().CoreV1().Secrets("ns4u").Get(context.TODO(), "s5", metav1.GetOptions{})
 			Expect(err).ToNot(BeNil())
+		})
+
+		It("Custom Secret #6 must not to have a ArgoCD labels", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			s, err := f.KubeClient().CoreV1().Secrets("ns1").Get(context.TODO(), "s6", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
+			_, found := s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
+			Expect(found).To(BeFalse())
 		})
 	})
 })

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -351,7 +351,7 @@ data:
 			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s6", metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
-			_, found = s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
+			_, found := s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
 			Expect(found).To(BeFalse())
 
 			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s2", metav1.GetOptions{})

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -273,7 +273,7 @@ data:
 			string(secretOriginalYAML3),
 			string(secretOriginalYAML4),
 			string(secretOriginalYAML5),
-			string(secretOriginalYAML6)
+			string(secretOriginalYAML6),
 			string(secretNeutralYAML),
 			string(secretExtraYAML1),
 			string(secretExtraYAML2),

--- a/modules/600-secret-copier/hooks/handler_test.go
+++ b/modules/600-secret-copier/hooks/handler_test.go
@@ -348,10 +348,10 @@ data:
 			_, found = s.ObjectMeta.Labels["certmanager.k8s.io/certificate-name"]
 			Expect(found).To(BeFalse())
 
-			s, err := f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s6", metav1.GetOptions{})
+			s, err = f.KubeClient().CoreV1().Secrets("ns1").Get(context.TODO(), "s6", metav1.GetOptions{})
 			Expect(err).To(BeNil())
 			Expect(string(s.Data["supersecret"])).To(Equal("s6data"))
-			_, found := s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
+			_, found = s.ObjectMeta.Labels["argocd.argoproj.io/instance"]
 			Expect(found).To(BeFalse())
 
 			s, err = f.KubeClient().CoreV1().Secrets("ns2").Get(context.TODO(), "s2", metav1.GetOptions{})


### PR DESCRIPTION
## Description
Delete labels that belong to ArgoCD on copied secrets
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Now secrets copied by module does not belong to ArgoCD.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: secret-copier
type: feature
summary: Delete ArgoCD labels on copied secrets
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
