### PR TITLE
[go_lib] add probe to the cloud-data reconciler

### DIFF
--- a/go_lib/cloud-data/reconciler.go
+++ b/go_lib/cloud-data/reconciler.go
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cloud_data
+package clouddata
 
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
 	"sort"
 	"syscall"
 	"time"
-
-	"math/rand"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -57,6 +56,7 @@ type Reconciler struct {
 	logger           *log.Entry
 	k8sDynamicClient dynamic.Interface
 	k8sClient        *kubernetes.Clientset
+	probe            bool
 }
 
 func NewReconciler(
@@ -74,6 +74,7 @@ func NewReconciler(
 		logger:           logger,
 		k8sClient:        k8sClient,
 		k8sDynamicClient: k8sDynamicClient,
+		probe:            true,
 	}
 }
 
@@ -120,6 +121,7 @@ func (c *Reconciler) Start() {
 		c.logger.Fatal(err)
 	}
 }
+
 func (c *Reconciler) registerMetrics() {
 	c.cloudRequestErrorMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "cloud_data",
@@ -152,6 +154,10 @@ func (c *Reconciler) registerMetrics() {
 	prometheus.MustRegister(c.orphanedDiskMetric)
 }
 
+func (c *Reconciler) setProbe(probe bool) {
+	c.probe = probe
+}
+
 func (c *Reconciler) reconcileLoop(ctx context.Context, doneCh chan<- struct{}) {
 	c.reconcile(ctx)
 
@@ -179,7 +185,16 @@ func (c *Reconciler) getHTTPServer() *http.Server {
 
 	router := http.NewServeMux()
 	router.Handle("/metrics", promhttp.Handler())
-	router.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) })
+	router.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if c.probe {
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("false"))
+		c.logger.Errorln("Probe failed")
+	})
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(indexPageContent))
 	})
@@ -261,10 +276,10 @@ func (c *Reconciler) instanceTypesReconcile(ctx context.Context) {
 		c.updateResourceErrorMetric.WithLabelValues().Set(0.0)
 		return nil
 	})
-
 	if err != nil {
 		c.updateResourceErrorMetric.WithLabelValues().Set(1.0)
 		c.logger.Errorln("Cannot update cloud data resource. Timed out. See error messages below.")
+		c.setProbe(false)
 	}
 }
 
@@ -311,16 +326,24 @@ func (c *Reconciler) discoveryDataReconcile(ctx context.Context) {
 
 	var cloudDiscoveryData []byte
 
-	secret, err := c.k8sClient.CoreV1().Secrets("kube-system").Get(cctx, "d8-provider-cluster-configuration", metav1.GetOptions{})
-	// d8-provider-cluster-configuration can not be exist in hybrid clusters
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			c.logger.Errorf("Failed to get 'd8-provider-cluster-configuration' secret: %v\n", err)
-			c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(1.0)
-			return
+	err := retryFunc(15, 3*time.Second, 30*time.Second, c.logger, func() error {
+		secret, err := c.k8sClient.CoreV1().Secrets("kube-system").Get(cctx, "d8-provider-cluster-configuration", metav1.GetOptions{})
+		// d8-provider-cluster-configuration can not be exist in hybrid clusters
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to get 'd8-provider-cluster-configuration' secret: %v", err)
+			}
+		} else {
+			cloudDiscoveryData = secret.Data["cloud-provider-discovery-data.json"]
 		}
-	} else {
-		cloudDiscoveryData = secret.Data["cloud-provider-discovery-data.json"]
+		c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(0.0)
+		return nil
+	})
+	if err != nil {
+		c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(1.0)
+		c.logger.Errorln("Cannot get 'd8-provider-cluster-configuration' secret. Timed out. See error messages below.")
+		c.setProbe(false)
+		return
 	}
 
 	discoveryData, err := c.discoverer.DiscoveryData(ctx, cloudDiscoveryData)
@@ -373,10 +396,10 @@ func (c *Reconciler) discoveryDataReconcile(ctx context.Context) {
 		c.updateResourceErrorMetric.WithLabelValues().Set(0.0)
 		return nil
 	})
-
 	if err != nil {
 		c.updateResourceErrorMetric.WithLabelValues().Set(1.0)
 		c.logger.Errorln("Cannot update cloud data resource. Timed out. See error messages below.")
+		c.setProbe(false)
 	}
 }
 
@@ -457,7 +480,6 @@ func (c *Reconciler) orphanedDisksReconcile(ctx context.Context) {
 		c.updateResourceErrorMetric.WithLabelValues().Set(0.0)
 		return nil
 	})
-
 	if err != nil {
 		c.updateResourceErrorMetric.WithLabelValues().Set(1.0)
 		c.logger.Errorln("Cannot update cloud data resource. Timed out. See error messages below.")


### PR DESCRIPTION
## Description
add probe to the cloud-data reconciler
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Some clients have cloud-data-discoverer hangs.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
When cloud-data-discoverer hangs, it should restart itself
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: go_lib
type: fix
summary: add probe to the cloud-data reconciler
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
