### PR TITLE
[multitenancy-manager] Add verify namespace object for messageExpression in ValidatingAdmissionPolicy

### DIFF
--- a/ee/modules/160-multitenancy-manager/templates/validation.yaml
+++ b/ee/modules/160-multitenancy-manager/templates/validation.yaml
@@ -19,7 +19,9 @@ spec:
     - expression: 'request.userInfo.username == "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"'
       reason: Forbidden
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
-      messageExpression: "'This resource is managed by ' + string(object.metadata.namespace) + ' Project. Manual modification is forbidden.'"
+      messageExpression: 'object.kind == ''Namespace'' ? ''This resource is managed
+            by '' + object.metadata.name + '' Project. Manual modification is forbidden.''
+            : ''This resource is managed by '' + object.metadata.namespace + '' Project. Manual modification is forbidden.'''
 {{- end }}
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
We have a special [message](https://github.com/deckhouse/deckhouse/blob/c883118690704fd8082917a1e3fb827b4570427c/ee/modules/160-multitenancy-manager/templates/validation.yaml#L22) in case of violation of the policy but this not work
```shell
# kubectl label ns my-project-test01 security.deckhouse.io/pod-policy=privileged --overwrite
Error from server (Forbidden): namespaces "my-project-test01" is forbidden: ValidatingAdmissionPolicy 'd8-multitenancy-manager' with binding 'd8-multitenancy-manager' denied request: failed expression: request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"
``` 
This is because the `namespace` resource does not have `object.metadata.namespace`
Changes add verify this

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: fix
summary: Add verify namespace object for messageExpression in ValidatingAdmissionPolicy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
