### PR TITLE
[ci] Add option to test any edition on release issue

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -154,8 +154,8 @@ steps:
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
         # Add edition name for non-FE builds
-        if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-          IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+        if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+          IMAGE_EDITION=${WERF_ENV,,}
         fi
         # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
         # Use it as image tag. Add suffix to not overlap with PRs in main repo.

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -154,7 +154,7 @@ steps:
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
         # Add edition name for non-FE builds
-        if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+        if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
           IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
         fi
         # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -153,9 +153,13 @@ steps:
 
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+        # Add edition name for non-FE builds
+        if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+          IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+        fi
         # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
         # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-        IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+        IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
         echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -642,7 +642,7 @@ check_e2e_labels:
 # <template: e2e_run_job_template>
 {!{ $ctx.jobID }!}:
   name: "{!{ $ctx.jobName }!}"
-  if: ${{ github.event.inputs.cri == '{!{ $ctx.cri }!}' && github.event.inputs.k8s_version == '{!{ $ctx.kubernetesVersion }!}' && github.event.inputs.layout == '{!{ $ctx.layout }!}' }}
+  if: ${{ fromJson(inputs.test_config).cri == '{!{ $ctx.cri }!}' && github.event.inputs.k8s_version == '{!{ $ctx.kubernetesVersion }!}' && github.event.inputs.layout == '{!{ $ctx.layout }!}' }}
   env:
     PROVIDER: {!{ $ctx.providerName }!}
     CRI: {!{ $ctx.criName }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -643,7 +643,7 @@ check_e2e_labels:
 # <template: e2e_run_job_template>
 {!{ $ctx.jobID }!}:
   name: "{!{ $ctx.jobName }!}"
-  if: ${{ fromJson(inputs.test_config).cri == '{!{ $ctx.cri }!}' && github.event.inputs.k8s_version == '{!{ $ctx.kubernetesVersion }!}' && github.event.inputs.layout == '{!{ $ctx.layout }!}' }}
+  if: ${{ fromJson(inputs.test_config).cri == '{!{ $ctx.cri }!}' && fromJson(inputs.test_config).ver == '{!{ $ctx.kubernetesVersion }!}' && github.event.inputs.layout == '{!{ $ctx.layout }!}' }}
   env:
     PROVIDER: {!{ $ctx.providerName }!}
     CRI: {!{ $ctx.criName }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -424,8 +424,8 @@ check_e2e_labels:
         fi
 
         # Add edition name for non-FE tests on branch
-        if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-          IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+        if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+          IMAGE_EDITION=${WERF_ENV,,}
         fi
 
         # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -422,16 +422,21 @@ check_e2e_labels:
           SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
         fi
 
+        # Add edition name for non-FE tests on branch
+        if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+          IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+        fi
+
         # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
         INITIAL_IMAGE_TAG=
         if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-          INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
         fi
 
         # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
         # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
         # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-        IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+        IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
         INSTALL_IMAGE_NAME=
 {!{- if eq $provider "eks" }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -653,6 +653,7 @@ check_e2e_labels:
     KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
 {!{- end }!}
     EVENT_LABEL: ${{ github.event.label.name }}
+    WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 4 }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -345,6 +345,7 @@ check_e2e_labels:
     KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
 {!{- end }!}
     EVENT_LABEL: ${{ github.event.label.name }}
+    WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 4 }!}
@@ -653,7 +654,6 @@ check_e2e_labels:
     KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
 {!{- end }!}
     EVENT_LABEL: ${{ github.event.label.name }}
