### PR TITLE
[docs] Changed manual on how to run docs locally

### DIFF
--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -24,7 +24,7 @@
        make up
        ```
 
-  For development mode use `make dev` instead:
+    For development mode use `make dev` instead:
 
     1. In the first console run:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -29,16 +29,16 @@
     1. In the first console run:
 
       ```shell
-       cd docs/documentation
-       make dev
-       ```
+      cd docs/documentation
+      make dev
+      ```
 
     2. In the second console run:
 
       ```shell
-       cd docs/site
-       make dev
-       ```
+      cd docs/site
+      make dev
+      ```
 
   - **The second method** — open console and run the necessary containers in the root of the repo:
 
@@ -49,7 +49,7 @@
 
     For development mode use `make docs-dev` instead:
 
-   ```shell
+    ```shell
     cd deckhouse
     make docs-dev
     ```

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -15,24 +15,24 @@
 1.  In the first console run:
 
     ```shell
-      cd docs/documentation
-      make up
+       cd docs/documentation
+       make up
     ```
 
 1.  In the second console run:
 
-    ```shell
+      ```shell
       cd docs/site
       make up
-    ```
+      ```
 
 1.  Open <http://localhost>
 
 - To stop documentation, open console and run:
 
-    ```shell
-      make down
-    ```    
+  ```shell
+  make down
+  ```    
 
 ## Starting and stopping a site with the documentation locally — the second method
 
@@ -41,17 +41,17 @@
 1.  In the console run:
 
     ```shell
-      cd deckhouse
-      make docs
+    cd deckhouse
+    make docs
     ```
 
 1.  Open <http://localhost>
 
 -  To stop documentation, open console and run:
 
-    ```shell
-      make docs-down
-    ```
+   ```shell
+   make docs-down
+   ```
 
 ## How to debug
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -12,33 +12,33 @@
 
     1. In the first console run:
 		
-      ```shell
-    cd docs/documentation
-    make up 
-      ```
+       ```shell
+       cd docs/documentation
+       make up 
+       ```
 
     2. In the second console run:
 
-      ```shell
-    cd docs/site
-    make up 
-      ```
+       ```shell
+       cd docs/site
+       make up 
+       ```
 	
 	For development mode use `make dev` instead:
 	
     1. In the first console run:
   
-	  ```shell
-    cd docs/documentation
-    make dev
-    ```
+	     ```shell
+       cd docs/documentation
+       make dev
+       ```
 	
     2. In the second console run:
 	
-	  ```shell
-    cd docs/site
-    make dev
-    ```
+	     ```shell
+       cd docs/site
+       make dev
+       ```
 	
   - **The second method** — open console and run the necessary containers in the root of the repo:
    

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -12,46 +12,46 @@
 
 - To start documentation, open two separate consoles and follow the steps:
 
-1.   In the first console run:
+1. In the first console run:
 
-     ```shell
-     cd docs/documentation
-     make up
-     ```
+   ```shell
+   cd docs/documentation
+   make up
+   ```
 
-1.   In the second console run:
+1. In the second console run:
 
-     ```shell
-     cd docs/site
-     make up
-     ```
+   ```shell
+   cd docs/site
+   make up
+   ```
 
-1.   Open <http://localhost>
+1. Open <http://localhost>
 
 - To stop documentation, open console and run:
 
   ```shell
   make down
-  ```    
+  ```
 
 ## Starting and stopping a site with the documentation locally — the second method
 
--  To start documentation, open console and follow the steps:
+- To start documentation, open console and follow the steps:
 
-1.   In the console run:
-
-     ```shell
-     cd deckhouse
-     make docs
-     ```
-
-1.   Open <http://localhost>
-
--  To stop documentation, open console and run:
+1. In the console run:
 
    ```shell
-   make docs-down
+   cd deckhouse
+   make docs
    ```
+
+1. Open <http://localhost>
+
+- To stop documentation, open console and run:
+
+  ```shell
+  make docs-down
+  ```
 
 ## How to debug
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -28,7 +28,7 @@
 
   1. Open <http://localhost>
 
-- To stop documentation, open console and run:
+- To stop documentation, cancel the process in the consoles and run:
 
   ```shell
   make down
