### PR TITLE
[dhctl] Added repo check to validateRegistryDockerCfg

### DIFF
--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -42,6 +42,8 @@ kind: InitConfiguration
 deckhouse:
    imagesRepo: test
    devBranch: test
+   # {"auths": { "test": {}}}
+   registryDockerCfg: eyJhdXRocyI6IHsgInRlc3QiOiB7fX19
    configOverrides: {}
 `
 	staticConfig := `

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -265,25 +265,24 @@ func TestPrepareRegistry(t *testing.T) {
 
 	t.Run("Validate registryDockerCfg", func(t *testing.T) {
 		t.Run("Expect successful validation", func(t *testing.T) {
-			creds := []string{
-				`{"auths": { "registry.deckhouse.io": {}}}`,
-				`{"auths": { "regi-stry.deckhouse.io": {}}}`,
-				`{"auths": { "registry.io": {}}}`,
-				`{"auths": { "1.io": {}}}`,
-				`{"auths": { "1.s.io": {}}}`,
-				`{"auths": { "regi.stry:5000": {}}}`,
-				`{"auths": { "1.2.3": {}}}`,
-				`{"auths": { "1.2:5000": {}}}`,
-				`{"auths": { "reg.dec.io1": {}}}`,
-				`{"auths": { "one.two.three.four.five.six.whatever": {}}}`,
-				`{"auths": { "1.2.3.4.5.6.0": {}}}`,
-				``,
+			creds := map[string]string{
+				"registry.deckhouse.io":                `{"auths": { "registry.deckhouse.io": {}}}`,
+				"regi-stry.deckhouse.io":               `{"auths": { "regi-stry.deckhouse.io": {}}}`,
+				"registry.io":                          `{"auths": { "registry.io": {}}}`,
+				"1.io":                                 `{"auths": { "1.io": {}}}`,
+				"1.s.io":                               `{"auths": { "1.s.io": {}}}`,
+				"regi.stry:5000":                       `{"auths": { "regi.stry:5000": {}}}`,
+				"1.2.3":                                `{"auths": { "1.2.3": {}}}`,
+				"1.2:5000":                             `{"auths": { "1.2:5000": {}}}`,
+				"reg.dec.io1":                          `{"auths": { "reg.dec.io1": {}}}`,
+				"one.two.three.four.five.six.whatever": `{"auths": { "one.two.three.four.five.six.whatever": {}}}`,
+				"1.2.3.4.5.6.0":                        `{"auths": { "1.2.3.4.5.6.0": {}}}`,
 			}
 
-			for _, cred := range creds {
+			for host, cred := range creds {
 				dockerCfg := base64.StdEncoding.EncodeToString([]byte(cred))
 
-				err := validateRegistryDockerCfg(dockerCfg,"registry.deckhouse.io/deckhouse/ce")
+				err := validateRegistryDockerCfg(dockerCfg, host)
 				require.NoError(t, err)
 			}
 		})
@@ -306,7 +305,7 @@ func TestPrepareRegistry(t *testing.T) {
 				creds := fmt.Sprintf("{\"auths\": { \"%s\": {}}}", host)
 				dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
 
-				err := validateRegistryDockerCfg(dockerCfg,"some-bad-host:1434/deckhouse")
+				err := validateRegistryDockerCfg(dockerCfg, host)
 				require.EqualErrorf(t,
 					err,
 					fmt.Sprintf("invalid registryDockerCfg. Your auths host \"%s\" should be similar to \"your.private.registry.example.com\"", host),

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -283,7 +283,7 @@ func TestPrepareRegistry(t *testing.T) {
 			for _, cred := range creds {
 				dockerCfg := base64.StdEncoding.EncodeToString([]byte(cred))
 
-				err := validateRegistryDockerCfg(dockerCfg)
+				err := validateRegistryDockerCfg(dockerCfg,"registry.deckhouse.io/deckhouse/ce")
 				require.NoError(t, err)
 			}
 		})
@@ -306,7 +306,7 @@ func TestPrepareRegistry(t *testing.T) {
 				creds := fmt.Sprintf("{\"auths\": { \"%s\": {}}}", host)
 				dockerCfg := base64.StdEncoding.EncodeToString([]byte(creds))
 
-				err := validateRegistryDockerCfg(dockerCfg)
+				err := validateRegistryDockerCfg(dockerCfg,"some-bad-host:1434/deckhouse")
 				require.EqualErrorf(t,
 					err,
 					fmt.Sprintf("invalid registryDockerCfg. Your auths host \"%s\" should be similar to \"your.private.registry.example.com\"", host),

--- a/dhctl/pkg/config/mocks/1-InitConfiguration.yml
+++ b/dhctl/pkg/config/mocks/1-InitConfiguration.yml
@@ -3,4 +3,3 @@ apiVersion: deckhouse.io/v1alpha1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: registry.deckhouse.io/deckhouse/ce
-  registryDockerCfg: eyJhdXRocyI6IHsgInJlZ2lzdHJ5LmRlY2tob3VzZS5ydSI6IHt9fX0K

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -147,21 +147,25 @@ func TestTryToSkippingCheck(t *testing.T) {
 
 	var tests = []struct {
 		registryAddress  string
+		registryDockerCfg string
 		noProxyAddresses []string
 		skipped          bool
 	}{
 		{
 			registryAddress:  "192.168.199.129/d8/deckhouse/ee",
+			registryDockerCfg: "registryDockerCfg: eyJhdXRocyI6eyIxOTIuMTY4LjE5OS4xMjkiOnsiYXV0aCI6ImEyOTJZV3hyYjNZNldHVnBiamxoWm1VPSJ9fX0K",
 			noProxyAddresses: []string{"127.0.0.1", "192.168.199.0/24"},
 			skipped:          true,
 		},
 		{
 			registryAddress:  "registry.deckhouse.io/ce",
+			registryDockerCfg: "",
 			noProxyAddresses: []string{"registry.deckhouse.io"},
 			skipped:          true,
 		},
 		{
 			registryAddress:  "quay.io",
+			registryDockerCfg: "registryDockerCfg: eyJhdXRocyI6eyJxdWF5LmlvIjp7fX19",
 			noProxyAddresses: []string{"docker.io"},
 			skipped:          false,
 		},
@@ -185,9 +189,9 @@ apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   imagesRepo: %s
-  registryDockerCfg: eyJhdXRocyI6eyIxOTIuMTY4LjE5OS4xMjkiOnsiYXV0aCI6ImEyOTJZV3hyYjNZNldHVnBiamxoWm1VPSJ9fX0K
+  %s
   registryScheme: HTTP
-`, strings.Join(test.noProxyAddresses, `", "`), test.registryAddress)
+`, strings.Join(test.noProxyAddresses, `", "`), test.registryAddress, test.registryDockerCfg)
 
 		metaConfig, err := config.ParseConfigFromData(clusterConfig)
 		s.NoError(err)


### PR DESCRIPTION
## Description
Added repo check to validateRegistryDockerCfg
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/3814
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Added repo check to validateRegistryDockerCfg
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
