### PR TITLE
[dynamix] capd add extnet to the dynamixcluster

### DIFF
--- a/ee/candi/cloud-providers/dynamix/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/dynamix/openapi/cluster_configuration.yaml
@@ -43,7 +43,7 @@ apiVersions:
           username: '<USERNAME>'
           password: '<PASSWORD>'
           insecure: true
-    required: [apiVersion, kind, sshPublicKey, location, account, masterNodeGroup, nodeNetworkCIDR, layout, provider]
+    required: [apiVersion, kind, sshPublicKey, location, account, externalNetwork, masterNodeGroup, nodeNetworkCIDR, layout, provider]
     properties:
       apiVersion:
         type: string
@@ -60,6 +60,11 @@ apiVersions:
       account:
         type: string
         description: Account name.
+      externalNetwork:
+        type: string
+        description: |
+          External network name.
+        example: extnet_vlan_1700
       masterNodeGroup:
         type: object
         additionalProperties: false
@@ -79,7 +84,7 @@ apiVersions:
           instanceClass:
             type: object
             additionalProperties: false
-            required: [numCPUs, memory, imageName, storageEndpoint, pool, externalNetwork]
+            required: [numCPUs, memory, imageName, storageEndpoint, pool]
             description: |
               Partial contents of the fields of the [DynamixInstanceClass](cr.html#dynamixinstanceclass).
             properties: &instanceClassProperties
@@ -122,11 +127,6 @@ apiVersions:
                 description: |
                   Storage pool name.
                 example: pool_a
-              externalNetwork:
-                type: string
-                description: |
-                  External network name.
-                example: extnet_vlan_1700
       nodeGroups:
         type: array
         description: |

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/variables.tf
@@ -33,7 +33,7 @@ locals{
   location = lookup(var.providerClusterConfiguration, "location", null)
   storage_endpoint = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "storageEndpoint", null)
   pool = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "pool", null)
-  extnet_name = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "externalNetwork", null)
+  extnet_name = lookup(var.providerClusterConfiguration, "externalNetwork", null)
   vins_name = join("-", [local.resource_name_prefix, "vins"])
   driver = "KVM_X86"
   net_type_vins = "VINS"

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/variables.tf
@@ -36,7 +36,7 @@ locals {
   image_name = lookup(local.instance_class, "imageName", null)
   resource_group_name = join("-", [local.resource_name_prefix, "rg"])
   pool = lookup(local.instance_class, "pool", null)
-  extnet_name = lookup(local.instance_class, "externalNetwork", null)
+  extnet_name = lookup(var.providerClusterConfiguration, "externalNetwork", null)
   vins_name = join("-", [local.resource_name_prefix, "vins"])
   driver = "KVM_X86"
   net_type_vins = "VINS"

--- a/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
@@ -11,5 +11,5 @@ spec:
   resourceGroup: "{{ $prefix }}-rg"
   {{- end }}
   {{- if $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}
-  resourceGroup: "{{ $prefix }}-rg"
+  externalNetwork: "{{ $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}"
   {{- end }}

--- a/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
@@ -11,7 +11,7 @@ spec:
   resourceGroup: "{{ $prefix }}-rg"
   internalNetwork: "{{ $prefix }}-vins"
   {{- end }}
-  {{- if $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}
-  externalNetwork: "{{ $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}"
+  {{- if $providerClusterConfiguration.externalNetwork }}
+  externalNetwork: "{{ $providerClusterConfiguration.externalNetwork }}"
   {{- end }}
 

--- a/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
@@ -1,4 +1,5 @@
 {{- $prefix := .Values.global.clusterConfiguration.cloud.prefix | required "global.clusterConfiguration.cloud.prefix is required" }}
+{{- $providerClusterConfiguration := .dynamix | required "internal.providerClusterConfiguration is required" }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: DynamixCluster
 metadata:
@@ -7,5 +8,8 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capd-controller-manager")) | nindent 2 }}
 spec:
   {{- if $prefix }}
+  resourceGroup: "{{ $prefix }}-rg"
+  {{- end }}
+  {{- if $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}
   resourceGroup: "{{ $prefix }}-rg"
   {{- end }}

--- a/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/capi/cluster.yaml
@@ -9,7 +9,9 @@ metadata:
 spec:
   {{- if $prefix }}
   resourceGroup: "{{ $prefix }}-rg"
+  internalNetwork: "{{ $prefix }}-vins"
   {{- end }}
   {{- if $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}
   externalNetwork: "{{ $providerClusterConfiguration.masterNodeGroup.instanceClass.externalNetwork }}"
   {{- end }}
+

--- a/ee/modules/030-cloud-provider-dynamix/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/openapi/values.yaml
@@ -48,7 +48,7 @@ properties:
               username: '<USERNAME>'
               password: '<PASSWORD>'
               insecure: true
-        required: [ apiVersion, kind, sshPublicKey, location, account, masterNodeGroup, nodeNetworkCIDR, layout, provider ]
+        required: [ apiVersion, kind, sshPublicKey, location, account, externalNetwork, masterNodeGroup, nodeNetworkCIDR, layout, provider ]
         properties:
           apiVersion:
             type: string
@@ -65,6 +65,11 @@ properties:
           account:
             type: string
             description: Account name.
+          externalNetwork:
+            type: string
+            description: |
+              External network name.
+            example: extnet_vlan_1700
           masterNodeGroup:
             type: object
             additionalProperties: false
@@ -84,7 +89,7 @@ properties:
               instanceClass:
                 type: object
                 additionalProperties: false
-                required: [ numCPUs, memory, imageName, storageEndpoint, pool, externalNetwork ]
+                required: [ numCPUs, memory, imageName, storageEndpoint, pool ]
                 description: |
                   Partial contents of the fields of the [DynamixInstanceClass](cr.html#dynamixinstanceclass).
                 properties: &instanceClassProperties
@@ -127,11 +132,6 @@ properties:
                     description: |
                       Storage pool name.
                     example: pool_a
-                  externalNetwork:
-                    type: string
-                    description: |
-                      External network name.
-                    example: extnet_vlan_1700
           nodeGroups:
             type: array
             description: |
@@ -194,7 +194,7 @@ properties:
                 instanceClass:
                   type: object
                   additionalProperties: false
-                  required: [ numCPUs, memory, imageName, externalNetwork ]
+                  required: [ numCPUs, memory, imageName ]
                   description: |
                     Partial contents of the fields of the.
                   properties:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
