### PR TITLE
[user-authn] feat: dex support base64 encoded and PEM encoded certs

### DIFF
--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -6,11 +6,12 @@ ENV GOPROXY=${GOPROXY}
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 WORKDIR /dex
-COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch /
+COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch patches/bytes-and-string-certificates.patch /
 RUN git clone --branch v2.41.1 --depth 1 ${SOURCE_REPO}/dexidp/dex.git . \
   && git apply /client-groups.patch \
   && git apply /static-user-groups.patch \
-  && git apply /gitlab-refresh-context.patch
+  && git apply /gitlab-refresh-context.patch \
+  && git apply /bytes-and-string-certificates.patch
 
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex
 

--- a/modules/150-user-authn/images/dex/patches/bytes-and-string-certificates.patch
+++ b/modules/150-user-authn/images/dex/patches/bytes-and-string-certificates.patch
@@ -1,0 +1,113 @@
+diff --git a/pkg/httpclient/httpclient_test.go b/pkg/httpclient/httpclient_test.go
+--- a/pkg/httpclient/httpclient_test.go	(revision 43956db7fd75c488a82c70cf231f44287300a75d)
++++ b/pkg/httpclient/httpclient_test.go	(date 1727427513361)
+@@ -2,10 +2,12 @@
+
+ import (
+ 	"crypto/tls"
++	"encoding/base64"
+ 	"fmt"
+ 	"io"
+ 	"net/http"
+ 	"net/http/httptest"
++	"os"
+ 	"testing"
+
+ 	"github.com/stretchr/testify/assert"
+@@ -20,18 +22,31 @@
+ 	assert.Nil(t, err)
+ 	defer ts.Close()
+
+-	rootCAs := []string{"testdata/rootCA.pem"}
+-	testClient, err := httpclient.NewHTTPClient(rootCAs, false)
+-	assert.Nil(t, err)
++	runTest := func(name string, certs []string) {
++		t.Run(name, func(t *testing.T) {
++			rootCAs := certs
++			testClient, err := httpclient.NewHTTPClient(rootCAs, false)
++			assert.Nil(t, err)
+
+-	res, err := testClient.Get(ts.URL)
+-	assert.Nil(t, err)
++			res, err := testClient.Get(ts.URL)
++			assert.Nil(t, err)
+
+-	greeting, err := io.ReadAll(res.Body)
+-	res.Body.Close()
+-	assert.Nil(t, err)
++			greeting, err := io.ReadAll(res.Body)
++			res.Body.Close()
++			assert.Nil(t, err)
+
+-	assert.Equal(t, "Hello, client", string(greeting))
++			assert.Equal(t, "Hello, client", string(greeting))
++		})
++	}
++
++	runTest("From file", []string{"testdata/rootCA.pem"})
++
++	content, err := os.ReadFile("testdata/rootCA.pem")
++	assert.NoError(t, err)
++	runTest("From string", []string{string(content)})
++
++	contentStr := base64.StdEncoding.EncodeToString(content)
++	runTest("From bytes", []string{contentStr})
+ }
+
+ func TestInsecureSkipVerify(t *testing.T) {
+diff --git a/pkg/httpclient/httpclient.go b/pkg/httpclient/httpclient.go
+--- a/pkg/httpclient/httpclient.go	(revision 43956db7fd75c488a82c70cf231f44287300a75d)
++++ b/pkg/httpclient/httpclient.go	(date 1727427513358)
+@@ -3,6 +3,7 @@
+ import (
+ 	"crypto/tls"
+ 	"crypto/x509"
++	"encoding/base64"
+ 	"fmt"
+ 	"net"
+ 	"net/http"
+@@ -10,6 +11,26 @@
+ 	"time"
+ )
+
++func extractCAs(input []string) [][]byte {
++	result := make([][]byte, 0, len(input))
++	for _, ca := range input {
++		if ca == "" {
++			continue
++		}
++
++		pemData, err := os.ReadFile(ca)
++		if err != nil {
++			pemData, err = base64.StdEncoding.DecodeString(ca)
++			if err != nil {
++				pemData = []byte(ca)
++			}
++		}
++
++		result = append(result, pemData)
++	}
++	return result
++}
++
+ func NewHTTPClient(rootCAs []string, insecureSkipVerify bool) (*http.Client, error) {
+ 	pool, err := x509.SystemCertPool()
+ 	if err != nil {
+@@ -17,13 +38,11 @@
+ 	}
+
+ 	tlsConfig := tls.Config{RootCAs: pool, InsecureSkipVerify: insecureSkipVerify}
+-	for _, rootCA := range rootCAs {
+-		rootCABytes, err := os.ReadFile(rootCA)
+-		if err != nil {
+-			return nil, fmt.Errorf("failed to read root-ca: %v", err)
+-		}
++	for index, rootCABytes := range extractCAs(rootCAs) {
+ 		if !tlsConfig.RootCAs.AppendCertsFromPEM(rootCABytes) {
+-			return nil, fmt.Errorf("no certs found in root CA file %q", rootCA)
++			return nil, fmt.Errorf("rootCAs.%d is not in PEM format, certificate must be "+
++				"a PEM encoded string, a base64 encoded bytes that contain PEM encoded string, "+
++				"or a path to a PEM encoded certificate", index)
+ 		}
+ 	}
+


### PR DESCRIPTION
## Description

Allow to load certificates from bytes and strings

## Why do we need it, and what problem does it solve?

In cloud environments, for publically available values it is easier to specify the content of a public certificate in the config than mounting it to the container.

## What is the expected result?

We can use certificates as base64 strings

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: feature
summary: dex support base64 encoded and PEM encoded certs
impact_level: default
```
