### PR TITLE
[docs] Refactor EE to CE and CE to EE instructions in the FAQ page for 1.64 and 1.63 releases

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -942,7 +942,7 @@ Perform the following steps to switch a Deckhouse Enterprise Edition cluster to 
    ```
 
    An example of the output you might get as a result of running the previous command:
-   
+
    ```console
    Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
    Module metallb-crd disabled
@@ -991,7 +991,7 @@ Perform the following steps to switch a Deckhouse Enterprise Edition cluster to 
    ```
 
    Wait for the `/etc/containerd/conf.d/ce-registry.toml` file to propagate to the nodes and for bashible synchronization to complete.
-   
+
    The synchronization status can be tracked by the `UPTODATE` value (the displayed number of nodes in this status must match the total number of nodes (`NODES`) in the group):
 
    ```shell
@@ -1036,7 +1036,7 @@ Perform the following steps to switch a Deckhouse Enterprise Edition cluster to 
    kubectl -n d8-system set image deployment/deckhouse deckhouse=registry.deckhouse.ru/deckhouse/ce:v1.63.7
    ```
 
-1. Wait for the Deckhouse pod to become `Ready` and for [ all the queued jobs to complete](https://deckhouse.io/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#how-to-check-the-job-queue-in-deckhouse). If an `ImagePullBackOff` error is generated in the process, wait for the pod to be restarted automatically.
+1. Wait for the Deckhouse pod to become `Ready` and for [all the queued jobs to complete](https://deckhouse.io/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#how-to-check-the-job-queue-in-deckhouse). If an `ImagePullBackOff` error is generated in the process, wait for the pod to be restarted automatically.
 
    Use the following command to check the Deckhouse pod's status:
 
@@ -1063,7 +1063,7 @@ Perform the following steps to switch a Deckhouse Enterprise Edition cluster to 
    > kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module enable registry-packages-proxy
    > ```
 
-1. Purge temporary files, `NodeGroupConfiguration`, and variables:
+1. Purge temporary files, NodeGroupConfiguration resource, and variables:
 
    ```shell
    kubectl delete ngc containerd-ce-config.sh
@@ -1086,7 +1086,7 @@ Perform the following steps to switch a Deckhouse Enterprise Edition cluster to 
    EOF
    ```
 
-   Once bashible synchronization is complete (you can track the synchronization status on nodes via the `UPTODATE` value of the NodeGroup), delete the ngc you created earlier:
+   Once bashible synchronization is complete (you can track the synchronization status on nodes via the `UPTODATE` value of the NodeGroup), delete the NodeGroupConfiguration resource you created earlier:
 
    ```shell
    kubectl  delete ngc del-temp-config.sh
@@ -1109,7 +1109,7 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
    AUTH_STRING="$(echo -n license-token:${LICENSE_TOKEN} | base64 )"
    ```
 
-1. Create a `NodeGroupConfiguration` for authorization in `registry.deckhouse.ru` during the migration:
+1. Create a NodeGroupConfiguration resource for authorization in `registry.deckhouse.ru` during the migration:
 
    ```shell
    kubectl apply -f - <<EOF
@@ -1142,9 +1142,9 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
    ```
 
    Wait for the `/etc/containerd/conf.d/ee-registry.toml` file to propagate to the nodes and for bashible synchronization to complete.
-   
+
    You can track the synchronization status via the `UPTODATE` value (the displayed number of nodes having this status must match the total number of nodes (`NODES`) in the group):
-   
+
    ```console
    $ kubectl  get ng  -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
    NAME     NODES   READY   UPTODATE
@@ -1228,7 +1228,7 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
      admission-policy-engine cert-manager chrony cloud-data-crd ...
      ```
 
-1. Create a `NodeGroupConfiguration`:
+1. Create a NodeGroupConfiguration resource:
 
    ```shell
    $ kubectl apply -f - <<EOF
@@ -1321,7 +1321,7 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
       | select(.image | contains("deckhouse.ru/deckhouse/ce"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
    ```
 
-1. Purge temporary files, `NodeGroupConfiguration`, and variables:
+1. Purge temporary files, NodeGroupConfiguration resource, and variables:
 
    ```shell
    kubectl delete ngc containerd-ee-config.sh ee-set-sha-images.sh
@@ -1347,7 +1347,7 @@ To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
    EOF
    ```
 
-   Once bashible synchronization is complete (you can track the synchronization status on nodes via the `UPTODATE` value of the NodeGroup), delete the ngc you created earlier:
+   Once bashible synchronization is complete (you can track the synchronization status on nodes via the `UPTODATE` value of the NodeGroup), delete the NodeGroupConfiguration resource you created earlier:
 
    ```shell
    kubectl  delete ngc del-temp-config.sh

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -841,63 +841,258 @@ The instruction implies using the public address of the container registry: `reg
 Deckhouse CE does not support cloud clusters on OpenStack and VMware vSphere.
 {% endalert %}
 
-To switch Deckhouse Enterprise Edition to Community Edition, follow these steps:
+Для переключения кластера Deckhouse Enterprise Edition на Community Edition выполните следующие действия (все команды выполняются на master-узле действующего кластера):
 
-1. Make sure that the modules used in the cluster [are supported in Deckhouse CE](revision-comparison.html). Disable modules that are not supported in Deckhouse CE.
+1. Выполните следующие команды для запуска временного пода CE-редакции для получения актуальных дайджестов и списка модулей:
 
