### PR TITLE
[registry-packages-proxy] Grooming logs for dhctl

### DIFF
--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -81,7 +81,7 @@ func (p *Proxy) Serve() {
 			repository = registry.DefaultRepository
 		}
 
-		logEntry := fmt.Sprintf("request from client %s received for repo %s digest %s", requestIP, repository, digest)
+		logEntry := fmt.Sprintf("Request from client %s received for repo %s digest %s", requestIP, repository, digest)
 
 		if additionalPath != "" {
 			logEntry = fmt.Sprintf("%s and additional path = %s", logEntry, additionalPath)
@@ -127,7 +127,7 @@ func (p *Proxy) Serve() {
 			return
 		}
 
-		p.logger.Infof("package for digest %s sent successfully", digest)
+		p.logger.Infof("Package for digest %s sent successfully", digest)
 	})
 
 	p.logger.Debugf("Starting packages proxy listener: %s", p.listener.Addr())
@@ -149,7 +149,7 @@ func (p *Proxy) Stop() {
 func (p *Proxy) getPackage(ctx context.Context, digest string, repository string, path string) (int64, io.ReadCloser, error) {
 	// if cache is nil, return digest directly from registry
 	if p.cache == nil {
-		p.logger.Infof("cache is not set, trying to fetch package from registry")
+		p.logger.Infof("Digest %s not found in local cache, trying to fetch package from registry", digest)
 		return p.getPackageFromRegistry(ctx, digest, repository, path)
 	}
 

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -81,10 +81,10 @@ func (p *Proxy) Serve() {
 			repository = registry.DefaultRepository
 		}
 
-		logEntry := fmt.Sprintf("request from %s received: repo = %s, digest = %s", requestIP, repository, digest)
+		logEntry := fmt.Sprintf("request from client %s received for repo %s digest %s", requestIP, repository, digest)
 
 		if additionalPath != "" {
-			logEntry = fmt.Sprintf("%s, additional_path = %s", logEntry, additionalPath)
+			logEntry = fmt.Sprintf("%s and additional path = %s", logEntry, additionalPath)
 		}
 
 		p.logger.Infof("%s", logEntry)
@@ -126,6 +126,8 @@ func (p *Proxy) Serve() {
 			p.logger.Errorf("send package: %v", err)
 			return
 		}
+
+		p.logger.Infof("package for digest %s sent successfully", digest)
 	})
 
 	p.logger.Debugf("Starting packages proxy listener: %s", p.listener.Addr())

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -81,7 +81,7 @@ func (p *Proxy) Serve() {
 			repository = registry.DefaultRepository
 		}
 
-		logEntry := fmt.Sprintf("Request from client %s received for repo %s digest %s", requestIP, repository, digest)
+		logEntry := fmt.Sprintf("Received request with digest %q for repo %s from client %s", digest, repository, requestIP)
 
 		if additionalPath != "" {
 			logEntry = fmt.Sprintf("%s and additional path = %s", logEntry, additionalPath)
@@ -127,7 +127,7 @@ func (p *Proxy) Serve() {
 			return
 		}
 
-		p.logger.Infof("Package for digest %s sent successfully", digest)
+		p.logger.Infof("Package for digest %q sent successfully", digest)
 	})
 
 	p.logger.Debugf("Starting packages proxy listener: %s", p.listener.Addr())
@@ -149,7 +149,7 @@ func (p *Proxy) Stop() {
 func (p *Proxy) getPackage(ctx context.Context, digest string, repository string, path string) (int64, io.ReadCloser, error) {
 	// if cache is nil, return digest directly from registry
 	if p.cache == nil {
-		p.logger.Infof("Digest %s not found in local cache, trying to fetch package from registry", digest)
+		p.logger.Infof("Digest %q not found in local cache, trying to fetch package from registry", digest)
 		return p.getPackageFromRegistry(ctx, digest, repository, path)
 	}
 


### PR DESCRIPTION
## Description
Edit log message for received params and add log with success message for sending package

## Why do we need it, and what problem does it solve?
Improve dhctl UX

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Grooming logs for dhctl
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
