### PR TITLE
[global-hooks] Fix cni secret migration

### DIFF
--- a/global-hooks/migrate/migrate_d8_cni_secret.go
+++ b/global-hooks/migrate/migrate_d8_cni_secret.go
@@ -108,6 +108,17 @@ func d8cniSecretMigrate(input *go_hook.HookInput, dc dependency.Container) error
 			if !moduleEnabled {
 				break
 			}
+
+			settings, settingsExists, err := unstructured.NestedMap(mc.UnstructuredContent(), "spec", "settings")
+			if err != nil {
+				return err
+			}
+
+			// simple bridge does not have any settings
+			if (!settingsExists || len(settings) == 0) && mc.GetName() != "cni-simple-bridge" {
+				break
+			}
+
 			input.LogEntry.Infof("Module config for %s found, skipping migration", mc.GetName())
 			return removeD8CniSecret(input, kubeCl, d8cniSecret)
 		}
@@ -181,6 +192,8 @@ func d8cniSecretMigrate(input *go_hook.HookInput, dc dependency.Container) error
 		switch ciliumConfig.MasqueradeMode {
 		case "Netfilter", "BPF":
 			ciliumSettings["masqueradeMode"] = ciliumConfig.MasqueradeMode
+		case "":
+			ciliumSettings["masqueradeMode"] = "BPF"
 		default:
 			return fmt.Errorf("unknown cilium masquerade mode %s", ciliumConfig.MasqueradeMode)
 		}
@@ -196,7 +209,7 @@ func d8cniSecretMigrate(input *go_hook.HookInput, dc dependency.Container) error
 	}
 
 	// create ModuleConfig
-	err = createMC(kubeCl, cniModuleConfig)
+	err = upToDateMC(kubeCl, cniModuleConfig)
 	if err != nil {
 		return err
 	}
@@ -217,11 +230,15 @@ func removeD8CniSecret(input *go_hook.HookInput, kubeCl k8s.Client, secret *v1.S
 }
 
 // create Module Config
-func createMC(kubeCl k8s.Client, mc *config.ModuleConfig) error {
+func upToDateMC(kubeCl k8s.Client, mc *config.ModuleConfig) error {
 	obj, err := sdk.ToUnstructured(mc)
 	if err != nil {
 		return err
 	}
 	_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), obj, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Update(context.TODO(), obj, metav1.UpdateOptions{})
+		return err
+	}
 	return err
 }

