### PR TITLE
[chore] Add ROSA Linux worker for e2e

### DIFF
--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -262,7 +262,7 @@ resource "openstack_compute_instance_v2" "worker" {
   flavor_name = var.flavor_name_large
   key_pair = "candi-${PREFIX}-key"
   availability_zone = var.az_zone
-  user_data = "${file("${each.key}-instance-bootstrap.sh")}"
+  user_data = file("${each.key}-instance-bootstrap.sh")
 
   network {
     port = openstack_networking_port_v2.worker_internal_without_security[each.key].id

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -22,7 +22,6 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
-      version = "2.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -18,46 +18,46 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: SSHCredentials
 metadata:
-  name: caps-0
+  name: caps-redos
 spec:
   privateSSHKey: '${b64_SSH_KEY}'
-  user: '${WORKER_0_USER}'
+  user: '${WORKER_REDOS_USER}'
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: worker-redos
+spec:
+  address: '${WORKER_REDOS_IP}'
+  credentialsRef:
+    kind: SSHCredentials
+    name: caps-redos
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: SSHCredentials
 metadata:
-  name: caps-rosa-id
+  name: caps-opensuse
+spec:
+  privateSSHKey: '${b64_SSH_KEY}'
+  user: '${WORKER_OPENSUSE_USER}'
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: worker-opensuse
+spec:
+  address: '${WORKER_OPENSUSE_IP}'
+  credentialsRef:
+    kind: SSHCredentials
+    name: caps-opensuse
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SSHCredentials
+metadata:
+  name: caps-rosa
 spec:
   privateSSHKey: '${b64_SSH_KEY}'
   user: '${WORKER_ROSA_USER}'
----
-apiVersion: deckhouse.io/v1alpha1
-kind: StaticInstance
-metadata:
-  name: worker-0
-spec:
-  address: '${WORKER_0_IP}'
-  credentialsRef:
-    kind: SSHCredentials
-    name: caps-0
----
-apiVersion: deckhouse.io/v1alpha1
-kind: SSHCredentials
-metadata:
-  name: caps-1
-spec:
-  privateSSHKey: '${b64_SSH_KEY}'
-  user: '${WORKER_1_USER}'
----
-apiVersion: deckhouse.io/v1alpha1
-kind: StaticInstance
-metadata:
-  name: worker-1
-spec:
-  address: '${WORKER_1_IP}'
-  credentialsRef:
-    kind: SSHCredentials
-    name: caps-1
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: StaticInstance
@@ -67,7 +67,7 @@ spec:
   address: '${WORKER_ROSA_IP}'
   credentialsRef:
     kind: SSHCredentials
-    name: caps-rosa-id
+    name: caps-rosa
 ---
 apiVersion: deckhouse.io/v1
 kind: NodeGroup
@@ -76,7 +76,7 @@ metadata:
 spec:
   nodeType: Static
   staticInstances:
-    count: 2
+    count: 3
   disruptions:
     approvalMode: Manual
   nodeTemplate:

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -24,6 +24,14 @@ spec:
   user: '${WORKER_0_USER}'
 ---
 apiVersion: deckhouse.io/v1alpha1
+kind: SSHCredentials
+metadata:
+  name: caps-rosa-id
+spec:
+  privateSSHKey: '${b64_SSH_KEY}'
+  user: '${WORKER_ROSA_USER}'
+---
+apiVersion: deckhouse.io/v1alpha1
 kind: StaticInstance
 metadata:
   name: worker-0
@@ -50,6 +58,16 @@ spec:
   credentialsRef:
     kind: SSHCredentials
     name: caps-1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-rosa
+spec:
+  address: '${WORKER_ROSA_IP}'
+  credentialsRef:
+    kind: SSHCredentials
+    name: caps-rosa-id
 ---
 apiVersion: deckhouse.io/v1
 kind: NodeGroup

--- a/testing/cloud_layouts/Static/rosa-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/rosa-instance-bootstrap.sh
@@ -17,6 +17,6 @@
 cat > /usr/local/bin/is-instance-bootstrapped << EOF
 #!/bin/bash
 set -Eeo pipefail
-cat /etc/redos-release | grep -q "ROSA Enterprise Linux Server release 7.9 (Cobalt)"
+cat /etc/rosa-release | grep -q "ROSA Enterprise Linux Server release 7.9 (Cobalt)"
 EOF
 chmod +x /usr/local/bin/is-instance-bootstrapped

--- a/testing/cloud_layouts/Static/rosa-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/rosa-instance-bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cloud_layouts/Static/rosa-instance-bootstrap.sh
+++ b/testing/cloud_layouts/Static/rosa-instance-bootstrap.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat > /usr/local/bin/is-instance-bootstrapped << EOF
+#!/bin/bash
+set -Eeo pipefail
+cat /etc/redos-release | grep -q "ROSA Enterprise Linux Server release 7.9 (Cobalt)"
+EOF
+chmod +x /usr/local/bin/is-instance-bootstrapped

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -785,6 +785,11 @@ ENDSSH
 
   registration_failed=
   >&2 echo 'Waiting until Node registration finishes ...'
+  if [ -n "${worker_rosa_ip}" ]; then
+    node_count=4
+  else
+    node_count=3
+  fi
   for ((i=1; i<=20; i++)); do
     if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<"ENDSSH"; then
 export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -379,8 +379,9 @@ function prepare_environment() {
     # use different users for different OSs
     ssh_user="astra"
     ssh_user_system="altlinux"
-    ssh_user_worker_0="redos"
-    ssh_user_worker_1="opensuse"
+    ssh_redos_user_worker="redos"
+    ssh_opensuse_user_worker="opensuse"
+    ssh_rosa_user_worker="centos"
     ;;
   esac
 
@@ -551,12 +552,16 @@ function bootstrap_static() {
     >&2 echo "ERROR: can't parse system_ip from terraform.log"
     return 1
   fi
-  if ! worker_0_ip="$(grep -m1 "worker_0_ip_address_for_ssh" "$cwd/terraform.log"| cut -d "=" -f2 | tr -d "\" ")" ; then
-    >&2 echo "ERROR: can't parse worker_0_ip from terraform.log"
+  if ! worker_redos_ip="$(grep -m1 "worker_redos_ip_address_for_ssh" "$cwd/terraform.log"| cut -d "=" -f2 | tr -d "\" ")" ; then
+    >&2 echo "ERROR: can't parse worker_redos_ip from terraform.log"
     return 1
   fi
-  if ! worker_1_ip="$(grep -m1 "worker_1_ip_address_for_ssh" "$cwd/terraform.log"| cut -d "=" -f2 | tr -d "\" ")" ; then
-    >&2 echo "ERROR: can't parse worker_1_ip from terraform.log"
+  if ! worker_opensuse_ip="$(grep -m1 "worker_opensuse_ip_address_for_ssh" "$cwd/terraform.log"| cut -d "=" -f2 | tr -d "\" ")" ; then
+    >&2 echo "ERROR: can't parse worker_opensuse_ip from terraform.log"
+    return 1
+  fi
+  if ! worker_rosa_ip="$(grep -m1 "worker_rosa_ip_address_for_ssh" "$cwd/terraform.log"| cut -d "=" -f2 | tr -d "\" ")" ; then
+        >&2 echo "ERROR: can't parse worker_ip from terraform.log"
     return 1
   fi
   if ! bastion_ip="$(grep -m1 "bastion_ip_address_for_ssh" "$cwd/terraform.log"| cut -d "=" -f2 | tr -d "\" ")" ; then
