### PR TITLE
helm_lib_tolerations taint fix

### DIFF
--- a/ee/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         control-plane: controller-manager
     spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "uninitialized") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "capz-controller-manager")) | nindent 6 }}

--- a/ee/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/deployment.yaml
@@ -65,7 +65,6 @@ spec:
         control-plane: controller-manager
     spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "capz-controller-manager")) | nindent 6 }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -209,7 +209,7 @@ spec:
     spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "uninitialized") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: d8-control-plane-manager

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         app: "bashible-apiserver"
     spec:
       {{- include "helm_lib_node_selector"  (tuple . "master")  | nindent 6 }}
-      {{- include "helm_lib_tolerations"    (tuple . "any-node" "uninitialized")  | nindent 6 }}
+      {{- include "helm_lib_tolerations"    (tuple . "any-node" "with-uninitialized")  | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" .   | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "bashible-apiserver"))  | nindent 6 }}

--- a/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         control-plane: controller-manager
     spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "uninitialized") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "caps-controller-manager")) | nindent 6 }}

--- a/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
@@ -65,7 +65,6 @@ spec:
         control-plane: controller-manager
     spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "caps-controller-manager")) | nindent 6 }}


### PR DESCRIPTION
## Description

Fixed tolerations in  daemonset/d8-control-plane-manager, deployment/bashible-apiserver and deployment/caps-controller-manager

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## What is the expected result?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: d8-control-plane-manager tolerations fix
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
