### PR TITLE
[user-authn] fix: allow system-users with + symbol in email

### DIFF
--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -16,7 +16,7 @@ spec:
         resources:   ["users"]
   validations:
     - expression: '!( request.userInfo.username != "system:serviceaccount:d8-system:deckhouse"
-        && !object.spec.email.matches("^[\\w\\-\\.]+@(?:[\\w-]+\\.)+[\\w-]{2,}$") )'
+        && !object.spec.email.matches("^[\\w\\+\\-\\.]+@(?:[\\w-]+\\.)+[\\w-]{2,}$") )'
       reason: Forbidden
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}


### PR DESCRIPTION
## Description

We have system users who are registered with an email that has + symbols in it.
It is necessary that the validation of such users takes place correctly.

## Why do we need it, and what problem does it solve?

Without proper validation, there is no way to allow users to make changes to the cluster configuration.

## What is the expected result?

Users with email containing a plus will be verified.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: allow system-users with + symbol in email
impact_level: default
```