-1. Run the following command:
-
-   ```shell
-   kubectl exec -ti -n d8-system svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry registry.deckhouse.io/deckhouse/ce
+   ```
+   kubectl run ce-image --image=registry.deckhouse.ru/deckhouse/ce/install:v1.63.7 --command sleep -- infinity
    ```
 
-1. Wait for the Deckhouse Pod to become `Ready`:
+   > Запускайте образ последней установленной версии DH в кластере, посмотреть можно командой:
+   >
+   > ```
+   > kubectl get deckhousereleases
+   > ```
 
-   ```shell
+
+2. Как только под перейдёт в статус `Running`, выполните следующие команды:
+
+  * Получите значение `CE_SANDBOX_IMAGE`:
+
+    ```
+    CE_SANDBOX_IMAGE=$(kubectl exec ce-image -- cat deckhouse/candi/images_digests.json | grep  pause | grep -oE 'sha256:\w*')
+    ```
+
+    Проверка:
+
+    ```
+    $ echo $CE_SANDBOX_IMAGE
+    sha256:2a909cb9df4d0207f1fe5bd9660a0529991ba18ce6ce7b389dc008c05d9022d1
+    ```
+  * Получите значение `CE_K8S_API_PROXY`:
+
+    ```
+    CE_K8S_API_PROXY=$(kubectl exec ce-image -- cat deckhouse/candi/images_digests.json | grep kubernetesApiProxy | grep -oE 'sha256:\w*')
+    ```
+
+    Проверка:
+
+    ```
+    $ echo $CE_K8S_API_PROXY
+    sha256:a5442437976a11dfa4860c2fbb025199d9d1b074222bb80173ed36b9006341dd
+    ```
+  * Получите значение `CE_MODULES`:
+
+    ```
+    CE_MODULES=$(kubectl exec ce-image -- ls -l deckhouse/modules/ | grep -oE "\d.*-\w*"  | awk {'print $9'} | cut -c5-)
+    ```
+
+    Проверка:
+
+    ```
+    $echo $CE_MODULES
+    common priority-class deckhouse external-module-manager registrypackages cloud-data-crd operator-prometheus-crd prometheus-crd snapshot-controller-crd user-authn-crd vertical-pod-autoscaler-crd flow-schema admission-policy-engine cni-cilium kube-proxy cloud-provider-aws cloud-provider-azure cloud-provider-gcp cloud-provider-yandex ceph-csi local-path-provisioner cni-flannel cni-simple-bridge control-plane-manager node-manager terraform-manager linstor kube-dns snapshot-controller network-policy-engine cert-manager istio user-authz user-authn operator-prometheus prometheus prometheus-metrics-adapter vertical-pod-autoscaler prometheus-pushgateway extended-monitoring monitoring-custom monitoring-deckhouse monitoring-kubernetes monitoring-kubernetes-control-plane monitoring-ping descheduler ingress-nginx log-shipper loki pod-reloader chrony cilium-hubble dashboard okmeter openvpn upmeter namespace-configurator secret-copier documentation
+    ```
+
+  * Получите значение `USED_MODULES`:
+
+    ```
+    USED_MODULES=$(kubectl get modules | grep -v 'snapshot-controller-crd' | grep Enabled |awk {'print $1'})
+    ```
+
+    Проверка:
+
+    ```
+    $ echo $USED_MODULES
+    admission-policy-engine cert-manager chrony cloud-data-crd cni-cilium control-plane-manager dashboard deckhouse descheduler documentation extended-monitoring external-module-manager flow-schema ingress-nginx kube-dns local-path-provisioner log-shipper metallb-crd monitoring-custom monitoring-deckhouse monitoring-kubernetes monitoring-kubernetes-control-plane monitoring-ping namespace-configurator node-local-dns node-manager operator-prometheus operator-prometheus-crd pod-reloader priority-class prometheus prometheus-crd prometheus-metrics-adapter registry-packages-proxy secret-copier snapshot-controller upmeter user-authn user-authn-crd user-authz vertical-pod-autoscaler vertical-pod-autoscaler-crd
+    ```
+
+  * Получите значение `MODULES_WILL_DISABLE`:
+
+    ```
+    MODULES_WILL_DISABLE=$(echo $USED_MODULES | tr ' ' '\n' | grep -Fxv -f <(echo $CE_MODULES | tr ' ' '\n'))
+    ```
+
+    Проверка:
+
+    ```
+    $ echo $MODULES_WILL_DISABLE
+    metallb-crd node-local-dns registry-packages-proxy
+    ```
+
+    > Обратите внимание, если в `$MODULES_WILL_DISABLE` указана `registry-packages-proxy`, то его надо будет включить обратно, иначе кластер не сможет перейти на образы CE редакции. Включение в 8 пункте.
+
+3. Убедитесь, что используемые в кластере модули поддерживаются в CE-редакции.
+
+   Отобразить список модулей, которые не поддерживаются в CE-редакции и будут отключены, можно следующей командой:
+
+   ```
+   echo $MODULES_WILL_DISABLE
+   ```
+
+   > Проверьте список и убедитесь, что функциональность указанных модулей не задействована вами в кластере, и вы готовы к их отключению.
+
+   Отключите неподдерживаемые в CE-редакции модули:
+
+   ```
+   echo $MODULES_WILL_DISABLE |
+     tr ' ' '\n' | awk {'print "kubectl -n d8-system exec  deploy/deckhouse -- deckhouse-controller module disable",$1'} | bash
+   ```
+
+   Результат выполнения:
+
+   ```
+   Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
+   Module metallb-crd disabled
+
+   Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
+   Module node-local-dns disabled
+
+   Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-external-modules (init)
+   Module registry-packages-proxy disabled
+   ```
+
+
+1. Создайте NodeGroupConfiguration:
+
+   ```yaml
+   kubectl apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha1
+   kind: NodeGroupConfiguration
+   metadata:
+     name: containerd-ce-config.sh
+   spec:
+     nodeGroups:
+     - '*'
+     bundles:
+     - '*'
+     weight: 30
+     content: |
+       _on_containerd_config_changed() {
+         bb-flag-set containerd-need-restart
+       }
+       bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
+
+       mkdir -p /etc/containerd/conf.d
+       bb-sync-file /etc/containerd/conf.d/ce-registry.toml - containerd-config-file-changed << "EOF_TOML"
+       [plugins]
+         [plugins."io.containerd.grpc.v1.cri"]
+           sandbox_image = "registry.deckhouse.ru/deckhouse/ce@$CE_SANDBOX_IMAGE"
+           [plugins."io.containerd.grpc.v1.cri".registry.configs]
+             [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.deckhouse.ru".auth]
+               auth = ""
+       EOF_TOML
+
+       sed -i 's|image: .*|image: registry.deckhouse.ru/deckhouse/ce@$CE_K8S_API_PROXY|' /var/lib/bashible/bundle_steps/051_pull_and_configure_kubernetes_api_proxy.sh
+       sed -i 's|crictl pull .*|crictl pull registry.deckhouse.ru/deckhouse/ce@$CE_K8S_API_PROXY|' /var/lib/bashible/bundle_steps/051_pull_and_configure_kubernetes_api_proxy.sh
+
+   EOF
+   ```
+
+   Дождитесь появления файла `/etc/containerd/conf.d/ce-registry.toml` на узлах и завершения синхронизации bashible.
+
+   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
+
+   ```
+   kubectl get ng -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
+   ```
+
+   Например:
+
+   ```
+   $ kubectl  get ng  -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
+       NAME     NODES   READY   UPTODATE
+       master   1       1       1
+       worker   2       2       2
+   ```
+
+   Также в журнале systemd-сервиса bashible должно появиться сообщение `Configuration is in sync, nothing to do`. Например:
+
+   ```
+   $ journalctl -u bashible -n 5
+       Aug 21 11:04:28 master-ee-to-ce-0 bashible.sh[53407]: Configuration is in sync, nothing to do.
+       Aug 21 11:04:28 master-ee-to-ce-0 bashible.sh[53407]: Annotate node master-ee-to-ce-0 with annotation node.deckhouse.io/ configuration-checksum=9cbe6db6c91574b8b732108a654c99423733b20f04848d0b4e1e2dadb231206a
+       Aug 21 11:04:29 master-ee-to-ce-0 bashible.sh[53407]: Succesful annotate node master-ee-to-ce-0 with annotation node.deckhouse.io/configuration-checksum=9cbe6db6c91574b8b732108a654c99423733b20f04848d0b4e1e2dadb231206a
+       Aug 21 11:04:29 master-ee-to-ce-0 systemd[1]: bashible.service: Deactivated successfully.
+   ```
+
+1. Актуализируйте секрет доступа к registry Deckhouse, выполнив следующую команду:
+
+   ```
+   kubectl -n d8-system create secret generic deckhouse-registry \
+     --from-literal=".dockerconfigjson"="{\"auths\": { \"registry.deckhouse.ru\": {}}}" \
+     --from-literal="address"=registry.deckhouse.ru \
+     --from-literal="path"=/deckhouse/ce \
+     --from-literal="scheme"=https \
+     --type=kubernetes.io/dockerconfigjson \
+     --dry-run='client' \
+     -o yaml | kubectl replace -f -
+   ```
+
+1. Примените CE-образ:
+
+   ```
+   kubectl -n d8-system set image deployment/deckhouse deckhouse=registry.deckhouse.ru/deckhouse/ce:v1.63.7
+   ```
+
+1. Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#%D0%BA%D0%B0%D0%BA-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D0%B8%D1%82%D1%8C-%D0%BE%D1%87%D0%B5%D1%80%D0%B5%D0%B4%D1%8C-%D0%B7%D0%B0%D0%B4%D0%B0%D0%BD%D0%B8%D0%B9-%D0%B2-deckhouse). Если в процессе возникает ошибка `ImagePullBackOff`, подождите автоматического перезапуска пода.
+
+   Посмотреть статус пода Deckhouse:
+
+   ```
    kubectl -n d8-system get po -l app=deckhouse
    ```
 
