### PR TITLE
[dhctl] Remove heritage label from cluster-configuration secrets by default

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -533,13 +533,8 @@ func DeckhouseRegistrySecret(registry config.RegistryData) *apiv1.Secret {
 	return ret
 }
 
-func generateSecret(name, namespace string, data map[string][]byte, labels map[string]string, heritageExclude bool) *apiv1.Secret {
-	var preparedLabels map[string]string
-	if !heritageExclude {
-		preparedLabels = map[string]string{"heritage": "deckhouse"}
-	} else {
-		preparedLabels = make(map[string]string)
-	}
+func generateSecret(name, namespace string, data map[string][]byte, labels map[string]string) *apiv1.Secret {
+	preparedLabels := make(map[string]string)
 	for key, value := range labels {
 		preparedLabels[key] = value
 	}
@@ -562,8 +557,9 @@ func SecretWithTerraformState(data []byte) *apiv1.Secret {
 		map[string][]byte{
 			"cluster-tf-state.json": data,
 		},
-		nil,
-		false,
+		map[string]string{
+			"heritage": "deckhouse",
+		},
 	)
 }
 
@@ -581,7 +577,6 @@ func SecretWithClusterConfig(data []byte) *apiv1.Secret {
 		"kube-system",
 		map[string][]byte{"cluster-configuration.yaml": data},
 		nil,
-		true,
 	)
 }
 
@@ -595,7 +590,12 @@ func SecretWithProviderClusterConfig(configData, discoveryData []byte) *apiv1.Se
 		data["cloud-provider-discovery-data.json"] = discoveryData
 	}
 
-	return generateSecret("d8-provider-cluster-configuration", "kube-system", data, nil, true)
+	return generateSecret(
+		"d8-provider-cluster-configuration",
+		"kube-system",
+		data,
+		nil,
+	)
 }
 
 func SecretWithStaticClusterConfig(configData []byte) *apiv1.Secret {
@@ -603,8 +603,14 @@ func SecretWithStaticClusterConfig(configData []byte) *apiv1.Secret {
 	if configData != nil {
 		data["static-cluster-configuration.yaml"] = configData
 	}
-
-	return generateSecret("d8-static-cluster-configuration", "kube-system", data, nil, false)
+	return generateSecret(
+		"d8-static-cluster-configuration",
+		"kube-system",
+		data,
+		map[string]string{
+			"heritage": "deckhouse",
+		},
+	)
 }
 
 func SecretNameForNodeTerraformState(nodeName string) string {
@@ -624,8 +630,8 @@ func SecretWithNodeTerraformState(nodeName, nodeGroup string, data, settings []b
 			"node.deckhouse.io/node-group":      nodeGroup,
 			"node.deckhouse.io/node-name":       nodeName,
 			"node.deckhouse.io/terraform-state": "",
+			"heritage":                          "deckhouse",
 		},
-		false,
 	)
 }
 
@@ -644,8 +650,9 @@ func SecretMasterDevicePath(nodeName string, devicePath []byte) *apiv1.Secret {
 		map[string][]byte{
 			nodeName: devicePath,
 		},
-		map[string]string{},
-		false,
+		map[string]string{
+			"heritage": "deckhouse",
+		},
 	)
 }
 

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -533,8 +533,13 @@ func DeckhouseRegistrySecret(registry config.RegistryData) *apiv1.Secret {
 	return ret
 }
 
-func generateSecret(name, namespace string, data map[string][]byte, labels map[string]string) *apiv1.Secret {
-	preparedLabels := map[string]string{"heritage": "deckhouse"}
+func generateSecret(name, namespace string, data map[string][]byte, labels map[string]string, heritageExclude bool) *apiv1.Secret {
+	var preparedLabels map[string]string
+	if !heritageExclude {
+		preparedLabels = map[string]string{"heritage": "deckhouse"}
+	} else {
+		preparedLabels = make(map[string]string)
+	}
 	for key, value := range labels {
 		preparedLabels[key] = value
 	}
@@ -558,6 +563,7 @@ func SecretWithTerraformState(data []byte) *apiv1.Secret {
 			"cluster-tf-state.json": data,
 		},
 		nil,
+		false,
 	)
 }
 
