### PR TITLE
[monitoring] Fix grafana home dashboard, panel `Controllers`

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
@@ -464,7 +464,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "count by (controller_type) (kube_controller_pod)",
+          "expr": "count by (controller_type) (count by (controller_type, controller_name) (kube_controller_pod))",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,

--- a/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana-v10/grafana_home_dashboard.json
@@ -464,7 +464,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "count by (controller_type) (count by (controller_type, controller_name) (kube_controller_pod))",
+          "expr": "count by (controller_type) (count by (controller_type, controller_name, namespace) (kube_controller_pod))",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,

--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -464,7 +464,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "count by (controller_type) (kube_controller_pod)",
+          "expr": "count by (controller_type) (count by (controller_type, controller_name) (kube_controller_pod))",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,

--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -464,7 +464,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "count by (controller_type) (count by (controller_type, controller_name) (kube_controller_pod))",
+          "expr": "count by (controller_type) (count by (controller_type, controller_name, namespace) (kube_controller_pod))",
           "interval": "",
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
## Description
I have made a few changes in the `Controllers` panel in our Grafana home dashboard.
Previously, it was showing the number of pods managed by each controller type instead of the number of each controller type present. 
I have corrected this and now the dashboard shows accurate data: the amount of each type of controllers.

## Why do we need it, and what problem does it solve?
This change is important to get an accurate overview of the controllers present in our system. 
The previous misrepresentation might have led to confusion or misguided decisions. 
Now the dashboard will reflect the true state of our cluster by portraying the correct number of each type of controllers.

## What is the expected result?
After the implementation of these changes, the `Controllers` panel in our Grafana home dashboard should provide a correct count of each type of controllers. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: fix
summary: Fix grafana home dashboard, panel "Controllers", change promQL expression
impact_level: low 
```
