### PR TITLE
[docs] Update source for the Deckhouse CLI version.

### DIFF
--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -1,12 +1,12 @@
 {% if include.os == "Windows" %}
 1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
-({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz).
+({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz).
 {% else %}
 1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
-({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz):
+({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz):
 
    ```shell
-   curl -LO {{ site.urls[page.lang] }}/downloads/deckhouse-cli/v{{ site.data.deckhouse-cli.version }}/d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
+   curl -LO {{ site.urls[page.lang] }}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
    ```
 {% endif %}
 
@@ -30,7 +30,7 @@
 1. {% if page.lang == 'ru' -%}Распакуйте архив{% else %}Extract the archive{% endif %}:
 
    ```bash
-   tar -xvf "d8-v{{ site.data.deckhouse-cli.version }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8"
+   tar -xvf "d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8"
    ```
 
 1. {% if page.lang == 'ru' -%}

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -328,9 +328,3 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
-- add: /modules/007-registrypackages/images/d8/werf.inc.yaml
-  to: /src/registrypackages/werf.inc.yaml
-  owner: jekyll
-  group: jekyll
-  stageDependencies:
-    setup: ['**/*']

--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -153,14 +153,6 @@ ansible:
         warn: false
         executable: /bin/bash
         chdir: /srv/jekyll-data/documentation/_data/
-    - name: "Get Deckhouse CLI version"
-      shell: |
-        grep -E '^\{\{- \$version' /src/registrypackages/werf.inc.yaml | sed -E 's/.+\"(.+)\".+/version: "\1"/' >> deckhouse-cli.yaml
-        echo "Deckhouse CLI version: $(cat deckhouse-cli.yaml)"
-      args:
-        warn: false
-        executable: /bin/bash
-        chdir: /srv/jekyll-data/documentation/_data/
     - shell: |
         mkdir -m 777 -p /app/_site/
         {{- if eq $.Env "development" }}

--- a/modules/810-documentation/images/web/werf.inc.yaml
+++ b/modules/810-documentation/images/web/werf.inc.yaml
@@ -163,14 +163,6 @@ ansible:
         executable: /bin/bash
         chdir: /srv/jekyll-data/documentation/
         warn: false
-    - name: "Get Deckhouse CLI version"
-      shell: |
-        grep -E '^\{\{- \$version' /src/registrypackages/werf.inc.yaml | sed -E 's/.+\"(.+)\".+/version: "\1"/' >> deckhouse-cli.yaml
-        echo "Deckhouse CLI version: $(cat deckhouse-cli.yaml)"
-      args:
-        warn: false
-        executable: /bin/bash
-        chdir: /srv/jekyll-data/documentation/_data/
     - name: "Generating static file's of the main part..."
       shell: |
         JEKYLL_ENV=production jekyll build -d /app/_site/site/ --config _config.yml,/tmp/_config_additional.yml


### PR DESCRIPTION
## Description
The source for the Deckhouse CLI version has been changed in the #9140. The PR fix the issue.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update source for the Deckhouse CLI version.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