@@ -575,6 +581,7 @@ func SecretWithClusterConfig(data []byte) *apiv1.Secret {
 		"kube-system",
 		map[string][]byte{"cluster-configuration.yaml": data},
 		nil,
+		true,
 	)
 }
 
@@ -588,7 +595,7 @@ func SecretWithProviderClusterConfig(configData, discoveryData []byte) *apiv1.Se
 		data["cloud-provider-discovery-data.json"] = discoveryData
 	}
 
-	return generateSecret("d8-provider-cluster-configuration", "kube-system", data, nil)
+	return generateSecret("d8-provider-cluster-configuration", "kube-system", data, nil, true)
 }
 
 func SecretWithStaticClusterConfig(configData []byte) *apiv1.Secret {
@@ -597,7 +604,7 @@ func SecretWithStaticClusterConfig(configData []byte) *apiv1.Secret {
 		data["static-cluster-configuration.yaml"] = configData
 	}
 
-	return generateSecret("d8-static-cluster-configuration", "kube-system", data, nil)
+	return generateSecret("d8-static-cluster-configuration", "kube-system", data, nil, false)
 }
 
 func SecretNameForNodeTerraformState(nodeName string) string {
@@ -618,6 +625,7 @@ func SecretWithNodeTerraformState(nodeName, nodeGroup string, data, settings []b
 			"node.deckhouse.io/node-name":       nodeName,
 			"node.deckhouse.io/terraform-state": "",
 		},
+		false,
 	)
 }
 
@@ -637,6 +645,7 @@ func SecretMasterDevicePath(nodeName string, devicePath []byte) *apiv1.Secret {
 			nodeName: devicePath,
 		},
 		map[string]string{},
+		false,
 	)
 }
 

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -607,9 +607,7 @@ func SecretWithStaticClusterConfig(configData []byte) *apiv1.Secret {
 		"d8-static-cluster-configuration",
 		"kube-system",
 		data,
-		map[string]string{
-			"heritage": "deckhouse",
-		},
+		nil,
 	)
 }
 

--- a/modules/002-deckhouse/hooks/migrate/remove_deckhouse_label_from_provider_cluster_static_cluster_config.go
+++ b/modules/002-deckhouse/hooks/migrate/remove_deckhouse_label_from_provider_cluster_static_cluster_config.go
@@ -23,7 +23,7 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -48,8 +48,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 				},
 			},
 			NameSelector:                 &types.NameSelector{MatchNames: []string{clusterConfiguration}},
-			ExecuteHookOnSynchronization: pointer.Bool(true),
-			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: ptr.To(true),
+			ExecuteHookOnEvents:          ptr.To(false),
 			FilterFunc:                   filterHasLabelHeritageDeckhouse,
 		},
 		{
@@ -62,8 +62,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 				},
 			},
 			NameSelector:                 &types.NameSelector{MatchNames: []string{providerConfiguration}},
-			ExecuteHookOnSynchronization: pointer.Bool(true),
-			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: ptr.To(true),
+			ExecuteHookOnEvents:          ptr.To(false),
 			FilterFunc:                   filterHasLabelHeritageDeckhouse,
 		},
 		{
@@ -76,8 +76,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 				},
 			},
 			NameSelector:                 &types.NameSelector{MatchNames: []string{staticConfiguration}},
-			ExecuteHookOnSynchronization: pointer.Bool(true),
-			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: ptr.To(true),
+			ExecuteHookOnEvents:          ptr.To(false),
 			FilterFunc:                   filterHasLabelHeritageDeckhouse,
 		},
 	},

