### PR TITLE
[prometheus] move externalLabels to remoteWrite and additionalAlertRelabelConfigs sections

### DIFF
--- a/modules/300-prometheus/templates/prometheus/alert-relable-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/alert-relable-secret.yaml
@@ -1,0 +1,22 @@
+{{- define "additional_relable_config_tier" }}
+{{- range $key, $value := .Values.prometheus.externalLabels }}
+- sourceLabels: [{{ $key }}]
+  targetLabel: __tmp_{{ $key }}_exists
+- sourceLabels: [__tmp_{{ $key }}_exists]
+  regex: "^$"
+  targetLabel: {{ $key }}
+  replacement: {{ $value | quote }}
+- target_label: __tmp_{{ $key }}_exists
+  action: drop
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: prometheus-alert-relable-secret
+  namespace: d8-monitoring
+data:
+  prometheus-alert-relabels.yaml: |
+    {{ include "additional_relable_config_tier" . | b64enc }}

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,5 +1,5 @@
 {{- define "external_labels_alert_relabel" }}
-{{- range $key, $value := .Values.prometheus.externalLabels }}
+{{- range $key, $value := merge (dict "prometheus" "deckhouse") .Values.externalLabels }}
 - source_labels: [{{ $key }}]
   target_label: __tmp_{{ $key }}_exists
 - source_labels: [__tmp_{{ $key }}_exists]

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,8 +1,6 @@
 {{- define "external_labels_alert_relabel" }}
 {{- range $key, $value := merge (dict "prometheus" "deckhouse") .Values.externalLabels }}
 - source_labels: [{{ $key }}]
-  target_label: __tmp_{{ $key }}_exists
-- source_labels: [__tmp_{{ $key }}_exists]
   regex: "^$"
   target_label: {{ $key }}
   replacement: {{ $value | quote }}

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,5 +1,5 @@
 {{- define "external_labels_alert_relabel" }}
-{{- $externalLabels := .Values.externalLabels }}
+{{- $externalLabels := .Values.prometheus.externalLabels }}
 {{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
 {{- range $key, $value := $externalLabels}}
 - source_labels: [{{ $key }}]

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,4 +1,4 @@
-{{- define "additional_relable_config_tier" }}
+{{- define "external_labels_alert_relabel" }}
 {{- range $key, $value := .Values.prometheus.externalLabels }}
 - sourceLabels: [{{ $key }}]
   targetLabel: __tmp_{{ $key }}_exists
@@ -15,8 +15,8 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: prometheus-alert-relable-secret
+  name: prometheus-external-labels-alert-relabel-secret
   namespace: d8-monitoring
 data:
   prometheus-alert-relabels.yaml: |
-    {{ include "additional_relable_config_tier" . | b64enc }}
+    {{ include "external_labels_alert_relabel" . | b64enc }}

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,5 +1,7 @@
 {{- define "external_labels_alert_relabel" }}
-{{- range $key, $value := merge (dict "prometheus" "deckhouse") .Values.externalLabels }}
+{{- $externalLabels := .Values.externalLabels }}
+{{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
+{{- range $key, $value := $externalLabels}}
 - source_labels: [{{ $key }}]
   regex: "^$"
   target_label: {{ $key }}

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -17,6 +17,7 @@ type: Opaque
 metadata:
   name: prometheus-external-labels-alert-relabel-secret
   namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "additional-configs-for-prometheus" "main")) | nindent 2 }}
 data:
-  prometheus-alert-relabels.yaml: |
+  alert-relabels.yaml: |
     {{ include "external_labels_alert_relabel" . | b64enc }}

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,13 +1,8 @@
 {{- define "external_labels_alert_relabel" }}
 {{- range $key, $value := .Values.prometheus.externalLabels }}
 - sourceLabels: [{{ $key }}]
-  targetLabel: __tmp_{{ $key }}_exists
-- sourceLabels: [__tmp_{{ $key }}_exists]
   regex: "^$"
-  targetLabel: {{ $key }}
   replacement: {{ $value | quote }}
-- target_label: __tmp_{{ $key }}_exists
-  action: drop
 {{- end }}
 {{- end }}
 ---

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,10 +1,10 @@
 {{- define "external_labels_alert_relabel" }}
 {{- range $key, $value := .Values.prometheus.externalLabels }}
