### PR TITLE
[testing] Fallback to curl if wget is not available on e2e tests

### DIFF
--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -460,8 +460,13 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 
-wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 -O /usr/bin/yq &&\
- chmod +x /usr/bin/yq
+if [[ ! -z "\$(which wget)" ]]; then
+  wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 -O /usr/bin/yq
+else
+  curl -sLfo /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386
+fi
+
+chmod +x /usr/bin/yq
 
 command -v yq >/dev/null 2>&1 || exit 1
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -460,7 +460,7 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 
-if [[ ! -z "\$(which wget)" ]]; then
+if which wget >/dev/null; then
   wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 -O /usr/bin/yq
 else
   curl -sLfo /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386


### PR DESCRIPTION
## Description
Added fallback to curl if wget is not available on e2e test machine.

## Why do we need it, and what problem does it solve?
In some cases, e2e testing can fail after running all tests as wget is not present on the current machine. It is possible to bypass that by using curl.

## What is the expected result?
e2e test script uses curl.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: fix
summary: Add fallback to curl if wget is not available on e2e test machine.
impact_level: low
```