### PR TITLE
[l2-load-balancer] Deprecating the module

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/ee/modules/160-multitenancy-manager/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/300-prometheus/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/381-l2-load-balancer/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/modules/381-l2-load-balancer/requirements"
 	_ "github.com/deckhouse/deckhouse/ee/modules/450-keepalived/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/450-network-gateway/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/500-operator-trivy/hooks"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2369,6 +2369,17 @@ alerts:
         Kubernetes version &quot;{{ $labels.k8s_version }}&quot; has reached End Of Life.
       severity: "4"
       markupFormat: markdown
+    - name: L2LoadBalancerModuleDeprecated
+      sourceFile: ee/modules/381-l2-load-balancer/monitoring/prometheus-rules/services.yaml
+      moduleUrl: 381-l2-load-balancer
+      module: l2-load-balancer
+      edition: ee
+      description: |
+        The L2LoadBalancer module is deprecated and will be removed in a future release. Disable the module and use MetalLB module in L2 mode.
+      summary: |
+        L2LoadBalancer module is deprecated
+      severity: "3"
+      markupFormat: markdown
     - name: L2LoadBalancerOrphanServiceFound
       sourceFile: ee/modules/381-l2-load-balancer/monitoring/prometheus-rules/services.yaml
       moduleUrl: 381-l2-load-balancer

--- a/ee/modules/381-l2-load-balancer/hooks/alert_module_deprecated.go
+++ b/ee/modules/381-l2-load-balancer/hooks/alert_module_deprecated.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	l2LoadBalancerModuleDeprecatedKey = "l2LoadBalancer:isModuleEnabled"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, alertModuleDeprecatedL2lbExists)
+
+func alertModuleDeprecatedL2lbExists(input *go_hook.HookInput) error {
+	requirements.SaveValue(l2LoadBalancerModuleDeprecatedKey, true)
+
+	input.MetricsCollector.Set(
+		"d8_l2_load_balancer_module_enabled",
+		1,
+		map[string]string{},
+		metrics.WithGroup("d8_l2_load_balancer_deprecated"),
+	)
+	return nil
+}

--- a/ee/modules/381-l2-load-balancer/hooks/alert_module_deprecated_test.go
+++ b/ee/modules/381-l2-load-balancer/hooks/alert_module_deprecated_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	_ "github.com/flant/addon-operator/sdk"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("l2LoadBalancer hooks :: set alert for deprecated module ::", func() {
+	const (
+		initValuesString       = `{"global": {"discovery": {}}}`
+		initConfigValuesString = `{}`
+	)
+
+	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+	f.RegisterCRD("network.deckhouse.io", "v1alpha1", "L2LoadBalancer", false)
+
+	Context("Module enable, l2LoadBalancer object exits in cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("The alert is set", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			metrics := f.MetricsCollector.CollectedMetrics()
+			Expect(metrics).To(HaveLen(1))
+			Expect(metrics[0].Name).To(Equal("d8_l2_load_balancer_module_enabled"))
+			Expect(*metrics[0].Value).To(Equal(float64(1)))
+			isModuleIsEnabled, exists := requirements.GetValue(l2LoadBalancerModuleDeprecatedKey)
+			Expect(exists).To(BeTrue())
+			Expect(isModuleIsEnabled).To(BeTrue())
+		})
+
+	})
+
+})

--- a/ee/modules/381-l2-load-balancer/hooks/disable_requirements_flag.go
+++ b/ee/modules/381-l2-load-balancer/hooks/disable_requirements_flag.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterDeleteHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:             "/modules/l2-load-balancer/discovery",
+}, handleDeleteFlag)
+
+func handleDeleteFlag(input *go_hook.HookInput) error {
+	_ = input.Snapshots
+	requirements.RemoveValue(l2LoadBalancerModuleDeprecatedKey)
+	return nil
+}

--- a/ee/modules/381-l2-load-balancer/hooks/disable_requirements_flag_test.go
+++ b/ee/modules/381-l2-load-balancer/hooks/disable_requirements_flag_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	_ "github.com/flant/addon-operator/sdk"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("l2LoadBalancer hooks :: disable requirements flag ::", func() {
+	const (
+		initValuesString       = `{"global": {"discovery": {}}}`
+		initConfigValuesString = `{}`
+	)
+
+	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+	Context("Module disable, requirements flag don't exist", func() {
+		BeforeEach(func() {
+			f.RunHook()
+		})
+
+		It("The alert is set", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			_, exists := requirements.GetValue(l2LoadBalancerModuleDeprecatedKey)
+			Expect(exists).To(BeFalse())
+		})
+
+	})
+
+})