--- a/global-hooks/migrate/migrate_d8_cni_secret_test.go
+++ b/global-hooks/migrate/migrate_d8_cni_secret_test.go
@@ -17,40 +17,75 @@ package hooks
 import (
 	"context"
 
+	"github.com/flant/addon-operator/sdk"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-func createFakeCNISecret(name, data string) {
-	secretData := make(map[string][]byte)
-	secretData["cni"] = []byte(name)
-	if data != "" {
-		secretData[name] = []byte(data)
-	}
-
-	s := &v1core.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "d8-cni-configuration",
-			Namespace: "kube-system",
-		},
-
-		Data: secretData,
-	}
-
-	_, _ = dependency.TestDC.MustGetK8sClient().CoreV1().Secrets("kube-system").Create(context.TODO(), s, metav1.CreateOptions{})
-}
-
 var _ = Describe("Global hooks :: migrate_d8_cni_secret ::", func() {
+	createFakeCNISecret := func(name, data string) {
+		secretData := make(map[string][]byte)
+		secretData["cni"] = []byte(name)
+		if data != "" {
+			secretData[name] = []byte(data)
+		}
+
+		s := &v1core.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "d8-cni-configuration",
+				Namespace: "kube-system",
+			},
+
+			Data: secretData,
+		}
+
+		_, err := dependency.TestDC.MustGetK8sClient().CoreV1().Secrets("kube-system").Create(context.TODO(), s, metav1.CreateOptions{})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	createCNIModuleConfig := func(name string, enabled *bool, settings config.SettingsValues) {
+		mc := config.ModuleConfig{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1alpha1",
+				Kind:       "ModuleConfig",
+			},
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+
+			Spec: config.ModuleConfigSpec{
+				Version:  1,
+				Settings: settings,
+				Enabled:  enabled,
+			},
+		}
+
+		mcu, err := sdk.ToUnstructured(&mc)
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = dependency.TestDC.MustGetK8sClient().Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), mcu, metav1.CreateOptions{})
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	f := HookExecutionConfigInit(`{"global": {"discovery": {}}}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 
@@ -65,10 +100,43 @@ var _ = Describe("Global hooks :: migrate_d8_cni_secret ::", func() {
 		})
 	})
 
-	Context("Cluster has d8-cni-configuration secret for cni-simple-bridge", func() {
+	Context("Cluster has ModuleConfig cni-flannel with disabled and ModuleConfig cni-cilium enabled and settings", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			createCNIModuleConfig("cni-flannel", pointer.Bool(false), nil)
+			createCNIModuleConfig("cni-cilium", pointer.Bool(true), config.SettingsValues{
+				"tunnelMode":     "VXLAN",
+				"masqueradeMode": "Netfilter",
+			})
+			f.RunHook()
+		})
+
+		It("Should run successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Module configs should not changed", func() {
+			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+			Expect(mc.Exists()).To(BeTrue())
+			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+			Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("VXLAN"))
+			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
+			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+			mc = f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+			Expect(mc.Exists()).To(BeTrue())
+			Expect(mc.Field("spec.enabled").Bool()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster has ModuleConfig cni-flannel cni-cilium enabled and settings and cni configuration secret with simple bridge", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(``))
 			createFakeCNISecret("simple-bridge", "")
+			createCNIModuleConfig("cni-cilium", pointer.Bool(true), config.SettingsValues{
+				"tunnelMode":     "VXLAN",
+				"masqueradeMode": "Netfilter",
+			})
 			f.RunHook()
 		})
 
@@ -76,115 +144,7 @@ var _ = Describe("Global hooks :: migrate_d8_cni_secret ::", func() {
 			Expect(f).To(ExecuteSuccessfully())
 		})
 
-		It("MC cni-simple-bridge should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-simple-bridge")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-flannel (VXLAN mode)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("flannel", `{"podNetworkMode": "VXLAN"}`)
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-flannel should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("VXLAN"))
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-flannel (HostGW mode)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("flannel", `{"podNetworkMode": "HostGW"}`)
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-flannel should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("HostGW"))
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-flannel (mode doesn't set)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("flannel", "")
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-flannel should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("HostGW"))
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (VXLAN, BPF)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "VXLAN", "masqueradeMode": "BPF"}`)
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("VXLAN"))
-			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
-			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
-
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (VXLAN, Netfilter)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "VXLAN", "masqueradeMode": "Netfilter"}`)
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+		It("ModuleConfig cni-cilium should not changed, ModuleConfig cni-simple-bridge should not created", func() {
 			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
 			Expect(mc.Exists()).To(BeTrue())
 			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
@@ -192,129 +152,431 @@ var _ = Describe("Global hooks :: migrate_d8_cni_secret ::", func() {
 			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
 			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
 
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
+			mc = f.KubernetesResource("ModuleConfig", "", "cni-simple-bridge")
+			Expect(mc.Exists()).To(BeFalse())
 		})
 	})
 
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (Direct, BPF)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "Direct", "masqueradeMode": "BPF"}`)
-			f.RunHook()
+	Context("CNI Simple Bridge", func() {
+		Context("Cluster has ModuleConfig enabled", func() {
+			Context("CNI secret does not exist", func() {
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSet(``))
+					createCNIModuleConfig("cni-simple-bridge", pointer.Bool(true), nil)
+					f.RunHook()
+				})
+
+				It("Should run successfully", func() {
+					Expect(f).To(ExecuteSuccessfully())
+				})
+
+				It("MC cni-simple-bridge should be not changed, d8-cni-configuration secret should be exist", func() {
+					mc := f.KubernetesResource("ModuleConfig", "", "cni-simple-bridge")
+					Expect(mc.Exists()).To(BeTrue())
+					Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+					secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+					Expect(secret.Exists()).To(BeFalse())
+				})
+			})
+
+			Context("CNI secret exists", func() {
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSet(``))
+					createCNIModuleConfig("cni-simple-bridge", pointer.Bool(true), nil)
+					createFakeCNISecret("simple-bridge", "")
+					f.RunHook()
+				})
+
+				It("Should run successfully", func() {
+					Expect(f).To(ExecuteSuccessfully())
+				})
+
+				It("MC cni-simple-bridge should be not changed, d8-cni-configuration secret should be removed", func() {
+					mc := f.KubernetesResource("ModuleConfig", "", "cni-simple-bridge")
+					Expect(mc.Exists()).To(BeTrue())
+					Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+					secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+					Expect(secret.Exists()).To(BeFalse())
+				})
+			})
 		})
 
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
+		Context("Cluster has d8-cni-configuration secret for cni-simple-bridge", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("simple-bridge", "")
+				f.RunHook()
+			})
 
-		It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
-			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
-			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
 
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (Direct, Netfilter)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "Direct", "masqueradeMode": "Netfilter"}`)
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
-			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
-			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
-
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
-		})
-	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (DirectWithNodeRoutes, BPF)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "BPF"}`)
-			f.RunHook()
-		})
-
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-
-		It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
-			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
-			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeTrue())
-
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
+			It("MC cni-simple-bridge should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-simple-bridge")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
 		})
 	})
 
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (DirectWithNodeRoutes, Netfilter)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "Netfilter"}`)
-			f.RunHook()
+	Context("CNI Flannel", func() {
+		Context("Cluster has ModuleConfig with enabled only and has configuration secret", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createCNIModuleConfig("cni-flannel", pointer.Bool(true), nil)
+				createFakeCNISecret("flannel", `{"podNetworkMode": "VXLAN"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-flannel should be updated, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("VXLAN"))
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
 		})
 
