### PR TITLE
[test] Only one default storage class proposal

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/hooks/discover.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover.go
@@ -159,28 +159,29 @@ func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, volumeTypes []v1al
 		return storageClasses[i].Name < storageClasses[j].Name
 	})
 
-	setStorageClassesValues(input, storageClasses)
+	// setStorageClassesValues(input, storageClasses)
+	input.Values.Set("cloudProviderOpenstack.internal.storageClasses", storageClasses)
 }
 
 func setStorageClassesValues(input *go_hook.HookInput, storageClasses []storageClass) {
-	const internalDefaultSCPath = "cloudProviderOpenstack.internal.defaultStorageClass"
+	// const internalDefaultSCPath = "cloudProviderOpenstack.internal.defaultStorageClass"
 
 	input.Values.Set("cloudProviderOpenstack.internal.storageClasses", storageClasses)
 
-	globalDefaultClusterStorageClass := input.Values.Get("global.defaultClusterStorageClass").String()
-	if globalDefaultClusterStorageClass != "" {
-		// override module's storageClass.default with global.defaultClusterStorageClass
-		input.LogEntry.Warnf("Override `cloudProviderOpenstack.storageClass.default` with `global.defaultClusterStorageClass` %q", globalDefaultClusterStorageClass)
-		input.Values.Set(internalDefaultSCPath, globalDefaultClusterStorageClass)
-	} else {
-		// if `global.defaultClusterStorageClass` is not set, then respect module's storageClass.default
-		def, ok := input.Values.GetOk("cloudProviderOpenstack.storageClass.default")
-		if ok {
-			input.Values.Set(internalDefaultSCPath, def.String())
-		} else {
-			input.Values.Remove(internalDefaultSCPath)
-		}
-	}
+	// globalDefaultClusterStorageClass := input.Values.Get("global.defaultClusterStorageClass").String()
+	// if globalDefaultClusterStorageClass != "" {
+	// 	// override module's storageClass.default with global.defaultClusterStorageClass
+	// 	input.LogEntry.Warnf("Override `cloudProviderOpenstack.storageClass.default` with `global.defaultClusterStorageClass` %q", globalDefaultClusterStorageClass)
+	// 	input.Values.Set(internalDefaultSCPath, globalDefaultClusterStorageClass)
+	// } else {
+	// 	// if `global.defaultClusterStorageClass` is not set, then respect module's storageClass.default
+	// 	def, ok := input.Values.GetOk("cloudProviderOpenstack.storageClass.default")
+	// 	if ok {
+	// 		input.Values.Set(internalDefaultSCPath, def.String())
+	// 	} else {
+	// 		input.Values.Remove(internalDefaultSCPath)
+	// 	}
+	// }
 }
 
 // Get StorageClass name from Volume type name to match Kubernetes restrictions from https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover.go
@@ -159,29 +159,7 @@ func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, volumeTypes []v1al
 		return storageClasses[i].Name < storageClasses[j].Name
 	})
 
-	// setStorageClassesValues(input, storageClasses)
 	input.Values.Set("cloudProviderOpenstack.internal.storageClasses", storageClasses)
-}
-
-func setStorageClassesValues(input *go_hook.HookInput, storageClasses []storageClass) {
-	// const internalDefaultSCPath = "cloudProviderOpenstack.internal.defaultStorageClass"
-
-	input.Values.Set("cloudProviderOpenstack.internal.storageClasses", storageClasses)
-
-	// globalDefaultClusterStorageClass := input.Values.Get("global.defaultClusterStorageClass").String()
-	// if globalDefaultClusterStorageClass != "" {
-	// 	// override module's storageClass.default with global.defaultClusterStorageClass
-	// 	input.LogEntry.Warnf("Override `cloudProviderOpenstack.storageClass.default` with `global.defaultClusterStorageClass` %q", globalDefaultClusterStorageClass)
-	// 	input.Values.Set(internalDefaultSCPath, globalDefaultClusterStorageClass)
-	// } else {
-	// 	// if `global.defaultClusterStorageClass` is not set, then respect module's storageClass.default
-	// 	def, ok := input.Values.GetOk("cloudProviderOpenstack.storageClass.default")
-	// 	if ok {
-	// 		input.Values.Set(internalDefaultSCPath, def.String())
-	// 	} else {
-	// 		input.Values.Remove(internalDefaultSCPath)
-	// 	}
-	// }
 }
 
 // Get StorageClass name from Volume type name to match Kubernetes restrictions from https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
@@ -18,19 +18,9 @@
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
   {{- end }}
 
-  {{- if hasKey $module_values.internal "defaultStorageClass" }}
-    {{- if eq $module_values.internal.defaultStorageClass $sc_name }}
+  {{- if $context.Values.global.discovery.defaultStorageClass }}
+    {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
       {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
-    {{- end }}
-  {{- else }}
-    {{- if eq $sc_index 0 }}
-      {{- if $context.Values.global.discovery.defaultStorageClass }}
-        {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
-          {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
-        {{- end }}
-      {{- else }}
-        {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
-      {{- end }}
     {{- end }}
   {{- end }}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
