### PR TITLE
[docs] changing docs on how to running site with the documentation locally

### DIFF
--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -6,47 +6,29 @@
 
 - Install werf
 
-- Open console and start documentation container with one of the following methods:
-  - Using makefile:
+- Open console and running documentation and site containers with the following method:
+
+  - using makefile:
 
     ```shell
     cd docs/documentation
     make up 
     ```
-
-    > For development mode use `make dev` instead.
-
-  - or using the following commands:
-
-    ```shell
-    cd docs/documentation
-    docker network create deckhouse
-    export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-    export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-    export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-    export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
-    werf compose up --follow --docker-compose-command-options='-d'
-    ```
-
-- Open a separate console and start site container with one of the following methods:
   - using makefile:
 
     ```shell
     cd docs/site
     make up 
     ```
-
     > For development mode use `make dev` instead.
 
-  - or using the following commands:
+- To start the containers in a single iteration, use the following method:
 
+  - using makefile in the root of the repo:
+  
     ```shell
-    cd docs/site
-    export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-    export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-    export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-    export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
-    werf compose up --follow --docker-compose-command-options='-d'
+    cd deckhouse
+    make docs-dev 
     ```
 
 - Open <http://localhost>.


### PR DESCRIPTION
## Description
<!---
   Changing the manual on how to install the documentation locally.
-->

## Why do we need it, and what problem does it solve?
<!---
  Solves the problem of incorrect installation of documentation via the werf compose up method in /docs/site
-->


<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: |
impact: Changing the manual on how to install the documentation locally
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->