### PR TITLE
[global-hooks] Fix migrate cni secret migration for updating existing secret

### DIFF
--- a/global-hooks/migrate/migrate_d8_cni_secret.go
+++ b/global-hooks/migrate/migrate_d8_cni_secret.go
@@ -96,8 +96,10 @@ func d8cniSecretMigrate(input *go_hook.HookInput, dc dependency.Container) error
 		return err
 	}
 
+	resourceVersion := ""
 	for _, mc := range moduleConfigs.Items {
 		if slices.Contains([]string{"cni-cilium", "cni-flannel", "cni-simple-bridge"}, mc.GetName()) {
+			resourceVersion = mc.GetResourceVersion()
 			moduleEnabled, exists, err := unstructured.NestedBool(mc.UnstructuredContent(), "spec", "enabled")
 			if err != nil {
 				return err
@@ -209,7 +211,7 @@ func d8cniSecretMigrate(input *go_hook.HookInput, dc dependency.Container) error
 	}
 
 	// create ModuleConfig
-	err = upToDateMC(kubeCl, cniModuleConfig)
+	err = upToDateMC(kubeCl, cniModuleConfig, resourceVersion)
 	if err != nil {
 		return err
 	}
@@ -230,13 +232,14 @@ func removeD8CniSecret(input *go_hook.HookInput, kubeCl k8s.Client, secret *v1.S
 }
 
 // create Module Config
-func upToDateMC(kubeCl k8s.Client, mc *config.ModuleConfig) error {
+func upToDateMC(kubeCl k8s.Client, mc *config.ModuleConfig, resourceVersion string) error {
 	obj, err := sdk.ToUnstructured(mc)
 	if err != nil {
 		return err
 	}
 	_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), obj, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
+		obj.SetResourceVersion(resourceVersion)
 		_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Update(context.TODO(), obj, metav1.UpdateOptions{})
 		return err
 	}


### PR DESCRIPTION
## Description
Fix migrate cni secret migration for updating existing secret

## Why do we need it, and what problem does it solve?
Fix error if mc already exists 
`failed: moduleconfigs.deckhouse.io \"cni-cilium\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix
summary: Fix CNI secret migration for updating existing secret.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
