### PR TITLE
[dhctl] del deprecated configOverrides

### DIFF
--- a/candi/openapi/doc-ru-init_configuration.yaml
+++ b/candi/openapi/doc-ru-init_configuration.yaml
@@ -45,14 +45,3 @@ apiVersions:
               Используйте параметр [logLevel](../modules/002-deckhouse/configuration.html#parameters-loglevel) ModuleConfig 'deckhouse' вместо этого параметра.
 
               Уровень логирования Deckhouse.
-          configOverrides:
-            description: |
-              Вместо этого параметра, используйте ресурсы ModuleConfig для настройки модулей.
-
-              Начальная [конфигурация Deckhouse](/products/kubernetes-platform/documentation/v1/#конфигурация-deckhouse).
-
-              Укажите здесь параметры конфигурации Deckhouse, с которыми он должен запуститься после установки.
-
-              Структура, указанная в параметре, будет использована для создания [глобальной конфигурации Deckhouse](../deckhouse-configure-global.html) (moduleConfig `global`) и [настроек модулей](../#настройка-модуля) (moduleConfig `<module-name>`).
-
-              **Внимание!** В `configOverrides` для включения/отключения модуля и указания его настроек используется название модуля в **camelCase** (например, `userAuthn`). После установки Deckhouse для управления модулем используется ресурс moduleConfig с названием модуля в **snake-case** (например, `user-authn`).

--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -89,16 +89,3 @@ apiVersions:
               Deckhouse logging Level.
             enum: [Debug, Info, Error]
             default: Info
-          configOverrides:
-            type: object
-            deprecated: true
-            description: |
-              Instead of this parameter, use ModuleConfig resources to configure modules.
-
-              Initial [Deckhouse configuration](/products/kubernetes-platform/documentation/v1/#deckhouse-configuration).
-
-              Specify here Deckhouse configuration parameters with which it should start after installation.
-
-              The structure specified in the parameter will be used to create a [global Deckhouse configuration](../deckhouse-configure-global.html) (moduleConfig `global`) and [module settings](../#configuring-the-module) (moduleConfig `<module-name>`).
-
-              **Caution!** The module name in **camelCase** is used to enable/disable the module and specify its settings (for example, `userAuthn`) in the `configOverrides` structure. After installing Deckhouse, the moduleConfig resource is used to manage the module with the module name in **snake-case** (for example, `user-authn`).

--- a/dhctl/README.md
+++ b/dhctl/README.md
@@ -61,10 +61,6 @@ deckhouse:
   registryDockerCfg: | # Base64-encoded section of docker.auths {"auths":{"registry.example.com":{"username":"oauth2","password":"token"}}}
     eyJhdXRocyI6eyJyZWdpc3RyeS5leGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6Im9hdXRoMiIsInBhc3N3b3JkIjoidG9rZW4ifX19Cg==
   releaseChannel: Stable
-  configOverrides:
-    global:
-    nginxIngressEnabled: false
-    flantIntegrationEnabled: false
 ```
 
 #### Cloud cluster

--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -44,7 +44,6 @@ deckhouse:
    devBranch: test
    # {"auths": { "test": {}}}
    registryDockerCfg: eyJhdXRocyI6IHsgInRlc3QiOiB7fX19
-   configOverrides: {}
 `
 	staticConfig := `
 ---

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -47,36 +47,6 @@ spec:
   settings:
     %s
 `
-	configOverridesWarn = `
-Config overrides are deprecated. Please use module config:
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ClusterConfiguration
-...
-apiVersion: deckhouse.io/v1alpha1
-kind: InitConfiguration
-...
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: global
-spec:
-  settings:
-    highAvailability: false
-    modules:
-      publicDomainTemplate: '%s.example.com'
-  version: 1
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-flannel
-spec:
-  enabled: true
----
-...
-`
 
 	DefaultBundle   = "Default"
 	DefaultLogLevel = "Info"
@@ -198,17 +168,7 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	schemasStore := NewSchemaStore()
 
 	if len(metaConfig.DeckhouseConfig.ConfigOverrides) > 0 {
-		log.WarnLn(configOverridesWarn)
-		if len(metaConfig.ModuleConfigs) > 0 {
-			return nil, fmt.Errorf("Cannot use ModuleConfig's and configOverrides at the same time. Please use ModuleConfig's")
-		}
-
-		mcs, err := ConvertInitConfigurationToModuleConfigs(metaConfig, schemasStore, bundle, logLevel)
-		if err != nil {
-			return nil, err
-		}
-
-		metaConfig.ModuleConfigs = mcs
+		return nil, fmt.Errorf("Support for 'configOverrides' was removed. Please use ModuleConfig's instead.")
 	}
 
 	var deckhouseCm *ModuleConfig
@@ -231,7 +191,7 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	}
 
 	if deckhouseCm == nil {
-		deckhouseCm, err = buildModuleConfigWithOverrides(schemasStore, "deckhouse", true, map[string]any{
+		deckhouseCm, err = buildModuleConfig(schemasStore, "deckhouse", true, map[string]any{
 			"bundle":   bundle,
 			"logLevel": logLevel,
 		})

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -60,38 +60,6 @@ internalNetworkCIDRs:
 }
 
 func TestModuleDeckhouseConfigOverridesAndMc(t *testing.T) {
-	t.Run("Fail whe module config and config overrides", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
-			"configOverrides": `
-configOverrides:
-  istioEnabled: false
-  global:
-    modules:
-      publicDomainTemplate: "%s.example.com"
-  cniCiliumEnabled: true
-  cniCilium:
-    tunnelMode: VXLAN
-  common:
-    testString: aaaaa
-`,
-			"moduleConfigs": `
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  creationTimestamp: "2022-11-22T09:12:26Z"
-  generation: 1
-  name: common
-  resourceVersion: "826312837"
-  uid: b275a253-dcb5-4321-b0ef-8881fdc8a2a8
-spec:
-  enabled: false
-`,
-		})
-
-		_, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.Error(t, err)
-	})
-
 	t.Run("Use default bundle and logLevel", func(t *testing.T) {
 		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
 			"moduleConfigs": `
@@ -185,7 +153,7 @@ spec:
 		require.Equal(t, iCfg.Bundle, "Minimal")
 	})
 
-	t.Run("Convert config overrides to module config", func(t *testing.T) {
+	t.Run("Prohibit use of configOverrides", func(t *testing.T) {
 		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
 			"configOverrides": `
 configOverrides:
@@ -201,10 +169,8 @@ configOverrides:
 `,
 		})
 
-		iCfg, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.NoError(t, err)
-
-		require.Len(t, iCfg.ModuleConfigs, 5)
+		_, err := PrepareDeckhouseInstallConfig(metaConfig)
+		require.Error(t, err)
 	})
 
 	t.Run("Correct parse module configs", func(t *testing.T) {

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -153,7 +153,7 @@ spec:
 		require.Equal(t, iCfg.Bundle, "Minimal")
 	})
 
-	t.Run("Prohibit use of configOverrides", func(t *testing.T) {
+	t.Run("Forbid to use configOverrides", func(t *testing.T) {
 		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
 			"configOverrides": `
 configOverrides:

--- a/dhctl/pkg/config/module_config.go
+++ b/dhctl/pkg/config/module_config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -62,46 +61,6 @@ type ModuleConfigSpec struct {
 	Enabled  *bool          `json:"enabled,omitempty"`
 }
 
-// ConvertInitConfigurationToModuleConfigs turns InitConfiguration into a set of ModuleConfig's.
-// At first, it creates a mandatory "deckhouse" ModuleConfig,
-// then it checks for any module configuration overrides within InitConfiguration.configOverrides.
-// If it detects such overrides, it converts them into ModuleConfig resources as well.
-// Finally, it unlocks further bootstrap by allowing modules hooks to run with created ModuleConfig's.
-func ConvertInitConfigurationToModuleConfigs(metaConfig *MetaConfig, schemasStore *SchemaStore, bundle string, level string) ([]*ModuleConfig, error) {
-	initConfiguration := metaConfig.DeckhouseConfig
-	dhModuleConfig, err := buildModuleConfigWithOverrides(schemasStore, "deckhouse", true, map[string]any{
-		"bundle":   bundle,
-		"logLevel": level,
-	})
-	if err != nil {
-		return nil, err
-	}
-	mcs := []*ModuleConfig{
-		dhModuleConfig,
-	}
-
-	modulesEnabledStatuses := computeModuleEnabledStatuses(initConfiguration.ConfigOverrides)
-	for moduleName, moduleEnabled := range modulesEnabledStatuses {
-		configOverride := initConfiguration.ConfigOverrides[moduleName]
-		settings := map[string]any{}
-		if configOverride != nil {
-			var settingsIsDict bool
-			settings, settingsIsDict = configOverride.(map[string]any)
-			if !settingsIsDict {
-				return nil, fmt.Errorf("Invalid configOverride, expected a dictionary, got %T", configOverride)
-			}
-		}
-
-		mc, err := buildModuleConfigWithOverrides(schemasStore, moduleName, moduleEnabled, settings)
-		if err != nil {
-			return nil, err
-		}
-		mcs = append(mcs, mc)
-	}
-
-	return mcs, nil
-}
-
 // computeModuleEnabledStatuses loops over a InitConfiguration.deckhouse.configOverrides structure,
 // figuring out which ModuleConfig's should be enabled or disabled.
 // Returns a mapping of module name and a if it should be enabled or not.
@@ -131,7 +90,7 @@ func computeModuleEnabledStatuses(configOverrides map[string]any) map[string]boo
 	return modulesEnabledStatuses
 }
 
-func buildModuleConfigWithOverrides(
+func buildModuleConfig(
 	schemasStore *SchemaStore,
 	moduleName string,
 	isEnabled bool,

--- a/dhctl/pkg/config/module_config.go
+++ b/dhctl/pkg/config/module_config.go
@@ -61,35 +61,6 @@ type ModuleConfigSpec struct {
 	Enabled  *bool          `json:"enabled,omitempty"`
 }
 
-// computeModuleEnabledStatuses loops over a InitConfiguration.deckhouse.configOverrides structure,
-// figuring out which ModuleConfig's should be enabled or disabled.
-// Returns a mapping of module name and a if it should be enabled or not.
-func computeModuleEnabledStatuses(configOverrides map[string]any) map[string]bool {
-	modulesEnabledStatuses := make(map[string]bool)
-	for key, override := range configOverrides {
-		moduleName := strings.TrimSuffix(key, "Enabled")
-		overrideIsEnableProperty := key != moduleName
-
-		if overrideIsEnableProperty {
-			enabled, isBool := override.(bool)
-			if isBool {
-				modulesEnabledStatuses[moduleName] = enabled
-			} else {
-				// Avoid enabling module if it's config is malformed
-				modulesEnabledStatuses[moduleName] = false
-			}
-			continue
-		}
-
-		if _, enableStatusAlreadyDefined := modulesEnabledStatuses[moduleName]; !enableStatusAlreadyDefined {
-			// Enabling module by default if it has no %moduleName%Enabled property, skipping otherwise
-			modulesEnabledStatuses[moduleName] = true
-		}
-	}
-
-	return modulesEnabledStatuses
-}
-
 func buildModuleConfig(
 	schemasStore *SchemaStore,
 	moduleName string,

--- a/dhctl/pkg/config/types.go
+++ b/dhctl/pkg/config/types.go
@@ -83,5 +83,5 @@ type DeckhouseClusterConfig struct {
 	RegistryDockerCfg string                 `json:"registryDockerCfg,omitempty"`
 	RegistryCA        string                 `json:"registryCA,omitempty"`
 	RegistryScheme    string                 `json:"registryScheme,omitempty"`
-	ConfigOverrides   map[string]interface{} `json:"configOverrides"`
+	ConfigOverrides   map[string]interface{} `json:"configOverrides"` // Deprecated
 }

--- a/docs/documentation/pages/installing/README.md
+++ b/docs/documentation/pages/installing/README.md
@@ -37,8 +37,6 @@ The YAML installation config contains multiple resource configurations (manifest
 
   This resource contains the parameters Deckhouse needs to start or run smoothly, such as the [placement-related parameters for Deckhouse components](../deckhouse-configure-global.html#parameters-modules-placement-customtolerationkeys), the [storageClass](../deckhouse-configure-global.html#parameters-storageclass) used, the [container registry](configuration.html#initconfiguration-deckhouse-registrydockercfg) credentials, the [DNS naming template](../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate), and more.
 
-  **Caution!** The [configOverrides](configuration.html#initconfiguration-deckhouse-configoverrides) parameter is deprecated and will be removed. Use the [ModuleConfig](../#configuring-the-module) in the installation config to set parameters for **built-in** Deckhouse modules. For other modules, use [installation resource file](#installation-resource-config).  
-
 - [ClusterConfiguration](configuration.html#clusterconfiguration) — general cluster parameters, such as network parameters, CRI parameters, control plane version, etc.
   
   > The `ClusterConfiguration` resource is only required if a Kubernetes cluster has to be pre-deployed when installing Deckhouse. That is, `ClusterConfiguration` is not required if Deckhouse is installed into an existing Kubernetes cluster.
@@ -79,10 +77,6 @@ apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        publicDomainTemplate: "%s.example.com"
 ---
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration

--- a/docs/documentation/pages/installing/README_RU.md
+++ b/docs/documentation/pages/installing/README_RU.md
@@ -37,8 +37,6 @@ YAML-файл конфигурации установки содержит па�
 - [InitConfiguration](configuration.html#initconfiguration) — начальные параметры [конфигурации Deckhouse](../#конфигурация-deckhouse). С этой конфигурацией Deckhouse запустится после установки.
 
   В этом ресурсе, в частности, указываются параметры, без которых Deckhouse не запустится или будет работать некорректно. Например, параметры [размещения компонентов Deckhouse](../deckhouse-configure-global.html#parameters-modules-placement-customtolerationkeys), используемый [storageClass](../deckhouse-configure-global.html#parameters-storageclass), параметры доступа к [container registry](configuration.html#initconfiguration-deckhouse-registrydockercfg), [шаблон используемых DNS-имен](../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) и другие.
-
-  **Внимание!** Параметр [configOverrides](configuration.html#initconfiguration-deckhouse-configoverrides) устарел и будет удален. Для установки параметров **встроенных модулей** Deckhouse используйте набор ресурсов [ModuleConfig](../#настройка-модуля) в файле конфигурации установки. Для остальных модулей используйте [файл ресурсов установки](#файл-ресурсов-установки).
   
 - [ClusterConfiguration](configuration.html#clusterconfiguration) — общие параметры кластера, такие как версия control plane, сетевые параметры, параметры CRI и т. д.
   
@@ -80,10 +78,6 @@ apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
   releaseChannel: Stable
-  configOverrides:
-    global:
-      modules:
-        publicDomainTemplate: "%s.example.com"
 ---
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration


### PR DESCRIPTION
## Description

Remove support for deprecated `InitConfiguration.configOverrides` parameter.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Parameter `configOverrides` was deprecated since v1.54.
Close #6354.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

<img width="1351" alt="image" src="https://github.com/user-attachments/assets/9a5fcdd6-68fe-45e9-b085-19dcb7941e10">


<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Remove support for deprecated 'InitConfiguration.configOverrides' parameter.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
