### PR TITLE
[testing] Fix static upgrade deckhouse e2e

### DIFF
--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -463,7 +463,7 @@ set -Eeuo pipefail
 
 >&2 echo "Download yq..."
 
-/opt/deckhouse/bin/d8-curl -sSLf https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -o - > /opt/deckhouse/bin/yq
+/opt/deckhouse/bin/d8-curl -sSLfv -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
 
 >&2 echo "chmod yq..."
 
@@ -501,7 +501,7 @@ metadata:
 spec:
   version: v1.96.3
   requirements: {}
-' | /opt/deckhouse/bin/yq '. | load("/tmp/releaseFile.yaml") as \$d1 | .spec.requirements=\$d1.requirements' | kubectl apply -f -
+' | /tmp/yq '. | load("/tmp/releaseFile.yaml") as \$d1 | .spec.requirements=\$d1.requirements' | kubectl apply -f -
 
 >&2 echo "Remove release file ..."
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -463,7 +463,7 @@ set -Eeuo pipefail
 
 >&2 echo "Download yq..."
 
-d8-curl -sLfo /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+/opt/deckhouse/bin/d8-curl -sLfo /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
 
 >&2 echo "chmod yq..."
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -462,7 +462,7 @@ set -Eeuo pipefail
 
 >&2 echo "Download yq..."
 
-/opt/deckhouse/bin/d8-curl -sSLfv -o /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+/opt/deckhouse/bin/d8-curl -sSLf -o /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
 
 >&2 echo "chmod yq..."
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -456,17 +456,28 @@ function test_requirements() {
   >&2 echo "Run script ... "
 
   testScript=$(cat <<ENDSC
+set -x
 export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export LANG=C
 set -Eeuo pipefail
 
-d8-curl -sLfo /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386
+>&2 echo "Download yq..."
 
-chmod +x /usr/bin/yq
+d8-curl -sLfo /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
 
-command -v yq >/dev/null 2>&1 || exit 1
+>&2 echo "chmod yq..."
+
+chmod +x /opt/deckhouse/bin/yq
+
+>&2 echo "Create release file ..."
 
 echo "$release" > /tmp/releaseFile.yaml
+
+>&2 echo "Release file ..."
+
+cat /tmp/releaseFile.yaml
+
+>&2 echo "Apply module config ..."
 
 echo 'apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -478,6 +489,8 @@ spec:
     update:
       mode: Auto' | kubectl apply -f -
 
+>&2 echo "Apply deckhousereleases ..."
+
 echo 'apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
@@ -487,10 +500,14 @@ metadata:
   name: v1.96.3
 spec:
   version: v1.96.3
-  requirements:
-' | yq '. | load("/tmp/releaseFile.yaml") as \$d1 | .spec.requirements=\$d1.requirements' | kubectl apply -f -
+  requirements: {}
+' | /opt/deckhouse/bin/yq '. | load("/tmp/releaseFile.yaml") as \$d1 | .spec.requirements=\$d1.requirements' | kubectl apply -f -
+
+>&2 echo "Remove release file ..."
 
 rm /tmp/releaseFile.yaml
+
+>&2 echo "Sleep 5 seconds before check..."
 
 sleep 5
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -521,7 +521,7 @@ ENDSC
 
   testRequirementsAttempts=10
   for ((i=1; i<=$testRequirementsAttempts; i++)); do
-    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<$testScript; then
+    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su - -c /bin/bash <<<$testScript; then
         return 0
     else
       >&2 echo "Test requirements $i/$testRequirementsAttempts failed. Sleeping 5 seconds..."
@@ -764,30 +764,6 @@ ENDSSH
   if [[ $registration_failed == "true" ]] ; then
     return 1
   fi
-
-  restartProxyFailed=""
-  restartProxyAttempts=10
-
-  >&2 echo "Restart proxy"
-
-  for ((i=1; i<=$restartProxyAttempts; i++)); do
-    # restart proxy
-    if  $ssh_command -i "$ssh_private_key_path" "$ssh_user@$bastion_ip" sudo su -c /bin/bash <<ENDSSH; then
-        docker container restart tinyproxy
-ENDSSH
-          restartProxyFailed=""
-          break
-        else
-          restartProxyFailed="true"
-          >&2 echo "Install yq setup of master in progress (attempt #$i of $restartProxyAttempts). Sleeping 5 seconds ..."
-          sleep 5
-        fi
-  done
-
-  if [[ $restartProxyFailed == "true" ]] ; then
-      return 1
-  fi
-
 }
 
 function bootstrap() {

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -463,7 +463,7 @@ set -Eeuo pipefail
 
 >&2 echo "Download yq..."
 
-/opt/deckhouse/bin/d8-curl -sLfo /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+/opt/deckhouse/bin/d8-curl -sSLf https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -o - > /opt/deckhouse/bin/yq
 
 >&2 echo "chmod yq..."
 


### PR DESCRIPTION
## Description
Add `-` for `su` command for pass envs (ex https_proxy that needs for curl) to new root env

## Why do we need it, and what problem does it solve?
Upgrade deckhouse version e2e test for static.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Fix static upgrade deckhouse e2e.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
