### PR TITLE
Changing clusterDomain without downtime

### DIFF
--- a/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
@@ -156,6 +156,10 @@ spec:
 
 {{- if .apiserver.serviceAccount }}
   {{- if .apiserver.serviceAccount.additionalAPIIssuers }}
+    {{- $uniqueIssuers := uniq .apiserver.serviceAccount.additionalAPIIssuers }}
+    {{- $defaultIssuer := printf "https://kubernetes.default.svc.%s" .clusterConfiguration.clusterDomain }}
+    {{- $filteredIssuers := difference $uniqueIssuers (list $defaultIssuer) }}
+    {{- if gt (len $filteredIssuers) 0 }}
 ---
 apiVersion: v1
 kind: Pod
@@ -166,8 +170,10 @@ spec:
   containers:
   - name: kube-apiserver
     args:
-    {{- range .apiserver.serviceAccount.additionalAPIIssuers }}
+    {{- range $filteredIssuers }}
     - --service-account-issuer={{ . }}
     {{- end }}
   {{- end }}
 {{- end }}
+{{- end }}
+

--- a/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
@@ -153,3 +153,21 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- if .apiserver.serviceAccount }}
+  {{- if .apiserver.serviceAccount.additionalAPIIssuers }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+    args:
+    {{- range .apiserver.serviceAccount.additionalAPIIssuers }}
+    - --service-account-issuer={{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
@@ -158,8 +158,7 @@ spec:
   {{- if .apiserver.serviceAccount.additionalAPIIssuers }}
     {{- $uniqueIssuers := uniq .apiserver.serviceAccount.additionalAPIIssuers }}
     {{- $defaultIssuer := printf "https://kubernetes.default.svc.%s" .clusterConfiguration.clusterDomain }}
-    {{- $filteredIssuers := difference $uniqueIssuers (list $defaultIssuer) }}
-    {{- if gt (len $filteredIssuers) 0 }}
+    {{- if not (and (eq (len $uniqueIssuers) 1) (eq (index $uniqueIssuers 0) $defaultIssuer)) }}
 ---
 apiVersion: v1
 kind: Pod
@@ -170,10 +169,11 @@ spec:
   containers:
   - name: kube-apiserver
     args:
-    {{- range $filteredIssuers }}
+    {{- range $uniqueIssuers }}
+      {{- if ne . $defaultIssuer }}
     - --service-account-issuer={{ . }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}
-

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -44,6 +44,12 @@ properties:
               A list of API audiences to add when provisioning ServiceAccount tokens.
             items:
               type: string
+          additionalAPIIssuers:
+            type: array
+            description: |
+              A list of API issuers to add when provisioning ServiceAccount tokens.
+            items:
+              type: string
       admissionPlugins:
         type: array
         description: |

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -41,13 +41,19 @@ properties:
           additionalAPIAudiences:
             type: array
             description: |
-              A list of API audiences to add when provisioning ServiceAccount tokens.
+              A list of API audiences to add when provisioning ServiceAccount tokens. 
+              The defautl audiences is automatically generated based on the template `https://kubernetes.default.svc.${clusterDomain}`, for example, `https://kubernetes.default.svc.cluster.local`.
+              The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences.
+              This option is beneficial when migrating from one API issuer to another.
             items:
               type: string
           additionalAPIIssuers:
             type: array
             description: |
-              A list of API issuers to add when provisioning ServiceAccount tokens.
+              A list of additional issuers to include when provisioning ServiceAccount tokens. Issuers (`iss`) are used to verify the source of the tokens, ensuring they originate from trusted entities.
+              The first issuer is automatically generated based on the template `https://kubernetes.default.svc.${clusterDomain}`, for example, `https://kubernetes.default.svc.cluster.local`.
+              When multiple issuers are specified, the first issuer is used to generate tokens, and all provided issuers are accepted for token verification.
+              This option is beneficial when migrating from one API issuer to another.
             items:
               type: string
       admissionPlugins:

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -15,6 +15,9 @@ properties:
           additionalAPIAudiences:
             description: |
               Список API audience'ов, которые следует добавить при создании токенов ServiceAccount.
+          additionalAPIIssuers:
+            description: |
+              Список дополнительных API issuer'ов, которые следует добавить при создании токенов ServiceAccount.
       admissionPlugins:
         description: |
           Список включенных дополнительных [admission plugin'ов](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers).

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -14,10 +14,16 @@ properties:
               **Обратите внимание**, что все поды в кластере, использующие токены ServiceAccount, должны быть перезапущены при изменении этой опции.
           additionalAPIAudiences:
             description: |
-              Список API audience'ов, которые следует добавить при создании токенов ServiceAccount.
+              Список дополнительных API audience'ов, которые нужно добавить при создании токенов ServiceAccount.
+              audience по умолчанию, автоматически генерируются на основе шаблона https://kubernetes.default.svc.${clusterDomain}, например, https://kubernetes.default.svc.cluster.local.
+              Аутентификатор токенов ServiceAccount ироверяет, что токены, использованные с API, привязаны как минимум к одной из этих audiences.
+              Этот вариант полезен при переходе от одного API issuer к другому.
           additionalAPIIssuers:
             description: |
-              Список дополнительных API issuer'ов, которые следует добавить при создании токенов ServiceAccount.
+              Список дополнительных API issuer'ов, которые нужно включить при создании токенов ServiceAccount. Issuer'ы (iss) используются для проверки источника токенов, обеспечивая, что они поступают от доверенных сущностей.
+              Первый issuer автоматически генерируется по шаблону `https://kubernetes.default.svc.${clusterDomain}`, например, `https://kubernetes.default.svc.cluster.local`.
+              Когда указано несколько issuer'ов, первый issuer используется для генерации токенов, а все указанные issuer'ы принимаются для валидации токенов.
+              Этот вариант полезен при переходе от одного API issuer к другому.
       admissionPlugins:
         description: |
           Список включенных дополнительных [admission plugin'ов](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers).

--- a/modules/042-kube-dns/docs/FAQ.md
+++ b/modules/042-kube-dns/docs/FAQ.md
@@ -7,15 +7,43 @@ search: DNS, domain, clusterdomain
 
 Add the new domain and save the old one:
 
-1. In the [controlPlaneManager.apiserver.certSANs](../040-control-plane-manager/configuration.html#parameters-apiserver-certsans) section, enter the following parameters:
-    - `kubernetes.default.svc.<old clusterDomain>`
-    - `kubernetes.default.svc.<new clusterDomain>`
+1. In the [controlPlaneManager.apiserver](../040-control-plane-manager/configuration.html) configure the following parameters:
+
+- [controlPlaneManager.apiserver.certSANs](../040-control-plane-manager/configuration.html#parameters-apiserver-certsans)
+- [apiserver.serviceAccount.additionalAPIAudiences](../040-control-plane-manager/configuration.html#parameters-apiserver-serviceaccount-additionalapiaudiences)
+- [apiserver.serviceAccount.additionalAPIIssuers](../040-control-plane-manager/configuration.html#parameters-apiserver-serviceaccount-additionalapiissuers)
+
+Example:
+
+```
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: control-plane-manager
+spec:
+  enabled: true
+  settings:
+    apiserver:
+      certSANs:
+       - kubernetes.default.svc.<old clusterDomain>
+       - kubernetes.default.svc.<new clusterDomain>
+      serviceAccount:
+        additionalAPIAudiences:
+        - https://kubernetes.default.svc.<old clusterDomain>
+        - https://kubernetes.default.svc.<new clusterDomain>
+        additionalAPIIssuers:
+        - https://kubernetes.default.svc.<old clusterDomain>
+        - https://kubernetes.default.svc.<new clusterDomain>
+```
+
+
 1. In the [kubeDns.clusterDomainAliases](configuration.html#parameters) section, enter:
     - the old clusterDomain.
     - the new clusterDomain.
 1. Wait until kube-apiserver is restarted.
 1. Replace the old `clusterDomain` with the new one in `dhctl config edit cluster-configuration`
+1.
 
-**Important!** If your Kubernetes version is 1.20 and higher, your controllers in the cluster use [advanced ServiceAccount tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to work with apiserver. Those tokens have extra fields `iss:` and `aud:` that contain `clusterDomain` (e.g. `"iss": "https://kubernetes.default.svc.cluster.local"`). After changing `clusterDomain` apiserver starts to deny queries with old tokens and controllers are bond to provide errors (including deckhouse). The solution is to wait until Kubernetes rotates the tokens (it will be quite fast despite the expiration date) or restart all pods with controllers.
+**Important!** If your Kubernetes version is 1.20 and higher, your controllers in the cluster use [advanced ServiceAccount tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to work with apiserver. Those tokens have extra fields `iss:` and `aud:` that contain `clusterDomain` (e.g. `"iss": "https://kubernetes.default.svc.cluster.local"`). After changing the clusterDomain, the apiserver will start issuing tokens with the new service-account-issuer, but thanks to the configuration of additionalAPIAudiences and additionalAPIIssuers, the apiserver will continue to accept the old tokens. After 48 minutes (80% of 3607 seconds), Kubernetes will begin to refresh the issued tokens, and the new service-account-issuer will be used for the updated tokens. After 90 minutes (3607 seconds plus a short buffer) following the kube-apiserver restart, you can remove the serviceAccount configuration from the control-plane-manager configuration.
 
 **Important!** If you use [istio](../../modules/110-istio/) module, you have to restart all the application pods under istio control after changing `clusterDomain`.

--- a/modules/042-kube-dns/docs/FAQ.md
+++ b/modules/042-kube-dns/docs/FAQ.md
@@ -15,7 +15,7 @@ Add the new domain and save the old one:
 
 Example:
 
-```
+```yaml
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -36,7 +36,6 @@ spec:
         - https://kubernetes.default.svc.<new clusterDomain>
 ```
 
-
 1. In the [kubeDns.clusterDomainAliases](configuration.html#parameters) section, enter:
     - the old clusterDomain.
     - the new clusterDomain.
@@ -44,6 +43,7 @@ spec:
 1. Replace the old `clusterDomain` with the new one in `dhctl config edit cluster-configuration`
 1.
 
-**Important!** If your Kubernetes version is 1.20 and higher, your controllers in the cluster use [advanced ServiceAccount tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to work with apiserver. Those tokens have extra fields `iss:` and `aud:` that contain `clusterDomain` (e.g. `"iss": "https://kubernetes.default.svc.cluster.local"`). After changing the clusterDomain, the apiserver will start issuing tokens with the new service-account-issuer, but thanks to the configuration of additionalAPIAudiences and additionalAPIIssuers, the apiserver will continue to accept the old tokens. After 48 minutes (80% of 3607 seconds), Kubernetes will begin to refresh the issued tokens, and the new service-account-issuer will be used for the updated tokens. After 90 minutes (3607 seconds plus a short buffer) following the kube-apiserver restart, you can remove the serviceAccount configuration from the control-plane-manager configuration.
+**Important!** If your Kubernetes version is 1.20 and higher, your controllers in the cluster use [advanced ServiceAccount tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to work with apiserver. Those tokens have extra fields `iss:` and `aud:` that contain `clusterDomain` (e.g. `"iss": "https://kubernetes.default.svc.cluster.local"`). After changing the clusterDomain, the apiserver will start issuing tokens with the new service-account-issuer, but thanks to the configuration of additionalAPIAudiences and additionalAPIIssuers, the apiserver will continue to accept the old tokens.
+After 48 minutes (80% of 3607 seconds), Kubernetes will begin to refresh the issued tokens, and the new service-account-issuer will be used for the updated tokens. After 90 minutes (3607 seconds plus a short buffer) following the kube-apiserver restart, you can remove the serviceAccount configuration from the control-plane-manager configuration.
 
 **Important!** If you use [istio](../../modules/110-istio/) module, you have to restart all the application pods under istio control after changing `clusterDomain`.

--- a/modules/042-kube-dns/docs/FAQ.md
+++ b/modules/042-kube-dns/docs/FAQ.md
@@ -22,6 +22,7 @@ metadata:
   name: control-plane-manager
 spec:
   enabled: true
+  version: 1
   settings:
     apiserver:
       certSANs:
@@ -39,6 +40,23 @@ spec:
 1. In the [kubeDns.clusterDomainAliases](configuration.html#parameters) section, enter:
     - the old clusterDomain.
     - the new clusterDomain.
+
+Example:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: kube-dns
+spec:
+  version: 1
+  enabled: true
+  settings:
+    clusterDomainAliases:
+      - <old clusterDomain>
+      - <new clusterDomain>
+```
+
 1. Wait until kube-apiserver is restarted.
 1. Replace the old `clusterDomain` with the new one in `dhctl config edit cluster-configuration`
 1.

--- a/modules/042-kube-dns/docs/FAQ_RU.md
+++ b/modules/042-kube-dns/docs/FAQ_RU.md
@@ -15,7 +15,7 @@ search: DNS, domain, домен, clusterdomain
 
 Пример:
 
-```
+```yaml
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
@@ -36,13 +36,13 @@ spec:
         - https://kubernetes.default.svc.<новый clusterDomain>
 ```
 
-
 1. В [kubeDns.clusterDomainAliases](configuration.html#параметры) указать:
     - старый clusterDomain;
     - новый clusterDomain.
 1. Дождаться переката kube-apiserver.
 1. Поменять `clusterDomain` на новый в `dhctl config edit cluster-configuration`.
 
-**Важно!** Если версия вашего Kubernetes 1.20 и выше, контроллеры для работы с apiserver гарантированно используют [расширенные токены для ServiceAccount'ов](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection). Это означает, что каждый такой токен содержит дополнительные поля `iss:` и `aud:`, которые включают в себя старый `clusterDomain` (например, `"iss": "https://kubernetes.default.svc.cluster.local"`). При смене `clusterDomain` apiserver начнет выдвать токены с новым `service-account-issuer`, но багодаря произведенной конфигурации `additionalAPIAudiences` и `additionalAPIIssuers`, по прежнему будет принимать старые токены. По истечению 48 минут (80% от 3607 секнуд) kubernetes начнет обновлять выпущенные токены, при обновлении будет использован новый `service-account-issuer`. Через 90 минут (3607 секунд и еще немного) после переката kube-apiserver вы можете удалить конфигурацию serviceAccount из конфигурации control-plane-manager.
+**Важно!** Если версия вашего Kubernetes 1.20 и выше, контроллеры для работы с apiserver гарантированно используют [расширенные токены для ServiceAccount'ов](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection). Это означает, что каждый такой токен содержит дополнительные поля `iss:` и `aud:`, которые включают в себя старый `clusterDomain` (например, `"iss": "https://kubernetes.default.svc.cluster.local"`).
+При смене `clusterDomain` apiserver начнет выдавать токены с новым `service-account-issuer`, но благодаря произведенной конфигурации `additionalAPIAudiences` и `additionalAPIIssuers` по-прежнему будет принимать старые токены. По истечении 48 минут (80% от 3607 секунд) Kubernetes начнет обновлять выпущенные токены, при обновлении будет использован новый `service-account-issuer`. Через 90 минут (3607 секунд и немного больше) после перезагрузки kube-apiserver вы можете удалить конфигурацию `serviceAccount` из конфигурации control-plane-manager.
 
 **Важно!** Если вы используете модуль [istio](../../modules/110-istio/), после смены `clusterDomain` обязательно потребуется рестарт всех прикладных подов под управлением Istio.

--- a/modules/042-kube-dns/docs/FAQ_RU.md
+++ b/modules/042-kube-dns/docs/FAQ_RU.md
@@ -7,15 +7,42 @@ search: DNS, domain, домен, clusterdomain
 
 Добавляем новый домен и сохраняем предыдущий:
 
-1. В [controlPlaneManager.apiserver.certSANs](../040-control-plane-manager/configuration.html#parameters-apiserver-certsans) прописать:
-    - `kubernetes.default.svc.<старый clusterDomain>`;
-    - `kubernetes.default.svc.<новый clusterDomain>`.
+1. В [controlPlaneManager.apiserver](../040-control-plane-manager/configuration.html) выполнить конфигурацию параметров:
+
+- [controlPlaneManager.apiserver.certSANs](../040-control-plane-manager/configuration.html#parameters-apiserver-certsans)
+- [apiserver.serviceAccount.additionalAPIAudiences](../040-control-plane-manager/configuration.html#parameters-apiserver-serviceaccount-additionalapiaudiences)
+- [apiserver.serviceAccount.additionalAPIIssuers](../040-control-plane-manager/configuration.html#parameters-apiserver-serviceaccount-additionalapiissuers)
+
+Пример:
+
+```
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: control-plane-manager
+spec:
+  enabled: true
+  settings:
+    apiserver:
+      certSANs:
+       - kubernetes.default.svc.<старый clusterDomain>
+       - kubernetes.default.svc.<новый clusterDomain>
+      serviceAccount:
+        additionalAPIAudiences:
+        - https://kubernetes.default.svc.<старый clusterDomain>
+        - https://kubernetes.default.svc.<новый clusterDomain>
+        additionalAPIIssuers:
+        - https://kubernetes.default.svc.<старый clusterDomain>
+        - https://kubernetes.default.svc.<новый clusterDomain>
+```
+
+
 1. В [kubeDns.clusterDomainAliases](configuration.html#параметры) указать:
     - старый clusterDomain;
     - новый clusterDomain.
 1. Дождаться переката kube-apiserver.
 1. Поменять `clusterDomain` на новый в `dhctl config edit cluster-configuration`.
 
-**Важно!** Если версия вашего Kubernetes 1.20 и выше, контроллеры для работы с apiserver гарантированно используют [расширенные токены для ServiceAccount'ов](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection). Это означает, что каждый такой токен содержит дополнительные поля `iss:` и `aud:`, которые включают в себя старый `clusterDomain` (например, `"iss": "https://kubernetes.default.svc.cluster.local"`). При смене `clusterDomain` apiserver перестанет принимать запросы со старыми токенами, что приведет к ошибкам в работе всех контроллеров, включая deckhouse. Решение — дождаться ротации токенов, которая произойдет раньше, чем expiration time токена, либо рестартнуть все поды со всеми контроллерами.
+**Важно!** Если версия вашего Kubernetes 1.20 и выше, контроллеры для работы с apiserver гарантированно используют [расширенные токены для ServiceAccount'ов](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection). Это означает, что каждый такой токен содержит дополнительные поля `iss:` и `aud:`, которые включают в себя старый `clusterDomain` (например, `"iss": "https://kubernetes.default.svc.cluster.local"`). При смене `clusterDomain` apiserver начнет выдвать токены с новым `service-account-issuer`, но багодаря произведенной конфигурации `additionalAPIAudiences` и `additionalAPIIssuers`, по прежнему будет принимать старые токены. По истечению 48 минут (80% от 3607 секнуд) kubernetes начнет обновлять выпущенные токены, при обновлении будет использован новый `service-account-issuer`. Через 90 минут (3607 секунд и еще немного) после переката kube-apiserver вы можете удалить конфигурацию serviceAccount из конфигурации control-plane-manager.
 
 **Важно!** Если вы используете модуль [istio](../../modules/110-istio/), после смены `clusterDomain` обязательно потребуется рестарт всех прикладных подов под управлением Istio.

--- a/modules/042-kube-dns/docs/FAQ_RU.md
+++ b/modules/042-kube-dns/docs/FAQ_RU.md
@@ -21,6 +21,7 @@ kind: ModuleConfig
 metadata:
   name: control-plane-manager
 spec:
+  version: 1
   enabled: true
   settings:
     apiserver:

--- a/modules/042-kube-dns/docs/FAQ_RU.md
+++ b/modules/042-kube-dns/docs/FAQ_RU.md
@@ -40,6 +40,23 @@ spec:
 1. В [kubeDns.clusterDomainAliases](configuration.html#параметры) указать:
     - старый clusterDomain;
     - новый clusterDomain.
+
+Пример:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: kube-dns
+spec:
+  version: 1
+  enabled: true
+  settings:
+    clusterDomainAliases:
+      - <старый clusterDomain>
+      - <новый clusterDomain>
+```
+
 1. Дождаться переката kube-apiserver.
 1. Поменять `clusterDomain` на новый в `dhctl config edit cluster-configuration`.
 


### PR DESCRIPTION
## Description

Updating documentation  and  kubeadm config for seamless `clusterDomain` swapping

## Why do we need it, and what problem does it solve?

The current instruction to change the `clusterDomain` may cause short-term cluster issues. The updated instruction allows you to do this seamlessly without downtime, as described here:

https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection

> You can specify the --service-account-issuer argument multiple times, this can be useful to enable a non-disruptive change of the issuer. When this flag is specified multiple times, the first is used to generate tokens and all are used to determine which issuers are accepted. You must be running Kubernetes v1.22 or later to be able to specify --service-account-issuer multiple times.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

You can specify an additional service-account-issuer by configuring the control-plane-manager module (`apiserver.serviceAccount.additionalAPIIssuers`).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi,control-plane-manager,kube-dns
type: fix 
summary: Seamless change of clusterDomain
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