-1. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state:
+   Проверить состояние очереди Deckhouse:
 
-   ```shell
-   kubectl -n d8-system delete po -l app=deckhouse
+   ```
+   kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue list
    ```
 
-1. Wait until Deckhouse restarts and [all tasks in the queue are completed](#how-to-check-the-job-queue-in-deckhouse):
+1. Проверьте, не осталось ли в кластере подов с адресом registry для Deckhouse EE:
 
-   ```shell
-   kubectl -n d8-system exec -it svc/deckhouse-leader -c deckhouse -- deckhouse-controller queue list
    ```
-
-1. On the master node, check the application of the new settings.
-
-   The message `Configuration is in sync, nothing to do` should appear in the `bashible` systemd service log on the master node.
-
-   An example::
-
-   ```console
-   # journalctl -u bashible -n 5
-   Jan 12 12:38:20 demo-master-0 bashible.sh[868379]: Configuration is in sync, nothing to do.
-   Jan 12 12:38:20 demo-master-0 systemd[1]: bashible.service: Deactivated successfully.
-   Jan 12 12:39:18 demo-master-0 systemd[1]: Started Bashible service.
-   Jan 12 12:39:19 demo-master-0 bashible.sh[869714]: Configuration is in sync, nothing to do.
-   Jan 12 12:39:19 demo-master-0 systemd[1]: bashible.service: Deactivated successfully.
-   ```
-
-1. Check if there are any Pods left in the cluster with the Deckhouse EE registry address:
-
-   ```shell
    kubectl get pods -A -o json | jq -r '.items[] | select(.spec.containers[]
