### PR TITLE
[docs] Add CEF format example in docs

### DIFF
--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -325,6 +325,38 @@ spec:
     # the request_id field should be present in the log message
     syslog.message_id: "{{ request_id }}"
 ```
+## Logs in CEF Format
+
+There is a way to format logs in CEF format using `codec: CEF`, with overriding `cef.name` and `cef.severity` based on values from the `message` field (application log) in JSON format.
+
+In the example below, `app` and `log_level` are keys containing values for overriding:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: siem-kafka
+spec:
+  extraLabels:
+    cef.name: '{{ app }}'
+    cef.severity: '{{ log_level }}'
+  type: Kafka
+  kafka:
+    bootstrapServers:
+      - my-cluster-kafka-brokers.kafka:9092
+    encoding:
+      codec: CEF
+    tls:
+      verifyCertificate: false
+      verifyHostname: true
+    topic: logs
+```
+You can also manually set your own values:
+```yaml
+extraLabels:
+  cef.name: 'TestName'
+  cef.severity: '1'
+```
 
 ## Collect Kubernetes Events
 

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -325,6 +325,7 @@ spec:
     # the request_id field should be present in the log message
     syslog.message_id: "{{ request_id }}"
 ```
+
 ## Logs in CEF Format
 
 There is a way to format logs in CEF format using `codec: CEF`, with overriding `cef.name` and `cef.severity` based on values from the `message` field (application log) in JSON format.
@@ -351,7 +352,9 @@ spec:
       verifyHostname: true
     topic: logs
 ```
+
 You can also manually set your own values:
+
 ```yaml
 extraLabels:
   cef.name: 'TestName'

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -325,6 +325,38 @@ spec:
     # поле request_id должно присутствовать в сообщении
     syslog.message_id: "{{ request_id }}"
 ```
+##  Логи в CEF формате
+
+Существует способ формировать логи в формате CEF, используя `codec: CEF`, с переопределением `cef.name` и `cef.severity` по значениям из поля `message` (лога приложения) в формате JSON.
+
+В примере ниже `app` и `log_level` это ключи содержащие значения для переопределения:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: siem-kafka
+spec:
+  extraLabels:
+    cef.name: '{{ app }}'
+    cef.severity: '{{ log_level }}'
+  type: Kafka
+  kafka:
+    bootstrapServers:
+      - my-cluster-kafka-brokers.kafka:9092
+    encoding:
+      codec: CEF
+    tls:
+      verifyCertificate: false
+      verifyHostname: true
+    topic: logs
+```
+Так же можно вручную задать свои значения:
+```yaml
+extraLabels:
+  cef.name: 'TestName'
+  cef.severity: '1'
+```
 
 ## Сбор событий Kubernetes
 

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -325,7 +325,8 @@ spec:
     # поле request_id должно присутствовать в сообщении
     syslog.message_id: "{{ request_id }}"
 ```
-##  Логи в CEF формате
+
+## Логи в CEF формате
 
 Существует способ формировать логи в формате CEF, используя `codec: CEF`, с переопределением `cef.name` и `cef.severity` по значениям из поля `message` (лога приложения) в формате JSON.
 
@@ -351,7 +352,9 @@ spec:
       verifyHostname: true
     topic: logs
 ```
+
 Так же можно вручную задать свои значения:
+
 ```yaml
 extraLabels:
   cef.name: 'TestName'


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add CEF format example in [docs](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/460-log-shipper/examples.html#syslog) log-shipper

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Add CEF format example in docs log-shipper
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
