### PR TITLE
[node-manager] fix cleanup command for nodes managed by caps-сontroller.

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
@@ -78,7 +78,7 @@ func (c *Client) cleanupFromCleaningPhase(ctx context.Context, instanceScope *sc
 
 func (c *Client) cleanup(instanceScope *scope.InstanceScope) bool {
 	done := c.cleanupTaskManager.spawn(taskID(instanceScope.MachineScope.StaticMachine.Spec.ProviderID), func() bool {
-		err := ssh.ExecSSHCommand(instanceScope, "if [[ ! -f /var/lib/bashible/cleanup_static_node.sh ]]; then rm -rf /var/lib/bashible; (sleep 5 && shutdown -r now) & else bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing; fi", nil)
+		err := ssh.ExecSSHCommand(instanceScope, "if [ ! -f /var/lib/bashible/cleanup_static_node.sh ]; then rm -rf /var/lib/bashible; (sleep 5 && shutdown -r now) & else bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing; fi", nil)
 		if err != nil {
 			instanceScope.Logger.Error(err, "Failed to clean up StaticInstance: failed to exec ssh command")
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Don't use bash builtin functions ( `[[ ... ]]` ) in shell command.

## Why do we need it, and what problem does it solve?

```
I0912 09:17:52.005909       1 logger.go:62] "stderr: OpenSSH client output" controller="staticmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="StaticMachine" StaticMachine="d8-cloud-instance-manager/static-worker-st5km-fngml" namespace="d8-cloud-instance-manager" name="static-worker-st5km-fngml" reconcileID="b1ae2aae-568e-46ef-8550-52e0f1e2f7d1" line=59 output="debug1: Sending command: sudo sh -c \"if [[ ! -f /var/lib/bashible/cleanup_static_node.sh ]]; then rm -rf /var/lib/bashible; (sleep 5 && shutdown -r now) & else bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing; fi\""
I0912 09:17:52.015639       1 logger.go:62] "stderr: OpenSSH client output" controller="staticmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="StaticMachine" StaticMachine="d8-cloud-instance-manager/static-worker-st5km-fngml" namespace="d8-cloud-instance-manager" name="static-worker-st5km-fngml" reconcileID="b1ae2aae-568e-46ef-8550-52e0f1e2f7d1" line=61 output="sh: 1: [[: not found"
```

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Cleanup nodes managed by caps-controller without errors.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix cleanup command for nodes managed by caps-сontroller.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
