### PR TITLE
[cni-cilium] Applying the ModuleConfig changes immediately

### DIFF
--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -22,8 +22,8 @@ import (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnStartup: &go_hook.OrderedConfig{Order: 10},
-	Queue:     "/modules/cni-cilium",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/cni-cilium",
 }, setCiliumMode)
 
 func setCiliumMode(input *go_hook.HookInput) error {


### PR DESCRIPTION
## Description

Forcing cni-cilium module to apply ModuleConfig settings immediately without d8 restart. (`tunnelMode`, for example).
Some module settings are being handled in the `set_cilium_mode.go` hook which was configured to run only OnStartup (https://github.com/deckhouse/deckhouse/pull/9347). The PR fixes the problem by configuring the hook to run OnBeforeHelm.

## Why do we need it, and what problem does it solve?
To apply cni-cilium MC settings we have to restart deckhouse controller.

## What is the expected result?
Settings are being applied immediately. `tunnelMode`, for example.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cilium
type: fix
summary: Forcing module to apply ModuleConfig settings immediately without d8 restart.
impact_level: low
```
