### PR TITLE
[node-manager] fix caps bootstrap multiple nodes  

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
@@ -231,11 +231,13 @@ func waitForNode(ctx context.Context, instanceScope *scope.InstanceScope) (*core
 
 	node := &nodes.Items[0]
 
-	if node.Annotations["node.deckhouse.io/configuration-checksum"] == "" {
-		return nil, errors.Errorf("Node '%s' doesn't have 'node.deckhouse.io/configuration-checksum' annotation", node.Name)
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+			return node, nil
+		}
 	}
 
-	return node, nil
+	return nil, errors.Errorf("Node '%s' is not ready", node.Name)
 }
 
 // getBootstrapScript returns the bootstrap data from the secret in the Machine's bootstrap.dataSecretName.

--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
@@ -10,7 +10,7 @@ if [[ -f /var/lib/bashible/bootstrap-token ]]; then
 fi
 
 checkBashible=$(systemctl is-active bashible.timer)
-if [[ "$checkBashible" != "active" ]]; then
+if [[ "$checkBashible" == "active" ]]; then
   echo "The node already exists in the cluster and under bashible."
   exit 1
 fi

--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
@@ -4,6 +4,17 @@
   {{- $bootstrap_token := index . 2 -}}
 #!/bin/bash
 
+if [[ -f /var/lib/bashible/bootstrap-token ]]; then
+  echo "The node already have bootstrap-token and under bashible."
+  exit 1
+fi
+
+checkBashible=$(systemctl is-active bashible.timer)
+if [[ "$checkBashible" != "active" ]]; then
+  echo "The node already exists in the cluster and under bashible."
+  exit 1
+fi
+
 mkdir -p /var/lib/bashible
 
 cat > /var/lib/bashible/bootstrap.sh <<"END"
@@ -22,10 +33,5 @@ chmod 0600 /var/lib/bashible/bootstrap-token
 
 touch /var/lib/bashible/first_run
 
-checkBashible=$(systemctl is-active bashible.timer)
-if [[ "$checkBashible" != "active" ]]; then
-  /var/lib/bashible/bootstrap.sh
-else
-  echo "The node already exists in the cluster and under bashible."
-fi
+/var/lib/bashible/bootstrap.sh
 {{ end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Fix recreate bootstrap-token on already bootstraped nodes.
2. Fixes from PR : #9680 
    - Remove checking for node.deckhouse.io/configuration-checksum annotation before change StaticInstance phase to Running.
    -  Check if the node status is Ready before change StaticInstance phase to Running.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In cases with parallel bootstrap of multiple nodes:
- Caps-controller may run bootstrap second time on node, which already bootstraping.
- Caps-controller may slowly check and set `Running` status on staticinstances.

## Why do we need it in the patch release (if we do)?

Fix errors when caps bootstrap multiple nodes.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manger
type: fix
summary: fix caps bootstrap multiple nodes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
