### PR TITLE
[site] Proxy d8-cli checksum files

### DIFF
--- a/docs/site/.werf/nginx.conf
+++ b/docs/site/.werf/nginx.conf
@@ -82,8 +82,8 @@ http {
             return 301 https://$host/products/kubernetes-platform/documentation/v1/$1;
         }
 
-        location ~* ^/downloads/deckhouse-cli/v[0-9]+\.[0-9]+\.[0-9]+/d8-v[0-9]+\.[0-9]+\.[0-9]+-(darwin|linux|windows)-(amd|arm)64.tar.gz$   {
-            rewrite ^/downloads/deckhouse-cli/([^/]+/[^/]+\.gz)$ /deckhouse/deckhouse-cli/releases/download/$1/  break;
+        location ~* ^/downloads/deckhouse-cli/v[0-9]+\.[0-9]+\.[0-9]+/d8-v[0-9]+\.[0-9]+\.[0-9]+-(darwin|linux|windows)-(amd|arm)64.tar.gz(\.sha256sum)?$   {
+            rewrite ^/downloads/deckhouse-cli/([^/]+/[^/]+\.gz(\.sha256sum)?)$ /deckhouse/deckhouse-cli/releases/download/$1/  break;
 
             proxy_cache             dcache;
             proxy_cache_key         $uri;


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Adjusted regular expressions in deckhouse website nginx configuration to allow downloading of d8-cli checksum files via `location` that is used to proxy the main `d8` binary.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Some users are either afraid or forbidden to download from github, but still wish to validate checksums of `d8` binaries they are installing

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Proxy d8-cli checksum files alongside main d8 binaries.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