@@ -41,13 +41,12 @@
   1. In the console run:
 
      ```shell
-     cd deckhouse
      make docs
      ```
 
   1. Open <http://localhost>
 
-- To stop documentation, open console and run:
+- To stop documentation, cancel the process in the console and run:
 
   ```shell
   make docs-down

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -12,17 +12,17 @@
 
     1. In the first console run:
 		
-    ```shell
+      ```shell
     cd docs/documentation
     make up 
-    ```
+      ```
 
     2. In the second console run:
 
-    ```shell
+      ```shell
     cd docs/site
     make up 
-    ```
+      ```
 	
 	For development mode use `make dev` instead:
 	
@@ -42,10 +42,10 @@
 	
   - **The second method** — open console and run the necessary containers in the root of the repo:
    
-    ```shell
+      ```shell
     cd deckhouse
     make docs
-    ```
+      ```
 	
     For development mode use `make docs-dev` instead:
 	
@@ -58,17 +58,20 @@
 
 - To stop the running containers use the following command:
   - For the first method (in the each console):
-    ```shell
-    make down
-    ```
-  - For the second method:
-    ```shell
-    make docs-down
-    ```
 
-  ```shell
-  werf compose down
-  ```
+      ```shell
+    make down
+      ```
+  - For the second method:
+
+      ```shell
+    make docs-down
+      ```
+  - To stop the documentation and site containers run:
+
+      ```shell
+     werf compose down
+      ```
 
 ## How to debug
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -8,7 +8,7 @@
 
 - Open console and run documentation and site containers with one of the following methods:
 
-  - The first method — open two consoles and run containers using the Makefile:
+  - **The first method** — open two consoles and do the following steps.
 
     1. In the first console run:
 		

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -1,4 +1,4 @@
-# Running a site with the documentation locally.
+# Running a site with the documentation locally
 
 - Clone repo firstly.
 
@@ -24,18 +24,18 @@
        make up
        ```
 
-	For development mode use `make dev` instead:
+ For development mode use `make dev` instead:
 
     1. In the first console run:
 
-	     ```shell
+      ```shell
        cd docs/documentation
        make dev
        ```
 
     2. In the second console run:
 
-	     ```shell
+      ```shell
        cd docs/site
        make dev
        ```
@@ -49,7 +49,7 @@
 
     For development mode use `make docs-dev` instead:
 
-	  ```shell
+   ```shell
     cd deckhouse
     make docs-dev
     ```
@@ -62,11 +62,13 @@
     ```shell
     make down
     ```
+
   - For the second method:
 
     ```shell
     make docs-down
     ```
+
   - You can also stop documentation and site containers by running:
 
     ```shell

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -42,10 +42,10 @@
 	
   - **The second method** — open console and run the necessary containers in the root of the repo:
    
-      ```shell
+    ```shell
     cd deckhouse
     make docs
-      ```
+    ```
 	
     For development mode use `make docs-dev` instead:
 	
@@ -59,19 +59,19 @@
 - To stop the running containers use the following command:
   - For the first method (in the each console):
 
-      ```shell
+    ```shell
     make down
-      ```
+    ```
   - For the second method:
 
-      ```shell
+    ```shell
     make docs-down
-      ```
+    ```
   - You can also stop documentation and site containers by running:
 
-      ```shell
-     werf compose down
-      ```
+    ```shell
+    werf compose down
+    ```
 
 ## How to debug
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -56,7 +56,15 @@
 	
 - Open <http://localhost>.
 
