### PR TITLE
[vertical-pod-autoscaler] fix cve and build for cse edition

### DIFF
--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
@@ -1,12 +1,11 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2024-09-25 00:00"
 import:
-- artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
-  add: /admission-controller
-  to: /admission-controller
-  before: setup
+  - artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
+    add: /admission-controller
+    to: /admission-controller
+    before: setup
 docker:
   ENTRYPOINT: ["/admission-controller"]
   CMD: ["--v=4", "--stderrthreshold=info"]

--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
+fromCacheVersion: "2024-09-25 00:00"
 import:
 - artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
   add: /admission-controller

--- a/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
@@ -1,11 +1,10 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2024-09-25 00:00"
 import:
-- artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
-  add: /recommender
-  to: /recommender
-  before: setup
+  - artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
+    add: /recommender
+    to: /recommender
+    before: setup
 docker:
   ENTRYPOINT: ["/recommender"]

--- a/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
+fromCacheVersion: "2024-09-25 00:00"
 import:
 - artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
   add: /recommender

--- a/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
+fromCacheVersion: "2024-09-25 00:00"
 import:
 - artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
   add: /updater

--- a/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
@@ -1,12 +1,11 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2024-09-25 00:00"
 import:
-- artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
-  add: /updater
-  to: /updater
-  before: setup
+  - artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
+    add: /updater
+    to: /updater
+    before: setup
 docker:
   ENTRYPOINT: ["/updater"]
   CMD: ["--v=4", "--stderrthreshold=info"]

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/dep-upgrade.patch
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/dep-upgrade.patch
@@ -1,0 +1,54 @@
+diff --git a/vertical-pod-autoscaler/go.mod b/vertical-pod-autoscaler/go.mod
+index 43614a03c..ebf8b89c7 100644
+--- a/vertical-pod-autoscaler/go.mod
++++ b/vertical-pod-autoscaler/go.mod
+@@ -50,11 +50,11 @@ require (
+ 	github.com/spf13/cobra v1.6.0 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/stretchr/objx v0.4.0 // indirect
+-	golang.org/x/net v0.8.0 // indirect
++	golang.org/x/net v0.29.0 // indirect
+ 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+-	golang.org/x/sys v0.6.0 // indirect
+-	golang.org/x/term v0.6.0 // indirect
+-	golang.org/x/text v0.8.0 // indirect
++	golang.org/x/sys v0.25.0 // indirect
++	golang.org/x/term v0.24.0 // indirect
++	golang.org/x/text v0.18.0 // indirect
+ 	google.golang.org/appengine v1.6.7 // indirect
+ 	google.golang.org/protobuf v1.28.1 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+diff --git a/vertical-pod-autoscaler/go.sum b/vertical-pod-autoscaler/go.sum
+index bffb8ca8f..3d391ddda 100644
+--- a/vertical-pod-autoscaler/go.sum
++++ b/vertical-pod-autoscaler/go.sum
+@@ -346,6 +346,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
+ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+ golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+ golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
++golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
++golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -408,10 +410,12 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+ golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
++golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -421,6 +425,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+ golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
+ golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
++golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/dep-upgrade.patch
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/dep-upgrade.patch
@@ -19,35 +19,44 @@ index 43614a03c..ebf8b89c7 100644
  	google.golang.org/protobuf v1.28.1 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/vertical-pod-autoscaler/go.sum b/vertical-pod-autoscaler/go.sum
-index bffb8ca8f..3d391ddda 100644
+index bffb8ca8f..f6b2c0b92 100644
 --- a/vertical-pod-autoscaler/go.sum
 +++ b/vertical-pod-autoscaler/go.sum
-@@ -346,6 +346,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
+@@ -344,8 +344,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
+ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
  golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
- golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
- golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+-golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+-golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 +golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
 +golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-@@ -408,10 +410,12 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
+@@ -406,12 +406,12 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
- golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 +golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
- golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
- golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
+-golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+-golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
++golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=
 +golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=
  golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-@@ -421,6 +425,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+@@ -419,8 +419,8 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
- golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
- golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+-golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
+-golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
++golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 +golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
  golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/recommender.patch
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/recommender.patch
@@ -1,6 +1,8 @@
+diff --git a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+index c738c95e4..522d3e3c6 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
-@@ -130,16 +130,19 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
+@@ -130,12 +130,14 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
  	// checkpoint to avoid having multiple peaks in the same interval after the state is restored from
  	// the checkpoint. Therefore we are extracting the current peak from all containers.
  	// TODO: Avoid the nested loop over all containers for each VPA.
@@ -21,7 +23,3 @@
  				}
  			}
  		}