@@ -596,7 +601,7 @@ function bootstrap_static() {
   done
 
   attempt=0
-  until $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user_worker_0@$worker_0_ip" /usr/local/bin/is-instance-bootstrapped; do
+  until $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_redos_user_worker@$worker_redos_ip" /usr/local/bin/is-instance-bootstrapped; do
     attempt=$(( attempt + 1 ))
     if [ "$attempt" -gt "$waitForInstancesAreBootstrappedAttempts" ]; then
       >&2 echo "ERROR: worker instance couldn't get bootstrapped"
@@ -607,13 +612,24 @@ function bootstrap_static() {
   done
 
   attempt=0
-  until $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user_worker_1@$worker_1_ip" /usr/local/bin/is-instance-bootstrapped; do
+  until $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_opensuse_user_worker@$worker_opensuse_ip" /usr/local/bin/is-instance-bootstrapped; do
     attempt=$(( attempt + 1 ))
     if [ "$attempt" -gt "$waitForInstancesAreBootstrappedAttempts" ]; then
       >&2 echo "ERROR: worker instance couldn't get bootstrapped"
       return 1
     fi
     >&2 echo "ERROR: worker instance isn't bootstrapped yet (attempt #$attempt of $waitForInstancesAreBootstrappedAttempts)"
+    sleep 5
+  done
+
+  attempt=0
+  until $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_rosa_user_worker@$worker_rosa_ip" /usr/local/bin/is-instance-bootstrapped; do
+    attempt=$(( attempt + 1 ))
+    if [ "$attempt" -gt "$waitForInstancesAreBootstrappedAttempts" ]; then
+      >&2 echo "ERROR: rosa worker instance couldn't get bootstrapped"
+      return 1
+    fi
+    >&2 echo "ERROR: rosa worker instance isn't bootstrapped yet (attempt #$attempt of $waitForInstancesAreBootstrappedAttempts)"
     sleep 5
   done
 
@@ -736,9 +752,11 @@ ENDSSH
 
   # Prepare resources.yaml for starting working node with CAPS
   # shellcheck disable=SC2016
-  env b64_SSH_KEY="$(base64 -w0 "$ssh_private_key_path")" WORKER_0_USER="$ssh_user_worker_0" WORKER_0_IP="$worker_0_ip" \
-      WORKER_1_USER="$ssh_user_worker_1" WORKER_1_IP="$worker_1_ip" \
-      envsubst '${b64_SSH_KEY} ${WORKER_0_USER} ${WORKER_0_IP} ${WORKER_1_USER} ${WORKER_1_IP}' \
+  env b64_SSH_KEY="$(base64 -w0 "$ssh_private_key_path")" \
+      WORKER_REDOS_USER="$ssh_redos_user_worker" WORKER_REDOS_IP="$worker_redos_ip" \
+      WORKER_OPENSUSE_USER="$ssh_opensuse_user_worker" WORKER_OPENSUSE_IP="$worker_opensuse_ip" \
+      WORKER_ROSA_USER="$ssh_rosa_user_worker" WORKER_ROSA_IP="$worker_rosa_ip" \
+      envsubst '${b64_SSH_KEY} ${WORKER_REDOS_USER} ${WORKER_REDOS_IP} ${WORKER_OPENSUSE_USER} ${WORKER_OPENSUSE_IP} ${WORKER_ROSA_USER} ${WORKER_ROSA_IP}' \
       <"$cwd/resources.tpl.yaml" >"$cwd/resources.yaml"
 
   # Bootstrap
@@ -791,7 +809,7 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 kubectl get nodes -o wide
-kubectl get nodes -o json | jq -re '.items | length == 4' >/dev/null
+kubectl get nodes -o json | jq -re '.items | length == 5' >/dev/null
 kubectl get nodes -o json | jq -re '[ .items[].status.conditions[] | select(.type == "Ready") ] | map(.status == "True") | all' >/dev/null
 ENDSSH
       registration_failed=""

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -785,11 +785,6 @@ ENDSSH
 
   registration_failed=
   >&2 echo 'Waiting until Node registration finishes ...'
-  if [ -n "${worker_rosa_ip}" ]; then
-    node_count=4
-  else
-    node_count=3
-  fi
   for ((i=1; i<=20; i++)); do
     if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<"ENDSSH"; then
 export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -705,7 +705,7 @@ ENDSSH
   fi
 
   for ((i=1; i<=$testRunAttempts; i++)); do
-    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user_worker_0@$worker_0_ip" sudo su -c /bin/bash <<ENDSSH; then
+    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_redos_user_worker@$worker_redos_ip" sudo su -c /bin/bash <<ENDSSH; then
        echo "#!/bin/sh" > /etc/NetworkManager/dispatcher.d/add-routes
        echo "ip route add 10.111.0.0/16 dev lo" >> /etc/NetworkManager/dispatcher.d/add-routes
        echo "ip route add 10.222.0.0/16 dev lo" >> /etc/NetworkManager/dispatcher.d/add-routes
@@ -719,7 +719,7 @@ ENDSSH
       break
     else
       initial_setup_failed="true"
-      >&2 echo "Initial setup of worker in progress (attempt #$i of $testRunAttempts). Sleeping 5 seconds ..."
+      >&2 echo "Initial setup of redos worker in progress (attempt #$i of $testRunAttempts). Sleeping 5 seconds ..."
       sleep 5
     fi
   done
@@ -728,7 +728,7 @@ ENDSSH
   fi
 
   for ((i=1; i<=$testRunAttempts; i++)); do
-    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user_worker_1@$worker_1_ip" sudo su -c /bin/bash <<ENDSSH; then
+    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_opensuse_user_worker@$worker_opensuse_ip" sudo su -c /bin/bash <<ENDSSH; then
        echo "#!/bin/sh" > /etc/NetworkManager/dispatcher.d/add-routes
        echo "ip route add 10.111.0.0/16 dev lo" >> /etc/NetworkManager/dispatcher.d/add-routes
        echo "ip route add 10.222.0.0/16 dev lo" >> /etc/NetworkManager/dispatcher.d/add-routes
@@ -742,7 +742,30 @@ ENDSSH
       break
     else
       initial_setup_failed="true"
-      >&2 echo "Initial setup of worker in progress (attempt #$i of $testRunAttempts). Sleeping 5 seconds ..."
+      >&2 echo "Initial setup of opensuse worker in progress (attempt #$i of $testRunAttempts). Sleeping 5 seconds ..."
+      sleep 5
+    fi
+  done
+  if [[ $initial_setup_failed == "true" ]] ; then
+    return 1
+  fi
+
+  for ((i=1; i<=$testRunAttempts; i++)); do
+    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_rosa_user_worker@$worker_rosa_ip" sudo su -c /bin/bash <<ENDSSH; then
+       echo "#!/bin/sh" > /etc/NetworkManager/dispatcher.d/add-routes
+       echo "ip route add 10.111.0.0/16 dev lo" >> /etc/NetworkManager/dispatcher.d/add-routes
+       echo "ip route add 10.222.0.0/16 dev lo" >> /etc/NetworkManager/dispatcher.d/add-routes
+       echo "ip route del default" >> /etc/NetworkManager/dispatcher.d/add-routes
+       chmod 0755 /etc/NetworkManager/dispatcher.d/add-routes
+       ip route del default
+       ip route add 10.111.0.0/16 dev lo
+       ip route add 10.222.0.0/16 dev lo
+ENDSSH
+      initial_setup_failed=""
+      break
+    else
+      initial_setup_failed="true"
+      >&2 echo "Initial setup of rosa worker in progress (attempt #$i of $testRunAttempts). Sleeping 5 seconds ..."
       sleep 5
     fi
   done


### PR DESCRIPTION
## Description
<!---
  
-->
Add ROSA Linux worker for e2e
## Why do we need it, and what problem does it solve?

Adding RosaOS for e2e tests

## Why do we need it in the patch release (if we do)?

Not related to release

## What is the expected result?

E2e tests use RosaOS

## Checklist
- [x] e2e tests passed.

## Changelog entries
Add ROSA Linux worker for e2e

```changes
section: testing
type: chore
summary: Add ROSA Linux worker for e2e.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
