### PR TITLE
[candi][vcd] Add PVC disks to ignore_changes lifecycle

### DIFF
--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -88,7 +88,8 @@ resource "vcd_vapp_vm" "master" {
 
   lifecycle {
     ignore_changes = [
-      guest_properties
+      guest_properties,
+      disk
     ]
   }
 

--- a/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
@@ -75,7 +75,8 @@ resource "vcd_vapp_vm" "node" {
 
   lifecycle {
     ignore_changes = [
-      guest_properties
+      guest_properties,
+      disk
     ]
   }
 


### PR DESCRIPTION
## Description
Add PVC disks to ignore_changes lifecycle for CloudPermanent nodes at VMware Cloud Director.

## Why do we need it, and what problem does it solve?
We have cluster with CloudPermanent NodeGroup system what means, that Prometheus pods was scheduled and mount PVC to node. After this we have alert `D8TerraformStateExporterNodeStateChanged` and terraform show that we need to detach disks:

```
┌ 🌱 ~ Terraform: Check state static-node for cmdr-system-1
│ ┌ terraform init ...
│ │
│ │ Initializing the backend...
│ │
│ │ Initializing provider plugins...
│ │ - Reusing previous version of vmware/vcd from the dependency lock file
│ │ - Using previously-installed vmware/vcd v3.10.0
│ │
│ │
│ │ Warning: No-op -get-plugins flag used
│ │
│ │ As of Terraform 0.13+, the -get-plugins=false command is a no-op flag. If you
│ │ would like to customize provider installation, use a provider_installation
│ │ block or other available Terraform settings.
│ │
│ │ Terraform has been successfully initialized!
│ │ Terraform runner "static-node" process exited.
│ └ terraform init ... (0.49 seconds)
│
│ ┌ terraform plan ...
│ │ vcd_vapp_vm.node: Refreshing state... [id=urn:vcloud:vm:6dd8d10a-5035-4799-b52d-3c29cadbceb4]
│ │
│ │ An execution plan has been generated and is shown below.
│ │ Resource actions are indicated with the following symbols:
│ │   ~ update in-place
│ │
│ │ Terraform will perform the following actions:
│ │
│ │   # vcd_vapp_vm.node will be updated in-place
│ │   ~ resource "vcd_vapp_vm" "node" {
│ │         id                             = "urn:vcloud:vm:6dd8d10a-5035-4799-b52d-3c29cadbceb4"
│ │         name                           = "cmdr-system-1"
│ │         # (25 unchanged attributes hidden)
│ │
│ │
│ │       - disk {
│ │           - bus_number  = "0" -> null
│ │           - name        = "pvc-16728952-1843-4229-84bc-47136c13e440" -> null
│ │           - size_in_mb  = 40960 -> null
│ │           - unit_number = "1" -> null
│ │         }
│ │
│ │
│ │         # (3 unchanged blocks hidden)
│ │     }
│ │
│ │ Plan: 0 to add, 1 to change, 0 to destroy.
│ │ Terraform runner "static-node" process exited.
│ └ terraform plan ... (61.39 seconds)
└ 🌱 ~ Terraform: Check state static-node for cmdr-system-1 (62.63 seconds)
cluster:
  status: ok
node_templates:
...
- name: system
  status: ok
nodes:
...
- group: system
  name: cmdr-system-1
  status: changed
```
And if we converge - disks will be detached and pods will be broken.
With this patch we have good and expected situation:
```
┌ 🌱 ~ Terraform: Check state static-node for cmdr-system-1
│ ┌ terraform init ...
│ │
│ │ Initializing the backend...
│ │
│ │ Initializing provider plugins...
│ │ - Reusing previous version of vmware/vcd from the dependency lock file
│ │ - Using previously-installed vmware/vcd v3.10.0
│ │
│ │
│ │ Warning: No-op -get-plugins flag used
│ │
│ │ As of Terraform 0.13+, the -get-plugins=false command is a no-op flag. If you
│ │ would like to customize provider installation, use a provider_installation
│ │ block or other available Terraform settings.
│ │
│ │ Terraform has been successfully initialized!
│ │ Terraform runner "static-node" process exited.
│ └ terraform init ... (0.50 seconds)
│
│ ┌ terraform plan ...
│ │ vcd_vapp_vm.node: Refreshing state... [id=urn:vcloud:vm:6dd8d10a-5035-4799-b52d-3c29cadbceb4]
│ │
│ │ No changes. Infrastructure is up-to-date.
│ │
│ │ This means that Terraform did not detect any differences between your
│ │ configuration and real physical resources that exist. As a result, no
│ │ actions need to be performed.
│ │ Terraform runner "static-node" process exited.
│ └ terraform plan ... (6.03 seconds)
└ 🌱 ~ Terraform: Check state static-node for cmdr-system-1 (7.23 seconds)
cluster:
  status: ok
node_templates:
...
- name: system
  status: ok
nodes:
...
- group: system
  name: cmdr-system-1
  status: ok
```

These changes does not affect internal disks (such as root disk and kubernetes-data disk), because our internal disks we have in structure "internal_disk" like this:
```
            "internal_disk": [
              {
                "bus_number": 0,
                "bus_type": "paravirtual",
                "disk_id": "2000",
                "iops": 1,
                "size_in_mb": 51200,
                "storage_profile": "p01z30-sp-fast",
                "thin_provisioned": false,
                "unit_number": 0
              },
              {
                "bus_number": 0,
                "bus_type": "paravirtual",
                "disk_id": "2001",
                "iops": 1,
                "size_in_mb": 20480,
                "storage_profile": "p01z30-sp-fast",
                "thin_provisioned": false,
                "unit_number": 1
              }
            ],
```
and attached PVC creates in structure "disk":
```
"disk": []
```

## Why do we need it in the patch release (if we do)?
This problem confuses users and may encourage them to take destructive actions.
Also this problem cause setups with Commander, as changes for Nodes not destructive, Commander will do automatic converge for clusters (and pods with PVC in clusters will be broken).

## What is the expected result?
We do not need to converge CloudPermanent nodes if we have pods with PVC on it.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Add PVC disks to ignore_changes lifecycle for CloudPermanent nodes at VMware Cloud Director.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
