### PR TITLE
[cni-cilium] Adding support for setting configuration on a per-node basis.

### DIFF
--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -14,6 +14,6 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{ $agent_daemonset_generation := include "agent_daemonset_template" (list . "undefined") | sha256sum }}
+{{ $agent_daemonset_generation := include "agent_daemonset_template" (list . "undefined" ) | sha256sum }}
 
-{{- include "agent_daemonset_template" (list . $agent_daemonset_generation) }}
+{{- include "agent_daemonset_template" (list . $agent_daemonset_generation ) }}

--- a/modules/021-cni-cilium/templates/agent/rbac-for-us.yaml
+++ b/modules/021-cni-cilium/templates/agent/rbac-for-us.yaml
@@ -164,3 +164,34 @@ subjects:
 - kind: ServiceAccount
   name: agent
   namespace: d8-{{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agent
+subjects:
+- kind: ServiceAccount
+  name: agent
+  namespace: d8-{{ .Chart.Name }}


### PR DESCRIPTION
## Description
The Cilium agent process (a.k.a. DaemonSet) supports setting configuration on a per-node basis. 
This allows overriding module config for a node or set of nodes. It is managed by `CiliumNodeConfig` objects.

Warning: Creating or modifying a `CiliumNodeConfig` will not cause changes to take effect until agent pods are deleted and re-created (or their node is restarted).

Note: Currently it is possible to customize only two parameters — `debug` and `single-cluster-route`.

## Why do we need it, and what problem does it solve?

Currently, we are unable to configure `cilium-agents` individually on each node. We need the feature to configure the d8-virtualization powered nodes joined to the same cluster in future.

## What is the expected result?

We can selectively enable or configure features for specific nodes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: feature
summary: Adding support for configuring each node individually using CiliumNodeConfig resources.
impact_level: default
```