--- a/modules/002-deckhouse/hooks/migrate/remove_deckhouse_label_from_provider_cluster_static_cluster_config.go
+++ b/modules/002-deckhouse/hooks/migrate/remove_deckhouse_label_from_provider_cluster_static_cluster_config.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	clusterConfiguration  = "d8-cluster-configuration"
+	providerConfiguration = "d8-provider-cluster-configuration"
+	staticConfiguration   = "d8-static-cluster-configuration"
+)
+
+// we need to change therese secrets without deckhouse pod
+// and we need to migrate existing secrets
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/deckhouse/migrate",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       clusterConfiguration,
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector:                 &types.NameSelector{MatchNames: []string{clusterConfiguration}},
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			FilterFunc:                   filterHasLabelHeritageDeckhouse,
+		},
+		{
+			Name:       providerConfiguration,
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector:                 &types.NameSelector{MatchNames: []string{providerConfiguration}},
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			FilterFunc:                   filterHasLabelHeritageDeckhouse,
+		},
+		{
+			Name:       staticConfiguration,
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector:                 &types.NameSelector{MatchNames: []string{staticConfiguration}},
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			FilterFunc:                   filterHasLabelHeritageDeckhouse,
+		},
+	},
+}, removeLabelHeritageDeckhouse)
+
+func filterHasLabelHeritageDeckhouse(secret *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	labels := secret.GetLabels()
+	if len(labels) == 0 {
+		return false, nil
+	}
+	val, ok := labels["heritage"]
+	if !ok {
+		return false, nil
+	}
+	return val == "deckhouse", nil
+}
+
+func removeLabelHeritageDeckhouse(input *go_hook.HookInput) error {
+	removeLabelIfNeed := func(input *go_hook.HookInput, snapSecretName string) {
+		snap := input.Snapshots[snapSecretName]
+
+		if len(snap) == 0 {
+			input.LogEntry.Debugf("Skip removing label 'heritage: deckhouse' for secret %s - secret not found", snapSecretName)
+			return
+		}
+
+		if !snap[0].(bool) {
+			input.LogEntry.Debugf("Skip removing label 'heritage: deckhouse' for secret %s - label not found", snapSecretName)
+			return
+		}
+
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"heritage": nil,
+				},
+			},
+		}
+
+		input.LogEntry.Warnf(fmt.Sprintf("Remove label 'heritage: deckhouse' from %s", snapSecretName))
+		input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", snapSecretName)
+	}
+
+	removeLabelIfNeed(input, clusterConfiguration)
+	removeLabelIfNeed(input, providerConfiguration)
+	removeLabelIfNeed(input, staticConfiguration)
+
+	return nil
+}

--- a/modules/040-control-plane-manager/create-d8-cluster-configuration.sh
+++ b/modules/040-control-plane-manager/create-d8-cluster-configuration.sh
@@ -147,7 +147,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    heritage: deckhouse
     validation.deckhouse.io/selector: d8-cluster-configuration
   name: d8-cluster-configuration
   namespace: kube-system


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add migration to delete `heritage: deckhouse` label for `d8-provider-cluster-configuration`, `d8-static-cluster-configuration` and `d8-cluster-configuration` secrets.

Also, remove labels set from dhctl.

## Why do we need it, and what problem does it solve?
Close [issue](https://github.com/deckhouse/deckhouse/issues/9722)
We need to provide the ability to edit a secrets from more than just the feed deckhouse

## What is the expected result?
Cloud cluster. before migration
![image](https://github.com/user-attachments/assets/c84405b1-ecf9-4e92-b766-ebfe46e3175d)
After migration. Label removed another fields not changed
![image](https://github.com/user-attachments/assets/c0ec6783-d3cd-4cab-b1de-50f7363b30b0)
deckhouse ready after restart and secrets does not changes (skip migrations)
![image](https://github.com/user-attachments/assets/86db9b41-be0f-49be-aec5-9de53a5e56f1)
![image](https://github.com/user-attachments/assets/3b5974dc-a96f-424c-a400-8332082fa384)


Static cluster
Before migration
![image](https://github.com/user-attachments/assets/df1c6baf-34ca-4f8c-baed-9ffbad6dd3dc)
After migration. Label removed another fields not changed
![image](https://github.com/user-attachments/assets/189ed65f-ac97-4401-b175-f54eeb1ba24b)
Deckhouse restarted successfully. Migration skipped.
![image](https://github.com/user-attachments/assets/8635cb70-d787-4456-857f-1e5f0deab211)

hybrid cluster
![image](https://github.com/user-attachments/assets/cdb98bf6-b2f2-4567-a83b-2eee02671aa8)
After migration. Label removed another fields not changed
![image](https://github.com/user-attachments/assets/b2af7d64-92b3-4576-8692-db8def22f945)
Deckhouse restarted successfully. Migration skipped
![image](https://github.com/user-attachments/assets/cc10fabc-d959-4506-be85-05341f9411ac)


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: delete heritage: deckhouse label from d8-provider-cluster-configuration and d8-cluster-configuration
impact: users can update secrets by IaC and serviceaccounts
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
