### PR TITLE
[docs] Fixed link to VCDInstanceClass on VMware Cloud Director page

### DIFF
--- a/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
@@ -76,7 +76,7 @@ apiVersions:
               additionalProperties: false
               required: [template, storageProfile, sizingPolicy]
               description: |
-                Partial contents of the fields of the [VCDInstanceClass](cr.html#vcdinstanceclass).
+                Partial contents of the fields of the [VCDInstanceClass](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-vcd/cr.html#vcdinstanceclass).
               properties:
                 rootDiskSizeGb:
                   description: |

--- a/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
@@ -24,7 +24,7 @@ apiVersions:
                 Количество создаваемых master-узлов. Для обеспечения кворума важно, чтобы оно было нечетным.
             instanceClass:
               description: |
-                Частичное содержимое полей [VCDInstanceClass](cr.html#vcdinstanceclass).
+                Частичное содержимое полей [VCDInstanceClass](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-vcd/cr.html#vcdinstanceclass).
               properties:
                 rootDiskSizeGb:
                   description: |


### PR DESCRIPTION
## Description
Fixed link to VCDInstanceClass on VMware Cloud Director page.

## Why do we need it, and what problem does it solve?
Fixed link to VCDInstanceClass on VMware Cloud Director page, it opens without 404 error.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: docs
type: fix 
summary: Fixed link to VCDInstanceClass on VMware Cloud Director page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
