### PR TITLE
D8EtcdExcessiveDatabaseGrowth alert fix

### DIFF
--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
@@ -67,7 +67,7 @@
             ....
     - alert: D8EtcdExcessiveDatabaseGrowth
       expr: predict_linear(etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}[6h], 24*3600) >= scalar(max(d8_etcd_quota_backend_total) * 0.95)
-      for: "10m"
+      for: "30m"
       labels:
         severity_level: "4"
         tier: cluster

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -24,6 +24,7 @@ allow_alerts=(
 "CertmanagerCertificateExpired" # On some system do not have DNS
 "CertmanagerCertificateExpiredSoon" # Same as above
 "DeckhouseModuleUseEmptyDir" # TODO Need made split storage class
+"D8EtcdExcessiveDatabaseGrowth" # It may trigger during bootstrap due to a sudden increase in resource count
 )
 
 # In e2e tests with OS on older cores (AWS, Azure), ebpf_exporter does not initiliaze. Ignore this alerts


### PR DESCRIPTION
## Description

Small fix for this [pr](https://github.com/deckhouse/deckhouse/pull/9464#issue-2480896609)

## Why do we need it, and what problem does it solve?

The alert may trigger during a short-term sharp increase in the number of resources (e.g., during cluster bootstrap). The alert firing time has been increased to 30 minutes.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

D8EtcdExcessiveDatabaseGrowth alert does not trigger during bootstrap.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix 
summary: D8EtcdExcessiveDatabaseGrowth alert fix
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
