### PR TITLE
[docs] Added a warning about changing ClusterConfiguration 

### DIFF
--- a/docs/documentation/pages/installing/CONFIGURATION.md
+++ b/docs/documentation/pages/installing/CONFIGURATION.md
@@ -6,7 +6,7 @@ permalink: en/installing/configuration.html
 Reference of the resources used during [Deckhouse installation](./).
 
 {% alert level="danger" %}
-Do not change the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in a running cluster. Deploy a new cluster, if you have to change these parameters.
+Do not change the `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` parameters in a running cluster. If you do need to change them, deploy a new cluster.
 {% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/installing/CONFIGURATION.md
+++ b/docs/documentation/pages/installing/CONFIGURATION.md
@@ -6,7 +6,7 @@ permalink: en/installing/configuration.html
 Reference of the resources used during [Deckhouse installation](./).
 
 {% alert level="danger" %}
-We do not recommend changing the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in an operational cluster. It is recommended to create a new cluster to change these parameters.
+We do not recommend changing the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in a running cluster. It is recommended to create a new cluster to change these parameters.
 {% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/installing/CONFIGURATION.md
+++ b/docs/documentation/pages/installing/CONFIGURATION.md
@@ -5,11 +5,9 @@ permalink: en/installing/configuration.html
 
 Reference of the resources used during [Deckhouse installation](./).
 
-{% alert level="warning" %}Attention!{% endalert %}
-
-Any changes to the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in an operational cluster are not recommended, as they lead to destructive changes in the cluster. It is recommended to create a new cluster from scratch to modify these parameters.
-
-To restore the cluster's functionality after such changes, it requires manual recovery and configuration updates of etcd, regeneration of all certificates, and restarting all pods, which results in significant downtime and may lead to data loss.
+{% alert level="danger" %}
+We do not recommend changing the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in an operational cluster. It is recommended to create a new cluster to change these parameters.
+{% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}
 

--- a/docs/documentation/pages/installing/CONFIGURATION.md
+++ b/docs/documentation/pages/installing/CONFIGURATION.md
@@ -5,6 +5,12 @@ permalink: en/installing/configuration.html
 
 Reference of the resources used during [Deckhouse installation](./).
 
+{% alert level="warning" %}Attention!{% endalert %}
+
+Any changes to the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in an operational cluster are not recommended, as they lead to destructive changes in the cluster. It is recommended to create a new cluster from scratch to modify these parameters.
+
+To restore the cluster's functionality after such changes, it requires manual recovery and configuration updates of etcd, regeneration of all certificates, and restarting all pods, which results in significant downtime and may lead to data loss.
+
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}
 
 {{ site.data.schemas.global.init_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/installing/CONFIGURATION.md
+++ b/docs/documentation/pages/installing/CONFIGURATION.md
@@ -6,7 +6,7 @@ permalink: en/installing/configuration.html
 Reference of the resources used during [Deckhouse installation](./).
 
 {% alert level="danger" %}
-We do not recommend changing the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in a running cluster. It is recommended to create a new cluster to change these parameters.
+Do not change the parameters `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` in a running cluster. Deploy a new cluster, if you have to change these parameters.
 {% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/installing/CONFIGURATION_RU.md
+++ b/docs/documentation/pages/installing/CONFIGURATION_RU.md
@@ -6,6 +6,12 @@ lang: ru
 
 Описание ресурсов, используемых при [установке Deckhouse](./).
 
+{% alert level="warning" %}Внимание!{% endalert %}
+
+Любые измения параметров `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере не рекомендуются, так как приводят к декструктивным изменениям кластера. Для их изменения, рекомендуется создание нового кластера с нуля.
+
+Для восстановления работоспособности кластера после изменения, требуюется ручное восстновление и изменение настроек etcd, перевыпуск всех сертификатов и перезапуск всех подов, что приводит к длительному простою, и может привести к потерям данных.
+
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}
 
 {{ site.data.schemas.global.init_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/installing/CONFIGURATION_RU.md
+++ b/docs/documentation/pages/installing/CONFIGURATION_RU.md
@@ -7,7 +7,7 @@ lang: ru
 Описание ресурсов, используемых при [установке Deckhouse](./).
 
 {% alert level="danger" %}
-Не рекомендуем изменять параметры `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере. Если изменение параметров необходимо — разверните новый кластер.
+Не изменяйте параметры `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере. Если изменение параметров необходимо — разверните новый кластер.
 {% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/installing/CONFIGURATION_RU.md
+++ b/docs/documentation/pages/installing/CONFIGURATION_RU.md
@@ -6,11 +6,9 @@ lang: ru
 
 Описание ресурсов, используемых при [установке Deckhouse](./).
 
-{% alert level="warning" %}Внимание!{% endalert %}
-
-Любые измения параметров `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере не рекомендуются, так как приводят к декструктивным изменениям кластера. Для их изменения, рекомендуется создание нового кластера с нуля.
-
-Для восстановления работоспособности кластера после изменения, требуюется ручное восстновление и изменение настроек etcd, перевыпуск всех сертификатов и перезапуск всех подов, что приводит к длительному простою, и может привести к потерям данных.
+{% alert level="danger" %}
+Не рекомендуем изменять параметры `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере. Если изменение параметров необходимо — рекомендуем развернуть новый кластер.
+{% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}
 

--- a/docs/documentation/pages/installing/CONFIGURATION_RU.md
+++ b/docs/documentation/pages/installing/CONFIGURATION_RU.md
@@ -7,7 +7,7 @@ lang: ru
 Описание ресурсов, используемых при [установке Deckhouse](./).
 
 {% alert level="danger" %}
-Не рекомендуем изменять параметры `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере. Если изменение параметров необходимо — рекомендуем развернуть новый кластер.
+Не рекомендуем изменять параметры `internalNetworkCIDRs`, `serviceSubnetCIDR`, `podSubnetNodeCIDRPrefix`, `podSubnetCIDR` в работающем кластере. Если изменение параметров необходимо — разверните новый кластер.
 {% endalert %}
 
 {{ site.data.schemas.global.cluster_configuration | format_cluster_configuration }}


### PR DESCRIPTION
## Description
Added a warning that we do not recommend changing ClusterConfiguration settings in a running cluster.

## Why do we need it, and what problem does it solve?
This solves the problem where users make changes in the ClusterConfiguration settings and the cluster fails.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Added a warning that we do not recommend changing ClusterConfiguration settings in a running cluster.

```changes
section: docs
type: chore
summary: Added a warning that we do not recommend changing ClusterConfiguration settings in a running cluster.
impact_level: low
```
