### PR TITLE
vcd-pvc-umount test

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/02-check-volume-umount.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/02-check-volume-umount.patch
@@ -1,0 +1,37 @@
+diff --git a/pkg/csi/node.go b/pkg/csi/node.go
+index a2356b5..3bf16f7 100644
+--- a/pkg/csi/node.go
++++ b/pkg/csi/node.go
+@@ -8,13 +8,14 @@ package csi
+ import (
+ 	"context"
+ 	"fmt"
+-	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/util"
+ 	"os"
+ 	"os/exec"
+ 	"path/filepath"
+ 	"regexp"
+ 	"strings"
+ 
++	"github.com/vmware/cloud-director-named-disk-csi-driver/pkg/util"
++
+ 	"github.com/akutz/gofsutil"
+ 	"github.com/container-storage-interface/spec/lib/go/csi"
+ 	"golang.org/x/sys/unix"
+@@ -236,6 +237,16 @@ func (ns *nodeService) NodeUnstageVolume(ctx context.Context,
+ 		return nil, status.Errorf(codes.Internal, "unable to unmount [%s]: [%v", mountDir, err)
+ 	}
+ 
++	isMountDirMounted, err = ns.checkIfDirMounted(ctx, mountDir)
++
++	if err != nil {
++		return nil, status.Errorf(codes.Internal, "unable to check if [%s] is mounted: [%v]", mountDir, err)
++	}
++
++	if isMountDirMounted {
++		return nil, status.Errorf(codes.Internal, "directory is still mounted: [%s]", mountDir)
++	}
++
+ 	klog.Infof("NodeUnstageVolume successful for target [%s] for volume [%s]", mountDir, deviceName)
+ 	return &csi.NodeUnstageVolumeResponse{}, nil
+ }

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/02-check-volume-umount.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/02-check-volume-umount.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/csi/node.go b/pkg/csi/node.go
-index a2356b5..3bf16f7 100644
+index a2356b5..18955f9 100644
 --- a/pkg/csi/node.go
 +++ b/pkg/csi/node.go
 @@ -8,13 +8,14 @@ package csi
@@ -34,4 +34,21 @@ index a2356b5..3bf16f7 100644
 +
  	klog.Infof("NodeUnstageVolume successful for target [%s] for volume [%s]", mountDir, deviceName)
  	return &csi.NodeUnstageVolumeResponse{}, nil
+ }
+@@ -379,6 +390,16 @@ func (ns *nodeService) NodeUnpublishVolume(ctx context.Context,
+ 		return nil, fmt.Errorf("unable to unmount pod mount dir [%s]: [%v]", podMountDir, err)
+ 	}
+ 
++	isDirMounted, err = ns.checkIfDirMounted(ctx, podMountDir)
++
++	if err != nil {
++		return nil, status.Errorf(codes.Internal, "unable to check if [%s] is mounted: [%v]", podMountDir, err)
++	}
++
++	if isDirMounted {
++		return nil, status.Errorf(codes.Internal, "directory is still mounted: [%s]", podMountDir)
++	}
++
+ 	klog.Infof("NodeUnpublishVolume successful for disk [%s] at mount dir [%s]", diskName, podMountDir)
+ 	return &csi.NodeUnpublishVolumeResponse{}, nil
  }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
