### PR TITLE
[istio] Improved resourceManagement validation in the ModuleConfig

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -300,7 +300,7 @@ properties:
                 properties:
                   cpu:
                     type: string
-                    pattern: '^(\"[0-9]+\"|[0-9]+m)$'
+                    pattern: '^[0-9]+m?$'
                     default: '100m'
                     description: |
                       Configuring CPU requests.
@@ -319,7 +319,7 @@ properties:
                 properties:
                   cpu:
                     type: string
-                    pattern: '^(\"[0-9]+\"|[0-9]+m)$'
+                    pattern: '^[0-9]+m?$'
                     default: '2000m'
                     description: |
                       Configuring CPU limits.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -299,10 +299,8 @@ properties:
                   Resource requests settings for pods.
                 properties:
                   cpu:
-                    x-examples: ["1", "1000m"]
-                    oneOf:
-                      - type: string
-                        pattern: '^(["][0-9]+["]|[0-9]+m)$'
+                    type: string
+                    pattern: '^(["][0-9]+["]|[0-9]+m)$'
                     default: '100m'
                     description: |
                       Configuring CPU requests.
@@ -320,10 +318,8 @@ properties:
                   Configuring CPU and memory limits.
                 properties:
                   cpu:
-                    x-examples: ["1", "1000m"]
-                    oneOf:
-                      - type: string
-                        pattern: '^(["][0-9]+["]|[0-9]+m)$'
+                    type: string
+                    pattern: '^(["][0-9]+["]|[0-9]+m)$'
                     default: '2000m'
                     description: |
                       Configuring CPU limits.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -302,8 +302,7 @@ properties:
                     x-examples: ["1", "1000m"]
                     oneOf:
                       - type: string
-                        pattern: "^[0-9]+m?$"
-                      - type: number
+                        pattern: '^(["].*["]|[0-9]+m)$'
                     default: '100m'
                     description: |
                       Configuring CPU requests.
@@ -324,8 +323,7 @@ properties:
                     x-examples: ["1", "1000m"]
                     oneOf:
                       - type: string
-                        pattern: "^[0-9]+m?$"
-                      - type: number
+                        pattern: '^(["].*["]|[0-9]+m)$'
                     default: '2000m'
                     description: |
                       Configuring CPU limits.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -302,7 +302,7 @@ properties:
                     x-examples: ["1", "1000m"]
                     oneOf:
                       - type: string
-                        pattern: '^(["].*["]|[0-9]+m)$'
+                        pattern: '^(["][0-9]+["]|[0-9]+m)$'
                     default: '100m'
                     description: |
                       Configuring CPU requests.
@@ -323,7 +323,7 @@ properties:
                     x-examples: ["1", "1000m"]
                     oneOf:
                       - type: string
-                        pattern: '^(["].*["]|[0-9]+m)$'
+                        pattern: '^(["][0-9]+["]|[0-9]+m)$'
                     default: '2000m'
                     description: |
                       Configuring CPU limits.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -299,6 +299,7 @@ properties:
                   Resource requests settings for pods.
                 properties:
                   cpu:
+                    x-examples: ["1", "1000m"]
                     oneOf:
                       - type: string
                         pattern: "^[0-9]+m?$"
@@ -320,6 +321,7 @@ properties:
                   Configuring CPU and memory limits.
                 properties:
                   cpu:
+                    x-examples: ["1", "1000m"]
                     oneOf:
                       - type: string
                         pattern: "^[0-9]+m?$"

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -300,7 +300,7 @@ properties:
                 properties:
                   cpu:
                     type: string
-                    pattern: '^("[0-9]+"|[0-9]+m)$'
+                    pattern: '^(\"[0-9]+\"|[0-9]+m)$'
                     default: '100m'
                     description: |
                       Configuring CPU requests.
@@ -319,7 +319,7 @@ properties:
                 properties:
                   cpu:
                     type: string
-                    pattern: '^("[0-9]+"|[0-9]+m)$'
+                    pattern: '^(\"[0-9]+\"|[0-9]+m)$'
                     default: '2000m'
                     description: |
                       Configuring CPU limits.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -300,7 +300,7 @@ properties:
                 properties:
                   cpu:
                     type: string