-    WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 4 }!}

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -1227,6 +1227,7 @@ You can trigger release related actions by commenting on this issue:
   - \`edition\` is one of \`${availableEditions}\`
 - \`/build git_ref\` will run build for release related refs.
   - \`git_ref\` is ${possibleGitRefs}
+  - \`/build/<edition> git_ref\` will also build specified edition
 
 
 **Note 1:**

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -437,12 +437,14 @@ const setCRIAndVersionsFromInputs = ({ context, core, kubernetesDefaultVersion }
   let ver = [defaultVersion];
   let multimaster = [defaultMultimaster];
 
-  if (!!context.payload.inputs.cri) {
-    const requested_cri = context.payload.inputs.cri.toLowerCase();
+  let test_config = JSON.parse(context.payload.inputs.test_config)
+
+  if (!!test_config.cri) {
+    const requested_cri = test_config.cri.toLowerCase();
     cri = requested_cri.split(',');
   }
-  if (!!context.payload.inputs.ver) {
-    const requested_ver = context.payload.inputs.ver.replace(/\./g, '_');
+  if (!!test_config.ver) {
+    const requested_ver = test_config.ver.replace(/\./g, '_');
     ver = requested_ver.split(',');
   }
   if (!!context.payload.inputs.multimaster) {
@@ -450,8 +452,10 @@ const setCRIAndVersionsFromInputs = ({ context, core, kubernetesDefaultVersion }
     multimaster = requested_multimaster;
   }
 
-  core.info(`workflow_dispatch is release related. e2e inputs: cri='${context.payload.inputs.cri}', multimaster='${context.payload.inputs.multimaster}' and version='${context.payload.inputs.ver}'.`);
+  core.info(`e2e inputs: '${JSON.stringify(context.payload.inputs)}'`);
+  core.info(`workflow_dispatch is release related. e2e parsed inputs: cri='${test_config.cri}' and version='${test_config.ver}'.`);
   core.setOutput(`multimaster`, `${multimaster}`);
+
   for (const out_cri of cri) {
     for (const out_ver of ver) {
       core.info(`run_${out_cri}_${out_ver}: true`);
@@ -737,8 +741,7 @@ const detectSlashCommand = ({ comment , context, core}) => {
       }
 
       inputs = {
-        cri: cri.join(','),
-        ver: ver.join(','),
+        test_config: JSON.stringify({ cri: cri.join(','), ver: ver.join(','), editions: "FE" }),
         multimaster: multimaster,
       }
 

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -725,6 +725,7 @@ const detectSlashCommand = ({ comment , context, core}) => {
       let ver = [];
       let cri = [];
       let multimaster;
+      let edition = "fe";
       for (const line of lines) {
         let useParts = line.split('/e2e/use/cri/');
         if (useParts[1]) {
@@ -738,10 +739,14 @@ const detectSlashCommand = ({ comment , context, core}) => {
         if (useParts[1]) {
           multimaster.push(true);
         }
+        useParts = line.split('/e2e/use/edition/');
+        if (useParts[1]) {
+          edition = useParts[1]
+        }
       }
 
       inputs = {
-        test_config: JSON.stringify({ cri: cri.join(','), ver: ver.join(','), editions: "FE" }),
+        test_config: JSON.stringify({ cri: cri.join(','), ver: ver.join(','), edition: edition }),
         multimaster: multimaster,
       }
 
@@ -1218,6 +1223,8 @@ You can trigger release related actions by commenting on this issue:
   - \`git_ref_2\` is a release-* or main branch
 - \`/e2e/use/k8s/<version>\` specifies which Kubernetes version to use for e2e test.
   - \`version\` is one of \`${availableKubernetesVersions}\`
+- \`/e2e/use/edition/<edition>\` specifies which edition to use for e2e test.
+  - \`edition\` is one of \`${availableEditions}\`
 - \`/build git_ref\` will run build for release related refs.
   - \`git_ref\` is ${possibleGitRefs}
 

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -778,9 +778,17 @@ const detectSlashCommand = ({ comment , context, core}) => {
     }
   }
 
-  const isBuild = command === '/build';
+  // Detect /build/* commands.
+  const isBuild = command.startsWith('/build');
   if (isBuild) {
     workflow_id = 'build-and-test_release.yml';
+    // Extract editions if command consists of 2 parts: /build/ce,ee release-1.64
+    const cmdParts = command.split('/');
+    if (cmdParts[2]) {
+      inputs = {
+        editions: cmdParts[2],
+      }
+    }
   }
 
   if (workflow_id === '') {

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -44,11 +44,18 @@ const labels = {
   'e2e/use/k8s/1.28': { type: 'e2e-use', ver: '1.28' },
   'e2e/use/k8s/1.29': { type: 'e2e-use', ver: '1.29' },
   'e2e/use/k8s/1.30': { type: 'e2e-use', ver: '1.30' },
-  'e2e/use/k8s/1.31': { type: 'e2e-use', ver: '1.31' },	
+  'e2e/use/k8s/1.31': { type: 'e2e-use', ver: '1.31' },
   'e2e/use/k8s/automatic': { type: 'e2e-use', ver: 'Automatic' },
 
   // E2E: use multimaster configuration
   'e2e/use/multimaster': { type: 'e2e-use', multimaster: true },
+
+  // E2E: edition
+  'e2e/use/edition/ce': { type: 'e2e-edition', edition: 'CE' },
+  'e2e/use/edition/ee': { type: 'e2e-edition', edition: 'EE' },
+  'e2e/use/edition/be': { type: 'e2e-edition', edition: 'BE' },
+  'e2e/use/edition/se': { type: 'e2e-edition', edition: 'SE' },
+  'e2e/use/edition/fe': { type: 'e2e-edition', edition: 'FE' },
 
   // Allow running workflows for external PRs.
   'status/ok-to-test': { type: 'ok-to-test' },

--- a/.github/scripts/js/e2e/slash_workflow_command.js
+++ b/.github/scripts/js/e2e/slash_workflow_command.js
@@ -60,8 +60,10 @@ function tryParseAbortE2eCluster({argv, context, core}){
   const layout = ranForSplit[1];
   const cri = ranForSplit[2];
   const k8s_version = ranForSplit[3];
+  const edition = 'fe';
   const k8sSlug = k8s_version.replace('.', '_');
   const state_artifact_name = `failed_cluster_state_${provider}_${cri}_${k8sSlug}`;
+  const test_config = JSON.stringify({ cri: cri, ver: k8s_version, edition: edition })
 
   const inputs = {
     run_id,
@@ -71,8 +73,7 @@ function tryParseAbortE2eCluster({argv, context, core}){
     ssh_master_connection_string: sshConnectStr,
 
     layout,
-    cri,
-    k8s_version,
+    test_config,
     issue_number: prNumber.toString(),
   };
 

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -100,7 +100,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'EE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ee') }}
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -114,7 +114,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'SE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'se') }}
     env:
       WERF_ENV: "SE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -128,7 +128,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'BE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'be') }}
     env:
       WERF_ENV: "BE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -142,7 +142,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'CE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ce') }}
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -32,6 +32,10 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma-separated list of editions to build'
+        required: false
+        type: string
 
 env:
 {!{ tmpl.Exec "werf_envs"               | strings.Indent 2 }!}
@@ -96,7 +100,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'EE') }}
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -110,7 +114,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'SE') }}
     env:
       WERF_ENV: "SE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -124,7 +128,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'BE') }}
     env:
       WERF_ENV: "BE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -138,7 +142,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'CE') }}
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}

--- a/.github/workflow_templates/e2e.abort.multi.yml
+++ b/.github/workflow_templates/e2e.abort.multi.yml
@@ -73,12 +73,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -90,12 +90,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -93,7 +93,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -726,7 +726,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -726,8 +726,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -725,9 +725,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -438,9 +438,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -439,7 +439,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -439,8 +439,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -566,8 +566,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
@@ -891,8 +891,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
@@ -1216,8 +1216,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
@@ -1541,8 +1541,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
@@ -1866,8 +1866,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
-              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+              IMAGE_EDITION=${WERF_ENV,,}
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -566,7 +566,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
@@ -891,7 +891,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
@@ -1216,7 +1216,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
@@ -1541,7 +1541,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
@@ -1866,7 +1866,7 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # Add edition name for non-FE builds
-            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "fe" ]]; then
               IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
             fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -32,6 +32,10 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma-separated list of editions to build'
+        required: false
+        type: string
 
 env:
 
@@ -692,7 +696,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'EE') }}
     env:
       WERF_ENV: "EE"
     # <template: build_template>
@@ -1013,7 +1017,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'SE') }}
     env:
       WERF_ENV: "SE"
     # <template: build_template>
@@ -1334,7 +1338,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'BE') }}
     env:
       WERF_ENV: "BE"
     # <template: build_template>
@@ -1655,7 +1659,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'CE') }}
     env:
       WERF_ENV: "CE"
     # <template: build_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -565,9 +565,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
@@ -886,9 +890,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
@@ -1207,9 +1215,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
@@ -1528,9 +1540,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
@@ -1849,9 +1865,13 @@ jobs:
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # Add edition name for non-FE builds
+            if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+              IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+            fi
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
             # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -696,7 +696,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'EE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ee') }}
     env:
       WERF_ENV: "EE"
     # <template: build_template>
@@ -1017,7 +1017,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'SE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'se') }}
     env:
       WERF_ENV: "SE"
     # <template: build_template>
@@ -1338,7 +1338,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'BE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'be') }}
     env:
       WERF_ENV: "BE"
     # <template: build_template>
@@ -1659,7 +1659,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'CE') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ce') }}
     env:
       WERF_ENV: "CE"
     # <template: build_template>

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -398,7 +398,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -688,7 +688,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -978,7 +978,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -1268,7 +1268,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -1848,7 +1848,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: AWS, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -1558,7 +1558,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -405,6 +406,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -695,6 +697,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -985,6 +988,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1275,6 +1279,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1855,6 +1860,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -398,7 +396,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -688,7 +686,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -978,7 +976,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -1268,7 +1266,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -1558,7 +1556,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd
@@ -1848,7 +1846,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: AWS, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: AWS
       CRI: Containerd

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -406,7 +405,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -697,7 +695,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -988,7 +985,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1279,7 +1275,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1860,7 +1855,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -402,7 +400,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -696,7 +694,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -990,7 +988,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -1284,7 +1282,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -1578,7 +1576,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -1872,7 +1870,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: Azure, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -409,6 +410,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -703,6 +705,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -997,6 +1000,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1291,6 +1295,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1879,6 +1884,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -410,7 +409,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -705,7 +703,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1000,7 +997,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1295,7 +1291,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1884,7 +1879,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -1578,7 +1578,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -402,7 +402,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -696,7 +696,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -990,7 +990,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -1284,7 +1284,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd
@@ -1872,7 +1872,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: Azure, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: Azure
       CRI: Containerd

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -401,7 +401,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -694,7 +694,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -987,7 +987,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -1280,7 +1280,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -1866,7 +1866,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: EKS, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -401,7 +399,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -694,7 +692,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -987,7 +985,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -1280,7 +1278,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -1573,7 +1571,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd
@@ -1866,7 +1864,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: EKS, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -409,7 +408,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -703,7 +701,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -997,7 +994,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1291,7 +1287,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1878,7 +1873,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -408,6 +409,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -701,6 +703,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -994,6 +997,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1287,6 +1291,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1873,6 +1878,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -1573,7 +1573,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: EKS
       CRI: Containerd

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -396,7 +394,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -684,7 +682,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -972,7 +970,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -1260,7 +1258,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -1548,7 +1546,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -1836,7 +1834,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: GCP, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -396,7 +396,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -684,7 +684,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -972,7 +972,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -1260,7 +1260,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd
@@ -1836,7 +1836,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: GCP, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -404,7 +403,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -693,7 +691,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -982,7 +979,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1271,7 +1267,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1848,7 +1843,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -1548,7 +1548,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: GCP
       CRI: Containerd

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -403,6 +404,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -691,6 +693,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -979,6 +982,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1267,6 +1271,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1843,6 +1848,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -1548,7 +1548,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -396,7 +396,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -684,7 +684,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -972,7 +972,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -1260,7 +1260,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -1836,7 +1836,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -396,7 +394,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -684,7 +682,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -972,7 +970,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -1260,7 +1258,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -1548,7 +1546,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd
@@ -1836,7 +1834,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: OpenStack
       CRI: Containerd

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -404,7 +403,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -693,7 +691,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -982,7 +979,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1271,7 +1267,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1848,7 +1843,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -403,6 +404,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -691,6 +693,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -979,6 +982,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1267,6 +1271,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1843,6 +1848,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -403,6 +404,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -691,6 +693,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -979,6 +982,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1267,6 +1271,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1843,6 +1848,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -404,7 +403,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -693,7 +691,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -982,7 +979,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1271,7 +1267,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1848,7 +1843,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -1548,7 +1548,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -396,7 +394,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -684,7 +682,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -972,7 +970,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -1260,7 +1258,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -1548,7 +1546,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -1836,7 +1834,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: Static, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -396,7 +396,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -684,7 +684,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -972,7 +972,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -1260,7 +1260,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd
@@ -1836,7 +1836,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: Static, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Static' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Static' }}
     env:
       PROVIDER: Static
       CRI: Containerd

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -1588,7 +1588,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -404,7 +404,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -700,7 +700,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -996,7 +996,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -1292,7 +1292,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -1884,7 +1884,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: VCD, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -404,7 +402,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -700,7 +698,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -996,7 +994,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -1292,7 +1290,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -1588,7 +1586,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd
@@ -1884,7 +1882,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: VCD, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: VCD
       CRI: Containerd

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -412,7 +411,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -709,7 +707,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1006,7 +1003,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1303,7 +1299,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1896,7 +1891,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -411,6 +412,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -707,6 +709,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1003,6 +1006,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1299,6 +1303,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1891,6 +1896,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -406,7 +405,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -697,7 +695,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -988,7 +985,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1279,7 +1275,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1860,7 +1855,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -398,7 +396,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -688,7 +686,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -978,7 +976,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -1268,7 +1266,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -1558,7 +1556,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -1848,7 +1846,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: vSphere, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -405,6 +406,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -695,6 +697,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -985,6 +988,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1275,6 +1279,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1855,6 +1860,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -398,7 +398,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -688,7 +688,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -978,7 +978,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -1268,7 +1268,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd
@@ -1848,7 +1848,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: vSphere, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -1558,7 +1558,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
     env:
       PROVIDER: vSphere
       CRI: Containerd

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -115,7 +115,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -408,7 +407,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -701,7 +699,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -994,7 +991,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1287,7 +1283,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1872,7 +1867,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -108,7 +108,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -400,7 +400,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -692,7 +692,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -984,7 +984,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.29"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -1276,7 +1276,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.30"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -1860,7 +1860,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes Automatic"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -25,12 +25,10 @@ on:
       layout:
         description: 'Cloud provider layout which was tested'
         required: true
-      cri:
-        description: 'CRI which was tested'
-        required: true
-      k8s_version:
-        description: 'CRI which was tested'
-        required: true
+      test_config:
+        description: 'JSON string of parameters which was tested'
+        required: false
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       # needs for run correct installer image for abort
       installer_image_path:
         description: 'Installer image without host'
@@ -108,7 +106,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -400,7 +398,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_27:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -692,7 +690,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_28:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -984,7 +982,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_29:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.29"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -1276,7 +1274,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_30:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.30"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -1568,7 +1566,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.31"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
@@ -1860,7 +1858,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_automatic:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes Automatic"
-    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && fromJson(inputs.test_config).ver == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -1568,7 +1568,7 @@ jobs:
   # <template: e2e_run_job_template>
   run_containerd_1_31:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.31"
-    if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
+    if: ${{ fromJson(inputs.test_config).cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
     env:
       PROVIDER: Yandex.Cloud
       CRI: Containerd

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -115,6 +115,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -407,6 +408,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -699,6 +701,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -991,6 +994,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1283,6 +1287,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1867,6 +1872,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -707,6 +708,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1198,6 +1200,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1689,6 +1692,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2180,6 +2184,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3157,6 +3162,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -2676,6 +2676,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2829,16 +2830,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -857,16 +862,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1343,16 +1353,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1829,16 +1844,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2315,16 +2335,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3287,16 +3312,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -863,8 +863,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1355,8 +1355,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1847,8 +1847,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2339,8 +2339,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2831,8 +2831,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3323,8 +3323,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -865,16 +870,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1359,16 +1369,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1853,16 +1868,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2347,16 +2367,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3335,16 +3360,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -871,8 +871,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1371,8 +1371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1871,8 +1871,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2371,8 +2371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2871,8 +2871,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3371,8 +3371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -715,6 +716,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1214,6 +1216,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1713,6 +1716,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2212,6 +2216,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3205,6 +3210,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -2716,6 +2716,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2869,16 +2870,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -292,8 +292,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -755,8 +755,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1226,8 +1226,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1685,8 +1685,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2152,8 +2152,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2611,8 +2611,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3074,8 +3074,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3549,8 +3549,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -290,16 +290,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -747,16 +752,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1212,16 +1222,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1665,16 +1680,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2126,16 +2146,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2579,16 +2604,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3036,16 +3066,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3505,16 +3540,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -151,6 +151,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -613,6 +614,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1083,6 +1085,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1541,6 +1544,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2007,6 +2011,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2465,6 +2470,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -2927,6 +2933,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3401,6 +3408,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -908,8 +908,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1445,8 +1445,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1982,8 +1982,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2519,8 +2519,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3056,8 +3056,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3593,8 +3593,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -2901,6 +2901,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3054,16 +3055,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=
@@ -902,16 +907,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=
@@ -1433,16 +1443,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=
@@ -1964,16 +1979,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=
@@ -2495,16 +2515,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=
@@ -3557,16 +3582,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           TERRAFORM_IMAGE_NAME=

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -752,6 +753,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1288,6 +1290,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1824,6 +1827,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2360,6 +2364,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3427,6 +3432,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -2656,6 +2656,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2809,16 +2810,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -853,16 +858,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1335,16 +1345,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1817,16 +1832,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2299,16 +2319,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3263,16 +3288,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -859,8 +859,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1347,8 +1347,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1835,8 +1835,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2323,8 +2323,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2811,8 +2811,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3299,8 +3299,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -703,6 +704,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1190,6 +1192,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1677,6 +1680,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2164,6 +2168,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3133,6 +3138,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -703,6 +704,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1190,6 +1192,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1677,6 +1680,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2164,6 +2168,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3133,6 +3138,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -2656,6 +2656,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2809,16 +2810,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -853,16 +858,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1335,16 +1345,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1817,16 +1832,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2299,16 +2319,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3263,16 +3288,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -859,8 +859,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1347,8 +1347,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1835,8 +1835,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2323,8 +2323,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2811,8 +2811,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3299,8 +3299,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -2656,6 +2656,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2809,16 +2810,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -853,16 +858,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1335,16 +1345,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1817,16 +1832,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2299,16 +2319,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3263,16 +3288,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -859,8 +859,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1347,8 +1347,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1835,8 +1835,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2323,8 +2323,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2811,8 +2811,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3299,8 +3299,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -703,6 +704,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1190,6 +1192,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1677,6 +1680,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2164,6 +2168,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3133,6 +3138,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -2736,6 +2736,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2889,16 +2890,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -869,16 +874,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1367,16 +1377,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1865,16 +1880,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2363,16 +2383,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3359,16 +3384,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -719,6 +720,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1222,6 +1224,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1725,6 +1728,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2228,6 +2232,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3229,6 +3234,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -875,8 +875,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1379,8 +1379,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1883,8 +1883,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2387,8 +2387,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2891,8 +2891,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3395,8 +3395,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -857,16 +862,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1343,16 +1353,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1829,16 +1844,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2315,16 +2335,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3287,16 +3312,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -707,6 +708,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1198,6 +1200,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1689,6 +1692,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -2180,6 +2184,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -3157,6 +3162,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -2676,6 +2676,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -2829,16 +2830,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -863,8 +863,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1355,8 +1355,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1847,8 +1847,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2339,8 +2339,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2831,8 +2831,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3323,8 +3323,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -2696,6 +2696,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2849,16 +2850,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -371,8 +371,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -867,8 +867,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1363,8 +1363,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -1859,8 +1859,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2355,8 +2355,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -2851,8 +2851,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
@@ -3347,8 +3347,8 @@ jobs:
           fi
 
           # Add edition name for non-FE tests on branch
-          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
-            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
           fi
 
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -371,16 +371,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -861,16 +866,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1351,16 +1361,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -1841,16 +1856,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -2331,16 +2351,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then
@@ -3311,16 +3336,21 @@ jobs:
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
+          # Add edition name for non-FE tests on branch
+          if [[ -n ${WERF_ENV} && ${WERF_ENV} != "FE" ]]; then
+            IMAGE_EDITION=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          fi
+
           # Prepare initial image tag for deploy/deckhouse to test switching from previous release.
           INITIAL_IMAGE_TAG=
           if [[ -n ${INITIAL_REF_SLUG} ]] ; then
-            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+            INITIAL_IMAGE_TAG=${INITIAL_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           fi
 
           # Prepare image tag for deploy/deckhouse (DECKHOUSE_IMAGE_TAG option in testing/cloud_layouts/script.sh).
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
           INSTALL_IMAGE_NAME=
           if [[ -n ${CI_COMMIT_BRANCH} ]]; then

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -216,6 +216,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -711,6 +712,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1206,6 +1208,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1701,6 +1704,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2196,6 +2200,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3181,6 +3186,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
+      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -45,7 +45,7 @@ on:
       test_config:
         description: 'JSON string of parameters of current test'
         required: false
-        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
+        default: '{"cri":"Containerd","ver":"1.27","edition":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -42,12 +42,10 @@ on:
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
-      cri:
-        description: 'A comma-separated list of cri to test. Available: Containerd.'
+      test_config:
+        description: 'JSON string of parameters of current test'
         required: false
-      ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.24 to 1.28.'
-        required: false
+        default: '{"cri":"Containerd","ver":"1.27","editions":"FE"}'
       initial_ref_slug:
         description: 'An image tag to install first and then switch to workflow context ref'
         required: false


### PR DESCRIPTION
## Description
Adds an option to build any edition on release issue with `/build/[edition]` command, and run e2e tests on any edition with `/e2e/use/edition/[edition]` command.
Resolves #4682 

## Why do we need it, and what problem does it solve?
Currently, e2e testing of various Deckhouse editions is somewhat inconvenient. This feature helps to streamline pre-release testing

## What is the expected result?
Support for comment commands `/build/[edition]` and `/e2e/use/edition/[edition]`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: feature
summary: Add option to test any edition on release issue.
impact_level: low
```

