### PR TITLE
[testing] Switch to d8-curl from Deckhouse package in e2e test script

### DIFF
--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -460,11 +460,7 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 
-if which wget >/dev/null; then
-  wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 -O /usr/bin/yq
-else
-  curl -sLfo /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386
-fi
+d8-curl -sLfo /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386
 
 chmod +x /usr/bin/yq
 


### PR DESCRIPTION
## Description
Use d8-curl from Deckhouse package for downloading files in e2e test script

## Why do we need it, and what problem does it solve?
In some cases, e2e testing can fail after running all tests as neither curl nor wget are present on the current machine. It is possible to bypass that by using d8-curl.

## What is the expected result?
e2e test script uses curl.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: fix
summary: Switch to d8-curl for downloading files in e2e test script.
impact_level: low
```

