### PR TITLE
[docs][getting started] add an explanation of externalNetworkName in VK Cloud

### DIFF
--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -105,7 +105,11 @@ kind: OpenStackClusterConfiguration
 layout: Standard
 standard:
   # [<en>] Network name for external communication.
+  # [<en>] When using SDN Neutron, the default name `ext-net`.
+  # [<en>] When using SDN Sprut, the default name `internet`.
   # [<ru>] Имя сети для внешнего взаимодействия.
+  # [<ru>] При использовании SDN Neutron имя по-умолчанию `ext-net`.
+  # [<ru>] При использовании SDN Sprut имя по-умолчанию `internet`.
   externalNetworkName: *!CHANGE_EXT_NET*
   # [<en>] Addressing for the internal network of the cluster nodes.
   # [<ru>] Адресация для внутренней сети узлов кластера.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -105,11 +105,8 @@ kind: OpenStackClusterConfiguration
 layout: Standard
 standard:
   # [<en>] Network name for external communication.
-  # [<en>] When using SDN Neutron, the default name `ext-net`.
-  # [<en>] When using SDN Sprut, the default name `internet`.
   # [<ru>] Имя сети для внешнего взаимодействия.
-  # [<ru>] При использовании SDN Neutron имя по-умолчанию `ext-net`.
-  # [<ru>] При использовании SDN Sprut имя по-умолчанию `internet`.
+  # [<ru>] В SDN Neutron и Sprut по умолчанию создаются сети ext-net и internet соответственно. Вы можете использовать их, или создать другие и указать их в конфигурации.
   externalNetworkName: *!CHANGE_EXT_NET*
   # [<en>] Addressing for the internal network of the cluster nodes.
   # [<ru>] Адресация для внутренней сети узлов кластера.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
@@ -105,6 +105,7 @@ kind: OpenStackClusterConfiguration
 layout: Standard
 standard:
   # [<en>] Network name for external communication.
+  # [<en>] In SDN Neutron and Sprut, ext-net and internet networks are created by default, respectively. You can use them, or create others and specify them in the configuration.
   # [<ru>] Имя сети для внешнего взаимодействия.
   externalNetworkName: *!CHANGE_EXT_NET*
   # [<en>] Addressing for the internal network of the cluster nodes.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added a default name for externalNetworkName based on the SDN used in the project.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
These changes are necessary for the convenience of users, enabling them to quickly set the externalNetworkName without needing to determine the specific naming for their SDN. This increases productivity and reduces the risk of configuration errors.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
After applying these changes, the documentation will automatically include the default name for externalNetworkName based on the SDN used. Users can verify the updated documentation to see the specified default name.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add default name for externalNetworkName based on the SDN used in the project.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