-		It("Should run successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
+		Context("Cluster has ModuleConfig with enabled and set settings and has configuration secret", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createCNIModuleConfig("cni-flannel", pointer.Bool(true), config.SettingsValues{
+					"podNetworkMode": "HostGW",
+				})
+				createFakeCNISecret("flannel", `{"podNetworkMode": "VXLAN"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-flannel should not be changed, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("HostGW"))
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
 		})
 
-		It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
-			mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
-			Expect(mc.Exists()).To(BeTrue())
-			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
-			Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
-			Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
-			Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeTrue())
+		Context("Cluster has ModuleConfig with enabled and set settings and does not have configuration secret", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createCNIModuleConfig("cni-flannel", pointer.Bool(true), config.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				})
+				f.RunHook()
+			})
 
-			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
-			Expect(secret.Exists()).To(BeFalse())
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-flannel should not be changed, d8-cni-configuration secret should not be created", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("VXLAN"))
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-flannel (VXLAN mode)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("flannel", `{"podNetworkMode": "VXLAN"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-flannel should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("VXLAN"))
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-flannel (HostGW mode)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("flannel", `{"podNetworkMode": "HostGW"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-flannel should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("HostGW"))
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-flannel (mode doesn't set)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("flannel", "")
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-flannel should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-flannel")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.podNetworkMode").String()).To(Equal("HostGW"))
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+
 		})
 	})
 
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (DirectWithNodeRoutes, not set)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", `{"mode": "DirectWithNodeRoutes"}`)
-			f.RunHook()
+	Context("CNI Cilium", func() {
+		Context("Cluster has ModuleConfig cni-cilium with enabled only and has cni configuration ", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createCNIModuleConfig("cni-cilium", pointer.Bool(true), nil)
+				createFakeCNISecret("cilium", `{"mode": "VXLAN", "masqueradeMode": "BPF"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be updated, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("VXLAN"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
 		})
 
-		It("Should not run successfully", func() {
-			Expect(f).NotTo(ExecuteSuccessfully())
+		Context("Cluster has ModuleConfig cni-cilium with enabled and settings and has cni configuration ", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createCNIModuleConfig("cni-cilium", pointer.Bool(true), config.SettingsValues{
+					"tunnelMode":     "VXLAN",
+					"masqueradeMode": "Netfilter",
+				})
+				createFakeCNISecret("cilium", `{"mode": "VXLAN", "masqueradeMode": "BPF"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should not be updated, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("VXLAN"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (VXLAN, BPF)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "VXLAN", "masqueradeMode": "BPF"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("VXLAN"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (VXLAN, Netfilter)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "VXLAN", "masqueradeMode": "Netfilter"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("VXLAN"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (Direct, BPF)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "Direct", "masqueradeMode": "BPF"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (Direct, Netfilter)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "Direct", "masqueradeMode": "Netfilter"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeFalse())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (DirectWithNodeRoutes, BPF)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "BPF"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("BPF"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeTrue())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (DirectWithNodeRoutes, Netfilter)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "Netfilter"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+
+			It("MC cni-cilium should be created, d8-cni-configuration secret should be removed", func() {
+				mc := f.KubernetesResource("ModuleConfig", "", "cni-cilium")
+				Expect(mc.Exists()).To(BeTrue())
+				Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+				Expect(mc.Field("spec.settings.tunnelMode").String()).To(Equal("Disabled"))
+				Expect(mc.Field("spec.settings.masqueradeMode").String()).To(Equal("Netfilter"))
+				Expect(mc.Field("spec.settings.createNodeRoutes").Bool()).To(BeTrue())
+
+				secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+				Expect(secret.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (DirectWithNodeRoutes, not set)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", `{"mode": "DirectWithNodeRoutes"}`)
+				f.RunHook()
+			})
+
+			It("Should run successfully", func() {
+				Expect(f).To(ExecuteSuccessfully())
+			})
+		})
+
+		Context("Cluster has d8-cni-configuration secret for cni-cilium (not set, not set)", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(``))
+				createFakeCNISecret("cilium", "")
+				f.RunHook()
+			})
+
+			It("Should not run successfully", func() {
+				Expect(f).NotTo(ExecuteSuccessfully())
+			})
 		})
 	})
-
-	Context("Cluster has d8-cni-configuration secret for cni-cilium (not set, not set)", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
-			createFakeCNISecret("cilium", "")
-			f.RunHook()
-		})
-
-		It("Should not run successfully", func() {
-			Expect(f).NotTo(ExecuteSuccessfully())
-		})
-	})
-
 })


### PR DESCRIPTION
## Description
Add default for cni-cilium default masquerade mode.
If module config cni-* exists and settings is empty (expect cni-simple-bridge) then do migration.  

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Migration fail with error `Error: global hook 'migrate/migrate_d8_cni_secret.go' failed: unknown cilium masquerade mode `

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix 
summary: Fix cni secret migration.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