-- sourceLabels: [{{ $key }}]
-  targetLabel: __tmp_{{ $key }}_exists
-- sourceLabels: [__tmp_{{ $key }}_exists]
+- source_labels: [{{ $key }}]
+  target_label: __tmp_{{ $key }}_exists
+- source_labels: [__tmp_{{ $key }}_exists]
   regex: "^$"
-  targetLabel: {{ $key }}
+  target_label: {{ $key }}
   replacement: {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus-external-labels-alert-relabel-secret.yaml
@@ -1,7 +1,10 @@
 {{- define "external_labels_alert_relabel" }}
 {{- range $key, $value := .Values.prometheus.externalLabels }}
 - sourceLabels: [{{ $key }}]
+  targetLabel: __tmp_{{ $key }}_exists
+- sourceLabels: [__tmp_{{ $key }}_exists]
   regex: "^$"
+  targetLabel: {{ $key }}
   replacement: {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -150,10 +150,7 @@ spec:
 {{- end }}
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
-  externalLabels:
-{{- with .Values.prometheus.externalLabels }}
-    {{- . | toYaml | nindent 4 }}
-{{- end }}
+  externalLabels: {}
     prometheus: deckhouse
   prometheusExternalLabelName: ""
   replicaExternalLabelName: ""
@@ -219,9 +216,16 @@ spec:
     headers:
       X-Auth-Token: {{ .spec.customAuthToken }}
     {{- end }}
+
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
-    {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
+      {{- .Values.spec.writeRelabelConfigs | toYaml | nindent 2 }}
+      {{- if .Values.externalLabels }}
+      {{- range $key, $value := .Values.externalLabels }}
+      - action: keep
+        regex: '{{ printf "%s:%s" $key $value | quote }}'
+      {{- end }}
+      {{- end }}
     {{- end }}
     {{- if .spec.tlsConfig }}
       {{- $tlsConfig := .spec.tlsConfig | deepCopy }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,11 +218,7 @@ spec:
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
-    - source_labels: [prometheus]
-      target_label: __tmp_prometheus_exists
-    - source_labels: [__tmp_prometheus_exists]
-      regex: "^$"
-      target_label: prometheus
+    - target_label: prometheus
       replacement: deckhouse
     {{- if .Values.prometheus.externalLabels }}
     {{- range $key, $value := .Values.prometheus.externalLabels }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -224,6 +224,8 @@ spec:
       {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]
+        targetLabel: __tmp_{{ $key }}_exists
+      - sourceLabels: [{{ $key }}]
         regex: "^$"
         replacement: {{ $value | quote }}
       {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -228,6 +228,8 @@ spec:
       - sourceLabels: [{{ $key }}]
         regex: "^$"
         replacement: {{ $value | quote }}
+      - target_label: __tmp_{{ $key }}_exists
+        action: drop
       {{- end }}
       {{- end }}
     {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -224,13 +224,8 @@ spec:
       {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]
-        targetLabel: __tmp_{{ $key }}_exists
-      - sourceLabels: [__tmp_{{ $key }}_exists]
         regex: "^$"
-        targetLabel: {{ $key }}
         replacement: {{ $value | quote }}
-      - target_label: __tmp_{{ $key }}_exists
-        action: drop
       {{- end }}
       {{- end }}
     {{- end }}
@@ -252,9 +247,9 @@ spec:
   - name: prometheus-main-additional-configs
     key: alert-relabels.yaml
     {{- if .Values.prometheus.externalLabels }}
-  - name: prometheus-alert-relable-secret
+  - name: prometheus-external-labels-alert-relabel-secret
     key: prometheus-alert-relabels.yaml
-    {{ end }}
+    {{- end }}
   additionalAlertManagerConfigs:
     name: prometheus-main-additional-configs
     key: alert-managers.yaml

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,11 +218,11 @@ spec:
 
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
-      {{- .Values.spec.writeRelabelConfigs | toYaml | nindent 2 }}
+      {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
       - action: keep
         regex: "prometheus: deckhouse.*"
-      {{- if .Values.externalLabels }}
-      {{- range $key, $value := .Values.externalLabels }}
+      {{- if .Values.prometheus.externalLabels }}
+      {{- range $key, $value := .Values.prometheus.externalLabels }}
       - action: keep
         regex: '{{ printf "%s:%s.*" $key $value | quote }}'
       {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -220,8 +220,6 @@ spec:
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
       {{- .spec.writeRelabelConfigs | toYaml | nindent 6 }}
-      - targetLabel: prometheus
-        replacement: deckhouse
       {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -215,22 +215,22 @@ spec:
     headers:
       X-Auth-Token: {{ .spec.customAuthToken }}
     {{- end }}
-  {{- if .spec.writeRelabelConfigs }}
-  writeRelabelConfigs:
-    {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
-    - targetLabel: prometheus
-      replacement: deckhouse
-    {{- if .Values.prometheus.externalLabels }}
-    {{- range $key, $value := .Values.prometheus.externalLabels }}
-    - sourceLabels: [{{ $key }}]
-      targetLabel: __tmp_{{ $key }}_exists
-    - sourceLabels: [__tmp_{{ $key }}_exists]
-      regex: "^$"
-      targetLabel: {{ $key }}
-      replacement: {{ $value | quote }}
+    {{- if .spec.writeRelabelConfigs }}
+    writeRelabelConfigs:
+      {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
+      - targetLabel: prometheus
+        replacement: deckhouse
+      {{- with .Values.prometheus.externalLabels }}
+      {{- range $key, $value := . }}
+      - sourceLabels: [{{ $key }}]
+        targetLabel: __tmp_{{ $key }}_exists
+      - sourceLabels: [__tmp_{{ $key }}_exists]
+        regex: "^$"
+        targetLabel: {{ $key }}
+        replacement: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     {{- end }}
-    {{- end }}
-  {{- end }}
     {{- if .spec.tlsConfig }}
       {{- $tlsConfig := .spec.tlsConfig | deepCopy }}
       {{- if .spec.tlsConfig.ca }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -229,6 +229,8 @@ spec:
         regex: "^$"
         targetLabel: {{ $key }}
         replacement: {{ $value | quote }}
+      - target_label: __tmp_{{ $key }}_exists
+        action: drop
       {{- end }}
       {{- end }}
     {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -196,7 +196,7 @@ spec:
     matchLabels:
       prometheus: main
       component: rules
-{{- $externalLabels := .Values.externalLabels }}
+{{- $externalLabels := .Values.prometheus.externalLabels }}
 {{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
 {{- if .Values.prometheus.internal.remoteWrite }}
   remoteWrite:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,7 +218,7 @@ spec:
     {{- end }}
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
-      {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
+      {{- .spec.writeRelabelConfigs | toYaml | nindent 6 }}
       - targetLabel: prometheus
         replacement: deckhouse
       {{- with $externalLabels }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -246,10 +246,6 @@ spec:
   additionalAlertRelabelConfigs:
   - name: prometheus-main-additional-configs
     key: alert-relabels.yaml
-    {{- if .Values.prometheus.externalLabels }}
-  - name: prometheus-external-labels-alert-relabel-secret
-    key: prometheus-alert-relabels.yaml
-    {{- end }}
   additionalAlertManagerConfigs:
     name: prometheus-main-additional-configs
     key: alert-managers.yaml

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -220,8 +220,8 @@ spec:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
     - targetLabel: prometheus
       replacement: deckhouse
-    {{- if .Values.prometheus.externalLabels }}
-    {{- range $key, $value := .Values.prometheus.externalLabels }}
+    {{- if .Values.externalLabels }}
+    {{- range $key, $value := .Values.externalLabels }}
     - sourceLabels: [{{ $key }}]
       targetLabel: __tmp_{{ $key }}_exists
     - sourceLabels: [__tmp_{{ $key }}_exists]

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -150,6 +150,9 @@ spec:
 {{- end }}
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+  # Empty field becouse when scraping metrics via the Federation API,
+  # labels from externalLabels are being added, 
+  # which makes the series in long-term storage and regular Prometheus different
   externalLabels: {}
   prometheusExternalLabelName: ""
   replicaExternalLabelName: ""

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,12 +218,20 @@ spec:
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
-    - action: keep
-      regex: "prometheus: deckhouse.*"
+    - source_labels: [prometheus]
+      target_label: __tmp_prometheus_exists
+    - source_labels: [__tmp_prometheus_exists]
+      regex: "^$"
+      target_label: prometheus
+      replacement: deckhouse
     {{- if .Values.prometheus.externalLabels }}
     {{- range $key, $value := .Values.prometheus.externalLabels }}
-    - action: keep
-      regex: '{{ printf "%s:%s.*" $key $value | quote }}'
+    - source_labels: [{{ $key }}]
+      target_label: __tmp_{{ $key }}_exists
+    - source_labels: [__tmp_{{ $key }}_exists]
+      regex: "^$"
+      target_label: {{ $key }}
+      replacement: {{ $value | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -217,15 +217,15 @@ spec:
     {{- end }}
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
-      {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
-      - action: keep
-        regex: "prometheus: deckhouse.*"
-      {{- if .Values.prometheus.externalLabels }}
-      {{- range $key, $value := .Values.prometheus.externalLabels }}
-      - action: keep
-        regex: '{{ printf "%s:%s.*" $key $value | quote }}'
-      {{- end }}
-      {{- end }}
+    {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
+    - action: keep
+      regex: "prometheus: deckhouse.*"
+    {{- if .Values.prometheus.externalLabels }}
+    {{- range $key, $value := .Values.prometheus.externalLabels }}
+    - action: keep
+      regex: '{{ printf "%s:%s.*" $key $value | quote }}'
+    {{- end }}
+    {{- end }}
     {{- end }}
     {{- if .spec.tlsConfig }}
       {{- $tlsConfig := .spec.tlsConfig | deepCopy }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -215,13 +215,13 @@ spec:
     headers:
       X-Auth-Token: {{ .spec.customAuthToken }}
     {{- end }}
-    {{- if .spec.writeRelabelConfigs }}
-    writeRelabelConfigs:
+  {{- if .spec.writeRelabelConfigs }}
+  writeRelabelConfigs:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
     - targetLabel: prometheus
       replacement: deckhouse
-    {{- if .Values.externalLabels }}
-    {{- range $key, $value := .Values.externalLabels }}
+    {{- if .Values.prometheus.externalLabels }}
+    {{- range $key, $value := .Values.prometheus.externalLabels }}
     - sourceLabels: [{{ $key }}]
       targetLabel: __tmp_{{ $key }}_exists
     - sourceLabels: [__tmp_{{ $key }}_exists]
@@ -230,7 +230,7 @@ spec:
       replacement: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- end }}
+  {{- end }}
     {{- if .spec.tlsConfig }}
       {{- $tlsConfig := .spec.tlsConfig | deepCopy }}
       {{- if .spec.tlsConfig.ca }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -224,7 +224,10 @@ spec:
       {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]
+        targetLabel: __tmp_{{ $key }}_exists
+      - sourceLabels: [__tmp_{{ $key }}_exists]
         regex: "^$"
+        targetLabel: {{ $key }}
         replacement: {{ $value | quote }}
       {{- end }}
       {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -215,7 +215,6 @@ spec:
     headers:
       X-Auth-Token: {{ .spec.customAuthToken }}
     {{- end }}
-
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
       {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -196,8 +196,8 @@ spec:
     matchLabels:
       prometheus: main
       component: rules
-{{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
 {{- $externalLabels := .Values.externalLabels }}
+{{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
 {{- if .Values.prometheus.internal.remoteWrite }}
   remoteWrite:
   {{- range .Values.prometheus.internal.remoteWrite }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -197,6 +197,7 @@ spec:
       prometheus: main
       component: rules
 {{- $externalLabels := .Values.externalLabels }}
+{{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
 {{- if .Values.prometheus.internal.remoteWrite }}
   remoteWrite:
   {{- range .Values.prometheus.internal.remoteWrite }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -218,15 +218,15 @@ spec:
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
     {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
-    - target_label: prometheus
+    - targetLabel: prometheus
       replacement: deckhouse
     {{- if .Values.prometheus.externalLabels }}
     {{- range $key, $value := .Values.prometheus.externalLabels }}
-    - source_labels: [{{ $key }}]
-      target_label: __tmp_{{ $key }}_exists
-    - source_labels: [__tmp_{{ $key }}_exists]
+    - sourceLabels: [{{ $key }}]
+      targetLabel: __tmp_{{ $key }}_exists
+    - sourceLabels: [__tmp_{{ $key }}_exists]
       regex: "^$"
-      target_label: {{ $key }}
+      targetLabel: {{ $key }}
       replacement: {{ $value | quote }}
     {{- end }}
     {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -196,7 +196,8 @@ spec:
     matchLabels:
       prometheus: main
       component: rules
-{{- $externalLabels := .Values.prometheus.externalLabels }}
+{{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
+{{- $externalLabels := .Values.externalLabels }}
 {{- if .Values.prometheus.internal.remoteWrite }}
   remoteWrite:
   {{- range .Values.prometheus.internal.remoteWrite }}
@@ -224,8 +225,6 @@ spec:
       {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]
-        targetLabel: __tmp_{{ $key }}_exists
-      - sourceLabels: [__tmp_{{ $key }}_exists]
         regex: "^$"
         targetLabel: {{ $key }}
         replacement: {{ $value | quote }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -150,7 +150,7 @@ spec:
 {{- end }}
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
-  # Empty field becouse when scraping metrics via the Federation API,
+  # Empty field because when scraping metrics via the Federation API,
   # labels from externalLabels are being added, 
   # which makes the series in long-term storage and regular Prometheus different
   externalLabels: {}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -244,7 +244,7 @@ spec:
     name: prometheus-main-additional-configs
     key: scrapes.yaml
   additionalAlertRelabelConfigs:
-  - name: prometheus-main-additional-configs
+    name: prometheus-main-additional-configs
     key: alert-relabels.yaml
   additionalAlertManagerConfigs:
     name: prometheus-main-additional-configs

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -197,7 +197,6 @@ spec:
       prometheus: main
       component: rules
 {{- $externalLabels := .Values.externalLabels }}
-{{- $externalLabels = merge (dict "prometheus" "deckhouse") $externalLabels }}
 {{- if .Values.prometheus.internal.remoteWrite }}
   remoteWrite:
   {{- range .Values.prometheus.internal.remoteWrite }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -151,7 +151,6 @@ spec:
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
   externalLabels: {}
-    prometheus: deckhouse
   prometheusExternalLabelName: ""
   replicaExternalLabelName: ""
   serviceAccountName: prometheus
@@ -220,10 +219,12 @@ spec:
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:
       {{- .Values.spec.writeRelabelConfigs | toYaml | nindent 2 }}
+      - action: keep
+        regex: "prometheus: deckhouse.*"
       {{- if .Values.externalLabels }}
       {{- range $key, $value := .Values.externalLabels }}
       - action: keep
-        regex: '{{ printf "%s:%s" $key $value | quote }}'
+        regex: '{{ printf "%s:%s.*" $key $value | quote }}'
       {{- end }}
       {{- end }}
     {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -196,6 +196,7 @@ spec:
     matchLabels:
       prometheus: main
       component: rules
+{{- $externalLabels := .Values.prometheus.externalLabels }}
 {{- if .Values.prometheus.internal.remoteWrite }}
   remoteWrite:
   {{- range .Values.prometheus.internal.remoteWrite }}
@@ -220,7 +221,7 @@ spec:
       {{- .spec.writeRelabelConfigs | toYaml | nindent 4 }}
       - targetLabel: prometheus
         replacement: deckhouse
-      {{- with .Values.prometheus.externalLabels }}
+      {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]
         targetLabel: __tmp_{{ $key }}_exists

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -249,8 +249,12 @@ spec:
     name: prometheus-main-additional-configs
     key: scrapes.yaml
   additionalAlertRelabelConfigs:
-    name: prometheus-main-additional-configs
+  - name: prometheus-main-additional-configs
     key: alert-relabels.yaml
+    {{- if .Values.prometheus.externalLabels }}
+  - name: prometheus-alert-relable-secret
+    key: prometheus-alert-relabels.yaml
+    {{ end }}
   additionalAlertManagerConfigs:
     name: prometheus-main-additional-configs
     key: alert-managers.yaml

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -224,12 +224,8 @@ spec:
       {{- with $externalLabels }}
       {{- range $key, $value := . }}
       - sourceLabels: [{{ $key }}]
-        targetLabel: __tmp_{{ $key }}_exists
-      - sourceLabels: [{{ $key }}]
         regex: "^$"
         replacement: {{ $value | quote }}
-      - target_label: __tmp_{{ $key }}_exists
-        action: drop
       {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
## Description
Move externalLabels to remote_write and additionalAlertRelabelConfigs sections

## Why do we need it, and what problem does it solve?
When scraping metrics via the Federation API, labels from externalLabels are being added, which makes the series in long-term storage and regular Prometheus different. This behavior seems unclear, and we need the ability to control it.

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
When scraping metrics from long-term storage, labels from the externalLabels field will not be present in the response. However, when scraping from a regular Prometheus instance, these labels are included.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: move externalLabels to remoteWrite section
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
