### PR TITLE
[dhctl] Add validation rules for ClusterConfiguration.cloud.prefix specific to cloud providers

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -127,6 +127,10 @@ func (m *MetaConfig) Prepare() (*MetaConfig, error) {
 	}
 
 	if cloud.Provider == "Yandex" {
+		if err := ValidateClusterConfigurationPrefix(cloud.Prefix, cloud.Provider); err != nil {
+			return nil, err
+		}
+
 		var masterNodeGroup YandexMasterNodeGroupSpec
 		if err := json.Unmarshal(m.ProviderClusterConfig["masterNodeGroup"], &masterNodeGroup); err != nil {
 			return nil, fmt.Errorf("unable to unmarshal master node group from provider cluster configuration: %v", err)
@@ -134,7 +138,7 @@ func (m *MetaConfig) Prepare() (*MetaConfig, error) {
 
 		if masterNodeGroup.Replicas > 0 &&
 			len(masterNodeGroup.InstanceClass.ExternalIPAddresses) > 0 &&
-			masterNodeGroup.Replicas != len(masterNodeGroup.InstanceClass.ExternalIPAddresses) {
+			masterNodeGroup.Replica s != len(masterNodeGroup.InstanceClass.ExternalIPAddresses) {
 			return nil, fmt.Errorf("number of masterNodeGroup.replicas should be equal to the length of masterNodeGroup.instanceClass.externalIPAddresses")
 		}
 

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -138,7 +138,7 @@ func (m *MetaConfig) Prepare() (*MetaConfig, error) {
 
 		if masterNodeGroup.Replicas > 0 &&
 			len(masterNodeGroup.InstanceClass.ExternalIPAddresses) > 0 &&
-			masterNodeGroup.Replica s != len(masterNodeGroup.InstanceClass.ExternalIPAddresses) {
+			masterNodeGroup.Replicas != len(masterNodeGroup.InstanceClass.ExternalIPAddresses) {
 			return nil, fmt.Errorf("number of masterNodeGroup.replicas should be equal to the length of masterNodeGroup.instanceClass.externalIPAddresses")
 		}
 

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -756,7 +756,7 @@ func (i *namedIndex) String() string {
 func ValidateClusterConfigurationPrefix(prefix string, provider string) error {
 	regex, ok := cloudProviderSpecificClusterPrefix[provider]
 	if !ok {
-		return fmt.Errorf("validation failed: unknown provider '%v'", provider)
+		return nil
 	}
 
 	if !regex.(*regexp.Regexp).MatchString(prefix) {


### PR DESCRIPTION
## Description

Different cloud providers have different restrictions on resource names (instances, networks, etc.). In this case we added validation for YandexCloud.

This is not a complete solution because we cannot accurately validate the length of the claud resource name, which is the length of the prefix and the name, e.g. `bob-yc-9858` + `-master-` + `1`.

terraform-provider-yandex has validation for some resources, but not for all, for example here: https://github.com/yandex-cloud/terraform-provider-yandex/blob/9a7e19d14e32a9d5e05ff349afbc3ba2d60bb46e/yandex/resource_yandex_smartcaptcha_captcha.go#L92
 

Similar issue:
https://github.com/yandex-cloud/terraform-provider-yandex/issues/353#issuecomment-1614502414

## Why do we need it, and what problem does it solve?

At the moment we don't do prefix validation, based on which we then create cloud resources with terraform. This can lead to problems as described in the linked issue

## Why do we need it in the patch release (if we do)?

## What is the expected result?

An invalid prefix will cause an error when attempting to bootstrap:
```
invalid prefix '1bob-yc-9858' for provider 'Yandex', prefix must match the pattern: ^([a-z]([-a-z0-9]{0,61}[a-z0-9])?)$
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add validation for ClusterConfiguration.cloud.prefix
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
