### PR TITLE
[docs] Changing code block with example in maxStreamsPerUser

### DIFF
--- a/modules/462-loki/openapi/config-values.yaml
+++ b/modules/462-loki/openapi/config-values.yaml
@@ -79,7 +79,7 @@ properties:
         description: |
           The maximum total number of streams for the Loki instance.
 
-          Each stream has unique labels. The number of streams is the number of unique label sets. E. g. '{job="my-app", instance="kube-node-1", namespace="production", pod_name="backend-79dbf6fcb7-v5gs7", app="backend"}'.
+          Each stream has unique labels. The number of streams is the number of unique label sets. E. g. `{job="my-app", instance="kube-node-1", namespace="production", pod_name="backend-79dbf6fcb7-v5gs7", app="backend"}`.
 
           0 means unlimited.
         default: 0

--- a/modules/462-loki/openapi/doc-ru-config-values.yaml
+++ b/modules/462-loki/openapi/doc-ru-config-values.yaml
@@ -46,7 +46,7 @@ properties:
         description: |
           Максимальное общее количество потоков логов для экземпляра Loki.
 
-          Каждый поток логов имеет уникальный набор меток. Количество потоков равно количеству уникальных наборов меток. Например: '{job="my-app", instance="kube-node-1", namespace="production", pod_name="backend-79dbf6fcb7-v5gs7", app="backend"}'.
+          Каждый поток логов имеет уникальный набор меток. Количество потоков равно количеству уникальных наборов меток. Например: `{job="my-app", instance="kube-node-1", namespace="production", pod_name="backend-79dbf6fcb7-v5gs7", app="backend"}`.
 
           Значение 0 отключает ограничение.
       maxEntriesLimitPerQuery:


### PR DESCRIPTION
## Description
Changing code block with example in maxStreamsPerUser


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: loki
type: fix 
summary: Update `maxStreamsPerUser` parameter description.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