-Don't forget to stop documentation and site containers by running:
+- To stop the running containers use the following command:
+  - For the first method (in the each console):
+    ```shell
+    make down
+    ```
+  - For the second method:
+    ```shell
+    make docs-down
+    ```
 
   ```shell
   werf compose down

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -8,37 +8,39 @@
 
 - Open console and run documentation and site containers with one of the following methods:
 
-  - **The first method** — open two consoles and do the following steps.
+  - **The first method** — open two consoles and do any of the following steps:
 
-    1. In the first console run:
+  1. For the main mode use `make up`:
 
-       ```shell
-       cd docs/documentation
-       make up
-       ```
+     In the first console run:
 
-    2. In the second console run:
+     ```shell
+     cd docs/documentation
+     make up
+     ```
 
-       ```shell
-       cd docs/site
-       make up
-       ```
+     In the second console run:
 
-    For development mode use `make dev` instead:
+     ```shell
+     cd docs/site
+     make up
+     ```
 
-    1. In the first console run:
+  2. For the development mode use `make dev` instead:
 
-      ```shell
-      cd docs/documentation
-      make dev
-      ```
+     In the first console run:
 
-    2. In the second console run:
+     ```shell
+     cd docs/documentation
+     make dev
+     ```
 
-      ```shell
-      cd docs/site
-      make dev
-      ```
+    In the second console run:
+
+    ```shell
+    cd docs/site
+    make dev
+    ```
 
   - **The second method** — open console and run the necessary containers in the root of the repo:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -11,49 +11,49 @@
   - **The first method** — open two consoles and do the following steps.
 
     1. In the first console run:
-		
+
        ```shell
        cd docs/documentation
-       make up 
+       make up
        ```
 
     2. In the second console run:
 
        ```shell
        cd docs/site
-       make up 
+       make up
        ```
-	
+
 	For development mode use `make dev` instead:
-	
+
     1. In the first console run:
-  
+
 	     ```shell
        cd docs/documentation
        make dev
        ```
-	
+
     2. In the second console run:
-	
+
 	     ```shell
        cd docs/site
        make dev
        ```
-	
+
   - **The second method** — open console and run the necessary containers in the root of the repo:
-   
+
     ```shell
     cd deckhouse
     make docs
     ```
-	
+
     For development mode use `make docs-dev` instead:
-	
+
 	  ```shell
     cd deckhouse
-    make docs-dev 
+    make docs-dev
     ```
-	
+
 - Open <http://localhost>.
 
 - To stop the running containers use the following command:

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -12,21 +12,21 @@
 
 - To start documentation, open two separate consoles and follow the steps:
 
-1. In the first console run:
+  1. In the first console run:
 
    ```shell
    cd docs/documentation
    make up
    ```
 
-1. In the second console run:
+  1. In the second console run:
 
    ```shell
    cd docs/site
    make up
    ```
 
-1. Open <http://localhost>
+  1. Open <http://localhost>
 
 - To stop documentation, open console and run:
 
@@ -38,14 +38,14 @@
 
 - To start documentation, open console and follow the steps:
 
-1. In the console run:
+  1. In the console run:
 
    ```shell
    cd deckhouse
    make docs
    ```
 
-1. Open <http://localhost>
+  1. Open <http://localhost>
 
 - To stop documentation, open console and run:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -1,82 +1,57 @@
 # Running a site with the documentation locally
 
+## Requirements
+
 - Clone repo firstly.
 
 - Free 80 port to bind.
 
-- Install werf.
+- Install [werf](https://werf.io/getting_started/).
 
-- Open console and run documentation and site containers with one of the following methods:
+## Starting and stopping a site with the documentation locally — the first method
 
-  - **The first method** — open two consoles and do any of the following steps:
+- To start documentation, open two separate consoles and follow the steps:
 
-    1. For the main mode use `make up`:
+  1.  In the first console run:
 
-       In the first console run:
+      ```shell
+      cd docs/documentation
+      make up
+      ```
 
-       ```shell
-       cd docs/documentation
-       make up
-       ```
+  1.  In the second console run:
 
-       In the second console run:
+      ```shell
+      cd docs/site
+      make up
+      ```
 
-       ```shell
-       cd docs/site
-       make up
-       ```
+  1.  Open <http://localhost>
 
-    2. For the development mode use `make dev` instead:
+ - To stop documentation, open console and run:
 
-       In the first console run:
+      ```shell
+      make down
+      ```    
 
-       ```shell
-       cd docs/documentation
-       make dev
-       ```
+## Starting and stopping a site with the documentation locally — the second method
 
-       In the second console run:
+-  To start documentation, open console and follow the steps:
 
-       ```shell
-       cd docs/site
-       make dev
-       ```
+1.  In the console run:
 
-  - **The second method** — open console and run the necessary containers in the root of the repo:
+      ```shell
+      cd deckhouse
+      make docs
+      ```
 
-    ```shell
-    cd deckhouse
-    make docs
-    ```
+1.  Open <http://localhost>
 
-    For development mode use `make docs-dev` instead:
+-  To stop documentation, open console and run:
 
-    ```shell
-    cd deckhouse
-    make docs-dev
-    ```
-
-- Open <http://localhost>.
-
-- To stop the running containers use the following command:
-
-  - For the first method (in the each console):
-
-    ```shell
-    make down
-    ```
-
-  - For the second method:
-
-    ```shell
-    make docs-down
-    ```
-
-  - You can also stop documentation and site containers by running:
-
-    ```shell
-    werf compose down
-    ```
+      ```shell
+      make docs-down
+      ```
 
 ## How to debug
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -14,17 +14,17 @@
 
   1. In the first console run:
 
-   ```shell
-   cd docs/documentation
-   make up
-   ```
+     ```shell
+     cd docs/documentation
+     make up
+     ```
 
   1. In the second console run:
 
-   ```shell
-   cd docs/site
-   make up
-   ```
+     ```shell
+     cd docs/site
+     make up
+     ```
 
   1. Open <http://localhost>
 
@@ -40,10 +40,10 @@
 
   1. In the console run:
 
-   ```shell
-   cd deckhouse
-   make docs
-   ```
+     ```shell
+     cd deckhouse
+     make docs
+     ```
 
   1. Open <http://localhost>
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -6,7 +6,7 @@
 
 - Install werf.
 
-- Open console and running documentation and site containers with one of the following methods:
+- Open console and run documentation and site containers with one of the following methods:
 
   - The first method — open two consoles and run containers using the Makefile:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -40,7 +40,7 @@
     make dev
     ```
 	
