### PR TITLE
[extended-monitoring] bump image-availability-exporter version

### DIFF
--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -13,7 +13,7 @@ ENV GOPROXY=${GOPROXY}
 WORKDIR /src
 ENV GOARCH=amd64
 RUN apk add patch git
-RUN git clone --depth 1 --branch v0.8.0 ${SOURCE_REPO}/deckhouse/k8s-image-availability-exporter.git .
+RUN git clone --depth 1 --branch v0.9.0 ${SOURCE_REPO}/deckhouse/k8s-image-availability-exporter.git .
 COPY patches/001-support-legacy-annotation.patch /src/
 RUN patch -p1 < 001-support-legacy-annotation.patch
 RUN CGO_ENABLED=0 go build -a -ldflags '-s -w -extldflags "-static"' -o /k8s-image-availability-exporter main.go && \

--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_DISTROLESS
-ARG BASE_GOLANG_21_ALPINE
+ARG BASE_GOLANG_22_ALPINE
 
 # Based on https://github.com/deckhouse/k8s-image-availability-exporter/blob/master/Dockerfile
-FROM $BASE_GOLANG_21_ALPINE as artifact
+FROM $BASE_GOLANG_22_ALPINE as artifact
 
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}


### PR DESCRIPTION
## Description
Bumped image-availability-exporter version

## Why do we need it, and what problem does it solve?
To keep module in fresh state and to use new features

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
Latest image of image-availability-exporter in containers

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: chore
summary: newer version of image-availability-export with new features
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