- 	}
-+
- 	return aggregateContainerStateMap
- }

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -12,7 +12,7 @@ shell:
     - cd /src
     - git clone --depth 1 -b vertical-pod-autoscaler-0.14.0 {{ $.SOURCE_REPO }}/kubernetes/autoscaler.git .
     - git apply /patches/*.patch --verbose
-    - mv vertical-pod-autoscaler /src/vertical-pod-autoscaler
+    - mv autoscaler/vertical-pod-autoscaler /src/vertical-pod-autoscaler
     - rm -rf /src/autoscaler
     - rm -rf /src/vertical-pod-autoscaler/e2e/
 ---

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -30,8 +30,9 @@ shell:
   {{- include "alpine packages proxy" . | nindent 2 }}
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+    - cd /src/vertical-pod-autoscaler/
     - go mod vendor
-    
+
     - cd /src/vertical-pod-autoscaler/pkg/admission-controller
     - go build -ldflags="-s -w" -o /admission-controller
 

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -30,6 +30,7 @@ shell:
   {{- include "alpine packages proxy" . | nindent 2 }}
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+    - go mod vendor
     
     - cd /src/vertical-pod-autoscaler/pkg/admission-controller
     - go build -ldflags="-s -w" -o /admission-controller

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -31,6 +31,7 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src/vertical-pod-autoscaler/
+    - go mod tidy
     - go mod vendor
 
     - cd /src/vertical-pod-autoscaler/pkg/admission-controller

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -8,11 +8,10 @@ git:
       - '**/*'
 shell:
   install:
-    - mkdir -p /src
-    - cd /src
-    - git clone --depth 1 -b vertical-pod-autoscaler-0.14.0 {{ $.SOURCE_REPO }}/kubernetes/autoscaler.git .
+    - git clone --depth 1 -b vertical-pod-autoscaler-0.14.0 {{ $.SOURCE_REPO }}/kubernetes/autoscaler.git /src/autoscaler
+    - cd /src/autoscaler
     - git apply /patches/*.patch --verbose
-    - mv autoscaler/vertical-pod-autoscaler /src/vertical-pod-autoscaler
+    - mv vertical-pod-autoscaler /src/vertical-pod-autoscaler
     - rm -rf /src/autoscaler
     - rm -rf /src/vertical-pod-autoscaler/e2e/
 ---

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -1,6 +1,5 @@
----
-artifact: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
-from: {{ .Images.BASE_GOLANG_19_ALPINE }}
+artifact: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+fromArtifact: src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/302-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -9,22 +8,38 @@ git:
       - '**/*'
 shell:
   install:
-    - apk add --no-cache git
     - mkdir -p /src
     - cd /src
     - git clone --depth 1 -b vertical-pod-autoscaler-0.14.0 {{ $.SOURCE_REPO }}/kubernetes/autoscaler.git .
-    - find /patches -name '*.patch' -exec git apply {} \;
-    - export GO_VERSION=${GOLANG_VERSION}
-    - export GOPROXY={{ $.GOPROXY }}
-    - cd vertical-pod-autoscaler/pkg/admission-controller
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /admission-controller
-    - chown 64535:64535 /admission-controller
-    - chmod 0700 /admission-controller
-    - cd ../../../vertical-pod-autoscaler/pkg/recommender
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /recommender
-    - chown 64535:64535 /recommender
-    - chmod 0700 /recommender
-    - cd ../../../vertical-pod-autoscaler/pkg/updater
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /updater
-    - chown 64535:64535 /updater
-    - chmod 0700 /updater
+    - git apply /patches/*.patch --verbose
+    - mv vertical-pod-autoscaler /src/vertical-pod-autoscaler
+    - rm -rf /src/autoscaler
+    - rm -rf /src/vertical-pod-autoscaler/e2e/
+---
+artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+import:
+  - artifact: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+    add: /src
+    to: /src
+    before: install
+mount:
+  - fromPath: ~/go-pkg-cache
+    to: /go/pkg
+shell:
+  beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}
+  install:
+    - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+    
+    - cd /src/vertical-pod-autoscaler/pkg/admission-controller
+    - go build -ldflags="-s -w" -o /admission-controller
+
+    - cd /src/vertical-pod-autoscaler/pkg/recommender
+    - go build -ldflags="-s -w" -o /recommender
+
+    - cd /src/vertical-pod-autoscaler/pkg/updater
+    - go build -ldflags="-s -w" -o /updater
+
+    - chown 64535:64535 /admission-controller  /updater /recommender
+    - chmod 0700 /updater /recommender /admission-controller

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -31,7 +31,6 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src/vertical-pod-autoscaler/
-    - go mod tidy
     - go mod vendor
 
     - cd /src/vertical-pod-autoscaler/pkg/admission-controller

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -26,8 +26,6 @@ mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src/vertical-pod-autoscaler/


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