-                    pattern: '^(["][0-9]+["]|[0-9]+m)$'
+                    pattern: '^("[0-9]+"|[0-9]+m)$'
                     default: '100m'
                     description: |
                       Configuring CPU requests.
@@ -319,7 +319,7 @@ properties:
                 properties:
                   cpu:
                     type: string
-                    pattern: '^(["][0-9]+["]|[0-9]+m)$'
+                    pattern: '^("[0-9]+"|[0-9]+m)$'
                     default: '2000m'
                     description: |
                       Configuring CPU limits.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -628,10 +628,8 @@ properties:
                   Resource requests settings for pods.
                 properties:
                   cpu:
-                    oneOf:
-                    - type: string
-                      pattern: "^[0-9]+m?$"
-                    - type: number
+                    type: string
+                    pattern: "^[0-9]+m?$"
                     description: |
                       Configuring CPU requests.
                   memory:
@@ -647,10 +645,8 @@ properties:
                   Configuring CPU and memory limits.
                 properties:
                   cpu:
-                    oneOf:
-                    - type: string
-                      pattern: "^[0-9]+m?$"
-                    - type: number
+                    type: string
+                    attern: "^[0-9]+m?$"
                     description: |
                       Configuring CPU limits.
                   memory:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -150,7 +150,7 @@ properties:
                 properties:
                   cpu:
                     description: |
-                      Настройка запроса CPU (CPU requests). Пример указания параметра - "1", "1000m".
+                      Настройка запроса CPU (CPU requests).
                   memory:
                     description: |
                       Настройка запроса памяти (memory requests).
@@ -160,7 +160,7 @@ properties:
                 properties:
                   cpu:
                     description: |
-                      Настройка ограничений использования CPU (CPU limits). Пример указания параметра - "1", "1000m".
+                      Настройка ограничений использования CPU (CPU limits).
                   memory:
                     description: |
                       Настройка ограничений использования памяти (memory limits).

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -150,7 +150,7 @@ properties:
                 properties:
                   cpu:
                     description: |
-                      Настройка запроса CPU (CPU requests).
+                      Настройка запроса CPU (CPU requests). Пример указания параметра - "1", "1000m".
                   memory:
                     description: |
                       Настройка запроса памяти (memory requests).
@@ -160,7 +160,7 @@ properties:
                 properties:
                   cpu:
                     description: |
-                      Настройка ограничений использования CPU (CPU limits).
+                      Настройка ограничений использования CPU (CPU limits). Пример указания параметра - "1", "1000m".
                   memory:
                     description: |
                       Настройка ограничений использования памяти (memory limits).

--- a/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -23,5 +23,26 @@ positive:
           static:
             requests:
               memory: "2G"
+    - sidecar:
+        resourcesManagement:
+          static:
+            limits:
+              cpu: 2000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
   values:
     - {}
+negative:
+  configValues:
+  #Bad cpu limit value
+    - sidecar:
+        resourcesManagement:
+          static:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -573,7 +573,7 @@ static:
     cpu: 11m
     memory: 22Mi
   limits:
-    cpu: 33
+    cpu: "33"
     memory: 44Gi
 `)
 			f.HelmRender()
@@ -589,7 +589,7 @@ requests:
   memory: 22Mi
   ephemeral-storage: 50Mi
 limits:
-  cpu: 33
+  cpu: "33"
   memory: 44Gi
 `))
 			vpa := f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "istiod-v1x19x7")


### PR DESCRIPTION
## Description

Improved validation of the `spec.sidecar.resourcesManagement.static` parameter in istio ModuleConfig.

## Why do we need it, and what problem does it solve?

Onder-the-hood resource `IstioOperator` doesn't support the numberic resource specifications, it can handle only the string's. We decided to handle it by forbidding the numbering notation in ModuleConfig.

## What is the expected result?

The values that you enter in `moduleConfig` do not cause errors in the Istio operation. If you enter an invalid value, you will immediately know about it before it is applied.

## Why do we need it in patch release?

The consequences of wrong configuration aren't obvious, istio-operator just stops working and the logs aren't obvious.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: fix
summary: Improved validation of the ModuleConfig
impact_level: default
```