--- a/ee/modules/381-l2-load-balancer/monitoring/prometheus-rules/services.yaml
+++ b/ee/modules/381-l2-load-balancer/monitoring/prometheus-rules/services.yaml
@@ -16,3 +16,19 @@
           There is orphan service in the namespace: `{{$labels.namespace}}` with the name: `{{$labels.name}}` which has irrelevant L2LoadBalancer name.
 
           It is recommended to check L2LoadBalancer name in annotations (`network.deckhouse.io/l2-load-balancer-name`).
+- name: d8.l2-load-balancer.deprecated
+  rules:
+    - alert: L2LoadBalancerModuleDeprecated
+      expr: d8_l2_load_balancer_module_enabled == 1
+      for: 1m
+      labels:
+        severity_level: "3"
+        tier: application
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__istio_irrelevant_external_services: ClusterHasL2LoadBalancerDeprecatedModule,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__istio_irrelevant_external_services: ClusterHasL2LoadBalancerDeprecatedModule,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        summary: L2LoadBalancer module is deprecated
+        description: |
+          The L2LoadBalancer module is deprecated and will be removed in a future release. Disable the module and use MetalLB module in L2 mode.

--- a/ee/modules/381-l2-load-balancer/requirements/check.go
+++ b/ee/modules/381-l2-load-balancer/requirements/check.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package requirements
+
+import (
+	"errors"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	l2LoadBalancerModuleDeprecatedKey                = "l2LoadBalancer:isModuleEnabled"
+	l2LoadBalancerModuleDeprecatedKeyRequirementsKey = "l2LoadBalancerModuleEnabled"
+)
+
+func init() {
+	checkRequirementIsModuleEnabled := func(_ string, getter requirements.ValueGetter) (bool, error) {
+		isModuleIsEnabled, exists := getter.Get(l2LoadBalancerModuleDeprecatedKey)
+		if exists && isModuleIsEnabled.(bool) {
+			return false, errors.New("the L2LoadBalancer module is deprecated and will be removed in a future release. Use MetalLB module in L2 mode")
+		}
+		return true, nil
+	}
+
+	requirements.RegisterCheck(l2LoadBalancerModuleDeprecatedKeyRequirementsKey, checkRequirementIsModuleEnabled)
+}

--- a/ee/modules/381-l2-load-balancer/requirements/check_test.go
+++ b/ee/modules/381-l2-load-balancer/requirements/check_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package requirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+func TestKubernetesVersionRequirement(t *testing.T) {
+	t.Run("in-config requirement met", func(t *testing.T) {
+		requirements.SaveValue(l2LoadBalancerModuleDeprecatedKey, false)
+		ok, err := requirements.CheckRequirement(l2LoadBalancerModuleDeprecatedKeyRequirementsKey, "")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("in-config requirement failed", func(t *testing.T) {
+		requirements.SaveValue(l2LoadBalancerModuleDeprecatedKey, true)
+		ok, err := requirements.CheckRequirement(l2LoadBalancerModuleDeprecatedKeyRequirementsKey, "")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+}

--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -64,15 +64,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
-  name: l2-load-balancer
-spec:
-  enabled: true
-  settings:
-  version: 1
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
   name: static-routing-manager
 spec:
   version: 1

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -54,16 +54,6 @@ spec:
       value: worker
 ---
 apiVersion: network.deckhouse.io/v1alpha1
-kind: L2LoadBalancer
-metadata:
-  name: ingress
-spec:
-  nodeSelector:
-    dedicated.worker: ""
-  addressPool:
-    - 192.168.2.100-192.168.2.150
----
-apiVersion: network.deckhouse.io/v1alpha1
 kind: RoutingTable
 metadata:
   name: myrt-main


### PR DESCRIPTION
## Description
Module `l2LoadBalancer` is deprecated. Add an alert about it.

## Why do we need it, and what problem does it solve? 
It is necessary to warn and prepare for the transfer of clients to use the MetalLB module.

## What is the expected result?
- Users are warned that the module is deprecated.
- Not allowed to update cluster if the l2-load-balancer module is enabled.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: l2-load-balancer
type: feature
summary: Set the l2-load-balancer module to deprecated status.
impact: l2-load-balancer module is deprecated. To upgrade to the next DKP version, you must disable the l2-load-balancer module.
impact_level: high
```