-  - The second method — open console and run containers in a single iteration using Makefile in the root of the repo:
+  - **The second method** — open console and run the necessary containers in the root of the repo:
    
     ```shell
     cd deckhouse

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -24,7 +24,7 @@
        make up
        ```
 
- For development mode use `make dev` instead:
+  For development mode use `make dev` instead:
 
     1. In the first console run:
 
@@ -57,6 +57,7 @@
 - Open <http://localhost>.
 
 - To stop the running containers use the following command:
+
   - For the first method (in the each console):
 
     ```shell

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -12,27 +12,27 @@
 
 - To start documentation, open two separate consoles and follow the steps:
 
-  1.  In the first console run:
+1.  In the first console run:
 
-      ```shell
+    ```shell
       cd docs/documentation
       make up
-      ```
+    ```
 
-  1.  In the second console run:
+1.  In the second console run:
 
-      ```shell
+    ```shell
       cd docs/site
       make up
-      ```
+    ```
 
-  1.  Open <http://localhost>
+1.  Open <http://localhost>
 
- - To stop documentation, open console and run:
+- To stop documentation, open console and run:
 
-      ```shell
+    ```shell
       make down
-      ```    
+    ```    
 
 ## Starting and stopping a site with the documentation locally — the second method
 
@@ -40,18 +40,18 @@
 
 1.  In the console run:
 
-      ```shell
+    ```shell
       cd deckhouse
       make docs
-      ```
+    ```
 
 1.  Open <http://localhost>
 
 -  To stop documentation, open console and run:
 
-      ```shell
+    ```shell
       make docs-down
-      ```
+    ```
 
 ## How to debug
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -12,21 +12,21 @@
 
 - To start documentation, open two separate consoles and follow the steps:
 
-1.  In the first console run:
+1.   In the first console run:
 
-    ```shell
-       cd docs/documentation
-       make up
-    ```
+     ```shell
+     cd docs/documentation
+     make up
+     ```
 
-1.  In the second console run:
+1.   In the second console run:
 
-      ```shell
-      cd docs/site
-      make up
-      ```
+     ```shell
+     cd docs/site
+     make up
+     ```
 
-1.  Open <http://localhost>
+1.   Open <http://localhost>
 
 - To stop documentation, open console and run:
 
@@ -38,14 +38,14 @@
 
 -  To start documentation, open console and follow the steps:
 
-1.  In the console run:
+1.   In the console run:
 
-    ```shell
-    cd deckhouse
-    make docs
-    ```
+     ```shell
+     cd deckhouse
+     make docs
+     ```
 
-1.  Open <http://localhost>
+1.   Open <http://localhost>
 
 -  To stop documentation, open console and run:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -35,12 +35,12 @@
        make dev
        ```
 
