### PR TITLE
[cloud-provider-vcd] Fix getting `vcd_catalog_vapp_template` data source by `org` and `catalog_id`

### DIFF
--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -18,6 +18,7 @@ data "vcd_catalog" "catalog" {
 }
 
 data "vcd_catalog_vapp_template" "template" {
+  org        = local.org
   catalog_id = data.vcd_catalog.catalog.id
   name       = local.template
 }

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/patches/fix_getting_vcd_catalog_vapp_template_data_source_by_org_and_catalog_id.patch
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/patches/fix_getting_vcd_catalog_vapp_template_data_source_by_org_and_catalog_id.patch
@@ -1,0 +1,43 @@
+Subject: [PATCH] Fix getting vcd_catalog_vapp_template data source by org and catalog_id
+---
+Index: vcd/resource_vcd_catalog_vapp_template.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/vcd/resource_vcd_catalog_vapp_template.go b/vcd/resource_vcd_catalog_vapp_template.go
+--- a/vcd/resource_vcd_catalog_vapp_template.go	(revision 2df7e589a92135093f3327e9d8698404bdf65bd0)
++++ b/vcd/resource_vcd_catalog_vapp_template.go	(date 1727329211575)
+@@ -382,6 +382,32 @@
+ 	// No filter: we continue with single item  GET
+ 
+ 	if isSearchedByCatalog {
++		orgName, ok := d.GetOk("org")
++		if ok {
++			org, err := vcdClient.GetOrg(orgName.(string))
++			if err != nil {
++				return nil, fmt.Errorf("error retrieving org: %s", err)
++			}
++
++			vAppTemplates, err := catalog.QueryVappTemplateList()
++			if err != nil {
++				return nil, fmt.Errorf("error retrieving vApp Templates from catalog: %s", err)
++			}
++
++			for _, vAppTemplate := range vAppTemplates {
++				if vAppTemplate.Name == identifier && vAppTemplate.Org == org.Org.HREF {
++					vAppTemplateHrefPrefix := vcdClient.Client.VCDHREF
++					vAppTemplateHrefPrefix.Path += "/vAppTemplate/vappTemplate-"
++
++					id, found := strings.CutPrefix(vAppTemplate.HREF, vAppTemplateHrefPrefix.String())
++					if found {
++						identifier = id
++						break
++					}
++				}
++			}
++		}
++
+ 		// In a resource, this is the only possibility
+ 		vAppTemplate, err = catalog.GetVAppTemplateByNameOrId(identifier, false)
+ 	} else {

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
@@ -15,6 +15,12 @@ from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+git:
+  - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+    to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
 shell:
   beforeInstall:
     - apk add --no-cache make patch git bash
@@ -23,5 +29,6 @@ shell:
     - export GOPROXY={{ $.GOPROXY }}
     - git clone --depth 1 --branch v{{ .TF.vcd.version }} {{ $.SOURCE_REPO }}/vmware/terraform-provider-vcd.git /src
     - cd /src
+    - git apply /patches/*.patch --verbose
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build LDFLAGS="-s -w -extldflags \"-static\""
     - mv /go/bin/terraform-provider-vcd /terraform-provider-vcd


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Add patch to `terraform-provider-vcd` with fixes to `vcd_catalog_vapp_template` data source.
- Add `org` argument to `vcd_catalog_vapp_template` data source.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

See https://github.com/vmware/terraform-provider-vcd/issues/1331.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Fix vcd catalogs sharing.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
