### PR TITLE
[cloud-provider-openstack] Fix ServerGroup creation

### DIFF
--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -144,3 +144,9 @@ resource "openstack_compute_floatingip_associate_v2" "bastion" {
     ]
   }
 }
+
+resource "openstack_compute_servergroup_v2" "server_group" {
+  count    = local.server_group_policy == "AntiAffinity" ? 1 : 0
+  name     = local.prefix
+  policies = ["anti-affinity"]
+}

--- a/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
@@ -11,7 +11,6 @@ locals {
   root_disk_size       = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "rootDiskSize", "") # Openstack can have disks predefined within vm flavours, so we do not set any defaults here
   etcd_volume_size     = var.providerClusterConfiguration.masterNodeGroup.instanceClass.etcdDiskSizeGb
   additional_tags      = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {})
-  server_group         = lookup(var.providerClusterConfiguration.masterNodeGroup, "serverGroup", {})
 }
 
 module "network_security_info" {

--- a/ee/candi/cloud-providers/openstack/layouts/standard/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/variables.tf
@@ -37,4 +37,6 @@ locals {
   image_name            = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
   tags                  = lookup(var.providerClusterConfiguration, "tags", {})
   ssh_allow_list        = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
+  server_group          = lookup(var.providerClusterConfiguration.masterNodeGroup, "serverGroup", {})
+  server_group_policy   = lookup(local.server_group, "policy", "")
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -27,10 +27,9 @@ resource "openstack_blockstorage_volume_v3" "master" {
   }
 }
 
-resource "openstack_compute_servergroup_v2" "master" {
-  count    = local.server_group_policy == "AntiAffinity" ? 1 : 0
-  name     = var.prefix
-  policies = ["anti-affinity"]
+data "openstack_compute_servergroup_v2" "master" {
+  count = local.server_group_policy == "AntiAffinity" ? 1 : 0
+  name  = var.prefix
 }
 
 resource "openstack_compute_instance_v2" "master" {
@@ -72,7 +71,7 @@ resource "openstack_compute_instance_v2" "master" {
   dynamic "scheduler_hints" {
     for_each = (
       local.server_group_policy == "AntiAffinity" ?
-        list(openstack_compute_servergroup_v2.master[0]) :
+        list(data.openstack_compute_servergroup_v2.master[0]) :
       local.server_group_policy == "ManuallyManaged" ?
         list({"id": lookup(var.server_group.manuallyManaged, "id", "")}) :
       []

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/implement_openstack_compute_servergroup_v2_data_source.patch
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/implement_openstack_compute_servergroup_v2_data_source.patch
@@ -1,0 +1,97 @@
+Subject: [PATCH] Implement openstack_compute_servergroup_v2 data source
+---
+Index: openstack/data_source_openstack_compute_servergroup_v2.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/openstack/data_source_openstack_compute_servergroup_v2.go b/openstack/data_source_openstack_compute_servergroup_v2.go
+new file mode 100644
+--- /dev/null	(date 1727169550523)
++++ b/openstack/data_source_openstack_compute_servergroup_v2.go	(date 1727169550523)
+@@ -0,0 +1,69 @@
++package openstack
++
++import (
++	"fmt"
++	"log"
++
++	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
++	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
++)
++
++func dataSourceComputeServerGroupV2() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceComputeServerGroupV2Read,
++		Schema: map[string]*schema.Schema{
++			"region": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++			},
++
++			"name": {
++				Type:     schema.TypeString,
++				Required: true,
++			},
++		},
++	}
++}
++
++func dataSourceComputeServerGroupV2Read(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*Config)
++	computeClient, err := config.ComputeV2Client(GetRegion(d, config))
++	if err != nil {
++		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
++	}
++
++	allPages, err := servergroups.List(computeClient).AllPages()
++	if err != nil {
++		return fmt.Errorf("Error retrieving openstack_compute_servergroup_v2: %s", err)
++	}
++
++	allServerGroups, err := servergroups.ExtractServerGroups(allPages)
++	if err != nil {
++		return fmt.Errorf("Error extracting openstack_compute_servergroup_v2 from response: %s", err)
++	}
++
++	var sg *servergroups.ServerGroup
++
++	for i, serverGroup := range allServerGroups {
++		if serverGroup.Name == d.Get("name").(string) {
++			sg = &allServerGroups[i]
++			d.SetId(serverGroup.ID)
++			break
++		}
++	}
++	
++	if sg == nil {
++		return fmt.Errorf("Server group not found")
++	}
++
++	log.Printf("[DEBUG] Retrieved openstack_compute_servergroup_v2 %s: %#v", d.Id(), sg)
++
++	d.Set("name", sg.Name)
++	d.Set("policies", sg.Policies)
++	d.Set("members", sg.Members)
++
++	d.Set("region", GetRegion(d, config))
++
++	return nil
++}
+Index: openstack/provider.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/openstack/provider.go b/openstack/provider.go
+--- a/openstack/provider.go	(revision 144d9deab7788e6dd2165e1cb673b65f38ebf065)
++++ b/openstack/provider.go	(date 1727161245661)
+@@ -258,6 +258,7 @@
+ 			"openstack_compute_instance_v2":                      dataSourceComputeInstanceV2(),
+ 			"openstack_compute_flavor_v2":                        dataSourceComputeFlavorV2(),
+ 			"openstack_compute_keypair_v2":                       dataSourceComputeKeypairV2(),
++			"openstack_compute_servergroup_v2":                   dataSourceComputeServerGroupV2(),
+ 			"openstack_containerinfra_clustertemplate_v1":        dataSourceContainerInfraClusterTemplateV1(),
+ 			"openstack_containerinfra_cluster_v1":                dataSourceContainerInfraCluster(),
+ 			"openstack_dns_zone_v2":                              dataSourceDNSZoneV2(),

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -14,6 +14,12 @@ from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+git:
+  - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+    to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
 shell:
   beforeInstall:
     - apk add --no-cache make patch git bash
@@ -22,6 +28,7 @@ shell:
     - export GOPROXY={{ $.GOPROXY }}
     - git clone --depth 1 --branch v{{ .TF.openstack.version }} {{ $.SOURCE_REPO }}/terraform-provider-openstack/terraform-provider-openstack.git /src
     - cd /src
+    - git apply /patches/*.patch --verbose
     - make fmt
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build LDFLAGS="-s -w -extldflags \"-static\" -X github.com/terraform-provider-openstack/terraform-provider-openstack/version.ProviderVersion={{ .TF.openstack.version }}"
     - mv /go/bin/terraform-provider-openstack /terraform-provider-openstack


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Add patch to `terraform-provider-openstack` with `openstack_compute_servergroup_v2` data source implementation.
- Move `ServerGroup` creation to `base-infrastructure` step.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We only need one server group for all masters. If we try to create a server group at the `master-node` step, we will have multiple server groups.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Create one server group for all masters.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