-      In the second console run:
+       In the second console run:
 
-      ```shell
-      cd docs/site
-      make dev
-      ```
+       ```shell
+       cd docs/site
+       make dev
+       ```
 
   - **The second method** — open console and run the necessary containers in the root of the repo:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -10,37 +10,37 @@
 
   - **The first method** — open two consoles and do any of the following steps:
 
-  1. For the main mode use `make up`:
+    1. For the main mode use `make up`:
 
-     In the first console run:
+       In the first console run:
 
-     ```shell
-     cd docs/documentation
-     make up
-     ```
+       ```shell
+       cd docs/documentation
+       make up
+       ```
 
-     In the second console run:
+       In the second console run:
 
-     ```shell
-     cd docs/site
-     make up
-     ```
+       ```shell
+       cd docs/site
+       make up
+       ```
 
-  2. For the development mode use `make dev` instead:
+    2. For the development mode use `make dev` instead:
 
-     In the first console run:
+       In the first console run:
 
-     ```shell
-     cd docs/documentation
-     make dev
-     ```
+       ```shell
+       cd docs/documentation
+       make dev
+       ```
 
-    In the second console run:
+      In the second console run:
 
-    ```shell
-    cd docs/site
-    make dev
-    ```
+      ```shell
+      cd docs/site
+      make dev
+      ```
 
   - **The second method** — open console and run the necessary containers in the root of the repo:
 

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -67,7 +67,7 @@
       ```shell
     make docs-down
       ```
-  - To stop the documentation and site containers run:
+  - You can also stop documentation and site containers by running:
 
       ```shell
      werf compose down

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -1,61 +1,66 @@
-# Running a site with the documentation locally
+# Running a site with the documentation locally.
 
-- Don't forget to clone repo firstly.
+- Clone repo firstly.
 
 - Free 80 port to bind.
 
-- Install werf
+- Install werf.
 
-- Open console and start documentation container with one of the following methods:
-  - Using makefile:
+- Open console and running documentation and site containers with one of the following methods:
 
+  - The first method — open two consoles and run containers using the Makefile:
+
+    1. In the first console run:
+		
     ```shell
     cd docs/documentation
     make up 
     ```
 
-    > For development mode use `make dev` instead.
-
-  - or using the following commands:
-
-    ```shell
-    cd docs/documentation
-    docker network create deckhouse
-    export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-    export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-    export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-    export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
-    werf compose up --follow --docker-compose-command-options='-d'
-    ```
-
-- Open a separate console and start site container with one of the following methods:
-  - using makefile:
+    2. In the second console run:
 
     ```shell
     cd docs/site
     make up 
     ```
-
-    > For development mode use `make dev` instead.
-
-  - or using the following commands:
-
-    ```shell
-    cd docs/site
-    export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-    export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-    export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-    export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
-    werf compose up --follow --docker-compose-command-options='-d'
+	
+	For development mode use `make dev` instead:
+	
+    1. In the first console run:
+  
+	  ```shell
+    cd docs/documentation
+    make dev
     ```
-
+	
+    2. In the second console run:
+	
+	  ```shell
+    cd docs/site
+    make dev
+    ```
+	
+  - The second method — open console and run containers in a single iteration using Makefile in the root of the repo:
+   
+    ```shell
+    cd deckhouse
+    make docs
+    ```
+	
+    For development mode use `make docs-dev` instead:
+	
+	  ```shell
+    cd deckhouse
+    make docs-dev 
+    ```
+	
 - Open <http://localhost>.
 
 Don't forget to stop documentation and site containers by running:
 
-```shell
-werf compose down
-```
+  ```shell
+  werf compose down
+  ```
 
 ## How to debug
 


### PR DESCRIPTION
## Description

   Changed manual on how to install the documentation locally.


## Why do we need it, and what problem does it solve?

  Solves the problem of incorrect installation of documentation via the werf compose up method in /docs/site .



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: docs
type: chore
summary: Changed the manual on how to install the documentation locally.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->