-     | select(.image | contains("deckhouse.io/deckhouse/ee"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
+      | select(.image | contains("deckhouse.ru/deckhouse/ee"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
    ```
 
-   Sometimes, some static Pods may remain running (for example, `kubernetes-api-proxy-*`). This is due to the fact that kubelet does not restart the Pod despite changing the corresponding manifest, because the image used is the same for the Deckhouse CE and EE. To make sure that the corresponding manifests have also been changed, run the following command on any master node:
+   > Если в процессе был отключен модуль, то включите его обратно -
+   >
+   > ```
+   > kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module enable registry-packages-proxy
+   > ```
 
-   ```shell
-   grep -ri 'deckhouse.io/deckhouse/ee' /etc/kubernetes | grep -v backup
+1. Очистите временные файлы, ngc и переменные:
+
+   ```
+   $ kubectl delete ngc containerd-ce-config.sh
+
+   $ kubectl delete pod ce-image
+
+   $ kubectl apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha1
+   kind: NodeGroupConfiguration
+   metadata:
+     name: del-temp-config.sh
+   spec:
+     nodeGroups:
+     - '*'
+     bundles:
+     - '*'
+     weight: 90
+     content: |
+       if [ -f /etc/containerd/conf.d/ce-registry.toml ]; then
+         rm -f /etc/containerd/conf.d/ce-registry.toml
+       fi
+   EOF
    ```
 
-   The output of the command should be empty.
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданную ngc:
+
+   ```
+   kubectl  delete ngc del-temp-config.sh
+   ```
 
 ### How to switch Deckhouse CE to EE?
 
@@ -909,60 +1104,259 @@ The instruction implies using the public address of the container registry: `reg
 
 To switch Deckhouse Community Edition to Enterprise Edition, follow these steps:
 
-1. Run the following command:
+1. Подготовьте переменные с токеном лицензии:
 
-   ```shell
+   ```
    LICENSE_TOKEN=<PUT_YOUR_LICENSE_TOKEN_HERE>
-   kubectl exec -ti -n d8-system svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user license-token --password $LICENSE_TOKEN registry.deckhouse.io/deckhouse/ee
+   AUTH_STRING="$(echo -n license-token:${LICENSE_TOKEN} | base64 )"
    ```
 
-1. Wait for the Deckhouse Pod to become `Ready`:
+1. Cоздайте NodeGroupConfiguration для переходной авторизации в `registry.deckhouse.ru`:
 
-   ```shell
+   ```yaml
+   kubectl apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha1
+   kind: NodeGroupConfiguration
+   metadata:
+     name: containerd-ee-config.sh
+   spec:
+     nodeGroups:
+     - '*'
+     bundles:
+     - '*'
+     weight: 30
+     content: |
+       _on_containerd_config_changed() {
+         bb-flag-set containerd-need-restart
+       }
+       bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
+
+       mkdir -p /etc/containerd/conf.d
+       bb-sync-file /etc/containerd/conf.d/ee-registry.toml - containerd-config-file-changed << "EOF_TOML"
+       [plugins]
+         [plugins."io.containerd.grpc.v1.cri"]
+           [plugins."io.containerd.grpc.v1.cri".registry.configs]
+             [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.deckhouse.ru".auth]
+               auth = "$AUTH_STRING"
+       EOF_TOML
+
+   EOF
+   ```
+
+   Дождитесь появления файла `/etc/containerd/conf.d/ee-registry.toml` на узлах и завершения синхронизации bashible.
+
+   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
+
+   ```
+   $ kubectl  get ng  -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
+   NAME     NODES   READY   UPTODATE
+   master   1       1       1
+   worker   2       2       2
+   ```
+
+   Также в журнале systemd-сервиса bashible должно появиться сообщение `Configuration is in sync, nothing to do`:
+
+   ```
+   $ journalctl -u bashible -n 5
+   Aug 21 11:04:28 master-ce-to-ee-0 bashible.sh[53407]: Configuration is in sync, nothing to do.
+   Aug 21 11:04:28 master-ce-to-ee-0 bashible.sh[53407]: Annotate node master-ce-to-ee-0 with annotation node.deckhouse.io/   configuration-checksum=9cbe6db6c91574b8b732108a654c99423733b20f04848d0b4e1e2dadb231206a
+   Aug 21 11:04:29 master ce-to-ee-0 bashible.sh[53407]: Succesful annotate node master-ce-to-ee-0 with annotation node.deckhouse.io/   configuration-checksum=9cbe6db6c91574b8b732108a654c99423733b20f04848d0b4e1e2dadb231206a
+   Aug 21 11:04:29 master-ce-to-ee-0 systemd[1]: bashible.service: Deactivated successfully.
+   ```
+
+   Выполните следующую команду для запуска временного пода EE-редакции для получения актуальных дайджестов и списка модулей:
+
+   ```
+   kubectl run ee-image --image=registry.deckhouse.ru/deckhouse/ee/install:v1.63.8 --command sleep -- infinity
+   ```
+
+   > Запускайте образ последней установленной версии DH в кластере, посмотреть можно командой
+   >
+   >  ```
+   >  kubectl get deckhousereleases
+   >  ```
+
+
+1. Как только под перейдёт в статус `Running`, выполните следующие команды:
+
+   * Получите значение `EE_SANDBOX_IMAGE`:
+
+     ```
+     EE_SANDBOX_IMAGE=$(kubectl exec ee-image -- cat deckhouse/candi/images_digests.json | grep  pause | grep -oE 'sha256:\w*')
+     ```
+
+     Проверка:
+
+     ```
+     $ echo $EE_SANDBOX_IMAGE
+     sha256:2a909cb9df4d0207f1fe5bd9660a0529991ba18ce6ce7b389dc008c05d9022d1
+     ```
+
+   * Получите значение `E_K8S_API_PROXY`:
+
+     ```
+     EE_K8S_API_PROXY=$(kubectl exec ee-image -- cat deckhouse/candi/images_digests.json | grep kubernetesApiProxy | grep -oE 'sha256:\w*')
+     ```
+
+     Проверка:
+
+     ```
+     $ echo $EE_K8S_API_PROXY
+     sha256:80a2cf757adad6a29514f82e1c03881de205780dbd87c6e24da0941f48355d6c
+     ```
+
+   * Получите значение `EE_MODULES`:
+
+     ```
+     EE_MODULES=$(kubectl exec ee-image -- ls -l deckhouse/modules/ | grep -oE "\d.*-\w*"  | awk {'print $9'} | cut -c5-)
+     ```
+
+     Проверка:
+
+     ```
+     $ echo $EE_MODULES
+     common priority-class deckhouse external-module-manager registrypackages cloud-data-crd metallb-crd operator-prometheus-crd prometheus-crd snapshot-controller-crd      user-authn-crd vertical-pod-autoscaler-crd flow-schema admission-policy-engine cni-cilium static-routing-manager cloud-provider-aws cloud-provider-azure cloud-provider-gcp      cloud-provider-openstack cloud-provider-vcd cloud-provider-vsphere cloud-provider-yandex cloud-provider-zvirt ceph-csi local-path-provisioner cni-flannel cni-simple-bridge      kube-proxy registry-packages-proxy control-plane-manager node-manager terraform-manager kube-dns snapshot-controller network-policy-engine cert-manager istio user-authz      user-authn multitenancy-manager operator-prometheus prometheus prometheus-metrics-adapter vertical-pod-autoscaler prometheus-pushgateway extended-monitoring      monitoring-custom monitoring-deckhouse monitoring-kubernetes monitoring-kubernetes-control-plane monitoring-ping node-local-dns metallb l2-load-balancer descheduler      ingress-nginx keepalived network-gateway log-shipper loki pod-reloader chrony cilium-hubble dashboard okmeter openvpn operator-trivy upmeter delivery flant-integration      namespace-configurator secret-copier runtime-audit-engine documentation
+     ```
+
+   * Получите значение `USED_MODULES`:
+
+     ```
+     USED_MODULES=$(kubectl get modules | grep -v 'snapshot-controller-crd' | grep Enabled |awk {'print $1'})
+     ```
+
+     Проверка:
+
+     ```
+     $ echo $USED_MODULES
+     admission-policy-engine cert-manager chrony cloud-data-crd cni-cilium control-plane-manager dashboard deckhouse descheduler documentation extended-monitoring      external-module-manager flow-schema ingress-nginx kube-dns local-path-provisioner log-shipper monitoring-custom monitoring-deckhouse monitoring-kubernetes      monitoring-kubernetes-control-plane monitoring-ping namespace-configurator node-manager operator-prometheus operator-prometheus-crd pod-reloader priority-class prometheus      prometheus-crd prometheus-metrics-adapter registry-packages-proxy secret-copier snapshot-controller upmeter user-authn user-authn-crd user-authz vertical-pod-autoscaler      vertical-pod-autoscaler-crd
+     ```
+
+1. Создайте NodeGroupConfiguration:
+
+   ```yaml
+   $ kubectl apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha1
+   kind: NodeGroupConfiguration
+   metadata:
+     name: ee-set-sha-images.sh
+   spec:
+     nodeGroups:
+     - '*'
+     bundles:
+     - '*'
+     weight: 30
+     content: |
+       _on_containerd_config_changed() {
+         bb-flag-set containerd-need-restart
+       }
+       bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
+
+       bb-sync-file /etc/containerd/conf.d/ee-sandbox.toml - containerd-config-file-changed << "EOF_TOML"
+       [plugins]
+         [plugins."io.containerd.grpc.v1.cri"]
+           sandbox_image = "registry.deckhouse.ru/deckhouse/ee@$EE_SANDBOX_IMAGE"
+       EOF_TOML
+
+       sed -i 's|image: .*|image: registry.deckhouse.ru/deckhouse/ee@$EE_K8S_API_PROXY|' /var/lib/bashible/bundle_steps/051_pull_and_configure_kubernetes_api_proxy.sh
+       sed -i 's|crictl pull .*|crictl pull registry.deckhouse.ru/deckhouse/ee@$EE_K8S_API_PROXY|' /var/lib/bashible/bundle_steps/051_pull_and_configure_kubernetes_api_proxy.sh
+
+   EOF
+   ```
+
+   Дождитесь появления файла `/etc/containerd/conf.d/ee-sandbox.toml` на узлах и завершения синхронизации bashible.
+
+   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
+
+   ```
+   $ kubectl  get ng  -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
+   NAME     NODES   READY   UPTODATE
+   master   1       1       1
+   worker   2       2       2
+   ```
+
+   Также в журнале systemd-сервиса bashible должно появиться сообщение `Configuration is in sync, nothing to do`. Например:
+
+   ```
+   $ journalctl -u bashible -n 5
+   Aug 21 11:04:28 master-ce-to-ee-0 bashible.sh[53407]: Configuration is in sync, nothing to do.
+   Aug 21 11:04:28 master-ce-to-ee-0 bashible.sh[53407]: Annotate node master-ce-to-ee-0 with annotation node.deckhouse.io/ configuration-checksum=9cbe6db6c91574b8b732108a654c99423733b20f04848d0b4e1e2dadb231206a
+   Aug 21 11:04:29 master-ce-to-ee-0 bashible.sh[53407]: Succesful annotate node master-ce-to-ee-0 with annotation node.deckhouse.io/ configuration-checksum=9cbe6db6c91574b8b732108a654c99423733b20f04848d0b4e1e2dadb231206a
+   Aug 21 11:04:29 master-ce-to-ee-0 systemd[1]: bashible.service: Deactivated successfully.
+   ```
+
+1. Актуализируйте секрет доступа к registry Deckhouse, выполнив следующую команду:
+
+   ```
+   kubectl -n d8-system create secret generic deckhouse-registry \
+     --from-literal=".dockerconfigjson"="{\"auths\": { \"registry.deckhouse.ru\": { \"username\": \"license-token\", \"password\": \"$LICENSE_TOKEN\", \"auth\":    \"$AUTH_STRING\" }}}" \
+     --from-literal="address"=registry.deckhouse.ru \
+     --from-literal="path"=/deckhouse/ee \
+     --from-literal="scheme"=https \
+     --type=kubernetes.io/dockerconfigjson \
+     --dry-run='client' \
+     -o yaml | kubectl replace -f -
+   ```
+
+1. Примените EE-образ:
+
+   ```
+   kubectl -n d8-system set image deployment/deckhouse deckhouse=registry.deckhouse.ru/deckhouse/ee:v1.63.8
+   ```
+
+1. Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#%D0%BA%D0%B0%D0%BA-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D0%B8%D1%82%D1%8C-%D0%BE%D1%87%D0%B5%D1%80%D0%B5%D0%B4%D1%8C-%D0%B7%D0%B0%D0%B4%D0%B0%D0%BD%D0%B8%D0%B9-%D0%B2-deckhouse). Если в процессе возникает ошибка `ImagePullBackOff`, подождите автоматического перезапуска пода.
+
+   Посмотреть статус пода Deckhouse:
+
+   ```
    kubectl -n d8-system get po -l app=deckhouse
    ```
 
-1. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state:
+   Проверить состояние очереди Deckhouse:
 
-   ```shell
-   kubectl -n d8-system delete po -l app=deckhouse
+   ```
+    kubectl -n d8-system exec deploy/deckhouse -c deckhouse -- deckhouse-controller queue list
    ```
 
-1. Wait until Deckhouse restarts and [all tasks in the queue are completed](#how-to-check-the-job-queue-in-deckhouse):
+1. Проверьте, не осталось ли в кластере подов с адресом registry для Deckhouse CE:
 
-   ```shell
-   kubectl -n d8-system exec -it svc/deckhouse-leader -c deckhouse -- deckhouse-controller queue list
    ```
-
-1. On the master node, check the application of the new settings.
-
-   The message `Configuration is in sync, nothing to do` should appear in the `bashible` systemd service log on the master node.
-
-   An example:
-
-   ```console
-   # journalctl -u bashible -n 5
-   Jan 12 12:38:20 demo-master-0 bashible.sh[868379]: Configuration is in sync, nothing to do.
-   Jan 12 12:38:20 demo-master-0 systemd[1]: bashible.service: Deactivated successfully.
-   Jan 12 12:39:18 demo-master-0 systemd[1]: Started Bashible service.
-   Jan 12 12:39:19 demo-master-0 bashible.sh[869714]: Configuration is in sync, nothing to do.
-   Jan 12 12:39:19 demo-master-0 systemd[1]: bashible.service: Deactivated successfully.
-   ```
-
-1. Check if there are any Pods left in the cluster with the Deckhouse CE registry address:
-
-   ```shell
    kubectl get pods -A -o json | jq -r '.items[] | select(.spec.containers[]
-     | select(.image | contains("deckhouse.io/deckhouse/ce"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
+      | select(.image | contains("deckhouse.ru/deckhouse/ce"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
    ```
 
-   Sometimes, some static Pods may remain running (for example, `kubernetes-api-proxy-*`). This is due to the fact that kubelet does not restart the Pod despite changing the corresponding manifest, because the image used is the same for the Deckhouse CE and EE. To make sure that the corresponding manifests have also been changed, run the following command on any master node:
+1. Очистите временные файлы, ngc и переменные:
 
-   ```shell
-   grep -ri 'deckhouse.io/deckhouse/ce' /etc/kubernetes | grep -v backup
+   ```
+   $ kubectl delete ngc containerd-ee-config.sh ee-set-sha-images.sh
+
+   $ kubectl delete pod ee-image
+
+   $ kubectl apply -f - <<EOF
+       apiVersion: deckhouse.io/v1alpha1
+       kind: NodeGroupConfiguration
+       metadata:
+         name: del-temp-config.sh
+       spec:
+         nodeGroups:
+         - '*'
+         bundles:
+         - '*'
+         weight: 90
+         content: |
+           if [ -f /etc/containerd/conf.d/ee-registry.toml ]; then
+             rm -f /etc/containerd/conf.d/ee-registry.toml
+           fi
+           if [ -f /etc/containerd/conf.d/ee-sandbox.toml ]; then
+             rm -f /etc/containerd/conf.d/ee-sandbox.toml
+           fi
+   EOF
    ```
 
-   The output of the command should be empty.
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у nodegroup) удалите созданную ngc:
+
+   ```
+   kubectl  delete ngc del-temp-config.sh
+   ```
 
 ### How do I get access to Deckhouse controller in multimaster cluster?
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -1065,7 +1065,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    > kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module enable registry-packages-proxy
    > ```
 
-1. Очистите временные файлы, `NodeGroupConfiguration` и переменные:
+1. Удалите временные файлы, ресурс NodeGroupConfiguration и переменные:
 
    ```shell
    kubectl delete ngc containerd-ce-config.sh
@@ -1088,7 +1088,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    EOF
    ```
 
-   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданную ngc:
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданный ресурс NodeGroupConfiguration:
 
    ```shell
    kubectl  delete ngc del-temp-config.sh
@@ -1111,7 +1111,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    AUTH_STRING="$(echo -n license-token:${LICENSE_TOKEN} | base64 )"
    ```
 
-1. Cоздайте `NodeGroupConfiguration` для переходной авторизации в `registry.deckhouse.ru`:
+1. Cоздайте ресурс NodeGroupConfiguration для переходной авторизации в `registry.deckhouse.ru`:
 
    ```shell
    kubectl apply -f - <<EOF
@@ -1230,7 +1230,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
      admission-policy-engine cert-manager chrony cloud-data-crd ...
      ```
 
-1. Создайте `NodeGroupConfiguration`:
+1. Создайте ресурс NodeGroupConfiguration:
 
    ```shell
    $ kubectl apply -f - <<EOF
@@ -1323,7 +1323,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
       | select(.image | contains("deckhouse.ru/deckhouse/ce"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
    ```
 
-1. Очистите временные файлы, `NodeGroupConfiguration` и переменные:
+1. Удалите временные файлы, ресурс NodeGroupConfiguration и переменные:
 
    ```shell
    kubectl delete ngc containerd-ee-config.sh ee-set-sha-images.sh
@@ -1349,7 +1349,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    EOF
    ```
 
-   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у nodegroup) удалите созданную ngc:
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданный ресурс NodeGroupConfiguration:
 
    ```shell
    kubectl  delete ngc del-temp-config.sh
@@ -1366,7 +1366,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
 
 Для переключения кластера Deckhouse Enterprise Edition на Certified Security Edition выполните следующие действия (все команды выполняются на master-узле действующего кластера):
 
-1. Подготовьте переменные с токеном лицензии и создайте NodeGroupConfiguration для переходной авторизации в `registry-cse.deckhouse.ru`:
+1. Подготовьте переменные с токеном лицензии и создайте ресурс NodeGroupConfiguration для переходной авторизации в `registry-cse.deckhouse.ru`:
 
    ```shell
    LICENSE_TOKEN=<PUT_YOUR_LICENSE_TOKEN_HERE>
@@ -1473,7 +1473,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
 
    Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](#как-проверить-очередь-заданий-в-deckhouse).
 
-1. Создайте NodeGroupConfiguration:
+1. Создайте ресурс NodeGroupConfiguration:
 
    ```shell
    kubectl apply -f - <<EOF
@@ -1570,7 +1570,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module enable chrony
    ```
 
-1. Очистите временные файлы, ngc и переменные:
+1. Удалите временные файлы, ресурс NodeGroupConfiguration и переменные:
 
    ```console
    rm /tmp/cse-deckhouse-registry.yaml
@@ -1600,7 +1600,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    EOF
    ```
 
-   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у nodegroup) удалите созданную ngc:
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданный ресурс NodeGroupConfiguration:
 
    ```shell
    kubectl  delete ngc del-temp-config.sh

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -933,9 +933,9 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    echo $MODULES_WILL_DISABLE
    ```
 
-   > Проверьте список и убедитесь, что функциональность указанных модулей не задействована вами в кластере, и вы готовы к их отключению.
+   > Проверьте список и убедитесь, что функциональность указанных модулей не задействована вами в кластере и вы готовы к их отключению.
 
-   Отключите неподдерживаемые в CE-редакции модули:
+   Отключите не поддерживаемые в CE-редакции модули:
 
    ```
    echo $MODULES_WILL_DISABLE |
@@ -994,7 +994,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
 
    Дождитесь появления файла `/etc/containerd/conf.d/ce-registry.toml` на узлах и завершения синхронизации bashible.
 
-   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
+   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
 
    ```
    kubectl get ng -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
@@ -1038,7 +1038,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    kubectl -n d8-system set image deployment/deckhouse deckhouse=registry.deckhouse.ru/deckhouse/ce:v1.63.7
    ```
 
-1. Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#%D0%BA%D0%B0%D0%BA-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D0%B8%D1%82%D1%8C-%D0%BE%D1%87%D0%B5%D1%80%D0%B5%D0%B4%D1%8C-%D0%B7%D0%B0%D0%B4%D0%B0%D0%BD%D0%B8%D0%B9-%D0%B2-deckhouse). Если в процессе возникает ошибка `ImagePullBackOff`, подождите автоматического перезапуска пода.
+1. Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#%D0%BA%D0%B0%D0%BA-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D0%B8%D1%82%D1%8C-%D0%BE%D1%87%D0%B5%D1%80%D0%B5%D0%B4%D1%8C-%D0%B7%D0%B0%D0%B4%D0%B0%D0%BD%D0%B8%D0%B9-%D0%B2-deckhouse). Если в процессе возникает ошибка `ImagePullBackOff`, подождите автоматического перезапуска пода.
 
    Посмотреть статус пода Deckhouse:
 
@@ -1059,7 +1059,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
       | select(.image | contains("deckhouse.ru/deckhouse/ee"))) | .metadata.namespace + "\t" + .metadata.name' | sort | uniq
    ```
 
-   > Если в процессе был отключен модуль, то включите его обратно -
+   > Если в процессе был отключён модуль, включите его обратно:
    >
    > ```
    > kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller module enable registry-packages-proxy
@@ -1090,7 +1090,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    EOF
    ```
 
-   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданную ngc:
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у NodeGroup) удалите созданную ngc:
 
    ```
    kubectl  delete ngc del-temp-config.sh
@@ -1147,7 +1147,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
 
    Дождитесь появления файла `/etc/containerd/conf.d/ee-registry.toml` на узлах и завершения синхронизации bashible.
 
-   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
+   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
 
    ```
    $ kubectl  get ng  -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
@@ -1172,7 +1172,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    kubectl run ee-image --image=registry.deckhouse.ru/deckhouse/ee/install:v1.63.8 --command sleep -- infinity
    ```
 
-   > Запускайте образ последней установленной версии DH в кластере, посмотреть можно командой
+   > Запускайте образ последней установленной версии DH в кластере, посмотреть можно командой:
    >
    >  ```
    >  kubectl get deckhousereleases
@@ -1267,7 +1267,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
 
    Дождитесь появления файла `/etc/containerd/conf.d/ee-sandbox.toml` на узлах и завершения синхронизации bashible.
 
-   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
+   Статус синхронизации можно отследить по значению `UPTODATE` (отображаемое число узлов в этом статусе должно совпадать с общим числом узлов (`NODES`) в группе):
 
    ```
    $ kubectl  get ng  -o custom-columns=NAME:.metadata.name,NODES:.status.nodes,READY:.status.ready,UPTODATE:.status.upToDate -w
@@ -1305,7 +1305,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    kubectl -n d8-system set image deployment/deckhouse deckhouse=registry.deckhouse.ru/deckhouse/ee:v1.63.8
    ```
 
-1. Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#%D0%BA%D0%B0%D0%BA-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D0%B8%D1%82%D1%8C-%D0%BE%D1%87%D0%B5%D1%80%D0%B5%D0%B4%D1%8C-%D0%B7%D0%B0%D0%B4%D0%B0%D0%BD%D0%B8%D0%B9-%D0%B2-deckhouse). Если в процессе возникает ошибка `ImagePullBackOff`, подождите автоматического перезапуска пода.
+1. Дождитесь перехода пода Deckhouse в статус `Ready` и [выполнения всех задач в очереди](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/deckhouse-faq.html#%D0%BA%D0%B0%D0%BA-%D0%BF%D1%80%D0%BE%D0%B2%D0%B5%D1%80%D0%B8%D1%82%D1%8C-%D0%BE%D1%87%D0%B5%D1%80%D0%B5%D0%B4%D1%8C-%D0%B7%D0%B0%D0%B4%D0%B0%D0%BD%D0%B8%D0%B9-%D0%B2-deckhouse). Если в процессе возникает ошибка `ImagePullBackOff`, подождите автоматического перезапуска пода.
 
    Посмотреть статус пода Deckhouse:
 
@@ -1354,7 +1354,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    EOF
    ```
 
-   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у nodegroup) удалите созданную ngc:
+   После синхронизации bashible (статус синхронизации на узлах можно отследить по значению `UPTODATE` у nodegroup) удалите созданную ngc:
 
    ```
    kubectl  delete ngc del-temp-config.sh
@@ -1467,7 +1467,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    echo $MODULES_WILL_DISABLE
    ```
 
-   > Проверьте список и убедитесь, что функциональность указанных модулей не задействована вами в кластере, и вы готовы к их отключению.
+   > Проверьте список и убедитесь, что функциональность указанных модулей не задействована вами в кластере и вы готовы к их отключению.
 
    Отключите неподдерживаемые в CSE-редакции модули:
 


### PR DESCRIPTION
## Description

The instructions for switching from EE redaction to CE and from CE to EE for releases 1.64 and 1.63 have been refactored.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: The instructions for switching from EE redaction to CE and from CE to EE for releases 1.64 and 1.63 have been refactored.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
