### PR TITLE
[deckhouse] fix rbacv2 hook

### DIFF
--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -241,7 +241,7 @@ func createBinding(binding *filteredUseBinding) *rbacv1.RoleBinding {
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
+			Kind:     "ClusterRole",
 			Name:     binding.RoleName,
 		},
 		Subjects: binding.Subjects,


### PR DESCRIPTION
## Description
It provides fix for the rbacv2 hook.

## Why do we need it, and what problem does it solve?
The hook does not work correctly.

## Why do we need it in the patch release (if we do)?
The hook creates RoleBindings with a Role instead of a ClusterRole.

## What is the expected result?
The hook creates RoleBindings with a ClusterRole.
<img width="927" alt="Screenshot 2024-09-25 at 5 06 21 PM" src="https://github.com/user-attachments/assets/89342b60-f277-4428-bdca-82e9bb469283">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix rbacv2 hook.
impact_level: low
```