### PR TITLE
[cloud-provider-yandex]  Fix hardcoded `diskType` parameter in `static-node`

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -88,7 +88,7 @@ resource "yandex_compute_instance" "static" {
 
   boot_disk {
     initialize_params {
-      type     = "network-ssd"
+      type     = local.disk_type
       image_id = local.image_id
       size     = local.disk_size_gb
     }

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
@@ -54,6 +54,7 @@ locals {
   core_fraction     = lookup(local.instance_class, "coreFraction", null)
   memory            = local.instance_class.memory / 1024
   disk_size_gb      = lookup(local.instance_class, "diskSizeGB", 50)
+  disk_type         = lookup(local.instance_class, "diskType", "network-ssd")
   image_id          = local.instance_class.imageID
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
   ssh_public_key    = var.providerClusterConfiguration.sshPublicKey


### PR DESCRIPTION
## Description
Updated the terraform module for the `static-node` resource in Yandex Cloud. Previously, the `diskType` parameter was hard-coded, but now it can be configured dynamically.

An missed revision that should have been included in the PR #8384 

## Why do we need it, and what problem does it solve?
The hard-coded `diskType` parameter limited the flexibility of our infrastructure as code implementations. 

## What is the expected result?
After applying these changes, users will be able to define the `diskType` parameter for the `static-node` resource in the terraform module according to their specific requirements. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-yandex
type: fix 
summary: Fix hardcoded `diskType` parameter in `static-node`
impact_level: low
```
